### PR TITLE
Fixing the memory corruption in the BEZIER.cpp

### DIFF
--- a/SOURCES/BEZIER.CPP
+++ b/SOURCES/BEZIER.CPP
@@ -13,10 +13,12 @@
 
 #include	"C_EXTERN.H"
 
+#define MAX_SCAN_LINES 480
+
 /*──────────────────────────────────────────────────────────────────────────*/
 //▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-S32		TabCoorPoint[480][4];
-S32		TabNbPoint[480];
+S32		TabCoorPoint[MAX_SCAN_LINES][4];
+S32		TabNbPoint[MAX_SCAN_LINES];
 S32		MinYTabPoint,MaxYTabPoint;
 
 S32		XS0,YS0,XS1,YS1,XS2,YS2,XS3,YS3 ;
@@ -55,22 +57,21 @@ void CalculeLigneOmbre( S32 x1, S32 y1, S32 x2, S32 y2 )
 		}
 
 		if (y2>ClipYMax) y2=ClipYMax;
-
-		if (y1<MinYTabPoint) MinYTabPoint=y1;
-
-		if (y2>MaxYTabPoint) MaxYTabPoint=y2;
-
-
 		x+=ix;
 		y1++;
 
-		for( y=y1; y<=y2; y++ )
+		if (y1<MinYTabPoint) MinYTabPoint=y1;
+		if (y2>MaxYTabPoint) MaxYTabPoint=y2;
+
+		for (y=y1; y<=y2; y++)
 		{
-			TabCoorPoint[y][TabNbPoint[y]++]=FTOW(x);
+			if ((U32)y < MAX_SCAN_LINES AND (U32)TabNbPoint[y] < 4)
+			{
+				TabCoorPoint[y][TabNbPoint[y]++]=FTOW(x);
+			}
 			//Plot(FTOW(x),y,15);
 			x+=ix;
 		}
-
 	}
 }
 
@@ -208,13 +209,19 @@ void	DrawLineShade(	S32 x0, S32 z0, S32 x1, S32 z1, S32 x2, S32 z2, S32 x3, S32 
 {
 	S32	y,j,k;
 	S32	temp;
+	S32	yStart, yEnd;
 
-	MinYTabPoint=ClipYMax;
-	MaxYTabPoint=ClipYMin;
-
+	MinYTabPoint = ClipYMax;
+	MaxYTabPoint = ClipYMin;
 	DrawOmbre(x0,z0,x1,z1,x2,z2,x3,z3);
 
-	for ( y = MinYTabPoint; y <= MaxYTabPoint; y++ )
+	yStart = MinYTabPoint;
+	yEnd   = MaxYTabPoint;
+	
+	if (yStart < 0) yStart = 0;
+	if (yEnd > MAX_SCAN_LINES - 1) yEnd = MAX_SCAN_LINES - 1;
+
+	for (y = yStart; y <= yEnd; y++)
 	{
 		switch( TabNbPoint[y] )
 		{


### PR DESCRIPTION
**Fix out-of-bounds memory corruption in `CalculeLigneOmbre` / `DrawLineShade`**

### Problem

`CalculeLigneOmbre` used an off-by-one trick when clipping a line's start point to `ClipYMin`: it set `y1 = ClipYMin - 1`, then relied on a following `y1++` to arrive at the correct first scanline. However, the `MinYTabPoint` update happened **before** that `y1++`, meaning `MinYTabPoint` could be set to `-1` when `ClipYMin = 0`.

In `DrawLineShade`, the loop `for (y = MinYTabPoint; ...)` would then start at `y = -1`, causing an out-of-bounds write into `TabCoorPoint[-1]` — **memory corruption**.

### How to reproduce

This bug manifested as Twinsen's tunic disappearing in rare ocasions when LM_SAVE_HERO / LM_RESTORE_HERO was used in the script. Just by circumstances, the SaveBodyHero variable was aligned just before the TabNbPoint array from BEZIER.CPP when built in the Release mode. This lead to the following code writing 0 to the SaveBodyHero, making Twinsen lose the tunic on LM_RESTORE_HERO call. 

```cpp
TabNbPoint[y] = 0 ;	// reinit for next Shadow
```

So, to reproduce it consistently, I have build the IdaJS build in **Release** mode, and then loaded this save game.

https://github.com/innerbytes/idajs/blob/main/Ida/Samples/saves/S6699.LBA  

It was enough to enter the crane and then exit from it, and Twinsen's tunic always disappeared. That's how I was able to hunt the reason of the memory overwrite. 

Obviously, if in the resulting memory layout of your build, something else is located before this array, this bug could manifest otherwise. So it's not guaranteed to be reproduced the same way in the other builds, but the memory corruption issue is still there, as you can see from the code. 

This bug is not related to the porting and is present in the original LBA2 published source code, that's why I'm publishing this PR. 

I have also checked the behavior in the LBA2 version from the GoG. This bug doesn't reproduce there - so the 2.21 must have fixed this in their build already, or the memory layout is simply different, and something else except SaveBodyHero gets changed.

### Fixes in this PR

**Root cause fix** — move `x += ix; y1++` before the `MinYTabPoint` update in `CalculeLigneOmbre`, so the tracked minimum always reflects the actual first scanline written, never the temporary sentinel value.

**Write-point guard** — bounds-check each access in the inner loop:
```cpp
if ((U32)y < MAX_SCAN_LINES AND (U32)TabNbPoint[y] < 4)
```

**Iterator clamp in `DrawLineShade`** — clamp `MinYTabPoint`/`MaxYTabPoint` into `[0, MAX_SCAN_LINES-1]` via local `yStart`/`yEnd` variables before the rendering loop, preventing any residual bad range from reaching array accesses.

**Constant** — replaced the magic number `480` with `MAX_SCAN_LINES` used consistently across array declarations, guards, and clamps.