### PR TITLE
Add Smacker video playback with libsmacker (LGPL)

### DIFF
--- a/LIB386/AIL/CMakeLists.txt
+++ b/LIB386/AIL/CMakeLists.txt
@@ -7,3 +7,10 @@ elseif (${SOUND_BACKEND} STREQUAL "miles")
 elseif (${SOUND_BACKEND} STREQUAL "sdl")
     add_subdirectory(SDL)
 endif ()
+
+# Smacker video needs SDL video/audio (StartVideoAudio, PushVideoAudio, etc.). When sound
+# backend is not SDL, the SDL subdirectory is not built, so add VIDEO_AUDIO_SDL here.
+if (MVIDEO_BACKEND STREQUAL "smacker" AND NOT SOUND_BACKEND STREQUAL "sdl")
+    target_sources(ail PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/SDL/VIDEO_AUDIO_SDL.CPP)
+    target_link_libraries(ail PRIVATE SDL3::SDL3)
+endif ()

--- a/LIB386/AIL/SDL/CD.CPP
+++ b/LIB386/AIL/SDL/CD.CPP
@@ -1,39 +1,93 @@
 #include "CD_SDL.H"
 
+#include <AIL/STREAM.H>
+
 #include <SDL3/SDL.h>
 
-const char* OpenCD(char *volume_name) {
-  SDL_Log("DEBUG - OpenCD(%s)", volume_name);
+#include <stdio.h>
+#include <string.h>
+
+static bool FileExists(const char *path) {
+  FILE *f = fopen(path, "rb");
+  if (f) {
+    fclose(f);
+    return true;
+  }
+  return false;
+}
+
+#ifndef ADELINE_MAX_PATH
+#define ADELINE_MAX_PATH 512
+#endif
+
+/* European layout: first CD track is 6 (Track06.wav). US layout: first is 2 (Track02.wav). */
+#define FIRST_CD_TRACK_EU  6
+#define FIRST_CD_TRACK_US  2
+
+static S32 cdVolume = 0;
+static bool cdPlaying = false;
+
+static void BuildCDTrackPath(char *outPath, S32 pathMax, S32 trackOneBased) {
+  char *cwd = SDL_GetCurrentDirectory();
+  if (!cwd) {
+    outPath[0] = '\0';
+    return;
+  }
+  int n = snprintf(outPath, pathMax, "%s/music/Track%02d.wav", cwd, trackOneBased);
+  SDL_free(cwd);
+  if (n < 0 || n >= pathMax)
+    outPath[0] = '\0';
+}
+
+const char *OpenCD(char *volume_name) {
+  (void)volume_name;
+  cdVolume = 127;
+  cdPlaying = false;
   return "D";
 }
 
 void PlayCD(S32 track) {
-  SDL_Log("DEBUG - PlayCD(%d)", track);
+  char path[ADELINE_MAX_PATH];
+  /* track is 0-based from the game (PtrTrackCD[num]&MUSIC - FirstCDTrack). */
+  /* European: track 0 -> Track06.wav (6), track 1 -> 7, etc. US: track 0 -> Track02.wav (2). */
+  BuildCDTrackPath(path, sizeof(path), FIRST_CD_TRACK_EU + track);
+  if (path[0] && FileExists(path)) {
+    PlayStream(path);
+    ChangeVolumeStream(cdVolume);
+    cdPlaying = true;
+    return;
+  }
+  BuildCDTrackPath(path, sizeof(path), FIRST_CD_TRACK_US + track);
+  if (path[0] && FileExists(path)) {
+    PlayStream(path);
+    ChangeVolumeStream(cdVolume);
+    cdPlaying = true;
+  }
 }
 
 void ChangeVolumeCD(S32 volume) {
-  SDL_Log("DEBUG - ChangeVolumeCD(%d)", volume);
+  cdVolume = volume;
+  if (cdPlaying)
+    ChangeVolumeStream(cdVolume);
 }
 
 S32 GetVolumeCD() {
-  SDL_Log("DEBUG - GetVolumeCD()");
-  return 0;
+  return cdVolume;
 }
 
 void StopCD() {
-  SDL_Log("DEBUG - StopCD()");
+  StopStream();
+  cdPlaying = false;
 }
 
 void PauseCD() {
-  SDL_Log("DEBUG - PauseCD()");
+  PauseStream();
 }
 
 void ResumeCD() {
-  SDL_Log("DEBUG - ResumeCD()");
+  ResumeStream();
 }
 
 S32 IsCDPlaying() {
-  SDL_Log("DEBUG - IsCDPlaying()");
-
-  return FALSE;
+  return (cdPlaying && IsStreamPlaying()) ? TRUE : FALSE;
 }

--- a/LIB386/AIL/SDL/CMakeLists.txt
+++ b/LIB386/AIL/SDL/CMakeLists.txt
@@ -1,3 +1,7 @@
-target_sources(ail PRIVATE CD.CPP COMMON.CPP MIDI.CPP SAMPLE.CPP STREAM.CPP stb_vorbis.c)
+set(AIL_SDL_SOURCES CD.CPP COMMON.CPP MIDI.CPP SAMPLE.CPP STREAM.CPP stb_vorbis.c)
+if(MVIDEO_BACKEND STREQUAL "smacker")
+  list(APPEND AIL_SDL_SOURCES VIDEO_AUDIO_SDL.CPP)
+endif()
+target_sources(ail PRIVATE ${AIL_SDL_SOURCES})
 target_compile_definitions(ail PUBLIC USE_SOUND_SDL)
 target_link_libraries(ail PRIVATE SDL3::SDL3)

--- a/LIB386/AIL/SDL/CMakeLists.txt
+++ b/LIB386/AIL/SDL/CMakeLists.txt
@@ -1,3 +1,3 @@
-target_sources(ail PRIVATE CD.CPP COMMON.CPP MIDI.CPP SAMPLE.CPP STREAM.CPP)
+target_sources(ail PRIVATE CD.CPP COMMON.CPP MIDI.CPP SAMPLE.CPP STREAM.CPP stb_vorbis.c)
 target_compile_definitions(ail PUBLIC USE_SOUND_SDL)
 target_link_libraries(ail PRIVATE SDL3::SDL3)

--- a/LIB386/AIL/SDL/COMMON.CPP
+++ b/LIB386/AIL/SDL/COMMON.CPP
@@ -3,5 +3,9 @@
 #include "SDL3/SDL.h"
 
 void InitAIL() {
-  SDL_Log("DEBUG - InitAIL()");
+  if (SDL_InitSubSystem(SDL_INIT_AUDIO)) {
+    SDL_Log("SDL AIL: Audio subsystem initialized");
+  } else {
+    SDL_Log("SDL AIL: Could not init audio: %s", SDL_GetError());
+  }
 }

--- a/LIB386/AIL/SDL/SAMPLE.CPP
+++ b/LIB386/AIL/SDL/SAMPLE.CPP
@@ -2,74 +2,453 @@
 
 #include <SDL3/SDL.h>
 
-#include <AIL/COMMON.H>
+#include <stdlib.h>
+#include <string.h>
 
-S32 Sample_Driver_Enabled = FALSE; // PUBLIC - From SAMPLE.H
-S32 UseWaveMixer = FALSE;          // PUBLIC - From SAMPLE.H
-S32 sampleVolume = 0;              // PRIVATE - From SAMPLE_SDL.H
+/*
+ * PlaySample() accepts RIFF WAV with PCM (tag=1) or IMA ADPCM (tag=17),
+ * Creative Voice (.voc), or raw 8-bit unsigned PCM.
+ */
+#define SAMPLE_RATE      22050
+#define NUM_VOICES       12
+#define MIX_CHUNK_FRAMES 512
+#define PITCHBEND_NORMAL 4096
+
+/* ── IMA ADPCM tables and decoder ────────────────────────────────────────── */
+
+static const S16 imaStepTable[89] = {
+  7,8,9,10,11,12,13,14,16,17,19,21,23,25,28,31,34,37,41,45,50,55,60,66,
+  73,80,88,97,107,118,130,143,157,173,190,209,230,253,279,307,337,371,408,
+  449,494,544,598,658,724,796,876,963,1060,1166,1282,1411,1552,1707,1878,
+  2066,2272,2499,2749,3024,3327,3660,4026,4428,4871,5358,5894,6484,7132,
+  7845,8630,9493,10442,11487,12635,13899,15289,16818,18500,20350,22385,
+  24623,27086,29794,32767
+};
+
+static const int imaIndexTable[16] = {
+  -1,-1,-1,-1, 2,4,6,8, -1,-1,-1,-1, 2,4,6,8
+};
+
+static S16 *DecodeImaAdpcm(const U8 *adpcmData, S32 adpcmSize,
+                           S32 blockAlign, S32 *outSamples) {
+  if (blockAlign < 8 || adpcmSize < blockAlign) { *outSamples = 0; return NULL; }
+  S32 samplesPerBlock = (blockAlign - 4) * 2 + 1;
+  S32 numBlocks = adpcmSize / blockAlign;
+  S32 remainder = adpcmSize % blockAlign;
+  S32 totalSamples = numBlocks * samplesPerBlock;
+  if (remainder >= 8)
+    totalSamples += (remainder - 4) * 2 + 1;
+  S16 *pcm = (S16 *)malloc((size_t)totalSamples * sizeof(S16));
+  if (!pcm) { *outSamples = 0; return NULL; }
+  S32 outIdx = 0;
+  const U8 *src = adpcmData;
+  S32 bytesLeft = adpcmSize;
+  while (bytesLeft >= 8) {
+    S32 blockSize = (bytesLeft >= blockAlign) ? blockAlign : bytesLeft;
+    S16 predictor = (S16)(src[0] | (src[1] << 8));
+    int stepIndex = src[2];
+    if (stepIndex < 0) stepIndex = 0;
+    if (stepIndex > 88) stepIndex = 88;
+    pcm[outIdx++] = predictor;
+    for (S32 i = 4; i < blockSize; i++) {
+      for (int nibbleIdx = 0; nibbleIdx < 2 && outIdx < totalSamples; nibbleIdx++) {
+        int nibble = (nibbleIdx == 0) ? (src[i] & 0x0F) : ((src[i] >> 4) & 0x0F);
+        int step = imaStepTable[stepIndex];
+        int diff = step >> 3;
+        if (nibble & 1) diff += step >> 2;
+        if (nibble & 2) diff += step >> 1;
+        if (nibble & 4) diff += step;
+        if (nibble & 8) diff = -diff;
+        int sample = (int)predictor + diff;
+        if (sample > 32767) sample = 32767;
+        if (sample < -32768) sample = -32768;
+        predictor = (S16)sample;
+        pcm[outIdx++] = predictor;
+        stepIndex += imaIndexTable[nibble];
+        if (stepIndex < 0) stepIndex = 0;
+        if (stepIndex > 88) stepIndex = 88;
+      }
+    }
+    src += blockSize;
+    bytesLeft -= blockSize;
+  }
+  *outSamples = outIdx;
+  return pcm;
+}
+
+/* ── VOC parser ──────────────────────────────────────────────────────────── */
+
+#define VOC_HEADER_MAGIC "reative Voice File\x1A"
+
+static int ParseVocIfPresent(const U8 *buffer, S32 sizeBytes,
+                             const U8 **data, S32 *payloadSize, S32 *outHz, int *outIs8bit) {
+  if (sizeBytes < 26) return 0;
+  if (buffer[0] != 'C' && buffer[0] != 'W' && buffer[0] != 0) return 0;
+  if (memcmp(buffer + 1, VOC_HEADER_MAGIC, 19) != 0) return 0;
+  *outHz = SAMPLE_RATE;
+  *outIs8bit = 1;
+  S32 pos = 26;
+  S32 extendedRate = 0;
+  while (pos + 4 <= sizeBytes) {
+    U8 type = buffer[pos];
+    S32 blockSize = (S32)(buffer[pos + 1] | (buffer[pos + 2] << 8) | (buffer[pos + 3] << 16));
+    if (type == 0x00) break;
+    if (pos + 4 + blockSize > sizeBytes) break;
+    if (type == 0x08 && blockSize >= 4) {
+      S32 freqDiv = (S32)(buffer[pos + 4] | (buffer[pos + 5] << 8));
+      int ch = (int)(buffer[pos + 7]) + 1;
+      if (ch < 1 || ch > 8) ch = 1;
+      if (freqDiv != 65535 && ch > 0)
+        extendedRate = 256000000 / ((65536 - freqDiv) * ch);
+    }
+    if (type == 0x01 && blockSize >= 2) {
+      U8 freqDiv = buffer[pos + 4];
+      U8 codec = buffer[pos + 5];
+      if (extendedRate > 0)
+        *outHz = extendedRate;
+      else if (freqDiv != 255)
+        *outHz = 1000000 / (256 - (S32)freqDiv);
+      if (*outHz <= 0 || *outHz > 192000) *outHz = SAMPLE_RATE;
+      *data = buffer + pos + 6;
+      *payloadSize = blockSize - 2;
+      *outIs8bit = (codec == 0) ? 1 : 0;
+      return 1;
+    }
+    pos += 4 + blockSize;
+  }
+  return 0;
+}
+
+/* ── WAV parser ──────────────────────────────────────────────────────────── */
+
+static void SkipWavHeaderIfPresent(const U8 *buffer, S32 sizeBytes,
+                                   const U8 **data, S32 *payloadSize, int *hadWav,
+                                   S32 *outWavHz, S32 *outWavChannels, S32 *outWavBits,
+                                   S32 *outFmtTag, S32 *outBlockAlign) {
+  *data = (const U8 *)buffer;
+  *payloadSize = sizeBytes;
+  *hadWav = 0;
+  if (outWavHz) *outWavHz = SAMPLE_RATE;
+  if (outWavChannels) *outWavChannels = 1;
+  if (outWavBits) *outWavBits = 16;
+  if (outFmtTag) *outFmtTag = 1;
+  if (outBlockAlign) *outBlockAlign = 0;
+  if (sizeBytes < 12) return;
+  if ((memcmp(buffer, "RIFF", 4) != 0 || memcmp(buffer + 8, "WAVE", 4) != 0) &&
+      (buffer[1] != 'I' || buffer[2] != 'F' || buffer[3] != 'F' || memcmp(buffer + 8, "WAVE", 4) != 0))
+    return;
+  S32 pos = 12;
+  S32 wavHz = SAMPLE_RATE, wavChannels = 1, wavBits = 16, fmtTag = 1, blkAlign = 0;
+  while (pos + 8 <= sizeBytes) {
+    S32 chunkSize = (S32)(buffer[pos + 4] | (buffer[pos + 5] << 8) |
+                       (buffer[pos + 6] << 16) | (buffer[pos + 7] << 24));
+    if (memcmp(buffer + pos, "fmt ", 4) == 0 && chunkSize >= 16 && pos + 8 + 16 <= sizeBytes) {
+      const U8 *f = buffer + pos + 8;
+      fmtTag = (S32)(f[0] | (f[1] << 8));
+      wavChannels = (S32)(f[2] | (f[3] << 8));
+      wavHz = (S32)(f[4] | (f[5] << 8) | (f[6] << 16) | (f[7] << 24));
+      blkAlign = (S32)(f[12] | (f[13] << 8));
+      wavBits = (S32)(f[14] | (f[15] << 8));
+      if (wavHz <= 0 || wavHz > 192000) wavHz = SAMPLE_RATE;
+      if (wavChannels <= 0 || wavChannels > 8) wavChannels = 1;
+      if (fmtTag == 1) {
+        if (blkAlign > 0 && wavChannels > 0)
+          wavBits = (blkAlign * 8) / wavChannels;
+        if (wavBits != 8 && wavBits != 16) wavBits = 16;
+      }
+    }
+    if (memcmp(buffer + pos, "data", 4) == 0 && chunkSize > 0 && pos + 8 + chunkSize <= sizeBytes) {
+      *data = buffer + pos + 8;
+      *payloadSize = chunkSize;
+      *hadWav = 1;
+      if (outWavHz) *outWavHz = wavHz;
+      if (outWavChannels) *outWavChannels = wavChannels;
+      if (outWavBits) *outWavBits = wavBits;
+      if (outFmtTag) *outFmtTag = fmtTag;
+      if (outBlockAlign) *outBlockAlign = blkAlign;
+      return;
+    }
+    pos += 8 + ((chunkSize + 1) & ~1);
+  }
+}
+
+/* ── Voices and mixer ────────────────────────────────────────────────────── */
+
+struct Voice {
+  const U8 *data;
+  S32 sizeBytes;
+  bool is8bit;
+  S32 sourceRateHz;
+  S32 sourceChannels;
+  float posSamples;
+  float stepSamples;
+  S32 volume;
+  S32 pan;
+  S32 repeat;
+  S32 repeatCount;
+  U32 handle;
+  bool active;
+  void *ownedBuf;
+};
+
+static SDL_AudioStream *sampleStream = NULL;
+static Voice voices[NUM_VOICES];
+static U32 nextHandle = 0x1000000;
+static S32 samplesPaused = 0;
+static S32 inverseStereo = 0;
+
+S32 Sample_Driver_Enabled = FALSE;
+S32 UseWaveMixer = FALSE;
+S32 sampleVolume = 0;
+
+static void FreeVoiceBuf(Voice *V) {
+  if (V->ownedBuf) { free(V->ownedBuf); V->ownedBuf = NULL; }
+}
+
+static int VoiceIndexFromHandle(U32 sample) {
+  if (sample < 0x1000000) {
+    for (int i = 0; i < NUM_VOICES; i++) {
+      if (voices[i].active && ((voices[i].handle >> 8) & 0xFFFF) == sample)
+        return i;
+    }
+  } else {
+    int slot = sample & 0xFF;
+    if (slot < NUM_VOICES && voices[slot].active && voices[slot].handle == sample)
+      return slot;
+  }
+  return -1;
+}
+
+static void MixVoices(S16 *out, int numFrames) {
+  memset(out, 0, (size_t)numFrames * 2 * sizeof(S16));
+  for (int v = 0; v < NUM_VOICES; v++) {
+    Voice *V = &voices[v];
+    if (!V->active || !V->data) continue;
+    float pos = V->posSamples;
+    float step = V->stepSamples;
+    int maxSamples = V->is8bit ? V->sizeBytes : (V->sizeBytes / 2);
+    const int fadeLen = 64;
+    float leftGain = (V->pan <= 64) ? 1.0f : (127 - V->pan) / 63.0f;
+    float rightGain = (V->pan >= 64) ? 1.0f : (float)V->pan / 64.0f;
+    if (inverseStereo) { float t = leftGain; leftGain = rightGain; rightGain = t; }
+    float vol = (float)(sampleVolume * V->volume) / (127.0f * 127.0f);
+    if (vol > 1.0f) vol = 1.0f;
+    leftGain *= vol;
+    rightGain *= vol;
+    for (int i = 0; i < numFrames; i++) {
+      int idx = (int)pos;
+      if (idx >= maxSamples) {
+        if (V->repeat == 0) { pos = 0; idx = 0; }
+        else {
+          V->repeatCount++;
+          if (V->repeatCount >= V->repeat) {
+            V->active = false;
+            FreeVoiceBuf(V);
+            break;
+          }
+          pos = 0; idx = 0;
+        }
+      }
+      float frac = pos - (float)idx;
+      int idx1 = (idx + 1 < maxSamples) ? idx + 1 : idx;
+      float s;
+      if (V->is8bit) {
+        float s0 = (float)((int)V->data[idx] - 128) * 256.0f;
+        float s1 = (float)((int)V->data[idx1] - 128) * 256.0f;
+        s = s0 + frac * (s1 - s0);
+      } else {
+        const S16 *src = (const S16 *)V->data;
+        float s0 = (float)src[idx];
+        float s1 = (float)src[idx1];
+        s = s0 + frac * (s1 - s0);
+      }
+      int samplesLeft = maxSamples - idx;
+      if (V->repeat != 0 && samplesLeft < fadeLen) {
+        float fade = (float)samplesLeft / (float)fadeLen;
+        s *= fade;
+      }
+      out[i * 2]     += (S16)(s * leftGain);
+      out[i * 2 + 1] += (S16)(s * rightGain);
+      pos += step;
+    }
+    V->posSamples = pos;
+  }
+}
+
+/* ── SDL3 audio callback ─────────────────────────────────────────────────── */
+
+static S16 mixChunkBuf[MIX_CHUNK_FRAMES * 2];
+
+static void SDLCALL SampleStreamCallback(void *userdata, SDL_AudioStream *stream,
+                                          int additional_amount, int total_amount) {
+  (void)userdata;
+  (void)total_amount;
+  if (samplesPaused || additional_amount <= 0) return;
+  int bytesLeft = additional_amount;
+  while (bytesLeft > 0) {
+    int frames = bytesLeft / (2 * (int)sizeof(S16));
+    if (frames > MIX_CHUNK_FRAMES) frames = MIX_CHUNK_FRAMES;
+    if (frames <= 0) break;
+    MixVoices(mixChunkBuf, frames);
+    SDL_PutAudioStreamData(stream, mixChunkBuf, frames * 2 * (int)sizeof(S16));
+    bytesLeft -= frames * 2 * (int)sizeof(S16);
+  }
+}
+
+/* ── Driver init / control ───────────────────────────────────────────────── */
 
 S32 InitSampleDriver(char *driver_name) {
-  SDL_Log("DEBUG - InitSampleDriver(%s)", driver_name);
-
-  if (Sample_Driver_Enabled) {
-    return TRUE;
+  (void)driver_name;
+  if (Sample_Driver_Enabled) return TRUE;
+  memset(voices, 0, sizeof(voices));
+  SDL_AudioSpec spec;
+  SDL_zero(spec);
+  spec.freq = SAMPLE_RATE;
+  spec.format = SDL_AUDIO_S16;
+  spec.channels = 2;
+  sampleStream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, SampleStreamCallback, NULL);
+  if (!sampleStream) {
+    SDL_Log("SDL AIL: Could not open sample stream: %s", SDL_GetError());
+    return FALSE;
   }
-
+  SDL_ResumeAudioStreamDevice(sampleStream);
   Sample_Driver_Enabled = TRUE;
-
   return TRUE;
 }
 
 void SetMasterVolumeSample(S32 volume) {
-  SDL_Log("DEBUG - SetMasterVolumeSample(%d)", volume);
   sampleVolume = volume;
 }
 
 S32 FadeOutSamples(S32 delay) {
-  SDL_Log("DEBUG - FadeOutSamples(%d)", delay);
+  (void)delay;
   return 0;
 }
 
 S32 FadeInSamples(S32 delay) {
-  SDL_Log("DEBUG - FadeInSamples(%d)", delay);
+  (void)delay;
   return delay;
 }
+
 void InverseStereoSample(S32 inverse) {
-  SDL_Log("DEBUG - InverseStereoSample(%d)", inverse);
+  inverseStereo = (inverse != 0);
 }
+
+/* ── PlaySample ──────────────────────────────────────────────────────────── */
 
 U32 PlaySample(void *buffer, S32 sizeBytes, U32 userhandle, S32 pitchbend,
                S32 repeat, S32 volume, S32 pan) {
-  SDL_Log("DEBUG - PlaySample(%p, %d, %u, %d, %d, %d, %d)", buffer, sizeBytes,
-          userhandle, pitchbend, repeat, volume, pan);
-  return 0xFFFFFFFF;
+  if (!Sample_Driver_Enabled || !buffer || sizeBytes <= 0) return 0xFFFFFFFF;
+  const U8 *data = NULL;
+  S32 payloadSize = 0;
+  int hadVoc = 0;
+  S32 vocHz = SAMPLE_RATE;
+  int vocIs8bit = 1;
+  int hadWav = 0;
+  S32 wavHz = SAMPLE_RATE, wavChannels = 1, wavBits = 16, fmtTag = 1, blkAlign = 0;
+  hadVoc = ParseVocIfPresent((const U8 *)buffer, sizeBytes, &data, &payloadSize, &vocHz, &vocIs8bit);
+  if (!hadVoc)
+    SkipWavHeaderIfPresent((const U8 *)buffer, sizeBytes, &data, &payloadSize,
+                           &hadWav, &wavHz, &wavChannels, &wavBits, &fmtTag, &blkAlign);
+  if (!data || payloadSize <= 0) return 0xFFFFFFFF;
+  if (pitchbend <= 0) pitchbend = PITCHBEND_NORMAL;
+  int slot = -1;
+  for (int i = 0; i < NUM_VOICES; i++) {
+    if (!voices[i].active) { slot = i; break; }
+  }
+  if (slot < 0) {
+    slot = 0;
+    voices[0].active = false;
+  }
+  Voice *V = &voices[slot];
+  FreeVoiceBuf(V);
+
+  if (hadWav && fmtTag == 17 && blkAlign > 0) {
+    S32 decodedSamples = 0;
+    S16 *pcm = DecodeImaAdpcm(data, payloadSize, blkAlign, &decodedSamples);
+    if (!pcm || decodedSamples <= 0) return 0xFFFFFFFF;
+    V->ownedBuf = pcm;
+    V->data = (const U8 *)pcm;
+    V->sizeBytes = decodedSamples * 2;
+    V->is8bit = false;
+    V->sourceRateHz = wavHz;
+    V->sourceChannels = wavChannels;
+  } else {
+    void *copy = malloc((size_t)payloadSize);
+    if (!copy) return 0xFFFFFFFF;
+    memcpy(copy, data, (size_t)payloadSize);
+    V->ownedBuf = copy;
+    V->data = (const U8 *)copy;
+    V->sizeBytes = payloadSize;
+    V->is8bit = hadVoc ? vocIs8bit : (hadWav ? (wavBits == 8) : 1);
+    V->sourceRateHz = hadVoc ? vocHz : (hadWav ? wavHz : SAMPLE_RATE);
+    V->sourceChannels = hadWav ? wavChannels : 1;
+  }
+
+  V->posSamples = 0;
+  {
+    float rateRatio = (float)V->sourceRateHz / (float)SAMPLE_RATE;
+    int ch = (V->sourceChannels >= 2) ? 2 : 1;
+    V->stepSamples = rateRatio * (float)ch * (float)pitchbend / (float)PITCHBEND_NORMAL;
+  }
+  V->volume = (volume > 127) ? 127 : volume;
+  V->pan = (pan > 127) ? 127 : pan;
+  V->repeat = repeat;
+  V->repeatCount = 0;
+  V->handle = nextHandle | ((userhandle & 0xFFFF) << 8) | (slot & 0xFF);
+  nextHandle += 0x1000000;
+  if (nextHandle == 0) nextHandle = 0x1000000;
+  V->active = true;
+  return V->handle;
 }
 
 void ChangePitchbendSample(U32 sample, S32 pitchbend) {
-  SDL_Log("DEBUG - ChangePitchbendSample(%u, %d)", sample, pitchbend);
+  int i = VoiceIndexFromHandle(sample);
+  if (i >= 0 && pitchbend > 0) {
+    Voice *V = &voices[i];
+    float rateRatio = (float)V->sourceRateHz / (float)SAMPLE_RATE;
+    int ch = (V->sourceChannels >= 2) ? 2 : 1;
+    V->stepSamples = rateRatio * (float)ch * (float)pitchbend / (float)PITCHBEND_NORMAL;
+  }
 }
 
 void ChangeVolumePanSample(U32 sample, S32 volume, S32 pan) {
-  SDL_Log("DEBUG - ChangeVolumePanSample(%u, %d, %d)", sample, volume, pan);
+  int i = VoiceIndexFromHandle(sample);
+  if (i >= 0) {
+    voices[i].volume = (volume > 127) ? 127 : volume;
+    voices[i].pan = (pan > 127) ? 127 : pan;
+  }
 }
 
 void StopOneSample(U32 sample) {
-  SDL_Log("DEBUG - StopOneSample(%u)", sample);
+  int i = VoiceIndexFromHandle(sample);
+  if (i >= 0) {
+    FreeVoiceBuf(&voices[i]);
+    voices[i].active = false;
+  }
 }
 
 void StopSamples() {
-  SDL_Log("DEBUG - StopSamples()");
+  for (int i = 0; i < NUM_VOICES; i++) {
+    FreeVoiceBuf(&voices[i]);
+    voices[i].active = false;
+  }
 }
 
 void PauseSamples() {
-  SDL_Log("DEBUG - PauseSamples()");
+  samplesPaused++;
+  if (samplesPaused == 1 && sampleStream)
+    SDL_PauseAudioStreamDevice(sampleStream);
 }
 
 void ResumeSamples() {
-  SDL_Log("DEBUG - ResumeSamples()");
+  if (samplesPaused <= 0) return;
+  samplesPaused--;
+  if (samplesPaused == 0 && sampleStream)
+    SDL_ResumeAudioStreamDevice(sampleStream);
 }
 
 U32 IsSamplePlaying(U32 sample) {
-  SDL_Log("DEBUG - IsSamplePlaying(%u)", sample);
-  return FALSE;
+  int i = VoiceIndexFromHandle(sample);
+  return (i >= 0) ? sample : (U32)FALSE;
 }

--- a/LIB386/AIL/SDL/STREAM.CPP
+++ b/LIB386/AIL/SDL/STREAM.CPP
@@ -2,44 +2,158 @@
 
 #include <SDL3/SDL.h>
 
-S32 streamVolume = 0; // PRIVATE - From STREAM_SDL.H
+#include "stb_vorbis.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef ADELINE_MAX_PATH
+#define ADELINE_MAX_PATH 512
+#endif
+
+static SDL_AudioStream *stream = NULL;
+static char streamPathName[ADELINE_MAX_PATH] = "";
+static bool streamPaused = false;
+
+S32 streamVolume = 0;
 
 void OpenStream() {
-  SDL_Log("DEBUG - OpenStream()");
+  /* State initialized on first PlayStream; ensure no stale stream. */
+  if (stream) {
+    SDL_DestroyAudioStream(stream);
+    stream = NULL;
+  }
+  streamPathName[0] = '\0';
+  streamPaused = false;
+}
+
+static void StopStreamInternal(void) {
+  if (stream) {
+    SDL_DestroyAudioStream(stream);
+    stream = NULL;
+  }
+  streamPathName[0] = '\0';
+  streamPaused = false;
+}
+
+/* Build path with extension replaced by .ogg (caller provides buffer of size pathMax). */
+static void PathToOgg(const char *wavPath, char *oggPath, int pathMax) {
+  strncpy(oggPath, wavPath, pathMax - 1);
+  oggPath[pathMax - 1] = '\0';
+  char *dot = strrchr(oggPath, '.');
+  if (dot) {
+    strcpy(dot, ".ogg");
+  } else {
+    int len = (int)strlen(oggPath);
+    if (len + 5 <= pathMax)
+      strcpy(oggPath + len, ".ogg");
+  }
+}
+
+static bool TryPlayOgg(const char *oggPath) {
+  int channels = 0, sample_rate = 0;
+  short *pcm = NULL;
+  int samplesPerChannel = stb_vorbis_decode_filename(oggPath, &channels, &sample_rate, &pcm);
+  if (samplesPerChannel <= 0 || !pcm || channels <= 0 || sample_rate <= 0) {
+    if (pcm) free(pcm);
+    return false;
+  }
+  SDL_AudioSpec spec;
+  SDL_zero(spec);
+  spec.freq = sample_rate;
+  spec.format = SDL_AUDIO_S16;
+  spec.channels = (Uint8)channels;
+  stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, NULL, NULL);
+  if (!stream) {
+    free(pcm);
+    return false;
+  }
+  Uint32 numBytes = (Uint32)(samplesPerChannel * channels * sizeof(short));
+  SDL_PutAudioStreamData(stream, pcm, numBytes);
+  free(pcm);
+  return true;
 }
 
 void PlayStream(char *name) {
-  SDL_Log("DEBUG - PlayStream(%s)", name);
+  if (!name || !name[0])
+    return;
+
+  StopStreamInternal();
+
+  SDL_AudioSpec spec;
+  Uint8 *wav_data = NULL;
+  Uint32 wav_data_len = 0;
+
+  if (SDL_LoadWAV(name, &spec, &wav_data, &wav_data_len)) {
+    stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, NULL, NULL);
+    if (!stream) {
+      SDL_Log("SDL AIL: Could not open audio stream: %s", SDL_GetError());
+      SDL_free(wav_data);
+      return;
+    }
+    SDL_PutAudioStreamData(stream, wav_data, wav_data_len);
+    SDL_free(wav_data);
+  } else {
+    /* Try .ogg (e.g. Steam ships OGG instead of WAV). */
+    char oggPath[ADELINE_MAX_PATH];
+    PathToOgg(name, oggPath, (int)sizeof(oggPath));
+    if (!TryPlayOgg(oggPath)) {
+      SDL_Log("SDL AIL: Could not load WAV '%s' or OGG '%s'", name, oggPath);
+      return;
+    }
+  }
+
+  {
+    float gain = (streamVolume <= 0) ? 0.0f : (float)streamVolume / 127.0f;
+    if (gain > 1.0f) gain = 1.0f;
+    SDL_SetAudioStreamGain(stream, gain);
+  }
+
+  SDL_ResumeAudioStreamDevice(stream);
+
+  strncpy(streamPathName, name, ADELINE_MAX_PATH - 1);
+  streamPathName[ADELINE_MAX_PATH - 1] = '\0';
 }
 
 void ChangeVolumeStream(S32 volume) {
-  SDL_Log("DEBUG - ChangeVolumeStream(%d)", volume);
   streamVolume = volume;
+  if (stream) {
+    float gain = (volume <= 0) ? 0.0f : (float)volume / 127.0f;
+    if (gain > 1.0f) gain = 1.0f;
+    SDL_SetAudioStreamGain(stream, gain);
+  }
 }
 
 S32 GetVolumeStream() {
-  SDL_Log("DEBUG - GetVolumeStream() -> %d", streamVolume);
   return streamVolume;
 }
 
 void StopStream() {
-  SDL_Log("DEBUG - StopStream()");
+  /* Preserve a paused stream so ResumeStream can unpause it later.
+     PlayStream calls StopStreamInternal directly, so new music still works. */
+  if (streamPaused)
+    return;
+  StopStreamInternal();
 }
 
 void PauseStream() {
-  SDL_Log("DEBUG - PauseStream()");
+  if (stream && !streamPaused) {
+    SDL_PauseAudioStreamDevice(stream);
+    streamPaused = true;
+  }
 }
 
 void ResumeStream() {
-  SDL_Log("DEBUG - ResumeStream()");
+  if (stream && streamPaused) {
+    SDL_ResumeAudioStreamDevice(stream);
+    streamPaused = false;
+  }
 }
 
 S32 IsStreamPlaying() {
-  SDL_Log("DEBUG - IsStreamPlaying()");
-  return FALSE;
+  return (stream != NULL) ? TRUE : FALSE;
 }
 
 char *StreamName() {
-  SDL_Log("DEBUG - StreamName()");
-  return "";
+  return streamPathName;
 }

--- a/LIB386/AIL/SDL/VIDEO_AUDIO_SDL.CPP
+++ b/LIB386/AIL/SDL/VIDEO_AUDIO_SDL.CPP
@@ -1,0 +1,41 @@
+#include <AIL/VIDEO_AUDIO.H>
+#include <SDL3/SDL.h>
+#include <stdlib.h>
+#include <string.h>
+
+static SDL_AudioStream *videoStream = NULL;
+
+S32 StartVideoAudio(S32 freq, S32 channels, S32 is16bit) {
+  StopVideoAudio();
+  SDL_AudioSpec spec;
+  SDL_zero(spec);
+  spec.freq = freq;
+  spec.format = is16bit ? SDL_AUDIO_S16 : SDL_AUDIO_U8;
+  spec.channels = (Uint8)(channels >= 2 ? 2 : 1);
+  videoStream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, NULL, NULL);
+  if (!videoStream) {
+    SDL_Log("SDL AIL: Could not open video audio stream: %s", SDL_GetError());
+    return 0;
+  }
+  /* Leave paused until ResumeVideoAudio() after pre-fill (avoids stutter like lba2-classic-ida's SoLoud buffer) */
+  return 1;
+}
+
+void ResumeVideoAudio(void) {
+  if (videoStream)
+    SDL_ResumeAudioStreamDevice(videoStream);
+}
+
+void PushVideoAudio(const void *data, U32 sizeBytes) {
+  if (!videoStream || !data || sizeBytes == 0)
+    return;
+  /* If stream is 16-bit we push as-is; if 8-bit we push as-is (SDL_AUDIO_U8). */
+  SDL_PutAudioStreamData(videoStream, data, (int)sizeBytes);
+}
+
+void StopVideoAudio(void) {
+  if (videoStream) {
+    SDL_DestroyAudioStream(videoStream);
+    videoStream = NULL;
+  }
+}

--- a/LIB386/AIL/SDL/stb_vorbis.c
+++ b/LIB386/AIL/SDL/stb_vorbis.c
@@ -1,0 +1,5584 @@
+// Ogg Vorbis audio decoder - v1.22 - public domain
+// http://nothings.org/stb_vorbis/
+//
+// Original version written by Sean Barrett in 2007.
+//
+// Originally sponsored by RAD Game Tools. Seeking implementation
+// sponsored by Phillip Bennefall, Marc Andersen, Aaron Baker,
+// Elias Software, Aras Pranckevicius, and Sean Barrett.
+//
+// LICENSE
+//
+//   See end of file for license information.
+//
+// Limitations:
+//
+//   - floor 0 not supported (used in old ogg vorbis files pre-2004)
+//   - lossless sample-truncation at beginning ignored
+//   - cannot concatenate multiple vorbis streams
+//   - sample positions are 32-bit, limiting seekable 192Khz
+//       files to around 6 hours (Ogg supports 64-bit)
+//
+// Feature contributors:
+//    Dougall Johnson (sample-exact seeking)
+//
+// Bugfix/warning contributors:
+//    Terje Mathisen     Niklas Frykholm     Andy Hill
+//    Casey Muratori     John Bolton         Gargaj
+//    Laurent Gomila     Marc LeBlanc        Ronny Chevalier
+//    Bernhard Wodo      Evan Balster        github:alxprd
+//    Tom Beaumont       Ingo Leitgeb        Nicolas Guillemot
+//    Phillip Bennefall  Rohit               Thiago Goulart
+//    github:manxorist   Saga Musix          github:infatum
+//    Timur Gagiev       Maxwell Koo         Peter Waller
+//    github:audinowho   Dougall Johnson     David Reid
+//    github:Clownacy    Pedro J. Estebanez  Remi Verschelde
+//    AnthoFoxo          github:morlat       Gabriel Ravier
+//
+// Partial history:
+//    1.22    - 2021-07-11 - various small fixes
+//    1.21    - 2021-07-02 - fix bug for files with no comments
+//    1.20    - 2020-07-11 - several small fixes
+//    1.19    - 2020-02-05 - warnings
+//    1.18    - 2020-02-02 - fix seek bugs; parse header comments; misc warnings etc.
+//    1.17    - 2019-07-08 - fix CVE-2019-13217..CVE-2019-13223 (by ForAllSecure)
+//    1.16    - 2019-03-04 - fix warnings
+//    1.15    - 2019-02-07 - explicit failure if Ogg Skeleton data is found
+//    1.14    - 2018-02-11 - delete bogus dealloca usage
+//    1.13    - 2018-01-29 - fix truncation of last frame (hopefully)
+//    1.12    - 2017-11-21 - limit residue begin/end to blocksize/2 to avoid large temp allocs in bad/corrupt files
+//    1.11    - 2017-07-23 - fix MinGW compilation
+//    1.10    - 2017-03-03 - more robust seeking; fix negative ilog(); clear error in open_memory
+//    1.09    - 2016-04-04 - back out 'truncation of last frame' fix from previous version
+//    1.08    - 2016-04-02 - warnings; setup memory leaks; truncation of last frame
+//    1.07    - 2015-01-16 - fixes for crashes on invalid files; warning fixes; const
+//    1.06    - 2015-08-31 - full, correct support for seeking API (Dougall Johnson)
+//                           some crash fixes when out of memory or with corrupt files
+//                           fix some inappropriately signed shifts
+//    1.05    - 2015-04-19 - don't define __forceinline if it's redundant
+//    1.04    - 2014-08-27 - fix missing const-correct case in API
+//    1.03    - 2014-08-07 - warning fixes
+//    1.02    - 2014-07-09 - declare qsort comparison as explicitly _cdecl in Windows
+//    1.01    - 2014-06-18 - fix stb_vorbis_get_samples_float (interleaved was correct)
+//    1.0     - 2014-05-26 - fix memory leaks; fix warnings; fix bugs in >2-channel;
+//                           (API change) report sample rate for decode-full-file funcs
+//
+// See end of file for full version history.
+
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//  HEADER BEGINS HERE
+//
+
+#ifndef STB_VORBIS_INCLUDE_STB_VORBIS_H
+#define STB_VORBIS_INCLUDE_STB_VORBIS_H
+
+#if defined(STB_VORBIS_NO_CRT) && !defined(STB_VORBIS_NO_STDIO)
+#define STB_VORBIS_NO_STDIO 1
+#endif
+
+#ifndef STB_VORBIS_NO_STDIO
+#include <stdio.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+///////////   THREAD SAFETY
+
+// Individual stb_vorbis* handles are not thread-safe; you cannot decode from
+// them from multiple threads at the same time. However, you can have multiple
+// stb_vorbis* handles and decode from them independently in multiple thrads.
+
+
+///////////   MEMORY ALLOCATION
+
+// normally stb_vorbis uses malloc() to allocate memory at startup,
+// and alloca() to allocate temporary memory during a frame on the
+// stack. (Memory consumption will depend on the amount of setup
+// data in the file and how you set the compile flags for speed
+// vs. size. In my test files the maximal-size usage is ~150KB.)
+//
+// You can modify the wrapper functions in the source (setup_malloc,
+// setup_temp_malloc, temp_malloc) to change this behavior, or you
+// can use a simpler allocation model: you pass in a buffer from
+// which stb_vorbis will allocate _all_ its memory (including the
+// temp memory). "open" may fail with a VORBIS_outofmem if you
+// do not pass in enough data; there is no way to determine how
+// much you do need except to succeed (at which point you can
+// query get_info to find the exact amount required. yes I know
+// this is lame).
+//
+// If you pass in a non-NULL buffer of the type below, allocation
+// will occur from it as described above. Otherwise just pass NULL
+// to use malloc()/alloca()
+
+typedef struct
+{
+   char *alloc_buffer;
+   int   alloc_buffer_length_in_bytes;
+} stb_vorbis_alloc;
+
+
+///////////   FUNCTIONS USEABLE WITH ALL INPUT MODES
+
+typedef struct stb_vorbis stb_vorbis;
+
+typedef struct
+{
+   unsigned int sample_rate;
+   int channels;
+
+   unsigned int setup_memory_required;
+   unsigned int setup_temp_memory_required;
+   unsigned int temp_memory_required;
+
+   int max_frame_size;
+} stb_vorbis_info;
+
+typedef struct
+{
+   char *vendor;
+
+   int comment_list_length;
+   char **comment_list;
+} stb_vorbis_comment;
+
+// get general information about the file
+extern stb_vorbis_info stb_vorbis_get_info(stb_vorbis *f);
+
+// get ogg comments
+extern stb_vorbis_comment stb_vorbis_get_comment(stb_vorbis *f);
+
+// get the last error detected (clears it, too)
+extern int stb_vorbis_get_error(stb_vorbis *f);
+
+// close an ogg vorbis file and free all memory in use
+extern void stb_vorbis_close(stb_vorbis *f);
+
+// this function returns the offset (in samples) from the beginning of the
+// file that will be returned by the next decode, if it is known, or -1
+// otherwise. after a flush_pushdata() call, this may take a while before
+// it becomes valid again.
+// NOT WORKING YET after a seek with PULLDATA API
+extern int stb_vorbis_get_sample_offset(stb_vorbis *f);
+
+// returns the current seek point within the file, or offset from the beginning
+// of the memory buffer. In pushdata mode it returns 0.
+extern unsigned int stb_vorbis_get_file_offset(stb_vorbis *f);
+
+///////////   PUSHDATA API
+
+#ifndef STB_VORBIS_NO_PUSHDATA_API
+
+// this API allows you to get blocks of data from any source and hand
+// them to stb_vorbis. you have to buffer them; stb_vorbis will tell
+// you how much it used, and you have to give it the rest next time;
+// and stb_vorbis may not have enough data to work with and you will
+// need to give it the same data again PLUS more. Note that the Vorbis
+// specification does not bound the size of an individual frame.
+
+extern stb_vorbis *stb_vorbis_open_pushdata(
+         const unsigned char * datablock, int datablock_length_in_bytes,
+         int *datablock_memory_consumed_in_bytes,
+         int *error,
+         const stb_vorbis_alloc *alloc_buffer);
+// create a vorbis decoder by passing in the initial data block containing
+//    the ogg&vorbis headers (you don't need to do parse them, just provide
+//    the first N bytes of the file--you're told if it's not enough, see below)
+// on success, returns an stb_vorbis *, does not set error, returns the amount of
+//    data parsed/consumed on this call in *datablock_memory_consumed_in_bytes;
+// on failure, returns NULL on error and sets *error, does not change *datablock_memory_consumed
+// if returns NULL and *error is VORBIS_need_more_data, then the input block was
+//       incomplete and you need to pass in a larger block from the start of the file
+
+extern int stb_vorbis_decode_frame_pushdata(
+         stb_vorbis *f,
+         const unsigned char *datablock, int datablock_length_in_bytes,
+         int *channels,             // place to write number of float * buffers
+         float ***output,           // place to write float ** array of float * buffers
+         int *samples               // place to write number of output samples
+     );
+// decode a frame of audio sample data if possible from the passed-in data block
+//
+// return value: number of bytes we used from datablock
+//
+// possible cases:
+//     0 bytes used, 0 samples output (need more data)
+//     N bytes used, 0 samples output (resynching the stream, keep going)
+//     N bytes used, M samples output (one frame of data)
+// note that after opening a file, you will ALWAYS get one N-bytes,0-sample
+// frame, because Vorbis always "discards" the first frame.
+//
+// Note that on resynch, stb_vorbis will rarely consume all of the buffer,
+// instead only datablock_length_in_bytes-3 or less. This is because it wants
+// to avoid missing parts of a page header if they cross a datablock boundary,
+// without writing state-machiney code to record a partial detection.
+//
+// The number of channels returned are stored in *channels (which can be
+// NULL--it is always the same as the number of channels reported by
+// get_info). *output will contain an array of float* buffers, one per
+// channel. In other words, (*output)[0][0] contains the first sample from
+// the first channel, and (*output)[1][0] contains the first sample from
+// the second channel.
+//
+// *output points into stb_vorbis's internal output buffer storage; these
+// buffers are owned by stb_vorbis and application code should not free
+// them or modify their contents. They are transient and will be overwritten
+// once you ask for more data to get decoded, so be sure to grab any data
+// you need before then.
+
+extern void stb_vorbis_flush_pushdata(stb_vorbis *f);
+// inform stb_vorbis that your next datablock will not be contiguous with
+// previous ones (e.g. you've seeked in the data); future attempts to decode
+// frames will cause stb_vorbis to resynchronize (as noted above), and
+// once it sees a valid Ogg page (typically 4-8KB, as large as 64KB), it
+// will begin decoding the _next_ frame.
+//
+// if you want to seek using pushdata, you need to seek in your file, then
+// call stb_vorbis_flush_pushdata(), then start calling decoding, then once
+// decoding is returning you data, call stb_vorbis_get_sample_offset, and
+// if you don't like the result, seek your file again and repeat.
+#endif
+
+
+//////////   PULLING INPUT API
+
+#ifndef STB_VORBIS_NO_PULLDATA_API
+// This API assumes stb_vorbis is allowed to pull data from a source--
+// either a block of memory containing the _entire_ vorbis stream, or a
+// FILE * that you or it create, or possibly some other reading mechanism
+// if you go modify the source to replace the FILE * case with some kind
+// of callback to your code. (But if you don't support seeking, you may
+// just want to go ahead and use pushdata.)
+
+#if !defined(STB_VORBIS_NO_STDIO) && !defined(STB_VORBIS_NO_INTEGER_CONVERSION)
+extern int stb_vorbis_decode_filename(const char *filename, int *channels, int *sample_rate, short **output);
+#endif
+#if !defined(STB_VORBIS_NO_INTEGER_CONVERSION)
+extern int stb_vorbis_decode_memory(const unsigned char *mem, int len, int *channels, int *sample_rate, short **output);
+#endif
+// decode an entire file and output the data interleaved into a malloc()ed
+// buffer stored in *output. The return value is the number of samples
+// decoded, or -1 if the file could not be opened or was not an ogg vorbis file.
+// When you're done with it, just free() the pointer returned in *output.
+
+extern stb_vorbis * stb_vorbis_open_memory(const unsigned char *data, int len,
+                                  int *error, const stb_vorbis_alloc *alloc_buffer);
+// create an ogg vorbis decoder from an ogg vorbis stream in memory (note
+// this must be the entire stream!). on failure, returns NULL and sets *error
+
+#ifndef STB_VORBIS_NO_STDIO
+extern stb_vorbis * stb_vorbis_open_filename(const char *filename,
+                                  int *error, const stb_vorbis_alloc *alloc_buffer);
+// create an ogg vorbis decoder from a filename via fopen(). on failure,
+// returns NULL and sets *error (possibly to VORBIS_file_open_failure).
+
+extern stb_vorbis * stb_vorbis_open_file(FILE *f, int close_handle_on_close,
+                                  int *error, const stb_vorbis_alloc *alloc_buffer);
+// create an ogg vorbis decoder from an open FILE *, looking for a stream at
+// the _current_ seek point (ftell). on failure, returns NULL and sets *error.
+// note that stb_vorbis must "own" this stream; if you seek it in between
+// calls to stb_vorbis, it will become confused. Moreover, if you attempt to
+// perform stb_vorbis_seek_*() operations on this file, it will assume it
+// owns the _entire_ rest of the file after the start point. Use the next
+// function, stb_vorbis_open_file_section(), to limit it.
+
+extern stb_vorbis * stb_vorbis_open_file_section(FILE *f, int close_handle_on_close,
+                int *error, const stb_vorbis_alloc *alloc_buffer, unsigned int len);
+// create an ogg vorbis decoder from an open FILE *, looking for a stream at
+// the _current_ seek point (ftell); the stream will be of length 'len' bytes.
+// on failure, returns NULL and sets *error. note that stb_vorbis must "own"
+// this stream; if you seek it in between calls to stb_vorbis, it will become
+// confused.
+#endif
+
+extern int stb_vorbis_seek_frame(stb_vorbis *f, unsigned int sample_number);
+extern int stb_vorbis_seek(stb_vorbis *f, unsigned int sample_number);
+// these functions seek in the Vorbis file to (approximately) 'sample_number'.
+// after calling seek_frame(), the next call to get_frame_*() will include
+// the specified sample. after calling stb_vorbis_seek(), the next call to
+// stb_vorbis_get_samples_* will start with the specified sample. If you
+// do not need to seek to EXACTLY the target sample when using get_samples_*,
+// you can also use seek_frame().
+
+extern int stb_vorbis_seek_start(stb_vorbis *f);
+// this function is equivalent to stb_vorbis_seek(f,0)
+
+extern unsigned int stb_vorbis_stream_length_in_samples(stb_vorbis *f);
+extern float        stb_vorbis_stream_length_in_seconds(stb_vorbis *f);
+// these functions return the total length of the vorbis stream
+
+extern int stb_vorbis_get_frame_float(stb_vorbis *f, int *channels, float ***output);
+// decode the next frame and return the number of samples. the number of
+// channels returned are stored in *channels (which can be NULL--it is always
+// the same as the number of channels reported by get_info). *output will
+// contain an array of float* buffers, one per channel. These outputs will
+// be overwritten on the next call to stb_vorbis_get_frame_*.
+//
+// You generally should not intermix calls to stb_vorbis_get_frame_*()
+// and stb_vorbis_get_samples_*(), since the latter calls the former.
+
+#ifndef STB_VORBIS_NO_INTEGER_CONVERSION
+extern int stb_vorbis_get_frame_short_interleaved(stb_vorbis *f, int num_c, short *buffer, int num_shorts);
+extern int stb_vorbis_get_frame_short            (stb_vorbis *f, int num_c, short **buffer, int num_samples);
+#endif
+// decode the next frame and return the number of *samples* per channel.
+// Note that for interleaved data, you pass in the number of shorts (the
+// size of your array), but the return value is the number of samples per
+// channel, not the total number of samples.
+//
+// The data is coerced to the number of channels you request according to the
+// channel coercion rules (see below). You must pass in the size of your
+// buffer(s) so that stb_vorbis will not overwrite the end of the buffer.
+// The maximum buffer size needed can be gotten from get_info(); however,
+// the Vorbis I specification implies an absolute maximum of 4096 samples
+// per channel.
+
+// Channel coercion rules:
+//    Let M be the number of channels requested, and N the number of channels present,
+//    and Cn be the nth channel; let stereo L be the sum of all L and center channels,
+//    and stereo R be the sum of all R and center channels (channel assignment from the
+//    vorbis spec).
+//        M    N       output
+//        1    k      sum(Ck) for all k
+//        2    *      stereo L, stereo R
+//        k    l      k > l, the first l channels, then 0s
+//        k    l      k <= l, the first k channels
+//    Note that this is not _good_ surround etc. mixing at all! It's just so
+//    you get something useful.
+
+extern int stb_vorbis_get_samples_float_interleaved(stb_vorbis *f, int channels, float *buffer, int num_floats);
+extern int stb_vorbis_get_samples_float(stb_vorbis *f, int channels, float **buffer, int num_samples);
+// gets num_samples samples, not necessarily on a frame boundary--this requires
+// buffering so you have to supply the buffers. DOES NOT APPLY THE COERCION RULES.
+// Returns the number of samples stored per channel; it may be less than requested
+// at the end of the file. If there are no more samples in the file, returns 0.
+
+#ifndef STB_VORBIS_NO_INTEGER_CONVERSION
+extern int stb_vorbis_get_samples_short_interleaved(stb_vorbis *f, int channels, short *buffer, int num_shorts);
+extern int stb_vorbis_get_samples_short(stb_vorbis *f, int channels, short **buffer, int num_samples);
+#endif
+// gets num_samples samples, not necessarily on a frame boundary--this requires
+// buffering so you have to supply the buffers. Applies the coercion rules above
+// to produce 'channels' channels. Returns the number of samples stored per channel;
+// it may be less than requested at the end of the file. If there are no more
+// samples in the file, returns 0.
+
+#endif
+
+////////   ERROR CODES
+
+enum STBVorbisError
+{
+   VORBIS__no_error,
+
+   VORBIS_need_more_data=1,             // not a real error
+
+   VORBIS_invalid_api_mixing,           // can't mix API modes
+   VORBIS_outofmem,                     // not enough memory
+   VORBIS_feature_not_supported,        // uses floor 0
+   VORBIS_too_many_channels,            // STB_VORBIS_MAX_CHANNELS is too small
+   VORBIS_file_open_failure,            // fopen() failed
+   VORBIS_seek_without_length,          // can't seek in unknown-length file
+
+   VORBIS_unexpected_eof=10,            // file is truncated?
+   VORBIS_seek_invalid,                 // seek past EOF
+
+   // decoding errors (corrupt/invalid stream) -- you probably
+   // don't care about the exact details of these
+
+   // vorbis errors:
+   VORBIS_invalid_setup=20,
+   VORBIS_invalid_stream,
+
+   // ogg errors:
+   VORBIS_missing_capture_pattern=30,
+   VORBIS_invalid_stream_structure_version,
+   VORBIS_continued_packet_flag_invalid,
+   VORBIS_incorrect_stream_serial_number,
+   VORBIS_invalid_first_page,
+   VORBIS_bad_packet_type,
+   VORBIS_cant_find_last_page,
+   VORBIS_seek_failed,
+   VORBIS_ogg_skeleton_not_supported
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // STB_VORBIS_INCLUDE_STB_VORBIS_H
+//
+//  HEADER ENDS HERE
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef STB_VORBIS_HEADER_ONLY
+
+// global configuration settings (e.g. set these in the project/makefile),
+// or just set them in this file at the top (although ideally the first few
+// should be visible when the header file is compiled too, although it's not
+// crucial)
+
+// STB_VORBIS_NO_PUSHDATA_API
+//     does not compile the code for the various stb_vorbis_*_pushdata()
+//     functions
+// #define STB_VORBIS_NO_PUSHDATA_API
+
+// STB_VORBIS_NO_PULLDATA_API
+//     does not compile the code for the non-pushdata APIs
+// #define STB_VORBIS_NO_PULLDATA_API
+
+// STB_VORBIS_NO_STDIO
+//     does not compile the code for the APIs that use FILE *s internally
+//     or externally (implied by STB_VORBIS_NO_PULLDATA_API)
+// #define STB_VORBIS_NO_STDIO
+
+// STB_VORBIS_NO_INTEGER_CONVERSION
+//     does not compile the code for converting audio sample data from
+//     float to integer (implied by STB_VORBIS_NO_PULLDATA_API)
+// #define STB_VORBIS_NO_INTEGER_CONVERSION
+
+// STB_VORBIS_NO_FAST_SCALED_FLOAT
+//      does not use a fast float-to-int trick to accelerate float-to-int on
+//      most platforms which requires endianness be defined correctly.
+//#define STB_VORBIS_NO_FAST_SCALED_FLOAT
+
+
+// STB_VORBIS_MAX_CHANNELS [number]
+//     globally define this to the maximum number of channels you need.
+//     The spec does not put a restriction on channels except that
+//     the count is stored in a byte, so 255 is the hard limit.
+//     Reducing this saves about 16 bytes per value, so using 16 saves
+//     (255-16)*16 or around 4KB. Plus anything other memory usage
+//     I forgot to account for. Can probably go as low as 8 (7.1 audio),
+//     6 (5.1 audio), or 2 (stereo only).
+#ifndef STB_VORBIS_MAX_CHANNELS
+#define STB_VORBIS_MAX_CHANNELS    16  // enough for anyone?
+#endif
+
+// STB_VORBIS_PUSHDATA_CRC_COUNT [number]
+//     after a flush_pushdata(), stb_vorbis begins scanning for the
+//     next valid page, without backtracking. when it finds something
+//     that looks like a page, it streams through it and verifies its
+//     CRC32. Should that validation fail, it keeps scanning. But it's
+//     possible that _while_ streaming through to check the CRC32 of
+//     one candidate page, it sees another candidate page. This #define
+//     determines how many "overlapping" candidate pages it can search
+//     at once. Note that "real" pages are typically ~4KB to ~8KB, whereas
+//     garbage pages could be as big as 64KB, but probably average ~16KB.
+//     So don't hose ourselves by scanning an apparent 64KB page and
+//     missing a ton of real ones in the interim; so minimum of 2
+#ifndef STB_VORBIS_PUSHDATA_CRC_COUNT
+#define STB_VORBIS_PUSHDATA_CRC_COUNT  4
+#endif
+
+// STB_VORBIS_FAST_HUFFMAN_LENGTH [number]
+//     sets the log size of the huffman-acceleration table.  Maximum
+//     supported value is 24. with larger numbers, more decodings are O(1),
+//     but the table size is larger so worse cache missing, so you'll have
+//     to probe (and try multiple ogg vorbis files) to find the sweet spot.
+#ifndef STB_VORBIS_FAST_HUFFMAN_LENGTH
+#define STB_VORBIS_FAST_HUFFMAN_LENGTH   10
+#endif
+
+// STB_VORBIS_FAST_BINARY_LENGTH [number]
+//     sets the log size of the binary-search acceleration table. this
+//     is used in similar fashion to the fast-huffman size to set initial
+//     parameters for the binary search
+
+// STB_VORBIS_FAST_HUFFMAN_INT
+//     The fast huffman tables are much more efficient if they can be
+//     stored as 16-bit results instead of 32-bit results. This restricts
+//     the codebooks to having only 65535 possible outcomes, though.
+//     (At least, accelerated by the huffman table.)
+#ifndef STB_VORBIS_FAST_HUFFMAN_INT
+#define STB_VORBIS_FAST_HUFFMAN_SHORT
+#endif
+
+// STB_VORBIS_NO_HUFFMAN_BINARY_SEARCH
+//     If the 'fast huffman' search doesn't succeed, then stb_vorbis falls
+//     back on binary searching for the correct one. This requires storing
+//     extra tables with the huffman codes in sorted order. Defining this
+//     symbol trades off space for speed by forcing a linear search in the
+//     non-fast case, except for "sparse" codebooks.
+// #define STB_VORBIS_NO_HUFFMAN_BINARY_SEARCH
+
+// STB_VORBIS_DIVIDES_IN_RESIDUE
+//     stb_vorbis precomputes the result of the scalar residue decoding
+//     that would otherwise require a divide per chunk. you can trade off
+//     space for time by defining this symbol.
+// #define STB_VORBIS_DIVIDES_IN_RESIDUE
+
+// STB_VORBIS_DIVIDES_IN_CODEBOOK
+//     vorbis VQ codebooks can be encoded two ways: with every case explicitly
+//     stored, or with all elements being chosen from a small range of values,
+//     and all values possible in all elements. By default, stb_vorbis expands
+//     this latter kind out to look like the former kind for ease of decoding,
+//     because otherwise an integer divide-per-vector-element is required to
+//     unpack the index. If you define STB_VORBIS_DIVIDES_IN_CODEBOOK, you can
+//     trade off storage for speed.
+//#define STB_VORBIS_DIVIDES_IN_CODEBOOK
+
+#ifdef STB_VORBIS_CODEBOOK_SHORTS
+#error "STB_VORBIS_CODEBOOK_SHORTS is no longer supported as it produced incorrect results for some input formats"
+#endif
+
+// STB_VORBIS_DIVIDE_TABLE
+//     this replaces small integer divides in the floor decode loop with
+//     table lookups. made less than 1% difference, so disabled by default.
+
+// STB_VORBIS_NO_INLINE_DECODE
+//     disables the inlining of the scalar codebook fast-huffman decode.
+//     might save a little codespace; useful for debugging
+// #define STB_VORBIS_NO_INLINE_DECODE
+
+// STB_VORBIS_NO_DEFER_FLOOR
+//     Normally we only decode the floor without synthesizing the actual
+//     full curve. We can instead synthesize the curve immediately. This
+//     requires more memory and is very likely slower, so I don't think
+//     you'd ever want to do it except for debugging.
+// #define STB_VORBIS_NO_DEFER_FLOOR
+
+
+
+
+//////////////////////////////////////////////////////////////////////////////
+
+#ifdef STB_VORBIS_NO_PULLDATA_API
+   #define STB_VORBIS_NO_INTEGER_CONVERSION
+   #define STB_VORBIS_NO_STDIO
+#endif
+
+#if defined(STB_VORBIS_NO_CRT) && !defined(STB_VORBIS_NO_STDIO)
+   #define STB_VORBIS_NO_STDIO 1
+#endif
+
+#ifndef STB_VORBIS_NO_INTEGER_CONVERSION
+#ifndef STB_VORBIS_NO_FAST_SCALED_FLOAT
+
+   // only need endianness for fast-float-to-int, which we don't
+   // use for pushdata
+
+   #ifndef STB_VORBIS_BIG_ENDIAN
+     #define STB_VORBIS_ENDIAN  0
+   #else
+     #define STB_VORBIS_ENDIAN  1
+   #endif
+
+#endif
+#endif
+
+
+#ifndef STB_VORBIS_NO_STDIO
+#include <stdio.h>
+#endif
+
+#ifndef STB_VORBIS_NO_CRT
+   #include <stdlib.h>
+   #include <string.h>
+   #include <assert.h>
+   #include <math.h>
+
+   // find definition of alloca if it's not in stdlib.h:
+   #if defined(_MSC_VER) || defined(__MINGW32__)
+      #include <malloc.h>
+   #endif
+   #if defined(__linux__) || defined(__linux) || defined(__sun__) || defined(__EMSCRIPTEN__) || defined(__NEWLIB__)
+      #include <alloca.h>
+   #endif
+#else // STB_VORBIS_NO_CRT
+   #define NULL 0
+   #define malloc(s)   0
+   #define free(s)     ((void) 0)
+   #define realloc(s)  0
+#endif // STB_VORBIS_NO_CRT
+
+#include <limits.h>
+
+#ifdef __MINGW32__
+   // eff you mingw:
+   //     "fixed":
+   //         http://sourceforge.net/p/mingw-w64/mailman/message/32882927/
+   //     "no that broke the build, reverted, who cares about C":
+   //         http://sourceforge.net/p/mingw-w64/mailman/message/32890381/
+   #ifdef __forceinline
+   #undef __forceinline
+   #endif
+   #define __forceinline
+   #ifndef alloca
+   #define alloca __builtin_alloca
+   #endif
+#elif !defined(_MSC_VER)
+   #if __GNUC__
+      #define __forceinline inline
+   #else
+      #define __forceinline
+   #endif
+#endif
+
+#if STB_VORBIS_MAX_CHANNELS > 256
+#error "Value of STB_VORBIS_MAX_CHANNELS outside of allowed range"
+#endif
+
+#if STB_VORBIS_FAST_HUFFMAN_LENGTH > 24
+#error "Value of STB_VORBIS_FAST_HUFFMAN_LENGTH outside of allowed range"
+#endif
+
+
+#if 0
+#include <crtdbg.h>
+#define CHECK(f)   _CrtIsValidHeapPointer(f->channel_buffers[1])
+#else
+#define CHECK(f)   ((void) 0)
+#endif
+
+#define MAX_BLOCKSIZE_LOG  13   // from specification
+#define MAX_BLOCKSIZE      (1 << MAX_BLOCKSIZE_LOG)
+
+
+typedef unsigned char  uint8;
+typedef   signed char   int8;
+typedef unsigned short uint16;
+typedef   signed short  int16;
+typedef unsigned int   uint32;
+typedef   signed int    int32;
+
+#ifndef TRUE
+#define TRUE 1
+#define FALSE 0
+#endif
+
+typedef float codetype;
+
+#ifdef _MSC_VER
+#define STBV_NOTUSED(v)  (void)(v)
+#else
+#define STBV_NOTUSED(v)  (void)sizeof(v)
+#endif
+
+// @NOTE
+//
+// Some arrays below are tagged "//varies", which means it's actually
+// a variable-sized piece of data, but rather than malloc I assume it's
+// small enough it's better to just allocate it all together with the
+// main thing
+//
+// Most of the variables are specified with the smallest size I could pack
+// them into. It might give better performance to make them all full-sized
+// integers. It should be safe to freely rearrange the structures or change
+// the sizes larger--nothing relies on silently truncating etc., nor the
+// order of variables.
+
+#define FAST_HUFFMAN_TABLE_SIZE   (1 << STB_VORBIS_FAST_HUFFMAN_LENGTH)
+#define FAST_HUFFMAN_TABLE_MASK   (FAST_HUFFMAN_TABLE_SIZE - 1)
+
+typedef struct
+{
+   int dimensions, entries;
+   uint8 *codeword_lengths;
+   float  minimum_value;
+   float  delta_value;
+   uint8  value_bits;
+   uint8  lookup_type;
+   uint8  sequence_p;
+   uint8  sparse;
+   uint32 lookup_values;
+   codetype *multiplicands;
+   uint32 *codewords;
+   #ifdef STB_VORBIS_FAST_HUFFMAN_SHORT
+    int16  fast_huffman[FAST_HUFFMAN_TABLE_SIZE];
+   #else
+    int32  fast_huffman[FAST_HUFFMAN_TABLE_SIZE];
+   #endif
+   uint32 *sorted_codewords;
+   int    *sorted_values;
+   int     sorted_entries;
+} Codebook;
+
+typedef struct
+{
+   uint8 order;
+   uint16 rate;
+   uint16 bark_map_size;
+   uint8 amplitude_bits;
+   uint8 amplitude_offset;
+   uint8 number_of_books;
+   uint8 book_list[16]; // varies
+} Floor0;
+
+typedef struct
+{
+   uint8 partitions;
+   uint8 partition_class_list[32]; // varies
+   uint8 class_dimensions[16]; // varies
+   uint8 class_subclasses[16]; // varies
+   uint8 class_masterbooks[16]; // varies
+   int16 subclass_books[16][8]; // varies
+   uint16 Xlist[31*8+2]; // varies
+   uint8 sorted_order[31*8+2];
+   uint8 neighbors[31*8+2][2];
+   uint8 floor1_multiplier;
+   uint8 rangebits;
+   int values;
+} Floor1;
+
+typedef union
+{
+   Floor0 floor0;
+   Floor1 floor1;
+} Floor;
+
+typedef struct
+{
+   uint32 begin, end;
+   uint32 part_size;
+   uint8 classifications;
+   uint8 classbook;
+   uint8 **classdata;
+   int16 (*residue_books)[8];
+} Residue;
+
+typedef struct
+{
+   uint8 magnitude;
+   uint8 angle;
+   uint8 mux;
+} MappingChannel;
+
+typedef struct
+{
+   uint16 coupling_steps;
+   MappingChannel *chan;
+   uint8  submaps;
+   uint8  submap_floor[15]; // varies
+   uint8  submap_residue[15]; // varies
+} Mapping;
+
+typedef struct
+{
+   uint8 blockflag;
+   uint8 mapping;
+   uint16 windowtype;
+   uint16 transformtype;
+} Mode;
+
+typedef struct
+{
+   uint32  goal_crc;    // expected crc if match
+   int     bytes_left;  // bytes left in packet
+   uint32  crc_so_far;  // running crc
+   int     bytes_done;  // bytes processed in _current_ chunk
+   uint32  sample_loc;  // granule pos encoded in page
+} CRCscan;
+
+typedef struct
+{
+   uint32 page_start, page_end;
+   uint32 last_decoded_sample;
+} ProbedPage;
+
+struct stb_vorbis
+{
+  // user-accessible info
+   unsigned int sample_rate;
+   int channels;
+
+   unsigned int setup_memory_required;
+   unsigned int temp_memory_required;
+   unsigned int setup_temp_memory_required;
+
+   char *vendor;
+   int comment_list_length;
+   char **comment_list;
+
+  // input config
+#ifndef STB_VORBIS_NO_STDIO
+   FILE *f;
+   uint32 f_start;
+   int close_on_free;
+#endif
+
+   uint8 *stream;
+   uint8 *stream_start;
+   uint8 *stream_end;
+
+   uint32 stream_len;
+
+   uint8  push_mode;
+
+   // the page to seek to when seeking to start, may be zero
+   uint32 first_audio_page_offset;
+
+   // p_first is the page on which the first audio packet ends
+   // (but not necessarily the page on which it starts)
+   ProbedPage p_first, p_last;
+
+  // memory management
+   stb_vorbis_alloc alloc;
+   int setup_offset;
+   int temp_offset;
+
+  // run-time results
+   int eof;
+   enum STBVorbisError error;
+
+  // user-useful data
+
+  // header info
+   int blocksize[2];
+   int blocksize_0, blocksize_1;
+   int codebook_count;
+   Codebook *codebooks;
+   int floor_count;
+   uint16 floor_types[64]; // varies
+   Floor *floor_config;
+   int residue_count;
+   uint16 residue_types[64]; // varies
+   Residue *residue_config;
+   int mapping_count;
+   Mapping *mapping;
+   int mode_count;
+   Mode mode_config[64];  // varies
+
+   uint32 total_samples;
+
+  // decode buffer
+   float *channel_buffers[STB_VORBIS_MAX_CHANNELS];
+   float *outputs        [STB_VORBIS_MAX_CHANNELS];
+
+   float *previous_window[STB_VORBIS_MAX_CHANNELS];
+   int previous_length;
+
+   #ifndef STB_VORBIS_NO_DEFER_FLOOR
+   int16 *finalY[STB_VORBIS_MAX_CHANNELS];
+   #else
+   float *floor_buffers[STB_VORBIS_MAX_CHANNELS];
+   #endif
+
+   uint32 current_loc; // sample location of next frame to decode
+   int    current_loc_valid;
+
+  // per-blocksize precomputed data
+
+   // twiddle factors
+   float *A[2],*B[2],*C[2];
+   float *window[2];
+   uint16 *bit_reverse[2];
+
+  // current page/packet/segment streaming info
+   uint32 serial; // stream serial number for verification
+   int last_page;
+   int segment_count;
+   uint8 segments[255];
+   uint8 page_flag;
+   uint8 bytes_in_seg;
+   uint8 first_decode;
+   int next_seg;
+   int last_seg;  // flag that we're on the last segment
+   int last_seg_which; // what was the segment number of the last seg?
+   uint32 acc;
+   int valid_bits;
+   int packet_bytes;
+   int end_seg_with_known_loc;
+   uint32 known_loc_for_packet;
+   int discard_samples_deferred;
+   uint32 samples_output;
+
+  // push mode scanning
+   int page_crc_tests; // only in push_mode: number of tests active; -1 if not searching
+#ifndef STB_VORBIS_NO_PUSHDATA_API
+   CRCscan scan[STB_VORBIS_PUSHDATA_CRC_COUNT];
+#endif
+
+  // sample-access
+   int channel_buffer_start;
+   int channel_buffer_end;
+};
+
+#if defined(STB_VORBIS_NO_PUSHDATA_API)
+   #define IS_PUSH_MODE(f)   FALSE
+#elif defined(STB_VORBIS_NO_PULLDATA_API)
+   #define IS_PUSH_MODE(f)   TRUE
+#else
+   #define IS_PUSH_MODE(f)   ((f)->push_mode)
+#endif
+
+typedef struct stb_vorbis vorb;
+
+static int error(vorb *f, enum STBVorbisError e)
+{
+   f->error = e;
+   if (!f->eof && e != VORBIS_need_more_data) {
+      f->error=e; // breakpoint for debugging
+   }
+   return 0;
+}
+
+
+// these functions are used for allocating temporary memory
+// while decoding. if you can afford the stack space, use
+// alloca(); otherwise, provide a temp buffer and it will
+// allocate out of those.
+
+#define array_size_required(count,size)  (count*(sizeof(void *)+(size)))
+
+#define temp_alloc(f,size)              (f->alloc.alloc_buffer ? setup_temp_malloc(f,size) : alloca(size))
+#define temp_free(f,p)                  (void)0
+#define temp_alloc_save(f)              ((f)->temp_offset)
+#define temp_alloc_restore(f,p)         ((f)->temp_offset = (p))
+
+#define temp_block_array(f,count,size)  make_block_array(temp_alloc(f,array_size_required(count,size)), count, size)
+
+// given a sufficiently large block of memory, make an array of pointers to subblocks of it
+static void *make_block_array(void *mem, int count, int size)
+{
+   int i;
+   void ** p = (void **) mem;
+   char *q = (char *) (p + count);
+   for (i=0; i < count; ++i) {
+      p[i] = q;
+      q += size;
+   }
+   return p;
+}
+
+static void *setup_malloc(vorb *f, int sz)
+{
+   sz = (sz+7) & ~7; // round up to nearest 8 for alignment of future allocs.
+   f->setup_memory_required += sz;
+   if (f->alloc.alloc_buffer) {
+      void *p = (char *) f->alloc.alloc_buffer + f->setup_offset;
+      if (f->setup_offset + sz > f->temp_offset) return NULL;
+      f->setup_offset += sz;
+      return p;
+   }
+   return sz ? malloc(sz) : NULL;
+}
+
+static void setup_free(vorb *f, void *p)
+{
+   if (f->alloc.alloc_buffer) return; // do nothing; setup mem is a stack
+   free(p);
+}
+
+static void *setup_temp_malloc(vorb *f, int sz)
+{
+   sz = (sz+7) & ~7; // round up to nearest 8 for alignment of future allocs.
+   if (f->alloc.alloc_buffer) {
+      if (f->temp_offset - sz < f->setup_offset) return NULL;
+      f->temp_offset -= sz;
+      return (char *) f->alloc.alloc_buffer + f->temp_offset;
+   }
+   return malloc(sz);
+}
+
+static void setup_temp_free(vorb *f, void *p, int sz)
+{
+   if (f->alloc.alloc_buffer) {
+      f->temp_offset += (sz+7)&~7;
+      return;
+   }
+   free(p);
+}
+
+#define CRC32_POLY    0x04c11db7   // from spec
+
+static uint32 crc_table[256];
+static void crc32_init(void)
+{
+   int i,j;
+   uint32 s;
+   for(i=0; i < 256; i++) {
+      for (s=(uint32) i << 24, j=0; j < 8; ++j)
+         s = (s << 1) ^ (s >= (1U<<31) ? CRC32_POLY : 0);
+      crc_table[i] = s;
+   }
+}
+
+static __forceinline uint32 crc32_update(uint32 crc, uint8 byte)
+{
+   return (crc << 8) ^ crc_table[byte ^ (crc >> 24)];
+}
+
+
+// used in setup, and for huffman that doesn't go fast path
+static unsigned int bit_reverse(unsigned int n)
+{
+  n = ((n & 0xAAAAAAAA) >>  1) | ((n & 0x55555555) << 1);
+  n = ((n & 0xCCCCCCCC) >>  2) | ((n & 0x33333333) << 2);
+  n = ((n & 0xF0F0F0F0) >>  4) | ((n & 0x0F0F0F0F) << 4);
+  n = ((n & 0xFF00FF00) >>  8) | ((n & 0x00FF00FF) << 8);
+  return (n >> 16) | (n << 16);
+}
+
+static float square(float x)
+{
+   return x*x;
+}
+
+// this is a weird definition of log2() for which log2(1) = 1, log2(2) = 2, log2(4) = 3
+// as required by the specification. fast(?) implementation from stb.h
+// @OPTIMIZE: called multiple times per-packet with "constants"; move to setup
+static int ilog(int32 n)
+{
+   static signed char log2_4[16] = { 0,1,2,2,3,3,3,3,4,4,4,4,4,4,4,4 };
+
+   if (n < 0) return 0; // signed n returns 0
+
+   // 2 compares if n < 16, 3 compares otherwise (4 if signed or n > 1<<29)
+   if (n < (1 << 14))
+        if (n < (1 <<  4))            return  0 + log2_4[n      ];
+        else if (n < (1 <<  9))       return  5 + log2_4[n >>  5];
+             else                     return 10 + log2_4[n >> 10];
+   else if (n < (1 << 24))
+             if (n < (1 << 19))       return 15 + log2_4[n >> 15];
+             else                     return 20 + log2_4[n >> 20];
+        else if (n < (1 << 29))       return 25 + log2_4[n >> 25];
+             else                     return 30 + log2_4[n >> 30];
+}
+
+#ifndef M_PI
+  #define M_PI  3.14159265358979323846264f  // from CRC
+#endif
+
+// code length assigned to a value with no huffman encoding
+#define NO_CODE   255
+
+/////////////////////// LEAF SETUP FUNCTIONS //////////////////////////
+//
+// these functions are only called at setup, and only a few times
+// per file
+
+static float float32_unpack(uint32 x)
+{
+   // from the specification
+   uint32 mantissa = x & 0x1fffff;
+   uint32 sign = x & 0x80000000;
+   uint32 exp = (x & 0x7fe00000) >> 21;
+   double res = sign ? -(double)mantissa : (double)mantissa;
+   return (float) ldexp((float)res, (int)exp-788);
+}
+
+
+// zlib & jpeg huffman tables assume that the output symbols
+// can either be arbitrarily arranged, or have monotonically
+// increasing frequencies--they rely on the lengths being sorted;
+// this makes for a very simple generation algorithm.
+// vorbis allows a huffman table with non-sorted lengths. This
+// requires a more sophisticated construction, since symbols in
+// order do not map to huffman codes "in order".
+static void add_entry(Codebook *c, uint32 huff_code, int symbol, int count, int len, uint32 *values)
+{
+   if (!c->sparse) {
+      c->codewords      [symbol] = huff_code;
+   } else {
+      c->codewords       [count] = huff_code;
+      c->codeword_lengths[count] = len;
+      values             [count] = symbol;
+   }
+}
+
+static int compute_codewords(Codebook *c, uint8 *len, int n, uint32 *values)
+{
+   int i,k,m=0;
+   uint32 available[32];
+
+   memset(available, 0, sizeof(available));
+   // find the first entry
+   for (k=0; k < n; ++k) if (len[k] < NO_CODE) break;
+   if (k == n) { assert(c->sorted_entries == 0); return TRUE; }
+   assert(len[k] < 32); // no error return required, code reading lens checks this
+   // add to the list
+   add_entry(c, 0, k, m++, len[k], values);
+   // add all available leaves
+   for (i=1; i <= len[k]; ++i)
+      available[i] = 1U << (32-i);
+   // note that the above code treats the first case specially,
+   // but it's really the same as the following code, so they
+   // could probably be combined (except the initial code is 0,
+   // and I use 0 in available[] to mean 'empty')
+   for (i=k+1; i < n; ++i) {
+      uint32 res;
+      int z = len[i], y;
+      if (z == NO_CODE) continue;
+      assert(z < 32); // no error return required, code reading lens checks this
+      // find lowest available leaf (should always be earliest,
+      // which is what the specification calls for)
+      // note that this property, and the fact we can never have
+      // more than one free leaf at a given level, isn't totally
+      // trivial to prove, but it seems true and the assert never
+      // fires, so!
+      while (z > 0 && !available[z]) --z;
+      if (z == 0) { return FALSE; }
+      res = available[z];
+      available[z] = 0;
+      add_entry(c, bit_reverse(res), i, m++, len[i], values);
+      // propagate availability up the tree
+      if (z != len[i]) {
+         for (y=len[i]; y > z; --y) {
+            assert(available[y] == 0);
+            available[y] = res + (1 << (32-y));
+         }
+      }
+   }
+   return TRUE;
+}
+
+// accelerated huffman table allows fast O(1) match of all symbols
+// of length <= STB_VORBIS_FAST_HUFFMAN_LENGTH
+static void compute_accelerated_huffman(Codebook *c)
+{
+   int i, len;
+   for (i=0; i < FAST_HUFFMAN_TABLE_SIZE; ++i)
+      c->fast_huffman[i] = -1;
+
+   len = c->sparse ? c->sorted_entries : c->entries;
+   #ifdef STB_VORBIS_FAST_HUFFMAN_SHORT
+   if (len > 32767) len = 32767; // largest possible value we can encode!
+   #endif
+   for (i=0; i < len; ++i) {
+      if (c->codeword_lengths[i] <= STB_VORBIS_FAST_HUFFMAN_LENGTH) {
+         uint32 z = c->sparse ? bit_reverse(c->sorted_codewords[i]) : c->codewords[i];
+         // set table entries for all bit combinations in the higher bits
+         while (z < FAST_HUFFMAN_TABLE_SIZE) {
+             c->fast_huffman[z] = i;
+             z += 1 << c->codeword_lengths[i];
+         }
+      }
+   }
+}
+
+#ifdef _MSC_VER
+#define STBV_CDECL __cdecl
+#else
+#define STBV_CDECL
+#endif
+
+static int STBV_CDECL uint32_compare(const void *p, const void *q)
+{
+   uint32 x = * (uint32 *) p;
+   uint32 y = * (uint32 *) q;
+   return x < y ? -1 : x > y;
+}
+
+static int include_in_sort(Codebook *c, uint8 len)
+{
+   if (c->sparse) { assert(len != NO_CODE); return TRUE; }
+   if (len == NO_CODE) return FALSE;
+   if (len > STB_VORBIS_FAST_HUFFMAN_LENGTH) return TRUE;
+   return FALSE;
+}
+
+// if the fast table above doesn't work, we want to binary
+// search them... need to reverse the bits
+static void compute_sorted_huffman(Codebook *c, uint8 *lengths, uint32 *values)
+{
+   int i, len;
+   // build a list of all the entries
+   // OPTIMIZATION: don't include the short ones, since they'll be caught by FAST_HUFFMAN.
+   // this is kind of a frivolous optimization--I don't see any performance improvement,
+   // but it's like 4 extra lines of code, so.
+   if (!c->sparse) {
+      int k = 0;
+      for (i=0; i < c->entries; ++i)
+         if (include_in_sort(c, lengths[i]))
+            c->sorted_codewords[k++] = bit_reverse(c->codewords[i]);
+      assert(k == c->sorted_entries);
+   } else {
+      for (i=0; i < c->sorted_entries; ++i)
+         c->sorted_codewords[i] = bit_reverse(c->codewords[i]);
+   }
+
+   qsort(c->sorted_codewords, c->sorted_entries, sizeof(c->sorted_codewords[0]), uint32_compare);
+   c->sorted_codewords[c->sorted_entries] = 0xffffffff;
+
+   len = c->sparse ? c->sorted_entries : c->entries;
+   // now we need to indicate how they correspond; we could either
+   //   #1: sort a different data structure that says who they correspond to
+   //   #2: for each sorted entry, search the original list to find who corresponds
+   //   #3: for each original entry, find the sorted entry
+   // #1 requires extra storage, #2 is slow, #3 can use binary search!
+   for (i=0; i < len; ++i) {
+      int huff_len = c->sparse ? lengths[values[i]] : lengths[i];
+      if (include_in_sort(c,huff_len)) {
+         uint32 code = bit_reverse(c->codewords[i]);
+         int x=0, n=c->sorted_entries;
+         while (n > 1) {
+            // invariant: sc[x] <= code < sc[x+n]
+            int m = x + (n >> 1);
+            if (c->sorted_codewords[m] <= code) {
+               x = m;
+               n -= (n>>1);
+            } else {
+               n >>= 1;
+            }
+         }
+         assert(c->sorted_codewords[x] == code);
+         if (c->sparse) {
+            c->sorted_values[x] = values[i];
+            c->codeword_lengths[x] = huff_len;
+         } else {
+            c->sorted_values[x] = i;
+         }
+      }
+   }
+}
+
+// only run while parsing the header (3 times)
+static int vorbis_validate(uint8 *data)
+{
+   static uint8 vorbis[6] = { 'v', 'o', 'r', 'b', 'i', 's' };
+   return memcmp(data, vorbis, 6) == 0;
+}
+
+// called from setup only, once per code book
+// (formula implied by specification)
+static int lookup1_values(int entries, int dim)
+{
+   int r = (int) floor(exp((float) log((float) entries) / dim));
+   if ((int) floor(pow((float) r+1, dim)) <= entries)   // (int) cast for MinGW warning;
+      ++r;                                              // floor() to avoid _ftol() when non-CRT
+   if (pow((float) r+1, dim) <= entries)
+      return -1;
+   if ((int) floor(pow((float) r, dim)) > entries)
+      return -1;
+   return r;
+}
+
+// called twice per file
+static void compute_twiddle_factors(int n, float *A, float *B, float *C)
+{
+   int n4 = n >> 2, n8 = n >> 3;
+   int k,k2;
+
+   for (k=k2=0; k < n4; ++k,k2+=2) {
+      A[k2  ] = (float)  cos(4*k*M_PI/n);
+      A[k2+1] = (float) -sin(4*k*M_PI/n);
+      B[k2  ] = (float)  cos((k2+1)*M_PI/n/2) * 0.5f;
+      B[k2+1] = (float)  sin((k2+1)*M_PI/n/2) * 0.5f;
+   }
+   for (k=k2=0; k < n8; ++k,k2+=2) {
+      C[k2  ] = (float)  cos(2*(k2+1)*M_PI/n);
+      C[k2+1] = (float) -sin(2*(k2+1)*M_PI/n);
+   }
+}
+
+static void compute_window(int n, float *window)
+{
+   int n2 = n >> 1, i;
+   for (i=0; i < n2; ++i)
+      window[i] = (float) sin(0.5 * M_PI * square((float) sin((i - 0 + 0.5) / n2 * 0.5 * M_PI)));
+}
+
+static void compute_bitreverse(int n, uint16 *rev)
+{
+   int ld = ilog(n) - 1; // ilog is off-by-one from normal definitions
+   int i, n8 = n >> 3;
+   for (i=0; i < n8; ++i)
+      rev[i] = (bit_reverse(i) >> (32-ld+3)) << 2;
+}
+
+static int init_blocksize(vorb *f, int b, int n)
+{
+   int n2 = n >> 1, n4 = n >> 2, n8 = n >> 3;
+   f->A[b] = (float *) setup_malloc(f, sizeof(float) * n2);
+   f->B[b] = (float *) setup_malloc(f, sizeof(float) * n2);
+   f->C[b] = (float *) setup_malloc(f, sizeof(float) * n4);
+   if (!f->A[b] || !f->B[b] || !f->C[b]) return error(f, VORBIS_outofmem);
+   compute_twiddle_factors(n, f->A[b], f->B[b], f->C[b]);
+   f->window[b] = (float *) setup_malloc(f, sizeof(float) * n2);
+   if (!f->window[b]) return error(f, VORBIS_outofmem);
+   compute_window(n, f->window[b]);
+   f->bit_reverse[b] = (uint16 *) setup_malloc(f, sizeof(uint16) * n8);
+   if (!f->bit_reverse[b]) return error(f, VORBIS_outofmem);
+   compute_bitreverse(n, f->bit_reverse[b]);
+   return TRUE;
+}
+
+static void neighbors(uint16 *x, int n, int *plow, int *phigh)
+{
+   int low = -1;
+   int high = 65536;
+   int i;
+   for (i=0; i < n; ++i) {
+      if (x[i] > low  && x[i] < x[n]) { *plow  = i; low = x[i]; }
+      if (x[i] < high && x[i] > x[n]) { *phigh = i; high = x[i]; }
+   }
+}
+
+// this has been repurposed so y is now the original index instead of y
+typedef struct
+{
+   uint16 x,id;
+} stbv__floor_ordering;
+
+static int STBV_CDECL point_compare(const void *p, const void *q)
+{
+   stbv__floor_ordering *a = (stbv__floor_ordering *) p;
+   stbv__floor_ordering *b = (stbv__floor_ordering *) q;
+   return a->x < b->x ? -1 : a->x > b->x;
+}
+
+//
+/////////////////////// END LEAF SETUP FUNCTIONS //////////////////////////
+
+
+#if defined(STB_VORBIS_NO_STDIO)
+   #define USE_MEMORY(z)    TRUE
+#else
+   #define USE_MEMORY(z)    ((z)->stream)
+#endif
+
+static uint8 get8(vorb *z)
+{
+   if (USE_MEMORY(z)) {
+      if (z->stream >= z->stream_end) { z->eof = TRUE; return 0; }
+      return *z->stream++;
+   }
+
+   #ifndef STB_VORBIS_NO_STDIO
+   {
+   int c = fgetc(z->f);
+   if (c == EOF) { z->eof = TRUE; return 0; }
+   return c;
+   }
+   #endif
+}
+
+static uint32 get32(vorb *f)
+{
+   uint32 x;
+   x = get8(f);
+   x += get8(f) << 8;
+   x += get8(f) << 16;
+   x += (uint32) get8(f) << 24;
+   return x;
+}
+
+static int getn(vorb *z, uint8 *data, int n)
+{
+   if (USE_MEMORY(z)) {
+      if (z->stream+n > z->stream_end) { z->eof = 1; return 0; }
+      memcpy(data, z->stream, n);
+      z->stream += n;
+      return 1;
+   }
+
+   #ifndef STB_VORBIS_NO_STDIO
+   if (fread(data, n, 1, z->f) == 1)
+      return 1;
+   else {
+      z->eof = 1;
+      return 0;
+   }
+   #endif
+}
+
+static void skip(vorb *z, int n)
+{
+   if (USE_MEMORY(z)) {
+      z->stream += n;
+      if (z->stream >= z->stream_end) z->eof = 1;
+      return;
+   }
+   #ifndef STB_VORBIS_NO_STDIO
+   {
+      long x = ftell(z->f);
+      fseek(z->f, x+n, SEEK_SET);
+   }
+   #endif
+}
+
+static int set_file_offset(stb_vorbis *f, unsigned int loc)
+{
+   #ifndef STB_VORBIS_NO_PUSHDATA_API
+   if (f->push_mode) return 0;
+   #endif
+   f->eof = 0;
+   if (USE_MEMORY(f)) {
+      if (f->stream_start + loc >= f->stream_end || f->stream_start + loc < f->stream_start) {
+         f->stream = f->stream_end;
+         f->eof = 1;
+         return 0;
+      } else {
+         f->stream = f->stream_start + loc;
+         return 1;
+      }
+   }
+   #ifndef STB_VORBIS_NO_STDIO
+   if (loc + f->f_start < loc || loc >= 0x80000000) {
+      loc = 0x7fffffff;
+      f->eof = 1;
+   } else {
+      loc += f->f_start;
+   }
+   if (!fseek(f->f, loc, SEEK_SET))
+      return 1;
+   f->eof = 1;
+   fseek(f->f, f->f_start, SEEK_END);
+   return 0;
+   #endif
+}
+
+
+static uint8 ogg_page_header[4] = { 0x4f, 0x67, 0x67, 0x53 };
+
+static int capture_pattern(vorb *f)
+{
+   if (0x4f != get8(f)) return FALSE;
+   if (0x67 != get8(f)) return FALSE;
+   if (0x67 != get8(f)) return FALSE;
+   if (0x53 != get8(f)) return FALSE;
+   return TRUE;
+}
+
+#define PAGEFLAG_continued_packet   1
+#define PAGEFLAG_first_page         2
+#define PAGEFLAG_last_page          4
+
+static int start_page_no_capturepattern(vorb *f)
+{
+   uint32 loc0,loc1,n;
+   if (f->first_decode && !IS_PUSH_MODE(f)) {
+      f->p_first.page_start = stb_vorbis_get_file_offset(f) - 4;
+   }
+   // stream structure version
+   if (0 != get8(f)) return error(f, VORBIS_invalid_stream_structure_version);
+   // header flag
+   f->page_flag = get8(f);
+   // absolute granule position
+   loc0 = get32(f);
+   loc1 = get32(f);
+   // @TODO: validate loc0,loc1 as valid positions?
+   // stream serial number -- vorbis doesn't interleave, so discard
+   get32(f);
+   //if (f->serial != get32(f)) return error(f, VORBIS_incorrect_stream_serial_number);
+   // page sequence number
+   n = get32(f);
+   f->last_page = n;
+   // CRC32
+   get32(f);
+   // page_segments
+   f->segment_count = get8(f);
+   if (!getn(f, f->segments, f->segment_count))
+      return error(f, VORBIS_unexpected_eof);
+   // assume we _don't_ know any the sample position of any segments
+   f->end_seg_with_known_loc = -2;
+   if (loc0 != ~0U || loc1 != ~0U) {
+      int i;
+      // determine which packet is the last one that will complete
+      for (i=f->segment_count-1; i >= 0; --i)
+         if (f->segments[i] < 255)
+            break;
+      // 'i' is now the index of the _last_ segment of a packet that ends
+      if (i >= 0) {
+         f->end_seg_with_known_loc = i;
+         f->known_loc_for_packet   = loc0;
+      }
+   }
+   if (f->first_decode) {
+      int i,len;
+      len = 0;
+      for (i=0; i < f->segment_count; ++i)
+         len += f->segments[i];
+      len += 27 + f->segment_count;
+      f->p_first.page_end = f->p_first.page_start + len;
+      f->p_first.last_decoded_sample = loc0;
+   }
+   f->next_seg = 0;
+   return TRUE;
+}
+
+static int start_page(vorb *f)
+{
+   if (!capture_pattern(f)) return error(f, VORBIS_missing_capture_pattern);
+   return start_page_no_capturepattern(f);
+}
+
+static int start_packet(vorb *f)
+{
+   while (f->next_seg == -1) {
+      if (!start_page(f)) return FALSE;
+      if (f->page_flag & PAGEFLAG_continued_packet)
+         return error(f, VORBIS_continued_packet_flag_invalid);
+   }
+   f->last_seg = FALSE;
+   f->valid_bits = 0;
+   f->packet_bytes = 0;
+   f->bytes_in_seg = 0;
+   // f->next_seg is now valid
+   return TRUE;
+}
+
+static int maybe_start_packet(vorb *f)
+{
+   if (f->next_seg == -1) {
+      int x = get8(f);
+      if (f->eof) return FALSE; // EOF at page boundary is not an error!
+      if (0x4f != x      ) return error(f, VORBIS_missing_capture_pattern);
+      if (0x67 != get8(f)) return error(f, VORBIS_missing_capture_pattern);
+      if (0x67 != get8(f)) return error(f, VORBIS_missing_capture_pattern);
+      if (0x53 != get8(f)) return error(f, VORBIS_missing_capture_pattern);
+      if (!start_page_no_capturepattern(f)) return FALSE;
+      if (f->page_flag & PAGEFLAG_continued_packet) {
+         // set up enough state that we can read this packet if we want,
+         // e.g. during recovery
+         f->last_seg = FALSE;
+         f->bytes_in_seg = 0;
+         return error(f, VORBIS_continued_packet_flag_invalid);
+      }
+   }
+   return start_packet(f);
+}
+
+static int next_segment(vorb *f)
+{
+   int len;
+   if (f->last_seg) return 0;
+   if (f->next_seg == -1) {
+      f->last_seg_which = f->segment_count-1; // in case start_page fails
+      if (!start_page(f)) { f->last_seg = 1; return 0; }
+      if (!(f->page_flag & PAGEFLAG_continued_packet)) return error(f, VORBIS_continued_packet_flag_invalid);
+   }
+   len = f->segments[f->next_seg++];
+   if (len < 255) {
+      f->last_seg = TRUE;
+      f->last_seg_which = f->next_seg-1;
+   }
+   if (f->next_seg >= f->segment_count)
+      f->next_seg = -1;
+   assert(f->bytes_in_seg == 0);
+   f->bytes_in_seg = len;
+   return len;
+}
+
+#define EOP    (-1)
+#define INVALID_BITS  (-1)
+
+static int get8_packet_raw(vorb *f)
+{
+   if (!f->bytes_in_seg) {  // CLANG!
+      if (f->last_seg) return EOP;
+      else if (!next_segment(f)) return EOP;
+   }
+   assert(f->bytes_in_seg > 0);
+   --f->bytes_in_seg;
+   ++f->packet_bytes;
+   return get8(f);
+}
+
+static int get8_packet(vorb *f)
+{
+   int x = get8_packet_raw(f);
+   f->valid_bits = 0;
+   return x;
+}
+
+static int get32_packet(vorb *f)
+{
+   uint32 x;
+   x = get8_packet(f);
+   x += get8_packet(f) << 8;
+   x += get8_packet(f) << 16;
+   x += (uint32) get8_packet(f) << 24;
+   return x;
+}
+
+static void flush_packet(vorb *f)
+{
+   while (get8_packet_raw(f) != EOP);
+}
+
+// @OPTIMIZE: this is the secondary bit decoder, so it's probably not as important
+// as the huffman decoder?
+static uint32 get_bits(vorb *f, int n)
+{
+   uint32 z;
+
+   if (f->valid_bits < 0) return 0;
+   if (f->valid_bits < n) {
+      if (n > 24) {
+         // the accumulator technique below would not work correctly in this case
+         z = get_bits(f, 24);
+         z += get_bits(f, n-24) << 24;
+         return z;
+      }
+      if (f->valid_bits == 0) f->acc = 0;
+      while (f->valid_bits < n) {
+         int z = get8_packet_raw(f);
+         if (z == EOP) {
+            f->valid_bits = INVALID_BITS;
+            return 0;
+         }
+         f->acc += z << f->valid_bits;
+         f->valid_bits += 8;
+      }
+   }
+
+   assert(f->valid_bits >= n);
+   z = f->acc & ((1 << n)-1);
+   f->acc >>= n;
+   f->valid_bits -= n;
+   return z;
+}
+
+// @OPTIMIZE: primary accumulator for huffman
+// expand the buffer to as many bits as possible without reading off end of packet
+// it might be nice to allow f->valid_bits and f->acc to be stored in registers,
+// e.g. cache them locally and decode locally
+static __forceinline void prep_huffman(vorb *f)
+{
+   if (f->valid_bits <= 24) {
+      if (f->valid_bits == 0) f->acc = 0;
+      do {
+         int z;
+         if (f->last_seg && !f->bytes_in_seg) return;
+         z = get8_packet_raw(f);
+         if (z == EOP) return;
+         f->acc += (unsigned) z << f->valid_bits;
+         f->valid_bits += 8;
+      } while (f->valid_bits <= 24);
+   }
+}
+
+enum
+{
+   VORBIS_packet_id = 1,
+   VORBIS_packet_comment = 3,
+   VORBIS_packet_setup = 5
+};
+
+static int codebook_decode_scalar_raw(vorb *f, Codebook *c)
+{
+   int i;
+   prep_huffman(f);
+
+   if (c->codewords == NULL && c->sorted_codewords == NULL)
+      return -1;
+
+   // cases to use binary search: sorted_codewords && !c->codewords
+   //                             sorted_codewords && c->entries > 8
+   if (c->entries > 8 ? c->sorted_codewords!=NULL : !c->codewords) {
+      // binary search
+      uint32 code = bit_reverse(f->acc);
+      int x=0, n=c->sorted_entries, len;
+
+      while (n > 1) {
+         // invariant: sc[x] <= code < sc[x+n]
+         int m = x + (n >> 1);
+         if (c->sorted_codewords[m] <= code) {
+            x = m;
+            n -= (n>>1);
+         } else {
+            n >>= 1;
+         }
+      }
+      // x is now the sorted index
+      if (!c->sparse) x = c->sorted_values[x];
+      // x is now sorted index if sparse, or symbol otherwise
+      len = c->codeword_lengths[x];
+      if (f->valid_bits >= len) {
+         f->acc >>= len;
+         f->valid_bits -= len;
+         return x;
+      }
+
+      f->valid_bits = 0;
+      return -1;
+   }
+
+   // if small, linear search
+   assert(!c->sparse);
+   for (i=0; i < c->entries; ++i) {
+      if (c->codeword_lengths[i] == NO_CODE) continue;
+      if (c->codewords[i] == (f->acc & ((1 << c->codeword_lengths[i])-1))) {
+         if (f->valid_bits >= c->codeword_lengths[i]) {
+            f->acc >>= c->codeword_lengths[i];
+            f->valid_bits -= c->codeword_lengths[i];
+            return i;
+         }
+         f->valid_bits = 0;
+         return -1;
+      }
+   }
+
+   error(f, VORBIS_invalid_stream);
+   f->valid_bits = 0;
+   return -1;
+}
+
+#ifndef STB_VORBIS_NO_INLINE_DECODE
+
+#define DECODE_RAW(var, f,c)                                  \
+   if (f->valid_bits < STB_VORBIS_FAST_HUFFMAN_LENGTH)        \
+      prep_huffman(f);                                        \
+   var = f->acc & FAST_HUFFMAN_TABLE_MASK;                    \
+   var = c->fast_huffman[var];                                \
+   if (var >= 0) {                                            \
+      int n = c->codeword_lengths[var];                       \
+      f->acc >>= n;                                           \
+      f->valid_bits -= n;                                     \
+      if (f->valid_bits < 0) { f->valid_bits = 0; var = -1; } \
+   } else {                                                   \
+      var = codebook_decode_scalar_raw(f,c);                  \
+   }
+
+#else
+
+static int codebook_decode_scalar(vorb *f, Codebook *c)
+{
+   int i;
+   if (f->valid_bits < STB_VORBIS_FAST_HUFFMAN_LENGTH)
+      prep_huffman(f);
+   // fast huffman table lookup
+   i = f->acc & FAST_HUFFMAN_TABLE_MASK;
+   i = c->fast_huffman[i];
+   if (i >= 0) {
+      f->acc >>= c->codeword_lengths[i];
+      f->valid_bits -= c->codeword_lengths[i];
+      if (f->valid_bits < 0) { f->valid_bits = 0; return -1; }
+      return i;
+   }
+   return codebook_decode_scalar_raw(f,c);
+}
+
+#define DECODE_RAW(var,f,c)    var = codebook_decode_scalar(f,c);
+
+#endif
+
+#define DECODE(var,f,c)                                       \
+   DECODE_RAW(var,f,c)                                        \
+   if (c->sparse) var = c->sorted_values[var];
+
+#ifndef STB_VORBIS_DIVIDES_IN_CODEBOOK
+  #define DECODE_VQ(var,f,c)   DECODE_RAW(var,f,c)
+#else
+  #define DECODE_VQ(var,f,c)   DECODE(var,f,c)
+#endif
+
+
+
+
+
+
+// CODEBOOK_ELEMENT_FAST is an optimization for the CODEBOOK_FLOATS case
+// where we avoid one addition
+#define CODEBOOK_ELEMENT(c,off)          (c->multiplicands[off])
+#define CODEBOOK_ELEMENT_FAST(c,off)     (c->multiplicands[off])
+#define CODEBOOK_ELEMENT_BASE(c)         (0)
+
+static int codebook_decode_start(vorb *f, Codebook *c)
+{
+   int z = -1;
+
+   // type 0 is only legal in a scalar context
+   if (c->lookup_type == 0)
+      error(f, VORBIS_invalid_stream);
+   else {
+      DECODE_VQ(z,f,c);
+      if (c->sparse) assert(z < c->sorted_entries);
+      if (z < 0) {  // check for EOP
+         if (!f->bytes_in_seg)
+            if (f->last_seg)
+               return z;
+         error(f, VORBIS_invalid_stream);
+      }
+   }
+   return z;
+}
+
+static int codebook_decode(vorb *f, Codebook *c, float *output, int len)
+{
+   int i,z = codebook_decode_start(f,c);
+   if (z < 0) return FALSE;
+   if (len > c->dimensions) len = c->dimensions;
+
+#ifdef STB_VORBIS_DIVIDES_IN_CODEBOOK
+   if (c->lookup_type == 1) {
+      float last = CODEBOOK_ELEMENT_BASE(c);
+      int div = 1;
+      for (i=0; i < len; ++i) {
+         int off = (z / div) % c->lookup_values;
+         float val = CODEBOOK_ELEMENT_FAST(c,off) + last;
+         output[i] += val;
+         if (c->sequence_p) last = val + c->minimum_value;
+         div *= c->lookup_values;
+      }
+      return TRUE;
+   }
+#endif
+
+   z *= c->dimensions;
+   if (c->sequence_p) {
+      float last = CODEBOOK_ELEMENT_BASE(c);
+      for (i=0; i < len; ++i) {
+         float val = CODEBOOK_ELEMENT_FAST(c,z+i) + last;
+         output[i] += val;
+         last = val + c->minimum_value;
+      }
+   } else {
+      float last = CODEBOOK_ELEMENT_BASE(c);
+      for (i=0; i < len; ++i) {
+         output[i] += CODEBOOK_ELEMENT_FAST(c,z+i) + last;
+      }
+   }
+
+   return TRUE;
+}
+
+static int codebook_decode_step(vorb *f, Codebook *c, float *output, int len, int step)
+{
+   int i,z = codebook_decode_start(f,c);
+   float last = CODEBOOK_ELEMENT_BASE(c);
+   if (z < 0) return FALSE;
+   if (len > c->dimensions) len = c->dimensions;
+
+#ifdef STB_VORBIS_DIVIDES_IN_CODEBOOK
+   if (c->lookup_type == 1) {
+      int div = 1;
+      for (i=0; i < len; ++i) {
+         int off = (z / div) % c->lookup_values;
+         float val = CODEBOOK_ELEMENT_FAST(c,off) + last;
+         output[i*step] += val;
+         if (c->sequence_p) last = val;
+         div *= c->lookup_values;
+      }
+      return TRUE;
+   }
+#endif
+
+   z *= c->dimensions;
+   for (i=0; i < len; ++i) {
+      float val = CODEBOOK_ELEMENT_FAST(c,z+i) + last;
+      output[i*step] += val;
+      if (c->sequence_p) last = val;
+   }
+
+   return TRUE;
+}
+
+static int codebook_decode_deinterleave_repeat(vorb *f, Codebook *c, float **outputs, int ch, int *c_inter_p, int *p_inter_p, int len, int total_decode)
+{
+   int c_inter = *c_inter_p;
+   int p_inter = *p_inter_p;
+   int i,z, effective = c->dimensions;
+
+   // type 0 is only legal in a scalar context
+   if (c->lookup_type == 0)   return error(f, VORBIS_invalid_stream);
+
+   while (total_decode > 0) {
+      float last = CODEBOOK_ELEMENT_BASE(c);
+      DECODE_VQ(z,f,c);
+      #ifndef STB_VORBIS_DIVIDES_IN_CODEBOOK
+      assert(!c->sparse || z < c->sorted_entries);
+      #endif
+      if (z < 0) {
+         if (!f->bytes_in_seg)
+            if (f->last_seg) return FALSE;
+         return error(f, VORBIS_invalid_stream);
+      }
+
+      // if this will take us off the end of the buffers, stop short!
+      // we check by computing the length of the virtual interleaved
+      // buffer (len*ch), our current offset within it (p_inter*ch)+(c_inter),
+      // and the length we'll be using (effective)
+      if (c_inter + p_inter*ch + effective > len * ch) {
+         effective = len*ch - (p_inter*ch - c_inter);
+      }
+
+   #ifdef STB_VORBIS_DIVIDES_IN_CODEBOOK
+      if (c->lookup_type == 1) {
+         int div = 1;
+         for (i=0; i < effective; ++i) {
+            int off = (z / div) % c->lookup_values;
+            float val = CODEBOOK_ELEMENT_FAST(c,off) + last;
+            if (outputs[c_inter])
+               outputs[c_inter][p_inter] += val;
+            if (++c_inter == ch) { c_inter = 0; ++p_inter; }
+            if (c->sequence_p) last = val;
+            div *= c->lookup_values;
+         }
+      } else
+   #endif
+      {
+         z *= c->dimensions;
+         if (c->sequence_p) {
+            for (i=0; i < effective; ++i) {
+               float val = CODEBOOK_ELEMENT_FAST(c,z+i) + last;
+               if (outputs[c_inter])
+                  outputs[c_inter][p_inter] += val;
+               if (++c_inter == ch) { c_inter = 0; ++p_inter; }
+               last = val;
+            }
+         } else {
+            for (i=0; i < effective; ++i) {
+               float val = CODEBOOK_ELEMENT_FAST(c,z+i) + last;
+               if (outputs[c_inter])
+                  outputs[c_inter][p_inter] += val;
+               if (++c_inter == ch) { c_inter = 0; ++p_inter; }
+            }
+         }
+      }
+
+      total_decode -= effective;
+   }
+   *c_inter_p = c_inter;
+   *p_inter_p = p_inter;
+   return TRUE;
+}
+
+static int predict_point(int x, int x0, int x1, int y0, int y1)
+{
+   int dy = y1 - y0;
+   int adx = x1 - x0;
+   // @OPTIMIZE: force int division to round in the right direction... is this necessary on x86?
+   int err = abs(dy) * (x - x0);
+   int off = err / adx;
+   return dy < 0 ? y0 - off : y0 + off;
+}
+
+// the following table is block-copied from the specification
+static float inverse_db_table[256] =
+{
+  1.0649863e-07f, 1.1341951e-07f, 1.2079015e-07f, 1.2863978e-07f,
+  1.3699951e-07f, 1.4590251e-07f, 1.5538408e-07f, 1.6548181e-07f,
+  1.7623575e-07f, 1.8768855e-07f, 1.9988561e-07f, 2.1287530e-07f,
+  2.2670913e-07f, 2.4144197e-07f, 2.5713223e-07f, 2.7384213e-07f,
+  2.9163793e-07f, 3.1059021e-07f, 3.3077411e-07f, 3.5226968e-07f,
+  3.7516214e-07f, 3.9954229e-07f, 4.2550680e-07f, 4.5315863e-07f,
+  4.8260743e-07f, 5.1396998e-07f, 5.4737065e-07f, 5.8294187e-07f,
+  6.2082472e-07f, 6.6116941e-07f, 7.0413592e-07f, 7.4989464e-07f,
+  7.9862701e-07f, 8.5052630e-07f, 9.0579828e-07f, 9.6466216e-07f,
+  1.0273513e-06f, 1.0941144e-06f, 1.1652161e-06f, 1.2409384e-06f,
+  1.3215816e-06f, 1.4074654e-06f, 1.4989305e-06f, 1.5963394e-06f,
+  1.7000785e-06f, 1.8105592e-06f, 1.9282195e-06f, 2.0535261e-06f,
+  2.1869758e-06f, 2.3290978e-06f, 2.4804557e-06f, 2.6416497e-06f,
+  2.8133190e-06f, 2.9961443e-06f, 3.1908506e-06f, 3.3982101e-06f,
+  3.6190449e-06f, 3.8542308e-06f, 4.1047004e-06f, 4.3714470e-06f,
+  4.6555282e-06f, 4.9580707e-06f, 5.2802740e-06f, 5.6234160e-06f,
+  5.9888572e-06f, 6.3780469e-06f, 6.7925283e-06f, 7.2339451e-06f,
+  7.7040476e-06f, 8.2047000e-06f, 8.7378876e-06f, 9.3057248e-06f,
+  9.9104632e-06f, 1.0554501e-05f, 1.1240392e-05f, 1.1970856e-05f,
+  1.2748789e-05f, 1.3577278e-05f, 1.4459606e-05f, 1.5399272e-05f,
+  1.6400004e-05f, 1.7465768e-05f, 1.8600792e-05f, 1.9809576e-05f,
+  2.1096914e-05f, 2.2467911e-05f, 2.3928002e-05f, 2.5482978e-05f,
+  2.7139006e-05f, 2.8902651e-05f, 3.0780908e-05f, 3.2781225e-05f,
+  3.4911534e-05f, 3.7180282e-05f, 3.9596466e-05f, 4.2169667e-05f,
+  4.4910090e-05f, 4.7828601e-05f, 5.0936773e-05f, 5.4246931e-05f,
+  5.7772202e-05f, 6.1526565e-05f, 6.5524908e-05f, 6.9783085e-05f,
+  7.4317983e-05f, 7.9147585e-05f, 8.4291040e-05f, 8.9768747e-05f,
+  9.5602426e-05f, 0.00010181521f, 0.00010843174f, 0.00011547824f,
+  0.00012298267f, 0.00013097477f, 0.00013948625f, 0.00014855085f,
+  0.00015820453f, 0.00016848555f, 0.00017943469f, 0.00019109536f,
+  0.00020351382f, 0.00021673929f, 0.00023082423f, 0.00024582449f,
+  0.00026179955f, 0.00027881276f, 0.00029693158f, 0.00031622787f,
+  0.00033677814f, 0.00035866388f, 0.00038197188f, 0.00040679456f,
+  0.00043323036f, 0.00046138411f, 0.00049136745f, 0.00052329927f,
+  0.00055730621f, 0.00059352311f, 0.00063209358f, 0.00067317058f,
+  0.00071691700f, 0.00076350630f, 0.00081312324f, 0.00086596457f,
+  0.00092223983f, 0.00098217216f, 0.0010459992f,  0.0011139742f,
+  0.0011863665f,  0.0012634633f,  0.0013455702f,  0.0014330129f,
+  0.0015261382f,  0.0016253153f,  0.0017309374f,  0.0018434235f,
+  0.0019632195f,  0.0020908006f,  0.0022266726f,  0.0023713743f,
+  0.0025254795f,  0.0026895994f,  0.0028643847f,  0.0030505286f,
+  0.0032487691f,  0.0034598925f,  0.0036847358f,  0.0039241906f,
+  0.0041792066f,  0.0044507950f,  0.0047400328f,  0.0050480668f,
+  0.0053761186f,  0.0057254891f,  0.0060975636f,  0.0064938176f,
+  0.0069158225f,  0.0073652516f,  0.0078438871f,  0.0083536271f,
+  0.0088964928f,  0.009474637f,   0.010090352f,   0.010746080f,
+  0.011444421f,   0.012188144f,   0.012980198f,   0.013823725f,
+  0.014722068f,   0.015678791f,   0.016697687f,   0.017782797f,
+  0.018938423f,   0.020169149f,   0.021479854f,   0.022875735f,
+  0.024362330f,   0.025945531f,   0.027631618f,   0.029427276f,
+  0.031339626f,   0.033376252f,   0.035545228f,   0.037855157f,
+  0.040315199f,   0.042935108f,   0.045725273f,   0.048696758f,
+  0.051861348f,   0.055231591f,   0.058820850f,   0.062643361f,
+  0.066714279f,   0.071049749f,   0.075666962f,   0.080584227f,
+  0.085821044f,   0.091398179f,   0.097337747f,   0.10366330f,
+  0.11039993f,    0.11757434f,    0.12521498f,    0.13335215f,
+  0.14201813f,    0.15124727f,    0.16107617f,    0.17154380f,
+  0.18269168f,    0.19456402f,    0.20720788f,    0.22067342f,
+  0.23501402f,    0.25028656f,    0.26655159f,    0.28387361f,
+  0.30232132f,    0.32196786f,    0.34289114f,    0.36517414f,
+  0.38890521f,    0.41417847f,    0.44109412f,    0.46975890f,
+  0.50028648f,    0.53279791f,    0.56742212f,    0.60429640f,
+  0.64356699f,    0.68538959f,    0.72993007f,    0.77736504f,
+  0.82788260f,    0.88168307f,    0.9389798f,     1.0f
+};
+
+
+// @OPTIMIZE: if you want to replace this bresenham line-drawing routine,
+// note that you must produce bit-identical output to decode correctly;
+// this specific sequence of operations is specified in the spec (it's
+// drawing integer-quantized frequency-space lines that the encoder
+// expects to be exactly the same)
+//     ... also, isn't the whole point of Bresenham's algorithm to NOT
+// have to divide in the setup? sigh.
+#ifndef STB_VORBIS_NO_DEFER_FLOOR
+#define LINE_OP(a,b)   a *= b
+#else
+#define LINE_OP(a,b)   a = b
+#endif
+
+#ifdef STB_VORBIS_DIVIDE_TABLE
+#define DIVTAB_NUMER   32
+#define DIVTAB_DENOM   64
+int8 integer_divide_table[DIVTAB_NUMER][DIVTAB_DENOM]; // 2KB
+#endif
+
+static __forceinline void draw_line(float *output, int x0, int y0, int x1, int y1, int n)
+{
+   int dy = y1 - y0;
+   int adx = x1 - x0;
+   int ady = abs(dy);
+   int base;
+   int x=x0,y=y0;
+   int err = 0;
+   int sy;
+
+#ifdef STB_VORBIS_DIVIDE_TABLE
+   if (adx < DIVTAB_DENOM && ady < DIVTAB_NUMER) {
+      if (dy < 0) {
+         base = -integer_divide_table[ady][adx];
+         sy = base-1;
+      } else {
+         base =  integer_divide_table[ady][adx];
+         sy = base+1;
+      }
+   } else {
+      base = dy / adx;
+      if (dy < 0)
+         sy = base - 1;
+      else
+         sy = base+1;
+   }
+#else
+   base = dy / adx;
+   if (dy < 0)
+      sy = base - 1;
+   else
+      sy = base+1;
+#endif
+   ady -= abs(base) * adx;
+   if (x1 > n) x1 = n;
+   if (x < x1) {
+      LINE_OP(output[x], inverse_db_table[y&255]);
+      for (++x; x < x1; ++x) {
+         err += ady;
+         if (err >= adx) {
+            err -= adx;
+            y += sy;
+         } else
+            y += base;
+         LINE_OP(output[x], inverse_db_table[y&255]);
+      }
+   }
+}
+
+static int residue_decode(vorb *f, Codebook *book, float *target, int offset, int n, int rtype)
+{
+   int k;
+   if (rtype == 0) {
+      int step = n / book->dimensions;
+      for (k=0; k < step; ++k)
+         if (!codebook_decode_step(f, book, target+offset+k, n-offset-k, step))
+            return FALSE;
+   } else {
+      for (k=0; k < n; ) {
+         if (!codebook_decode(f, book, target+offset, n-k))
+            return FALSE;
+         k += book->dimensions;
+         offset += book->dimensions;
+      }
+   }
+   return TRUE;
+}
+
+// n is 1/2 of the blocksize --
+// specification: "Correct per-vector decode length is [n]/2"
+static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int rn, uint8 *do_not_decode)
+{
+   int i,j,pass;
+   Residue *r = f->residue_config + rn;
+   int rtype = f->residue_types[rn];
+   int c = r->classbook;
+   int classwords = f->codebooks[c].dimensions;
+   unsigned int actual_size = rtype == 2 ? n*2 : n;
+   unsigned int limit_r_begin = (r->begin < actual_size ? r->begin : actual_size);
+   unsigned int limit_r_end   = (r->end   < actual_size ? r->end   : actual_size);
+   int n_read = limit_r_end - limit_r_begin;
+   int part_read = n_read / r->part_size;
+   int temp_alloc_point = temp_alloc_save(f);
+   #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
+   uint8 ***part_classdata = (uint8 ***) temp_block_array(f,f->channels, part_read * sizeof(**part_classdata));
+   #else
+   int **classifications = (int **) temp_block_array(f,f->channels, part_read * sizeof(**classifications));
+   #endif
+
+   CHECK(f);
+
+   for (i=0; i < ch; ++i)
+      if (!do_not_decode[i])
+         memset(residue_buffers[i], 0, sizeof(float) * n);
+
+   if (rtype == 2 && ch != 1) {
+      for (j=0; j < ch; ++j)
+         if (!do_not_decode[j])
+            break;
+      if (j == ch)
+         goto done;
+
+      for (pass=0; pass < 8; ++pass) {
+         int pcount = 0, class_set = 0;
+         if (ch == 2) {
+            while (pcount < part_read) {
+               int z = r->begin + pcount*r->part_size;
+               int c_inter = (z & 1), p_inter = z>>1;
+               if (pass == 0) {
+                  Codebook *c = f->codebooks+r->classbook;
+                  int q;
+                  DECODE(q,f,c);
+                  if (q == EOP) goto done;
+                  #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
+                  part_classdata[0][class_set] = r->classdata[q];
+                  #else
+                  for (i=classwords-1; i >= 0; --i) {
+                     classifications[0][i+pcount] = q % r->classifications;
+                     q /= r->classifications;
+                  }
+                  #endif
+               }
+               for (i=0; i < classwords && pcount < part_read; ++i, ++pcount) {
+                  int z = r->begin + pcount*r->part_size;
+                  #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
+                  int c = part_classdata[0][class_set][i];
+                  #else
+                  int c = classifications[0][pcount];
+                  #endif
+                  int b = r->residue_books[c][pass];
+                  if (b >= 0) {
+                     Codebook *book = f->codebooks + b;
+                     #ifdef STB_VORBIS_DIVIDES_IN_CODEBOOK
+                     if (!codebook_decode_deinterleave_repeat(f, book, residue_buffers, ch, &c_inter, &p_inter, n, r->part_size))
+                        goto done;
+                     #else
+                     // saves 1%
+                     if (!codebook_decode_deinterleave_repeat(f, book, residue_buffers, ch, &c_inter, &p_inter, n, r->part_size))
+                        goto done;
+                     #endif
+                  } else {
+                     z += r->part_size;
+                     c_inter = z & 1;
+                     p_inter = z >> 1;
+                  }
+               }
+               #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
+               ++class_set;
+               #endif
+            }
+         } else if (ch > 2) {
+            while (pcount < part_read) {
+               int z = r->begin + pcount*r->part_size;
+               int c_inter = z % ch, p_inter = z/ch;
+               if (pass == 0) {
+                  Codebook *c = f->codebooks+r->classbook;
+                  int q;
+                  DECODE(q,f,c);
+                  if (q == EOP) goto done;
+                  #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
+                  part_classdata[0][class_set] = r->classdata[q];
+                  #else
+                  for (i=classwords-1; i >= 0; --i) {
+                     classifications[0][i+pcount] = q % r->classifications;
+                     q /= r->classifications;
+                  }
+                  #endif
+               }
+               for (i=0; i < classwords && pcount < part_read; ++i, ++pcount) {
+                  int z = r->begin + pcount*r->part_size;
+                  #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
+                  int c = part_classdata[0][class_set][i];
+                  #else
+                  int c = classifications[0][pcount];
+                  #endif
+                  int b = r->residue_books[c][pass];
+                  if (b >= 0) {
+                     Codebook *book = f->codebooks + b;
+                     if (!codebook_decode_deinterleave_repeat(f, book, residue_buffers, ch, &c_inter, &p_inter, n, r->part_size))
+                        goto done;
+                  } else {
+                     z += r->part_size;
+                     c_inter = z % ch;
+                     p_inter = z / ch;
+                  }
+               }
+               #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
+               ++class_set;
+               #endif
+            }
+         }
+      }
+      goto done;
+   }
+   CHECK(f);
+
+   for (pass=0; pass < 8; ++pass) {
+      int pcount = 0, class_set=0;
+      while (pcount < part_read) {
+         if (pass == 0) {
+            for (j=0; j < ch; ++j) {
+               if (!do_not_decode[j]) {
+                  Codebook *c = f->codebooks+r->classbook;
+                  int temp;
+                  DECODE(temp,f,c);
+                  if (temp == EOP) goto done;
+                  #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
+                  part_classdata[j][class_set] = r->classdata[temp];
+                  #else
+                  for (i=classwords-1; i >= 0; --i) {
+                     classifications[j][i+pcount] = temp % r->classifications;
+                     temp /= r->classifications;
+                  }
+                  #endif
+               }
+            }
+         }
+         for (i=0; i < classwords && pcount < part_read; ++i, ++pcount) {
+            for (j=0; j < ch; ++j) {
+               if (!do_not_decode[j]) {
+                  #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
+                  int c = part_classdata[j][class_set][i];
+                  #else
+                  int c = classifications[j][pcount];
+                  #endif
+                  int b = r->residue_books[c][pass];
+                  if (b >= 0) {
+                     float *target = residue_buffers[j];
+                     int offset = r->begin + pcount * r->part_size;
+                     int n = r->part_size;
+                     Codebook *book = f->codebooks + b;
+                     if (!residue_decode(f, book, target, offset, n, rtype))
+                        goto done;
+                  }
+               }
+            }
+         }
+         #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
+         ++class_set;
+         #endif
+      }
+   }
+  done:
+   CHECK(f);
+   #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
+   temp_free(f,part_classdata);
+   #else
+   temp_free(f,classifications);
+   #endif
+   temp_alloc_restore(f,temp_alloc_point);
+}
+
+
+#if 0
+// slow way for debugging
+void inverse_mdct_slow(float *buffer, int n)
+{
+   int i,j;
+   int n2 = n >> 1;
+   float *x = (float *) malloc(sizeof(*x) * n2);
+   memcpy(x, buffer, sizeof(*x) * n2);
+   for (i=0; i < n; ++i) {
+      float acc = 0;
+      for (j=0; j < n2; ++j)
+         // formula from paper:
+         //acc += n/4.0f * x[j] * (float) cos(M_PI / 2 / n * (2 * i + 1 + n/2.0)*(2*j+1));
+         // formula from wikipedia
+         //acc += 2.0f / n2 * x[j] * (float) cos(M_PI/n2 * (i + 0.5 + n2/2)*(j + 0.5));
+         // these are equivalent, except the formula from the paper inverts the multiplier!
+         // however, what actually works is NO MULTIPLIER!?!
+         //acc += 64 * 2.0f / n2 * x[j] * (float) cos(M_PI/n2 * (i + 0.5 + n2/2)*(j + 0.5));
+         acc += x[j] * (float) cos(M_PI / 2 / n * (2 * i + 1 + n/2.0)*(2*j+1));
+      buffer[i] = acc;
+   }
+   free(x);
+}
+#elif 0
+// same as above, but just barely able to run in real time on modern machines
+void inverse_mdct_slow(float *buffer, int n, vorb *f, int blocktype)
+{
+   float mcos[16384];
+   int i,j;
+   int n2 = n >> 1, nmask = (n << 2) -1;
+   float *x = (float *) malloc(sizeof(*x) * n2);
+   memcpy(x, buffer, sizeof(*x) * n2);
+   for (i=0; i < 4*n; ++i)
+      mcos[i] = (float) cos(M_PI / 2 * i / n);
+
+   for (i=0; i < n; ++i) {
+      float acc = 0;
+      for (j=0; j < n2; ++j)
+         acc += x[j] * mcos[(2 * i + 1 + n2)*(2*j+1) & nmask];
+      buffer[i] = acc;
+   }
+   free(x);
+}
+#elif 0
+// transform to use a slow dct-iv; this is STILL basically trivial,
+// but only requires half as many ops
+void dct_iv_slow(float *buffer, int n)
+{
+   float mcos[16384];
+   float x[2048];
+   int i,j;
+   int n2 = n >> 1, nmask = (n << 3) - 1;
+   memcpy(x, buffer, sizeof(*x) * n);
+   for (i=0; i < 8*n; ++i)
+      mcos[i] = (float) cos(M_PI / 4 * i / n);
+   for (i=0; i < n; ++i) {
+      float acc = 0;
+      for (j=0; j < n; ++j)
+         acc += x[j] * mcos[((2 * i + 1)*(2*j+1)) & nmask];
+      buffer[i] = acc;
+   }
+}
+
+void inverse_mdct_slow(float *buffer, int n, vorb *f, int blocktype)
+{
+   int i, n4 = n >> 2, n2 = n >> 1, n3_4 = n - n4;
+   float temp[4096];
+
+   memcpy(temp, buffer, n2 * sizeof(float));
+   dct_iv_slow(temp, n2);  // returns -c'-d, a-b'
+
+   for (i=0; i < n4  ; ++i) buffer[i] = temp[i+n4];            // a-b'
+   for (   ; i < n3_4; ++i) buffer[i] = -temp[n3_4 - i - 1];   // b-a', c+d'
+   for (   ; i < n   ; ++i) buffer[i] = -temp[i - n3_4];       // c'+d
+}
+#endif
+
+#ifndef LIBVORBIS_MDCT
+#define LIBVORBIS_MDCT 0
+#endif
+
+#if LIBVORBIS_MDCT
+// directly call the vorbis MDCT using an interface documented
+// by Jeff Roberts... useful for performance comparison
+typedef struct
+{
+  int n;
+  int log2n;
+
+  float *trig;
+  int   *bitrev;
+
+  float scale;
+} mdct_lookup;
+
+extern void mdct_init(mdct_lookup *lookup, int n);
+extern void mdct_clear(mdct_lookup *l);
+extern void mdct_backward(mdct_lookup *init, float *in, float *out);
+
+mdct_lookup M1,M2;
+
+void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
+{
+   mdct_lookup *M;
+   if (M1.n == n) M = &M1;
+   else if (M2.n == n) M = &M2;
+   else if (M1.n == 0) { mdct_init(&M1, n); M = &M1; }
+   else {
+      if (M2.n) __asm int 3;
+      mdct_init(&M2, n);
+      M = &M2;
+   }
+
+   mdct_backward(M, buffer, buffer);
+}
+#endif
+
+
+// the following were split out into separate functions while optimizing;
+// they could be pushed back up but eh. __forceinline showed no change;
+// they're probably already being inlined.
+static void imdct_step3_iter0_loop(int n, float *e, int i_off, int k_off, float *A)
+{
+   float *ee0 = e + i_off;
+   float *ee2 = ee0 + k_off;
+   int i;
+
+   assert((n & 3) == 0);
+   for (i=(n>>2); i > 0; --i) {
+      float k00_20, k01_21;
+      k00_20  = ee0[ 0] - ee2[ 0];
+      k01_21  = ee0[-1] - ee2[-1];
+      ee0[ 0] += ee2[ 0];//ee0[ 0] = ee0[ 0] + ee2[ 0];
+      ee0[-1] += ee2[-1];//ee0[-1] = ee0[-1] + ee2[-1];
+      ee2[ 0] = k00_20 * A[0] - k01_21 * A[1];
+      ee2[-1] = k01_21 * A[0] + k00_20 * A[1];
+      A += 8;
+
+      k00_20  = ee0[-2] - ee2[-2];
+      k01_21  = ee0[-3] - ee2[-3];
+      ee0[-2] += ee2[-2];//ee0[-2] = ee0[-2] + ee2[-2];
+      ee0[-3] += ee2[-3];//ee0[-3] = ee0[-3] + ee2[-3];
+      ee2[-2] = k00_20 * A[0] - k01_21 * A[1];
+      ee2[-3] = k01_21 * A[0] + k00_20 * A[1];
+      A += 8;
+
+      k00_20  = ee0[-4] - ee2[-4];
+      k01_21  = ee0[-5] - ee2[-5];
+      ee0[-4] += ee2[-4];//ee0[-4] = ee0[-4] + ee2[-4];
+      ee0[-5] += ee2[-5];//ee0[-5] = ee0[-5] + ee2[-5];
+      ee2[-4] = k00_20 * A[0] - k01_21 * A[1];
+      ee2[-5] = k01_21 * A[0] + k00_20 * A[1];
+      A += 8;
+
+      k00_20  = ee0[-6] - ee2[-6];
+      k01_21  = ee0[-7] - ee2[-7];
+      ee0[-6] += ee2[-6];//ee0[-6] = ee0[-6] + ee2[-6];
+      ee0[-7] += ee2[-7];//ee0[-7] = ee0[-7] + ee2[-7];
+      ee2[-6] = k00_20 * A[0] - k01_21 * A[1];
+      ee2[-7] = k01_21 * A[0] + k00_20 * A[1];
+      A += 8;
+      ee0 -= 8;
+      ee2 -= 8;
+   }
+}
+
+static void imdct_step3_inner_r_loop(int lim, float *e, int d0, int k_off, float *A, int k1)
+{
+   int i;
+   float k00_20, k01_21;
+
+   float *e0 = e + d0;
+   float *e2 = e0 + k_off;
+
+   for (i=lim >> 2; i > 0; --i) {
+      k00_20 = e0[-0] - e2[-0];
+      k01_21 = e0[-1] - e2[-1];
+      e0[-0] += e2[-0];//e0[-0] = e0[-0] + e2[-0];
+      e0[-1] += e2[-1];//e0[-1] = e0[-1] + e2[-1];
+      e2[-0] = (k00_20)*A[0] - (k01_21) * A[1];
+      e2[-1] = (k01_21)*A[0] + (k00_20) * A[1];
+
+      A += k1;
+
+      k00_20 = e0[-2] - e2[-2];
+      k01_21 = e0[-3] - e2[-3];
+      e0[-2] += e2[-2];//e0[-2] = e0[-2] + e2[-2];
+      e0[-3] += e2[-3];//e0[-3] = e0[-3] + e2[-3];
+      e2[-2] = (k00_20)*A[0] - (k01_21) * A[1];
+      e2[-3] = (k01_21)*A[0] + (k00_20) * A[1];
+
+      A += k1;
+
+      k00_20 = e0[-4] - e2[-4];
+      k01_21 = e0[-5] - e2[-5];
+      e0[-4] += e2[-4];//e0[-4] = e0[-4] + e2[-4];
+      e0[-5] += e2[-5];//e0[-5] = e0[-5] + e2[-5];
+      e2[-4] = (k00_20)*A[0] - (k01_21) * A[1];
+      e2[-5] = (k01_21)*A[0] + (k00_20) * A[1];
+
+      A += k1;
+
+      k00_20 = e0[-6] - e2[-6];
+      k01_21 = e0[-7] - e2[-7];
+      e0[-6] += e2[-6];//e0[-6] = e0[-6] + e2[-6];
+      e0[-7] += e2[-7];//e0[-7] = e0[-7] + e2[-7];
+      e2[-6] = (k00_20)*A[0] - (k01_21) * A[1];
+      e2[-7] = (k01_21)*A[0] + (k00_20) * A[1];
+
+      e0 -= 8;
+      e2 -= 8;
+
+      A += k1;
+   }
+}
+
+static void imdct_step3_inner_s_loop(int n, float *e, int i_off, int k_off, float *A, int a_off, int k0)
+{
+   int i;
+   float A0 = A[0];
+   float A1 = A[0+1];
+   float A2 = A[0+a_off];
+   float A3 = A[0+a_off+1];
+   float A4 = A[0+a_off*2+0];
+   float A5 = A[0+a_off*2+1];
+   float A6 = A[0+a_off*3+0];
+   float A7 = A[0+a_off*3+1];
+
+   float k00,k11;
+
+   float *ee0 = e  +i_off;
+   float *ee2 = ee0+k_off;
+
+   for (i=n; i > 0; --i) {
+      k00     = ee0[ 0] - ee2[ 0];
+      k11     = ee0[-1] - ee2[-1];
+      ee0[ 0] =  ee0[ 0] + ee2[ 0];
+      ee0[-1] =  ee0[-1] + ee2[-1];
+      ee2[ 0] = (k00) * A0 - (k11) * A1;
+      ee2[-1] = (k11) * A0 + (k00) * A1;
+
+      k00     = ee0[-2] - ee2[-2];
+      k11     = ee0[-3] - ee2[-3];
+      ee0[-2] =  ee0[-2] + ee2[-2];
+      ee0[-3] =  ee0[-3] + ee2[-3];
+      ee2[-2] = (k00) * A2 - (k11) * A3;
+      ee2[-3] = (k11) * A2 + (k00) * A3;
+
+      k00     = ee0[-4] - ee2[-4];
+      k11     = ee0[-5] - ee2[-5];
+      ee0[-4] =  ee0[-4] + ee2[-4];
+      ee0[-5] =  ee0[-5] + ee2[-5];
+      ee2[-4] = (k00) * A4 - (k11) * A5;
+      ee2[-5] = (k11) * A4 + (k00) * A5;
+
+      k00     = ee0[-6] - ee2[-6];
+      k11     = ee0[-7] - ee2[-7];
+      ee0[-6] =  ee0[-6] + ee2[-6];
+      ee0[-7] =  ee0[-7] + ee2[-7];
+      ee2[-6] = (k00) * A6 - (k11) * A7;
+      ee2[-7] = (k11) * A6 + (k00) * A7;
+
+      ee0 -= k0;
+      ee2 -= k0;
+   }
+}
+
+static __forceinline void iter_54(float *z)
+{
+   float k00,k11,k22,k33;
+   float y0,y1,y2,y3;
+
+   k00  = z[ 0] - z[-4];
+   y0   = z[ 0] + z[-4];
+   y2   = z[-2] + z[-6];
+   k22  = z[-2] - z[-6];
+
+   z[-0] = y0 + y2;      // z0 + z4 + z2 + z6
+   z[-2] = y0 - y2;      // z0 + z4 - z2 - z6
+
+   // done with y0,y2
+
+   k33  = z[-3] - z[-7];
+
+   z[-4] = k00 + k33;    // z0 - z4 + z3 - z7
+   z[-6] = k00 - k33;    // z0 - z4 - z3 + z7
+
+   // done with k33
+
+   k11  = z[-1] - z[-5];
+   y1   = z[-1] + z[-5];
+   y3   = z[-3] + z[-7];
+
+   z[-1] = y1 + y3;      // z1 + z5 + z3 + z7
+   z[-3] = y1 - y3;      // z1 + z5 - z3 - z7
+   z[-5] = k11 - k22;    // z1 - z5 + z2 - z6
+   z[-7] = k11 + k22;    // z1 - z5 - z2 + z6
+}
+
+static void imdct_step3_inner_s_loop_ld654(int n, float *e, int i_off, float *A, int base_n)
+{
+   int a_off = base_n >> 3;
+   float A2 = A[0+a_off];
+   float *z = e + i_off;
+   float *base = z - 16 * n;
+
+   while (z > base) {
+      float k00,k11;
+      float l00,l11;
+
+      k00    = z[-0] - z[ -8];
+      k11    = z[-1] - z[ -9];
+      l00    = z[-2] - z[-10];
+      l11    = z[-3] - z[-11];
+      z[ -0] = z[-0] + z[ -8];
+      z[ -1] = z[-1] + z[ -9];
+      z[ -2] = z[-2] + z[-10];
+      z[ -3] = z[-3] + z[-11];
+      z[ -8] = k00;
+      z[ -9] = k11;
+      z[-10] = (l00+l11) * A2;
+      z[-11] = (l11-l00) * A2;
+
+      k00    = z[ -4] - z[-12];
+      k11    = z[ -5] - z[-13];
+      l00    = z[ -6] - z[-14];
+      l11    = z[ -7] - z[-15];
+      z[ -4] = z[ -4] + z[-12];
+      z[ -5] = z[ -5] + z[-13];
+      z[ -6] = z[ -6] + z[-14];
+      z[ -7] = z[ -7] + z[-15];
+      z[-12] = k11;
+      z[-13] = -k00;
+      z[-14] = (l11-l00) * A2;
+      z[-15] = (l00+l11) * -A2;
+
+      iter_54(z);
+      iter_54(z-8);
+      z -= 16;
+   }
+}
+
+static void inverse_mdct(float *buffer, int n, vorb *f, int blocktype)
+{
+   int n2 = n >> 1, n4 = n >> 2, n8 = n >> 3, l;
+   int ld;
+   // @OPTIMIZE: reduce register pressure by using fewer variables?
+   int save_point = temp_alloc_save(f);
+   float *buf2 = (float *) temp_alloc(f, n2 * sizeof(*buf2));
+   float *u=NULL,*v=NULL;
+   // twiddle factors
+   float *A = f->A[blocktype];
+
+   // IMDCT algorithm from "The use of multirate filter banks for coding of high quality digital audio"
+   // See notes about bugs in that paper in less-optimal implementation 'inverse_mdct_old' after this function.
+
+   // kernel from paper
+
+
+   // merged:
+   //   copy and reflect spectral data
+   //   step 0
+
+   // note that it turns out that the items added together during
+   // this step are, in fact, being added to themselves (as reflected
+   // by step 0). inexplicable inefficiency! this became obvious
+   // once I combined the passes.
+
+   // so there's a missing 'times 2' here (for adding X to itself).
+   // this propagates through linearly to the end, where the numbers
+   // are 1/2 too small, and need to be compensated for.
+
+   {
+      float *d,*e, *AA, *e_stop;
+      d = &buf2[n2-2];
+      AA = A;
+      e = &buffer[0];
+      e_stop = &buffer[n2];
+      while (e != e_stop) {
+         d[1] = (e[0] * AA[0] - e[2]*AA[1]);
+         d[0] = (e[0] * AA[1] + e[2]*AA[0]);
+         d -= 2;
+         AA += 2;
+         e += 4;
+      }
+
+      e = &buffer[n2-3];
+      while (d >= buf2) {
+         d[1] = (-e[2] * AA[0] - -e[0]*AA[1]);
+         d[0] = (-e[2] * AA[1] + -e[0]*AA[0]);
+         d -= 2;
+         AA += 2;
+         e -= 4;
+      }
+   }
+
+   // now we use symbolic names for these, so that we can
+   // possibly swap their meaning as we change which operations
+   // are in place
+
+   u = buffer;
+   v = buf2;
+
+   // step 2    (paper output is w, now u)
+   // this could be in place, but the data ends up in the wrong
+   // place... _somebody_'s got to swap it, so this is nominated
+   {
+      float *AA = &A[n2-8];
+      float *d0,*d1, *e0, *e1;
+
+      e0 = &v[n4];
+      e1 = &v[0];
+
+      d0 = &u[n4];
+      d1 = &u[0];
+
+      while (AA >= A) {
+         float v40_20, v41_21;
+
+         v41_21 = e0[1] - e1[1];
+         v40_20 = e0[0] - e1[0];
+         d0[1]  = e0[1] + e1[1];
+         d0[0]  = e0[0] + e1[0];
+         d1[1]  = v41_21*AA[4] - v40_20*AA[5];
+         d1[0]  = v40_20*AA[4] + v41_21*AA[5];
+
+         v41_21 = e0[3] - e1[3];
+         v40_20 = e0[2] - e1[2];
+         d0[3]  = e0[3] + e1[3];
+         d0[2]  = e0[2] + e1[2];
+         d1[3]  = v41_21*AA[0] - v40_20*AA[1];
+         d1[2]  = v40_20*AA[0] + v41_21*AA[1];
+
+         AA -= 8;
+
+         d0 += 4;
+         d1 += 4;
+         e0 += 4;
+         e1 += 4;
+      }
+   }
+
+   // step 3
+   ld = ilog(n) - 1; // ilog is off-by-one from normal definitions
+
+   // optimized step 3:
+
+   // the original step3 loop can be nested r inside s or s inside r;
+   // it's written originally as s inside r, but this is dumb when r
+   // iterates many times, and s few. So I have two copies of it and
+   // switch between them halfway.
+
+   // this is iteration 0 of step 3
+   imdct_step3_iter0_loop(n >> 4, u, n2-1-n4*0, -(n >> 3), A);
+   imdct_step3_iter0_loop(n >> 4, u, n2-1-n4*1, -(n >> 3), A);
+
+   // this is iteration 1 of step 3
+   imdct_step3_inner_r_loop(n >> 5, u, n2-1 - n8*0, -(n >> 4), A, 16);
+   imdct_step3_inner_r_loop(n >> 5, u, n2-1 - n8*1, -(n >> 4), A, 16);
+   imdct_step3_inner_r_loop(n >> 5, u, n2-1 - n8*2, -(n >> 4), A, 16);
+   imdct_step3_inner_r_loop(n >> 5, u, n2-1 - n8*3, -(n >> 4), A, 16);
+
+   l=2;
+   for (; l < (ld-3)>>1; ++l) {
+      int k0 = n >> (l+2), k0_2 = k0>>1;
+      int lim = 1 << (l+1);
+      int i;
+      for (i=0; i < lim; ++i)
+         imdct_step3_inner_r_loop(n >> (l+4), u, n2-1 - k0*i, -k0_2, A, 1 << (l+3));
+   }
+
+   for (; l < ld-6; ++l) {
+      int k0 = n >> (l+2), k1 = 1 << (l+3), k0_2 = k0>>1;
+      int rlim = n >> (l+6), r;
+      int lim = 1 << (l+1);
+      int i_off;
+      float *A0 = A;
+      i_off = n2-1;
+      for (r=rlim; r > 0; --r) {
+         imdct_step3_inner_s_loop(lim, u, i_off, -k0_2, A0, k1, k0);
+         A0 += k1*4;
+         i_off -= 8;
+      }
+   }
+
+   // iterations with count:
+   //   ld-6,-5,-4 all interleaved together
+   //       the big win comes from getting rid of needless flops
+   //         due to the constants on pass 5 & 4 being all 1 and 0;
+   //       combining them to be simultaneous to improve cache made little difference
+   imdct_step3_inner_s_loop_ld654(n >> 5, u, n2-1, A, n);
+
+   // output is u
+
+   // step 4, 5, and 6
+   // cannot be in-place because of step 5
+   {
+      uint16 *bitrev = f->bit_reverse[blocktype];
+      // weirdly, I'd have thought reading sequentially and writing
+      // erratically would have been better than vice-versa, but in
+      // fact that's not what my testing showed. (That is, with
+      // j = bitreverse(i), do you read i and write j, or read j and write i.)
+
+      float *d0 = &v[n4-4];
+      float *d1 = &v[n2-4];
+      while (d0 >= v) {
+         int k4;
+
+         k4 = bitrev[0];
+         d1[3] = u[k4+0];
+         d1[2] = u[k4+1];
+         d0[3] = u[k4+2];
+         d0[2] = u[k4+3];
+
+         k4 = bitrev[1];
+         d1[1] = u[k4+0];
+         d1[0] = u[k4+1];
+         d0[1] = u[k4+2];
+         d0[0] = u[k4+3];
+
+         d0 -= 4;
+         d1 -= 4;
+         bitrev += 2;
+      }
+   }
+   // (paper output is u, now v)
+
+
+   // data must be in buf2
+   assert(v == buf2);
+
+   // step 7   (paper output is v, now v)
+   // this is now in place
+   {
+      float *C = f->C[blocktype];
+      float *d, *e;
+
+      d = v;
+      e = v + n2 - 4;
+
+      while (d < e) {
+         float a02,a11,b0,b1,b2,b3;
+
+         a02 = d[0] - e[2];
+         a11 = d[1] + e[3];
+
+         b0 = C[1]*a02 + C[0]*a11;
+         b1 = C[1]*a11 - C[0]*a02;
+
+         b2 = d[0] + e[ 2];
+         b3 = d[1] - e[ 3];
+
+         d[0] = b2 + b0;
+         d[1] = b3 + b1;
+         e[2] = b2 - b0;
+         e[3] = b1 - b3;
+
+         a02 = d[2] - e[0];
+         a11 = d[3] + e[1];
+
+         b0 = C[3]*a02 + C[2]*a11;
+         b1 = C[3]*a11 - C[2]*a02;
+
+         b2 = d[2] + e[ 0];
+         b3 = d[3] - e[ 1];
+
+         d[2] = b2 + b0;
+         d[3] = b3 + b1;
+         e[0] = b2 - b0;
+         e[1] = b1 - b3;
+
+         C += 4;
+         d += 4;
+         e -= 4;
+      }
+   }
+
+   // data must be in buf2
+
+
+   // step 8+decode   (paper output is X, now buffer)
+   // this generates pairs of data a la 8 and pushes them directly through
+   // the decode kernel (pushing rather than pulling) to avoid having
+   // to make another pass later
+
+   // this cannot POSSIBLY be in place, so we refer to the buffers directly
+
+   {
+      float *d0,*d1,*d2,*d3;
+
+      float *B = f->B[blocktype] + n2 - 8;
+      float *e = buf2 + n2 - 8;
+      d0 = &buffer[0];
+      d1 = &buffer[n2-4];
+      d2 = &buffer[n2];
+      d3 = &buffer[n-4];
+      while (e >= v) {
+         float p0,p1,p2,p3;
+
+         p3 =  e[6]*B[7] - e[7]*B[6];
+         p2 = -e[6]*B[6] - e[7]*B[7];
+
+         d0[0] =   p3;
+         d1[3] = - p3;
+         d2[0] =   p2;
+         d3[3] =   p2;
+
+         p1 =  e[4]*B[5] - e[5]*B[4];
+         p0 = -e[4]*B[4] - e[5]*B[5];
+
+         d0[1] =   p1;
+         d1[2] = - p1;
+         d2[1] =   p0;
+         d3[2] =   p0;
+
+         p3 =  e[2]*B[3] - e[3]*B[2];
+         p2 = -e[2]*B[2] - e[3]*B[3];
+
+         d0[2] =   p3;
+         d1[1] = - p3;
+         d2[2] =   p2;
+         d3[1] =   p2;
+
+         p1 =  e[0]*B[1] - e[1]*B[0];
+         p0 = -e[0]*B[0] - e[1]*B[1];
+
+         d0[3] =   p1;
+         d1[0] = - p1;
+         d2[3] =   p0;
+         d3[0] =   p0;
+
+         B -= 8;
+         e -= 8;
+         d0 += 4;
+         d2 += 4;
+         d1 -= 4;
+         d3 -= 4;
+      }
+   }
+
+   temp_free(f,buf2);
+   temp_alloc_restore(f,save_point);
+}
+
+#if 0
+// this is the original version of the above code, if you want to optimize it from scratch
+void inverse_mdct_naive(float *buffer, int n)
+{
+   float s;
+   float A[1 << 12], B[1 << 12], C[1 << 11];
+   int i,k,k2,k4, n2 = n >> 1, n4 = n >> 2, n8 = n >> 3, l;
+   int n3_4 = n - n4, ld;
+   // how can they claim this only uses N words?!
+   // oh, because they're only used sparsely, whoops
+   float u[1 << 13], X[1 << 13], v[1 << 13], w[1 << 13];
+   // set up twiddle factors
+
+   for (k=k2=0; k < n4; ++k,k2+=2) {
+      A[k2  ] = (float)  cos(4*k*M_PI/n);
+      A[k2+1] = (float) -sin(4*k*M_PI/n);
+      B[k2  ] = (float)  cos((k2+1)*M_PI/n/2);
+      B[k2+1] = (float)  sin((k2+1)*M_PI/n/2);
+   }
+   for (k=k2=0; k < n8; ++k,k2+=2) {
+      C[k2  ] = (float)  cos(2*(k2+1)*M_PI/n);
+      C[k2+1] = (float) -sin(2*(k2+1)*M_PI/n);
+   }
+
+   // IMDCT algorithm from "The use of multirate filter banks for coding of high quality digital audio"
+   // Note there are bugs in that pseudocode, presumably due to them attempting
+   // to rename the arrays nicely rather than representing the way their actual
+   // implementation bounces buffers back and forth. As a result, even in the
+   // "some formulars corrected" version, a direct implementation fails. These
+   // are noted below as "paper bug".
+
+   // copy and reflect spectral data
+   for (k=0; k < n2; ++k) u[k] = buffer[k];
+   for (   ; k < n ; ++k) u[k] = -buffer[n - k - 1];
+   // kernel from paper
+   // step 1
+   for (k=k2=k4=0; k < n4; k+=1, k2+=2, k4+=4) {
+      v[n-k4-1] = (u[k4] - u[n-k4-1]) * A[k2]   - (u[k4+2] - u[n-k4-3])*A[k2+1];
+      v[n-k4-3] = (u[k4] - u[n-k4-1]) * A[k2+1] + (u[k4+2] - u[n-k4-3])*A[k2];
+   }
+   // step 2
+   for (k=k4=0; k < n8; k+=1, k4+=4) {
+      w[n2+3+k4] = v[n2+3+k4] + v[k4+3];
+      w[n2+1+k4] = v[n2+1+k4] + v[k4+1];
+      w[k4+3]    = (v[n2+3+k4] - v[k4+3])*A[n2-4-k4] - (v[n2+1+k4]-v[k4+1])*A[n2-3-k4];
+      w[k4+1]    = (v[n2+1+k4] - v[k4+1])*A[n2-4-k4] + (v[n2+3+k4]-v[k4+3])*A[n2-3-k4];
+   }
+   // step 3
+   ld = ilog(n) - 1; // ilog is off-by-one from normal definitions
+   for (l=0; l < ld-3; ++l) {
+      int k0 = n >> (l+2), k1 = 1 << (l+3);
+      int rlim = n >> (l+4), r4, r;
+      int s2lim = 1 << (l+2), s2;
+      for (r=r4=0; r < rlim; r4+=4,++r) {
+         for (s2=0; s2 < s2lim; s2+=2) {
+            u[n-1-k0*s2-r4] = w[n-1-k0*s2-r4] + w[n-1-k0*(s2+1)-r4];
+            u[n-3-k0*s2-r4] = w[n-3-k0*s2-r4] + w[n-3-k0*(s2+1)-r4];
+            u[n-1-k0*(s2+1)-r4] = (w[n-1-k0*s2-r4] - w[n-1-k0*(s2+1)-r4]) * A[r*k1]
+                                - (w[n-3-k0*s2-r4] - w[n-3-k0*(s2+1)-r4]) * A[r*k1+1];
+            u[n-3-k0*(s2+1)-r4] = (w[n-3-k0*s2-r4] - w[n-3-k0*(s2+1)-r4]) * A[r*k1]
+                                + (w[n-1-k0*s2-r4] - w[n-1-k0*(s2+1)-r4]) * A[r*k1+1];
+         }
+      }
+      if (l+1 < ld-3) {
+         // paper bug: ping-ponging of u&w here is omitted
+         memcpy(w, u, sizeof(u));
+      }
+   }
+
+   // step 4
+   for (i=0; i < n8; ++i) {
+      int j = bit_reverse(i) >> (32-ld+3);
+      assert(j < n8);
+      if (i == j) {
+         // paper bug: original code probably swapped in place; if copying,
+         //            need to directly copy in this case
+         int i8 = i << 3;
+         v[i8+1] = u[i8+1];
+         v[i8+3] = u[i8+3];
+         v[i8+5] = u[i8+5];
+         v[i8+7] = u[i8+7];
+      } else if (i < j) {
+         int i8 = i << 3, j8 = j << 3;
+         v[j8+1] = u[i8+1], v[i8+1] = u[j8 + 1];
+         v[j8+3] = u[i8+3], v[i8+3] = u[j8 + 3];
+         v[j8+5] = u[i8+5], v[i8+5] = u[j8 + 5];
+         v[j8+7] = u[i8+7], v[i8+7] = u[j8 + 7];
+      }
+   }
+   // step 5
+   for (k=0; k < n2; ++k) {
+      w[k] = v[k*2+1];
+   }
+   // step 6
+   for (k=k2=k4=0; k < n8; ++k, k2 += 2, k4 += 4) {
+      u[n-1-k2] = w[k4];
+      u[n-2-k2] = w[k4+1];
+      u[n3_4 - 1 - k2] = w[k4+2];
+      u[n3_4 - 2 - k2] = w[k4+3];
+   }
+   // step 7
+   for (k=k2=0; k < n8; ++k, k2 += 2) {
+      v[n2 + k2 ] = ( u[n2 + k2] + u[n-2-k2] + C[k2+1]*(u[n2+k2]-u[n-2-k2]) + C[k2]*(u[n2+k2+1]+u[n-2-k2+1]))/2;
+      v[n-2 - k2] = ( u[n2 + k2] + u[n-2-k2] - C[k2+1]*(u[n2+k2]-u[n-2-k2]) - C[k2]*(u[n2+k2+1]+u[n-2-k2+1]))/2;
+      v[n2+1+ k2] = ( u[n2+1+k2] - u[n-1-k2] + C[k2+1]*(u[n2+1+k2]+u[n-1-k2]) - C[k2]*(u[n2+k2]-u[n-2-k2]))/2;
+      v[n-1 - k2] = (-u[n2+1+k2] + u[n-1-k2] + C[k2+1]*(u[n2+1+k2]+u[n-1-k2]) - C[k2]*(u[n2+k2]-u[n-2-k2]))/2;
+   }
+   // step 8
+   for (k=k2=0; k < n4; ++k,k2 += 2) {
+      X[k]      = v[k2+n2]*B[k2  ] + v[k2+1+n2]*B[k2+1];
+      X[n2-1-k] = v[k2+n2]*B[k2+1] - v[k2+1+n2]*B[k2  ];
+   }
+
+   // decode kernel to output
+   // determined the following value experimentally
+   // (by first figuring out what made inverse_mdct_slow work); then matching that here
+   // (probably vorbis encoder premultiplies by n or n/2, to save it on the decoder?)
+   s = 0.5; // theoretically would be n4
+
+   // [[[ note! the s value of 0.5 is compensated for by the B[] in the current code,
+   //     so it needs to use the "old" B values to behave correctly, or else
+   //     set s to 1.0 ]]]
+   for (i=0; i < n4  ; ++i) buffer[i] = s * X[i+n4];
+   for (   ; i < n3_4; ++i) buffer[i] = -s * X[n3_4 - i - 1];
+   for (   ; i < n   ; ++i) buffer[i] = -s * X[i - n3_4];
+}
+#endif
+
+static float *get_window(vorb *f, int len)
+{
+   len <<= 1;
+   if (len == f->blocksize_0) return f->window[0];
+   if (len == f->blocksize_1) return f->window[1];
+   return NULL;
+}
+
+#ifndef STB_VORBIS_NO_DEFER_FLOOR
+typedef int16 YTYPE;
+#else
+typedef int YTYPE;
+#endif
+static int do_floor(vorb *f, Mapping *map, int i, int n, float *target, YTYPE *finalY, uint8 *step2_flag)
+{
+   int n2 = n >> 1;
+   int s = map->chan[i].mux, floor;
+   floor = map->submap_floor[s];
+   if (f->floor_types[floor] == 0) {
+      return error(f, VORBIS_invalid_stream);
+   } else {
+      Floor1 *g = &f->floor_config[floor].floor1;
+      int j,q;
+      int lx = 0, ly = finalY[0] * g->floor1_multiplier;
+      for (q=1; q < g->values; ++q) {
+         j = g->sorted_order[q];
+         #ifndef STB_VORBIS_NO_DEFER_FLOOR
+         STBV_NOTUSED(step2_flag);
+         if (finalY[j] >= 0)
+         #else
+         if (step2_flag[j])
+         #endif
+         {
+            int hy = finalY[j] * g->floor1_multiplier;
+            int hx = g->Xlist[j];
+            if (lx != hx)
+               draw_line(target, lx,ly, hx,hy, n2);
+            CHECK(f);
+            lx = hx, ly = hy;
+         }
+      }
+      if (lx < n2) {
+         // optimization of: draw_line(target, lx,ly, n,ly, n2);
+         for (j=lx; j < n2; ++j)
+            LINE_OP(target[j], inverse_db_table[ly]);
+         CHECK(f);
+      }
+   }
+   return TRUE;
+}
+
+// The meaning of "left" and "right"
+//
+// For a given frame:
+//     we compute samples from 0..n
+//     window_center is n/2
+//     we'll window and mix the samples from left_start to left_end with data from the previous frame
+//     all of the samples from left_end to right_start can be output without mixing; however,
+//        this interval is 0-length except when transitioning between short and long frames
+//     all of the samples from right_start to right_end need to be mixed with the next frame,
+//        which we don't have, so those get saved in a buffer
+//     frame N's right_end-right_start, the number of samples to mix with the next frame,
+//        has to be the same as frame N+1's left_end-left_start (which they are by
+//        construction)
+
+static int vorbis_decode_initial(vorb *f, int *p_left_start, int *p_left_end, int *p_right_start, int *p_right_end, int *mode)
+{
+   Mode *m;
+   int i, n, prev, next, window_center;
+   f->channel_buffer_start = f->channel_buffer_end = 0;
+
+  retry:
+   if (f->eof) return FALSE;
+   if (!maybe_start_packet(f))
+      return FALSE;
+   // check packet type
+   if (get_bits(f,1) != 0) {
+      if (IS_PUSH_MODE(f))
+         return error(f,VORBIS_bad_packet_type);
+      while (EOP != get8_packet(f));
+      goto retry;
+   }
+
+   if (f->alloc.alloc_buffer)
+      assert(f->alloc.alloc_buffer_length_in_bytes == f->temp_offset);
+
+   i = get_bits(f, ilog(f->mode_count-1));
+   if (i == EOP) return FALSE;
+   if (i >= f->mode_count) return FALSE;
+   *mode = i;
+   m = f->mode_config + i;
+   if (m->blockflag) {
+      n = f->blocksize_1;
+      prev = get_bits(f,1);
+      next = get_bits(f,1);
+   } else {
+      prev = next = 0;
+      n = f->blocksize_0;
+   }
+
+// WINDOWING
+
+   window_center = n >> 1;
+   if (m->blockflag && !prev) {
+      *p_left_start = (n - f->blocksize_0) >> 2;
+      *p_left_end   = (n + f->blocksize_0) >> 2;
+   } else {
+      *p_left_start = 0;
+      *p_left_end   = window_center;
+   }
+   if (m->blockflag && !next) {
+      *p_right_start = (n*3 - f->blocksize_0) >> 2;
+      *p_right_end   = (n*3 + f->blocksize_0) >> 2;
+   } else {
+      *p_right_start = window_center;
+      *p_right_end   = n;
+   }
+
+   return TRUE;
+}
+
+static int vorbis_decode_packet_rest(vorb *f, int *len, Mode *m, int left_start, int left_end, int right_start, int right_end, int *p_left)
+{
+   Mapping *map;
+   int i,j,k,n,n2;
+   int zero_channel[256];
+   int really_zero_channel[256];
+
+// WINDOWING
+
+   STBV_NOTUSED(left_end);
+   n = f->blocksize[m->blockflag];
+   map = &f->mapping[m->mapping];
+
+// FLOORS
+   n2 = n >> 1;
+
+   CHECK(f);
+
+   for (i=0; i < f->channels; ++i) {
+      int s = map->chan[i].mux, floor;
+      zero_channel[i] = FALSE;
+      floor = map->submap_floor[s];
+      if (f->floor_types[floor] == 0) {
+         return error(f, VORBIS_invalid_stream);
+      } else {
+         Floor1 *g = &f->floor_config[floor].floor1;
+         if (get_bits(f, 1)) {
+            short *finalY;
+            uint8 step2_flag[256];
+            static int range_list[4] = { 256, 128, 86, 64 };
+            int range = range_list[g->floor1_multiplier-1];
+            int offset = 2;
+            finalY = f->finalY[i];
+            finalY[0] = get_bits(f, ilog(range)-1);
+            finalY[1] = get_bits(f, ilog(range)-1);
+            for (j=0; j < g->partitions; ++j) {
+               int pclass = g->partition_class_list[j];
+               int cdim = g->class_dimensions[pclass];
+               int cbits = g->class_subclasses[pclass];
+               int csub = (1 << cbits)-1;
+               int cval = 0;
+               if (cbits) {
+                  Codebook *c = f->codebooks + g->class_masterbooks[pclass];
+                  DECODE(cval,f,c);
+               }
+               for (k=0; k < cdim; ++k) {
+                  int book = g->subclass_books[pclass][cval & csub];
+                  cval = cval >> cbits;
+                  if (book >= 0) {
+                     int temp;
+                     Codebook *c = f->codebooks + book;
+                     DECODE(temp,f,c);
+                     finalY[offset++] = temp;
+                  } else
+                     finalY[offset++] = 0;
+               }
+            }
+            if (f->valid_bits == INVALID_BITS) goto error; // behavior according to spec
+            step2_flag[0] = step2_flag[1] = 1;
+            for (j=2; j < g->values; ++j) {
+               int low, high, pred, highroom, lowroom, room, val;
+               low = g->neighbors[j][0];
+               high = g->neighbors[j][1];
+               //neighbors(g->Xlist, j, &low, &high);
+               pred = predict_point(g->Xlist[j], g->Xlist[low], g->Xlist[high], finalY[low], finalY[high]);
+               val = finalY[j];
+               highroom = range - pred;
+               lowroom = pred;
+               if (highroom < lowroom)
+                  room = highroom * 2;
+               else
+                  room = lowroom * 2;
+               if (val) {
+                  step2_flag[low] = step2_flag[high] = 1;
+                  step2_flag[j] = 1;
+                  if (val >= room)
+                     if (highroom > lowroom)
+                        finalY[j] = val - lowroom + pred;
+                     else
+                        finalY[j] = pred - val + highroom - 1;
+                  else
+                     if (val & 1)
+                        finalY[j] = pred - ((val+1)>>1);
+                     else
+                        finalY[j] = pred + (val>>1);
+               } else {
+                  step2_flag[j] = 0;
+                  finalY[j] = pred;
+               }
+            }
+
+#ifdef STB_VORBIS_NO_DEFER_FLOOR
+            do_floor(f, map, i, n, f->floor_buffers[i], finalY, step2_flag);
+#else
+            // defer final floor computation until _after_ residue
+            for (j=0; j < g->values; ++j) {
+               if (!step2_flag[j])
+                  finalY[j] = -1;
+            }
+#endif
+         } else {
+           error:
+            zero_channel[i] = TRUE;
+         }
+         // So we just defer everything else to later
+
+         // at this point we've decoded the floor into buffer
+      }
+   }
+   CHECK(f);
+   // at this point we've decoded all floors
+
+   if (f->alloc.alloc_buffer)
+      assert(f->alloc.alloc_buffer_length_in_bytes == f->temp_offset);
+
+   // re-enable coupled channels if necessary
+   memcpy(really_zero_channel, zero_channel, sizeof(really_zero_channel[0]) * f->channels);
+   for (i=0; i < map->coupling_steps; ++i)
+      if (!zero_channel[map->chan[i].magnitude] || !zero_channel[map->chan[i].angle]) {
+         zero_channel[map->chan[i].magnitude] = zero_channel[map->chan[i].angle] = FALSE;
+      }
+
+   CHECK(f);
+// RESIDUE DECODE
+   for (i=0; i < map->submaps; ++i) {
+      float *residue_buffers[STB_VORBIS_MAX_CHANNELS];
+      int r;
+      uint8 do_not_decode[256];
+      int ch = 0;
+      for (j=0; j < f->channels; ++j) {
+         if (map->chan[j].mux == i) {
+            if (zero_channel[j]) {
+               do_not_decode[ch] = TRUE;
+               residue_buffers[ch] = NULL;
+            } else {
+               do_not_decode[ch] = FALSE;
+               residue_buffers[ch] = f->channel_buffers[j];
+            }
+            ++ch;
+         }
+      }
+      r = map->submap_residue[i];
+      decode_residue(f, residue_buffers, ch, n2, r, do_not_decode);
+   }
+
+   if (f->alloc.alloc_buffer)
+      assert(f->alloc.alloc_buffer_length_in_bytes == f->temp_offset);
+   CHECK(f);
+
+// INVERSE COUPLING
+   for (i = map->coupling_steps-1; i >= 0; --i) {
+      int n2 = n >> 1;
+      float *m = f->channel_buffers[map->chan[i].magnitude];
+      float *a = f->channel_buffers[map->chan[i].angle    ];
+      for (j=0; j < n2; ++j) {
+         float a2,m2;
+         if (m[j] > 0)
+            if (a[j] > 0)
+               m2 = m[j], a2 = m[j] - a[j];
+            else
+               a2 = m[j], m2 = m[j] + a[j];
+         else
+            if (a[j] > 0)
+               m2 = m[j], a2 = m[j] + a[j];
+            else
+               a2 = m[j], m2 = m[j] - a[j];
+         m[j] = m2;
+         a[j] = a2;
+      }
+   }
+   CHECK(f);
+
+   // finish decoding the floors
+#ifndef STB_VORBIS_NO_DEFER_FLOOR
+   for (i=0; i < f->channels; ++i) {
+      if (really_zero_channel[i]) {
+         memset(f->channel_buffers[i], 0, sizeof(*f->channel_buffers[i]) * n2);
+      } else {
+         do_floor(f, map, i, n, f->channel_buffers[i], f->finalY[i], NULL);
+      }
+   }
+#else
+   for (i=0; i < f->channels; ++i) {
+      if (really_zero_channel[i]) {
+         memset(f->channel_buffers[i], 0, sizeof(*f->channel_buffers[i]) * n2);
+      } else {
+         for (j=0; j < n2; ++j)
+            f->channel_buffers[i][j] *= f->floor_buffers[i][j];
+      }
+   }
+#endif
+
+// INVERSE MDCT
+   CHECK(f);
+   for (i=0; i < f->channels; ++i)
+      inverse_mdct(f->channel_buffers[i], n, f, m->blockflag);
+   CHECK(f);
+
+   // this shouldn't be necessary, unless we exited on an error
+   // and want to flush to get to the next packet
+   flush_packet(f);
+
+   if (f->first_decode) {
+      // assume we start so first non-discarded sample is sample 0
+      // this isn't to spec, but spec would require us to read ahead
+      // and decode the size of all current frames--could be done,
+      // but presumably it's not a commonly used feature
+      f->current_loc = 0u - n2; // start of first frame is positioned for discard (NB this is an intentional unsigned overflow/wrap-around)
+      // we might have to discard samples "from" the next frame too,
+      // if we're lapping a large block then a small at the start?
+      f->discard_samples_deferred = n - right_end;
+      f->current_loc_valid = TRUE;
+      f->first_decode = FALSE;
+   } else if (f->discard_samples_deferred) {
+      if (f->discard_samples_deferred >= right_start - left_start) {
+         f->discard_samples_deferred -= (right_start - left_start);
+         left_start = right_start;
+         *p_left = left_start;
+      } else {
+         left_start += f->discard_samples_deferred;
+         *p_left = left_start;
+         f->discard_samples_deferred = 0;
+      }
+   } else if (f->previous_length == 0 && f->current_loc_valid) {
+      // we're recovering from a seek... that means we're going to discard
+      // the samples from this packet even though we know our position from
+      // the last page header, so we need to update the position based on
+      // the discarded samples here
+      // but wait, the code below is going to add this in itself even
+      // on a discard, so we don't need to do it here...
+   }
+
+   // check if we have ogg information about the sample # for this packet
+   if (f->last_seg_which == f->end_seg_with_known_loc) {
+      // if we have a valid current loc, and this is final:
+      if (f->current_loc_valid && (f->page_flag & PAGEFLAG_last_page)) {
+         uint32 current_end = f->known_loc_for_packet;
+         // then let's infer the size of the (probably) short final frame
+         if (current_end < f->current_loc + (right_end-left_start)) {
+            if (current_end < f->current_loc) {
+               // negative truncation, that's impossible!
+               *len = 0;
+            } else {
+               *len = current_end - f->current_loc;
+            }
+            *len += left_start; // this doesn't seem right, but has no ill effect on my test files
+            if (*len > right_end) *len = right_end; // this should never happen
+            f->current_loc += *len;
+            return TRUE;
+         }
+      }
+      // otherwise, just set our sample loc
+      // guess that the ogg granule pos refers to the _middle_ of the
+      // last frame?
+      // set f->current_loc to the position of left_start
+      f->current_loc = f->known_loc_for_packet - (n2-left_start);
+      f->current_loc_valid = TRUE;
+   }
+   if (f->current_loc_valid)
+      f->current_loc += (right_start - left_start);
+
+   if (f->alloc.alloc_buffer)
+      assert(f->alloc.alloc_buffer_length_in_bytes == f->temp_offset);
+   *len = right_end;  // ignore samples after the window goes to 0
+   CHECK(f);
+
+   return TRUE;
+}
+
+static int vorbis_decode_packet(vorb *f, int *len, int *p_left, int *p_right)
+{
+   int mode, left_end, right_end;
+   if (!vorbis_decode_initial(f, p_left, &left_end, p_right, &right_end, &mode)) return 0;
+   return vorbis_decode_packet_rest(f, len, f->mode_config + mode, *p_left, left_end, *p_right, right_end, p_left);
+}
+
+static int vorbis_finish_frame(stb_vorbis *f, int len, int left, int right)
+{
+   int prev,i,j;
+   // we use right&left (the start of the right- and left-window sin()-regions)
+   // to determine how much to return, rather than inferring from the rules
+   // (same result, clearer code); 'left' indicates where our sin() window
+   // starts, therefore where the previous window's right edge starts, and
+   // therefore where to start mixing from the previous buffer. 'right'
+   // indicates where our sin() ending-window starts, therefore that's where
+   // we start saving, and where our returned-data ends.
+
+   // mixin from previous window
+   if (f->previous_length) {
+      int i,j, n = f->previous_length;
+      float *w = get_window(f, n);
+      if (w == NULL) return 0;
+      for (i=0; i < f->channels; ++i) {
+         for (j=0; j < n; ++j)
+            f->channel_buffers[i][left+j] =
+               f->channel_buffers[i][left+j]*w[    j] +
+               f->previous_window[i][     j]*w[n-1-j];
+      }
+   }
+
+   prev = f->previous_length;
+
+   // last half of this data becomes previous window
+   f->previous_length = len - right;
+
+   // @OPTIMIZE: could avoid this copy by double-buffering the
+   // output (flipping previous_window with channel_buffers), but
+   // then previous_window would have to be 2x as large, and
+   // channel_buffers couldn't be temp mem (although they're NOT
+   // currently temp mem, they could be (unless we want to level
+   // performance by spreading out the computation))
+   for (i=0; i < f->channels; ++i)
+      for (j=0; right+j < len; ++j)
+         f->previous_window[i][j] = f->channel_buffers[i][right+j];
+
+   if (!prev)
+      // there was no previous packet, so this data isn't valid...
+      // this isn't entirely true, only the would-have-overlapped data
+      // isn't valid, but this seems to be what the spec requires
+      return 0;
+
+   // truncate a short frame
+   if (len < right) right = len;
+
+   f->samples_output += right-left;
+
+   return right - left;
+}
+
+static int vorbis_pump_first_frame(stb_vorbis *f)
+{
+   int len, right, left, res;
+   res = vorbis_decode_packet(f, &len, &left, &right);
+   if (res)
+      vorbis_finish_frame(f, len, left, right);
+   return res;
+}
+
+#ifndef STB_VORBIS_NO_PUSHDATA_API
+static int is_whole_packet_present(stb_vorbis *f)
+{
+   // make sure that we have the packet available before continuing...
+   // this requires a full ogg parse, but we know we can fetch from f->stream
+
+   // instead of coding this out explicitly, we could save the current read state,
+   // read the next packet with get8() until end-of-packet, check f->eof, then
+   // reset the state? but that would be slower, esp. since we'd have over 256 bytes
+   // of state to restore (primarily the page segment table)
+
+   int s = f->next_seg, first = TRUE;
+   uint8 *p = f->stream;
+
+   if (s != -1) { // if we're not starting the packet with a 'continue on next page' flag
+      for (; s < f->segment_count; ++s) {
+         p += f->segments[s];
+         if (f->segments[s] < 255)               // stop at first short segment
+            break;
+      }
+      // either this continues, or it ends it...
+      if (s == f->segment_count)
+         s = -1; // set 'crosses page' flag
+      if (p > f->stream_end)                     return error(f, VORBIS_need_more_data);
+      first = FALSE;
+   }
+   for (; s == -1;) {
+      uint8 *q;
+      int n;
+
+      // check that we have the page header ready
+      if (p + 26 >= f->stream_end)               return error(f, VORBIS_need_more_data);
+      // validate the page
+      if (memcmp(p, ogg_page_header, 4))         return error(f, VORBIS_invalid_stream);
+      if (p[4] != 0)                             return error(f, VORBIS_invalid_stream);
+      if (first) { // the first segment must NOT have 'continued_packet', later ones MUST
+         if (f->previous_length)
+            if ((p[5] & PAGEFLAG_continued_packet))  return error(f, VORBIS_invalid_stream);
+         // if no previous length, we're resynching, so we can come in on a continued-packet,
+         // which we'll just drop
+      } else {
+         if (!(p[5] & PAGEFLAG_continued_packet)) return error(f, VORBIS_invalid_stream);
+      }
+      n = p[26]; // segment counts
+      q = p+27;  // q points to segment table
+      p = q + n; // advance past header
+      // make sure we've read the segment table
+      if (p > f->stream_end)                     return error(f, VORBIS_need_more_data);
+      for (s=0; s < n; ++s) {
+         p += q[s];
+         if (q[s] < 255)
+            break;
+      }
+      if (s == n)
+         s = -1; // set 'crosses page' flag
+      if (p > f->stream_end)                     return error(f, VORBIS_need_more_data);
+      first = FALSE;
+   }
+   return TRUE;
+}
+#endif // !STB_VORBIS_NO_PUSHDATA_API
+
+static int start_decoder(vorb *f)
+{
+   uint8 header[6], x,y;
+   int len,i,j,k, max_submaps = 0;
+   int longest_floorlist=0;
+
+   // first page, first packet
+   f->first_decode = TRUE;
+
+   if (!start_page(f))                              return FALSE;
+   // validate page flag
+   if (!(f->page_flag & PAGEFLAG_first_page))       return error(f, VORBIS_invalid_first_page);
+   if (f->page_flag & PAGEFLAG_last_page)           return error(f, VORBIS_invalid_first_page);
+   if (f->page_flag & PAGEFLAG_continued_packet)    return error(f, VORBIS_invalid_first_page);
+   // check for expected packet length
+   if (f->segment_count != 1)                       return error(f, VORBIS_invalid_first_page);
+   if (f->segments[0] != 30) {
+      // check for the Ogg skeleton fishead identifying header to refine our error
+      if (f->segments[0] == 64 &&
+          getn(f, header, 6) &&
+          header[0] == 'f' &&
+          header[1] == 'i' &&
+          header[2] == 's' &&
+          header[3] == 'h' &&
+          header[4] == 'e' &&
+          header[5] == 'a' &&
+          get8(f)   == 'd' &&
+          get8(f)   == '\0')                        return error(f, VORBIS_ogg_skeleton_not_supported);
+      else
+                                                    return error(f, VORBIS_invalid_first_page);
+   }
+
+   // read packet
+   // check packet header
+   if (get8(f) != VORBIS_packet_id)                 return error(f, VORBIS_invalid_first_page);
+   if (!getn(f, header, 6))                         return error(f, VORBIS_unexpected_eof);
+   if (!vorbis_validate(header))                    return error(f, VORBIS_invalid_first_page);
+   // vorbis_version
+   if (get32(f) != 0)                               return error(f, VORBIS_invalid_first_page);
+   f->channels = get8(f); if (!f->channels)         return error(f, VORBIS_invalid_first_page);
+   if (f->channels > STB_VORBIS_MAX_CHANNELS)       return error(f, VORBIS_too_many_channels);
+   f->sample_rate = get32(f); if (!f->sample_rate)  return error(f, VORBIS_invalid_first_page);
+   get32(f); // bitrate_maximum
+   get32(f); // bitrate_nominal
+   get32(f); // bitrate_minimum
+   x = get8(f);
+   {
+      int log0,log1;
+      log0 = x & 15;
+      log1 = x >> 4;
+      f->blocksize_0 = 1 << log0;
+      f->blocksize_1 = 1 << log1;
+      if (log0 < 6 || log0 > 13)                       return error(f, VORBIS_invalid_setup);
+      if (log1 < 6 || log1 > 13)                       return error(f, VORBIS_invalid_setup);
+      if (log0 > log1)                                 return error(f, VORBIS_invalid_setup);
+   }
+
+   // framing_flag
+   x = get8(f);
+   if (!(x & 1))                                    return error(f, VORBIS_invalid_first_page);
+
+   // second packet!
+   if (!start_page(f))                              return FALSE;
+
+   if (!start_packet(f))                            return FALSE;
+
+   if (!next_segment(f))                            return FALSE;
+
+   if (get8_packet(f) != VORBIS_packet_comment)            return error(f, VORBIS_invalid_setup);
+   for (i=0; i < 6; ++i) header[i] = get8_packet(f);
+   if (!vorbis_validate(header))                    return error(f, VORBIS_invalid_setup);
+   //file vendor
+   len = get32_packet(f);
+   f->vendor = (char*)setup_malloc(f, sizeof(char) * (len+1));
+   if (f->vendor == NULL)                           return error(f, VORBIS_outofmem);
+   for(i=0; i < len; ++i) {
+      f->vendor[i] = get8_packet(f);
+   }
+   f->vendor[len] = (char)'\0';
+   //user comments
+   f->comment_list_length = get32_packet(f);
+   f->comment_list = NULL;
+   if (f->comment_list_length > 0)
+   {
+      f->comment_list = (char**) setup_malloc(f, sizeof(char*) * (f->comment_list_length));
+      if (f->comment_list == NULL)                  return error(f, VORBIS_outofmem);
+   }
+
+   for(i=0; i < f->comment_list_length; ++i) {
+      len = get32_packet(f);
+      f->comment_list[i] = (char*)setup_malloc(f, sizeof(char) * (len+1));
+      if (f->comment_list[i] == NULL)               return error(f, VORBIS_outofmem);
+
+      for(j=0; j < len; ++j) {
+         f->comment_list[i][j] = get8_packet(f);
+      }
+      f->comment_list[i][len] = (char)'\0';
+   }
+
+   // framing_flag
+   x = get8_packet(f);
+   if (!(x & 1))                                    return error(f, VORBIS_invalid_setup);
+
+
+   skip(f, f->bytes_in_seg);
+   f->bytes_in_seg = 0;
+
+   do {
+      len = next_segment(f);
+      skip(f, len);
+      f->bytes_in_seg = 0;
+   } while (len);
+
+   // third packet!
+   if (!start_packet(f))                            return FALSE;
+
+   #ifndef STB_VORBIS_NO_PUSHDATA_API
+   if (IS_PUSH_MODE(f)) {
+      if (!is_whole_packet_present(f)) {
+         // convert error in ogg header to write type
+         if (f->error == VORBIS_invalid_stream)
+            f->error = VORBIS_invalid_setup;
+         return FALSE;
+      }
+   }
+   #endif
+
+   crc32_init(); // always init it, to avoid multithread race conditions
+
+   if (get8_packet(f) != VORBIS_packet_setup)       return error(f, VORBIS_invalid_setup);
+   for (i=0; i < 6; ++i) header[i] = get8_packet(f);
+   if (!vorbis_validate(header))                    return error(f, VORBIS_invalid_setup);
+
+   // codebooks
+
+   f->codebook_count = get_bits(f,8) + 1;
+   f->codebooks = (Codebook *) setup_malloc(f, sizeof(*f->codebooks) * f->codebook_count);
+   if (f->codebooks == NULL)                        return error(f, VORBIS_outofmem);
+   memset(f->codebooks, 0, sizeof(*f->codebooks) * f->codebook_count);
+   for (i=0; i < f->codebook_count; ++i) {
+      uint32 *values;
+      int ordered, sorted_count;
+      int total=0;
+      uint8 *lengths;
+      Codebook *c = f->codebooks+i;
+      CHECK(f);
+      x = get_bits(f, 8); if (x != 0x42)            return error(f, VORBIS_invalid_setup);
+      x = get_bits(f, 8); if (x != 0x43)            return error(f, VORBIS_invalid_setup);
+      x = get_bits(f, 8); if (x != 0x56)            return error(f, VORBIS_invalid_setup);
+      x = get_bits(f, 8);
+      c->dimensions = (get_bits(f, 8)<<8) + x;
+      x = get_bits(f, 8);
+      y = get_bits(f, 8);
+      c->entries = (get_bits(f, 8)<<16) + (y<<8) + x;
+      ordered = get_bits(f,1);
+      c->sparse = ordered ? 0 : get_bits(f,1);
+
+      if (c->dimensions == 0 && c->entries != 0)    return error(f, VORBIS_invalid_setup);
+
+      if (c->sparse)
+         lengths = (uint8 *) setup_temp_malloc(f, c->entries);
+      else
+         lengths = c->codeword_lengths = (uint8 *) setup_malloc(f, c->entries);
+
+      if (!lengths) return error(f, VORBIS_outofmem);
+
+      if (ordered) {
+         int current_entry = 0;
+         int current_length = get_bits(f,5) + 1;
+         while (current_entry < c->entries) {
+            int limit = c->entries - current_entry;
+            int n = get_bits(f, ilog(limit));
+            if (current_length >= 32) return error(f, VORBIS_invalid_setup);
+            if (current_entry + n > (int) c->entries) { return error(f, VORBIS_invalid_setup); }
+            memset(lengths + current_entry, current_length, n);
+            current_entry += n;
+            ++current_length;
+         }
+      } else {
+         for (j=0; j < c->entries; ++j) {
+            int present = c->sparse ? get_bits(f,1) : 1;
+            if (present) {
+               lengths[j] = get_bits(f, 5) + 1;
+               ++total;
+               if (lengths[j] == 32)
+                  return error(f, VORBIS_invalid_setup);
+            } else {
+               lengths[j] = NO_CODE;
+            }
+         }
+      }
+
+      if (c->sparse && total >= c->entries >> 2) {
+         // convert sparse items to non-sparse!
+         if (c->entries > (int) f->setup_temp_memory_required)
+            f->setup_temp_memory_required = c->entries;
+
+         c->codeword_lengths = (uint8 *) setup_malloc(f, c->entries);
+         if (c->codeword_lengths == NULL) return error(f, VORBIS_outofmem);
+         memcpy(c->codeword_lengths, lengths, c->entries);
+         setup_temp_free(f, lengths, c->entries); // note this is only safe if there have been no intervening temp mallocs!
+         lengths = c->codeword_lengths;
+         c->sparse = 0;
+      }
+
+      // compute the size of the sorted tables
+      if (c->sparse) {
+         sorted_count = total;
+      } else {
+         sorted_count = 0;
+         #ifndef STB_VORBIS_NO_HUFFMAN_BINARY_SEARCH
+         for (j=0; j < c->entries; ++j)
+            if (lengths[j] > STB_VORBIS_FAST_HUFFMAN_LENGTH && lengths[j] != NO_CODE)
+               ++sorted_count;
+         #endif
+      }
+
+      c->sorted_entries = sorted_count;
+      values = NULL;
+
+      CHECK(f);
+      if (!c->sparse) {
+         c->codewords = (uint32 *) setup_malloc(f, sizeof(c->codewords[0]) * c->entries);
+         if (!c->codewords)                  return error(f, VORBIS_outofmem);
+      } else {
+         unsigned int size;
+         if (c->sorted_entries) {
+            c->codeword_lengths = (uint8 *) setup_malloc(f, c->sorted_entries);
+            if (!c->codeword_lengths)           return error(f, VORBIS_outofmem);
+            c->codewords = (uint32 *) setup_temp_malloc(f, sizeof(*c->codewords) * c->sorted_entries);
+            if (!c->codewords)                  return error(f, VORBIS_outofmem);
+            values = (uint32 *) setup_temp_malloc(f, sizeof(*values) * c->sorted_entries);
+            if (!values)                        return error(f, VORBIS_outofmem);
+         }
+         size = c->entries + (sizeof(*c->codewords) + sizeof(*values)) * c->sorted_entries;
+         if (size > f->setup_temp_memory_required)
+            f->setup_temp_memory_required = size;
+      }
+
+      if (!compute_codewords(c, lengths, c->entries, values)) {
+         if (c->sparse) setup_temp_free(f, values, 0);
+         return error(f, VORBIS_invalid_setup);
+      }
+
+      if (c->sorted_entries) {
+         // allocate an extra slot for sentinels
+         c->sorted_codewords = (uint32 *) setup_malloc(f, sizeof(*c->sorted_codewords) * (c->sorted_entries+1));
+         if (c->sorted_codewords == NULL) return error(f, VORBIS_outofmem);
+         // allocate an extra slot at the front so that c->sorted_values[-1] is defined
+         // so that we can catch that case without an extra if
+         c->sorted_values    = ( int   *) setup_malloc(f, sizeof(*c->sorted_values   ) * (c->sorted_entries+1));
+         if (c->sorted_values == NULL) return error(f, VORBIS_outofmem);
+         ++c->sorted_values;
+         c->sorted_values[-1] = -1;
+         compute_sorted_huffman(c, lengths, values);
+      }
+
+      if (c->sparse) {
+         setup_temp_free(f, values, sizeof(*values)*c->sorted_entries);
+         setup_temp_free(f, c->codewords, sizeof(*c->codewords)*c->sorted_entries);
+         setup_temp_free(f, lengths, c->entries);
+         c->codewords = NULL;
+      }
+
+      compute_accelerated_huffman(c);
+
+      CHECK(f);
+      c->lookup_type = get_bits(f, 4);
+      if (c->lookup_type > 2) return error(f, VORBIS_invalid_setup);
+      if (c->lookup_type > 0) {
+         uint16 *mults;
+         c->minimum_value = float32_unpack(get_bits(f, 32));
+         c->delta_value = float32_unpack(get_bits(f, 32));
+         c->value_bits = get_bits(f, 4)+1;
+         c->sequence_p = get_bits(f,1);
+         if (c->lookup_type == 1) {
+            int values = lookup1_values(c->entries, c->dimensions);
+            if (values < 0) return error(f, VORBIS_invalid_setup);
+            c->lookup_values = (uint32) values;
+         } else {
+            c->lookup_values = c->entries * c->dimensions;
+         }
+         if (c->lookup_values == 0) return error(f, VORBIS_invalid_setup);
+         mults = (uint16 *) setup_temp_malloc(f, sizeof(mults[0]) * c->lookup_values);
+         if (mults == NULL) return error(f, VORBIS_outofmem);
+         for (j=0; j < (int) c->lookup_values; ++j) {
+            int q = get_bits(f, c->value_bits);
+            if (q == EOP) { setup_temp_free(f,mults,sizeof(mults[0])*c->lookup_values); return error(f, VORBIS_invalid_setup); }
+            mults[j] = q;
+         }
+
+#ifndef STB_VORBIS_DIVIDES_IN_CODEBOOK
+         if (c->lookup_type == 1) {
+            int len, sparse = c->sparse;
+            float last=0;
+            // pre-expand the lookup1-style multiplicands, to avoid a divide in the inner loop
+            if (sparse) {
+               if (c->sorted_entries == 0) goto skip;
+               c->multiplicands = (codetype *) setup_malloc(f, sizeof(c->multiplicands[0]) * c->sorted_entries * c->dimensions);
+            } else
+               c->multiplicands = (codetype *) setup_malloc(f, sizeof(c->multiplicands[0]) * c->entries        * c->dimensions);
+            if (c->multiplicands == NULL) { setup_temp_free(f,mults,sizeof(mults[0])*c->lookup_values); return error(f, VORBIS_outofmem); }
+            len = sparse ? c->sorted_entries : c->entries;
+            for (j=0; j < len; ++j) {
+               unsigned int z = sparse ? c->sorted_values[j] : j;
+               unsigned int div=1;
+               for (k=0; k < c->dimensions; ++k) {
+                  int off = (z / div) % c->lookup_values;
+                  float val = mults[off]*c->delta_value + c->minimum_value + last;
+                  c->multiplicands[j*c->dimensions + k] = val;
+                  if (c->sequence_p)
+                     last = val;
+                  if (k+1 < c->dimensions) {
+                     if (div > UINT_MAX / (unsigned int) c->lookup_values) {
+                        setup_temp_free(f, mults,sizeof(mults[0])*c->lookup_values);
+                        return error(f, VORBIS_invalid_setup);
+                     }
+                     div *= c->lookup_values;
+                  }
+               }
+            }
+            c->lookup_type = 2;
+         }
+         else
+#endif
+         {
+            float last=0;
+            CHECK(f);
+            c->multiplicands = (codetype *) setup_malloc(f, sizeof(c->multiplicands[0]) * c->lookup_values);
+            if (c->multiplicands == NULL) { setup_temp_free(f, mults,sizeof(mults[0])*c->lookup_values); return error(f, VORBIS_outofmem); }
+            for (j=0; j < (int) c->lookup_values; ++j) {
+               float val = mults[j] * c->delta_value + c->minimum_value + last;
+               c->multiplicands[j] = val;
+               if (c->sequence_p)
+                  last = val;
+            }
+         }
+#ifndef STB_VORBIS_DIVIDES_IN_CODEBOOK
+        skip:;
+#endif
+         setup_temp_free(f, mults, sizeof(mults[0])*c->lookup_values);
+
+         CHECK(f);
+      }
+      CHECK(f);
+   }
+
+   // time domain transfers (notused)
+
+   x = get_bits(f, 6) + 1;
+   for (i=0; i < x; ++i) {
+      uint32 z = get_bits(f, 16);
+      if (z != 0) return error(f, VORBIS_invalid_setup);
+   }
+
+   // Floors
+   f->floor_count = get_bits(f, 6)+1;
+   f->floor_config = (Floor *)  setup_malloc(f, f->floor_count * sizeof(*f->floor_config));
+   if (f->floor_config == NULL) return error(f, VORBIS_outofmem);
+   for (i=0; i < f->floor_count; ++i) {
+      f->floor_types[i] = get_bits(f, 16);
+      if (f->floor_types[i] > 1) return error(f, VORBIS_invalid_setup);
+      if (f->floor_types[i] == 0) {
+         Floor0 *g = &f->floor_config[i].floor0;
+         g->order = get_bits(f,8);
+         g->rate = get_bits(f,16);
+         g->bark_map_size = get_bits(f,16);
+         g->amplitude_bits = get_bits(f,6);
+         g->amplitude_offset = get_bits(f,8);
+         g->number_of_books = get_bits(f,4) + 1;
+         for (j=0; j < g->number_of_books; ++j)
+            g->book_list[j] = get_bits(f,8);
+         return error(f, VORBIS_feature_not_supported);
+      } else {
+         stbv__floor_ordering p[31*8+2];
+         Floor1 *g = &f->floor_config[i].floor1;
+         int max_class = -1;
+         g->partitions = get_bits(f, 5);
+         for (j=0; j < g->partitions; ++j) {
+            g->partition_class_list[j] = get_bits(f, 4);
+            if (g->partition_class_list[j] > max_class)
+               max_class = g->partition_class_list[j];
+         }
+         for (j=0; j <= max_class; ++j) {
+            g->class_dimensions[j] = get_bits(f, 3)+1;
+            g->class_subclasses[j] = get_bits(f, 2);
+            if (g->class_subclasses[j]) {
+               g->class_masterbooks[j] = get_bits(f, 8);
+               if (g->class_masterbooks[j] >= f->codebook_count) return error(f, VORBIS_invalid_setup);
+            }
+            for (k=0; k < 1 << g->class_subclasses[j]; ++k) {
+               g->subclass_books[j][k] = (int16)get_bits(f,8)-1;
+               if (g->subclass_books[j][k] >= f->codebook_count) return error(f, VORBIS_invalid_setup);
+            }
+         }
+         g->floor1_multiplier = get_bits(f,2)+1;
+         g->rangebits = get_bits(f,4);
+         g->Xlist[0] = 0;
+         g->Xlist[1] = 1 << g->rangebits;
+         g->values = 2;
+         for (j=0; j < g->partitions; ++j) {
+            int c = g->partition_class_list[j];
+            for (k=0; k < g->class_dimensions[c]; ++k) {
+               g->Xlist[g->values] = get_bits(f, g->rangebits);
+               ++g->values;
+            }
+         }
+         // precompute the sorting
+         for (j=0; j < g->values; ++j) {
+            p[j].x = g->Xlist[j];
+            p[j].id = j;
+         }
+         qsort(p, g->values, sizeof(p[0]), point_compare);
+         for (j=0; j < g->values-1; ++j)
+            if (p[j].x == p[j+1].x)
+               return error(f, VORBIS_invalid_setup);
+         for (j=0; j < g->values; ++j)
+            g->sorted_order[j] = (uint8) p[j].id;
+         // precompute the neighbors
+         for (j=2; j < g->values; ++j) {
+            int low = 0,hi = 0;
+            neighbors(g->Xlist, j, &low,&hi);
+            g->neighbors[j][0] = low;
+            g->neighbors[j][1] = hi;
+         }
+
+         if (g->values > longest_floorlist)
+            longest_floorlist = g->values;
+      }
+   }
+
+   // Residue
+   f->residue_count = get_bits(f, 6)+1;
+   f->residue_config = (Residue *) setup_malloc(f, f->residue_count * sizeof(f->residue_config[0]));
+   if (f->residue_config == NULL) return error(f, VORBIS_outofmem);
+   memset(f->residue_config, 0, f->residue_count * sizeof(f->residue_config[0]));
+   for (i=0; i < f->residue_count; ++i) {
+      uint8 residue_cascade[64];
+      Residue *r = f->residue_config+i;
+      f->residue_types[i] = get_bits(f, 16);
+      if (f->residue_types[i] > 2) return error(f, VORBIS_invalid_setup);
+      r->begin = get_bits(f, 24);
+      r->end = get_bits(f, 24);
+      if (r->end < r->begin) return error(f, VORBIS_invalid_setup);
+      r->part_size = get_bits(f,24)+1;
+      r->classifications = get_bits(f,6)+1;
+      r->classbook = get_bits(f,8);
+      if (r->classbook >= f->codebook_count) return error(f, VORBIS_invalid_setup);
+      for (j=0; j < r->classifications; ++j) {
+         uint8 high_bits=0;
+         uint8 low_bits=get_bits(f,3);
+         if (get_bits(f,1))
+            high_bits = get_bits(f,5);
+         residue_cascade[j] = high_bits*8 + low_bits;
+      }
+      r->residue_books = (short (*)[8]) setup_malloc(f, sizeof(r->residue_books[0]) * r->classifications);
+      if (r->residue_books == NULL) return error(f, VORBIS_outofmem);
+      for (j=0; j < r->classifications; ++j) {
+         for (k=0; k < 8; ++k) {
+            if (residue_cascade[j] & (1 << k)) {
+               r->residue_books[j][k] = get_bits(f, 8);
+               if (r->residue_books[j][k] >= f->codebook_count) return error(f, VORBIS_invalid_setup);
+            } else {
+               r->residue_books[j][k] = -1;
+            }
+         }
+      }
+      // precompute the classifications[] array to avoid inner-loop mod/divide
+      // call it 'classdata' since we already have r->classifications
+      r->classdata = (uint8 **) setup_malloc(f, sizeof(*r->classdata) * f->codebooks[r->classbook].entries);
+      if (!r->classdata) return error(f, VORBIS_outofmem);
+      memset(r->classdata, 0, sizeof(*r->classdata) * f->codebooks[r->classbook].entries);
+      for (j=0; j < f->codebooks[r->classbook].entries; ++j) {
+         int classwords = f->codebooks[r->classbook].dimensions;
+         int temp = j;
+         r->classdata[j] = (uint8 *) setup_malloc(f, sizeof(r->classdata[j][0]) * classwords);
+         if (r->classdata[j] == NULL) return error(f, VORBIS_outofmem);
+         for (k=classwords-1; k >= 0; --k) {
+            r->classdata[j][k] = temp % r->classifications;
+            temp /= r->classifications;
+         }
+      }
+   }
+
+   f->mapping_count = get_bits(f,6)+1;
+   f->mapping = (Mapping *) setup_malloc(f, f->mapping_count * sizeof(*f->mapping));
+   if (f->mapping == NULL) return error(f, VORBIS_outofmem);
+   memset(f->mapping, 0, f->mapping_count * sizeof(*f->mapping));
+   for (i=0; i < f->mapping_count; ++i) {
+      Mapping *m = f->mapping + i;
+      int mapping_type = get_bits(f,16);
+      if (mapping_type != 0) return error(f, VORBIS_invalid_setup);
+      m->chan = (MappingChannel *) setup_malloc(f, f->channels * sizeof(*m->chan));
+      if (m->chan == NULL) return error(f, VORBIS_outofmem);
+      if (get_bits(f,1))
+         m->submaps = get_bits(f,4)+1;
+      else
+         m->submaps = 1;
+      if (m->submaps > max_submaps)
+         max_submaps = m->submaps;
+      if (get_bits(f,1)) {
+         m->coupling_steps = get_bits(f,8)+1;
+         if (m->coupling_steps > f->channels) return error(f, VORBIS_invalid_setup);
+         for (k=0; k < m->coupling_steps; ++k) {
+            m->chan[k].magnitude = get_bits(f, ilog(f->channels-1));
+            m->chan[k].angle = get_bits(f, ilog(f->channels-1));
+            if (m->chan[k].magnitude >= f->channels)        return error(f, VORBIS_invalid_setup);
+            if (m->chan[k].angle     >= f->channels)        return error(f, VORBIS_invalid_setup);
+            if (m->chan[k].magnitude == m->chan[k].angle)   return error(f, VORBIS_invalid_setup);
+         }
+      } else
+         m->coupling_steps = 0;
+
+      // reserved field
+      if (get_bits(f,2)) return error(f, VORBIS_invalid_setup);
+      if (m->submaps > 1) {
+         for (j=0; j < f->channels; ++j) {
+            m->chan[j].mux = get_bits(f, 4);
+            if (m->chan[j].mux >= m->submaps)                return error(f, VORBIS_invalid_setup);
+         }
+      } else
+         // @SPECIFICATION: this case is missing from the spec
+         for (j=0; j < f->channels; ++j)
+            m->chan[j].mux = 0;
+
+      for (j=0; j < m->submaps; ++j) {
+         get_bits(f,8); // discard
+         m->submap_floor[j] = get_bits(f,8);
+         m->submap_residue[j] = get_bits(f,8);
+         if (m->submap_floor[j] >= f->floor_count)      return error(f, VORBIS_invalid_setup);
+         if (m->submap_residue[j] >= f->residue_count)  return error(f, VORBIS_invalid_setup);
+      }
+   }
+
+   // Modes
+   f->mode_count = get_bits(f, 6)+1;
+   for (i=0; i < f->mode_count; ++i) {
+      Mode *m = f->mode_config+i;
+      m->blockflag = get_bits(f,1);
+      m->windowtype = get_bits(f,16);
+      m->transformtype = get_bits(f,16);
+      m->mapping = get_bits(f,8);
+      if (m->windowtype != 0)                 return error(f, VORBIS_invalid_setup);
+      if (m->transformtype != 0)              return error(f, VORBIS_invalid_setup);
+      if (m->mapping >= f->mapping_count)     return error(f, VORBIS_invalid_setup);
+   }
+
+   flush_packet(f);
+
+   f->previous_length = 0;
+
+   for (i=0; i < f->channels; ++i) {
+      f->channel_buffers[i] = (float *) setup_malloc(f, sizeof(float) * f->blocksize_1);
+      f->previous_window[i] = (float *) setup_malloc(f, sizeof(float) * f->blocksize_1/2);
+      f->finalY[i]          = (int16 *) setup_malloc(f, sizeof(int16) * longest_floorlist);
+      if (f->channel_buffers[i] == NULL || f->previous_window[i] == NULL || f->finalY[i] == NULL) return error(f, VORBIS_outofmem);
+      memset(f->channel_buffers[i], 0, sizeof(float) * f->blocksize_1);
+      #ifdef STB_VORBIS_NO_DEFER_FLOOR
+      f->floor_buffers[i]   = (float *) setup_malloc(f, sizeof(float) * f->blocksize_1/2);
+      if (f->floor_buffers[i] == NULL) return error(f, VORBIS_outofmem);
+      #endif
+   }
+
+   if (!init_blocksize(f, 0, f->blocksize_0)) return FALSE;
+   if (!init_blocksize(f, 1, f->blocksize_1)) return FALSE;
+   f->blocksize[0] = f->blocksize_0;
+   f->blocksize[1] = f->blocksize_1;
+
+#ifdef STB_VORBIS_DIVIDE_TABLE
+   if (integer_divide_table[1][1]==0)
+      for (i=0; i < DIVTAB_NUMER; ++i)
+         for (j=1; j < DIVTAB_DENOM; ++j)
+            integer_divide_table[i][j] = i / j;
+#endif
+
+   // compute how much temporary memory is needed
+
+   // 1.
+   {
+      uint32 imdct_mem = (f->blocksize_1 * sizeof(float) >> 1);
+      uint32 classify_mem;
+      int i,max_part_read=0;
+      for (i=0; i < f->residue_count; ++i) {
+         Residue *r = f->residue_config + i;
+         unsigned int actual_size = f->blocksize_1 / 2;
+         unsigned int limit_r_begin = r->begin < actual_size ? r->begin : actual_size;
+         unsigned int limit_r_end   = r->end   < actual_size ? r->end   : actual_size;
+         int n_read = limit_r_end - limit_r_begin;
+         int part_read = n_read / r->part_size;
+         if (part_read > max_part_read)
+            max_part_read = part_read;
+      }
+      #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
+      classify_mem = f->channels * (sizeof(void*) + max_part_read * sizeof(uint8 *));
+      #else
+      classify_mem = f->channels * (sizeof(void*) + max_part_read * sizeof(int *));
+      #endif
+
+      // maximum reasonable partition size is f->blocksize_1
+
+      f->temp_memory_required = classify_mem;
+      if (imdct_mem > f->temp_memory_required)
+         f->temp_memory_required = imdct_mem;
+   }
+
+
+   if (f->alloc.alloc_buffer) {
+      assert(f->temp_offset == f->alloc.alloc_buffer_length_in_bytes);
+      // check if there's enough temp memory so we don't error later
+      if (f->setup_offset + sizeof(*f) + f->temp_memory_required > (unsigned) f->temp_offset)
+         return error(f, VORBIS_outofmem);
+   }
+
+   // @TODO: stb_vorbis_seek_start expects first_audio_page_offset to point to a page
+   // without PAGEFLAG_continued_packet, so this either points to the first page, or
+   // the page after the end of the headers. It might be cleaner to point to a page
+   // in the middle of the headers, when that's the page where the first audio packet
+   // starts, but we'd have to also correctly skip the end of any continued packet in
+   // stb_vorbis_seek_start.
+   if (f->next_seg == -1) {
+      f->first_audio_page_offset = stb_vorbis_get_file_offset(f);
+   } else {
+      f->first_audio_page_offset = 0;
+   }
+
+   return TRUE;
+}
+
+static void vorbis_deinit(stb_vorbis *p)
+{
+   int i,j;
+
+   setup_free(p, p->vendor);
+   for (i=0; i < p->comment_list_length; ++i) {
+      setup_free(p, p->comment_list[i]);
+   }
+   setup_free(p, p->comment_list);
+
+   if (p->residue_config) {
+      for (i=0; i < p->residue_count; ++i) {
+         Residue *r = p->residue_config+i;
+         if (r->classdata) {
+            for (j=0; j < p->codebooks[r->classbook].entries; ++j)
+               setup_free(p, r->classdata[j]);
+            setup_free(p, r->classdata);
+         }
+         setup_free(p, r->residue_books);
+      }
+   }
+
+   if (p->codebooks) {
+      CHECK(p);
+      for (i=0; i < p->codebook_count; ++i) {
+         Codebook *c = p->codebooks + i;
+         setup_free(p, c->codeword_lengths);
+         setup_free(p, c->multiplicands);
+         setup_free(p, c->codewords);
+         setup_free(p, c->sorted_codewords);
+         // c->sorted_values[-1] is the first entry in the array
+         setup_free(p, c->sorted_values ? c->sorted_values-1 : NULL);
+      }
+      setup_free(p, p->codebooks);
+   }
+   setup_free(p, p->floor_config);
+   setup_free(p, p->residue_config);
+   if (p->mapping) {
+      for (i=0; i < p->mapping_count; ++i)
+         setup_free(p, p->mapping[i].chan);
+      setup_free(p, p->mapping);
+   }
+   CHECK(p);
+   for (i=0; i < p->channels && i < STB_VORBIS_MAX_CHANNELS; ++i) {
+      setup_free(p, p->channel_buffers[i]);
+      setup_free(p, p->previous_window[i]);
+      #ifdef STB_VORBIS_NO_DEFER_FLOOR
+      setup_free(p, p->floor_buffers[i]);
+      #endif
+      setup_free(p, p->finalY[i]);
+   }
+   for (i=0; i < 2; ++i) {
+      setup_free(p, p->A[i]);
+      setup_free(p, p->B[i]);
+      setup_free(p, p->C[i]);
+      setup_free(p, p->window[i]);
+      setup_free(p, p->bit_reverse[i]);
+   }
+   #ifndef STB_VORBIS_NO_STDIO
+   if (p->close_on_free) fclose(p->f);
+   #endif
+}
+
+void stb_vorbis_close(stb_vorbis *p)
+{
+   if (p == NULL) return;
+   vorbis_deinit(p);
+   setup_free(p,p);
+}
+
+static void vorbis_init(stb_vorbis *p, const stb_vorbis_alloc *z)
+{
+   memset(p, 0, sizeof(*p)); // NULL out all malloc'd pointers to start
+   if (z) {
+      p->alloc = *z;
+      p->alloc.alloc_buffer_length_in_bytes &= ~7;
+      p->temp_offset = p->alloc.alloc_buffer_length_in_bytes;
+   }
+   p->eof = 0;
+   p->error = VORBIS__no_error;
+   p->stream = NULL;
+   p->codebooks = NULL;
+   p->page_crc_tests = -1;
+   #ifndef STB_VORBIS_NO_STDIO
+   p->close_on_free = FALSE;
+   p->f = NULL;
+   #endif
+}
+
+int stb_vorbis_get_sample_offset(stb_vorbis *f)
+{
+   if (f->current_loc_valid)
+      return f->current_loc;
+   else
+      return -1;
+}
+
+stb_vorbis_info stb_vorbis_get_info(stb_vorbis *f)
+{
+   stb_vorbis_info d;
+   d.channels = f->channels;
+   d.sample_rate = f->sample_rate;
+   d.setup_memory_required = f->setup_memory_required;
+   d.setup_temp_memory_required = f->setup_temp_memory_required;
+   d.temp_memory_required = f->temp_memory_required;
+   d.max_frame_size = f->blocksize_1 >> 1;
+   return d;
+}
+
+stb_vorbis_comment stb_vorbis_get_comment(stb_vorbis *f)
+{
+   stb_vorbis_comment d;
+   d.vendor = f->vendor;
+   d.comment_list_length = f->comment_list_length;
+   d.comment_list = f->comment_list;
+   return d;
+}
+
+int stb_vorbis_get_error(stb_vorbis *f)
+{
+   int e = f->error;
+   f->error = VORBIS__no_error;
+   return e;
+}
+
+static stb_vorbis * vorbis_alloc(stb_vorbis *f)
+{
+   stb_vorbis *p = (stb_vorbis *) setup_malloc(f, sizeof(*p));
+   return p;
+}
+
+#ifndef STB_VORBIS_NO_PUSHDATA_API
+
+void stb_vorbis_flush_pushdata(stb_vorbis *f)
+{
+   f->previous_length = 0;
+   f->page_crc_tests  = 0;
+   f->discard_samples_deferred = 0;
+   f->current_loc_valid = FALSE;
+   f->first_decode = FALSE;
+   f->samples_output = 0;
+   f->channel_buffer_start = 0;
+   f->channel_buffer_end = 0;
+}
+
+static int vorbis_search_for_page_pushdata(vorb *f, uint8 *data, int data_len)
+{
+   int i,n;
+   for (i=0; i < f->page_crc_tests; ++i)
+      f->scan[i].bytes_done = 0;
+
+   // if we have room for more scans, search for them first, because
+   // they may cause us to stop early if their header is incomplete
+   if (f->page_crc_tests < STB_VORBIS_PUSHDATA_CRC_COUNT) {
+      if (data_len < 4) return 0;
+      data_len -= 3; // need to look for 4-byte sequence, so don't miss
+                     // one that straddles a boundary
+      for (i=0; i < data_len; ++i) {
+         if (data[i] == 0x4f) {
+            if (0==memcmp(data+i, ogg_page_header, 4)) {
+               int j,len;
+               uint32 crc;
+               // make sure we have the whole page header
+               if (i+26 >= data_len || i+27+data[i+26] >= data_len) {
+                  // only read up to this page start, so hopefully we'll
+                  // have the whole page header start next time
+                  data_len = i;
+                  break;
+               }
+               // ok, we have it all; compute the length of the page
+               len = 27 + data[i+26];
+               for (j=0; j < data[i+26]; ++j)
+                  len += data[i+27+j];
+               // scan everything up to the embedded crc (which we must 0)
+               crc = 0;
+               for (j=0; j < 22; ++j)
+                  crc = crc32_update(crc, data[i+j]);
+               // now process 4 0-bytes
+               for (   ; j < 26; ++j)
+                  crc = crc32_update(crc, 0);
+               // len is the total number of bytes we need to scan
+               n = f->page_crc_tests++;
+               f->scan[n].bytes_left = len-j;
+               f->scan[n].crc_so_far = crc;
+               f->scan[n].goal_crc = data[i+22] + (data[i+23] << 8) + (data[i+24]<<16) + (data[i+25]<<24);
+               // if the last frame on a page is continued to the next, then
+               // we can't recover the sample_loc immediately
+               if (data[i+27+data[i+26]-1] == 255)
+                  f->scan[n].sample_loc = ~0;
+               else
+                  f->scan[n].sample_loc = data[i+6] + (data[i+7] << 8) + (data[i+ 8]<<16) + (data[i+ 9]<<24);
+               f->scan[n].bytes_done = i+j;
+               if (f->page_crc_tests == STB_VORBIS_PUSHDATA_CRC_COUNT)
+                  break;
+               // keep going if we still have room for more
+            }
+         }
+      }
+   }
+
+   for (i=0; i < f->page_crc_tests;) {
+      uint32 crc;
+      int j;
+      int n = f->scan[i].bytes_done;
+      int m = f->scan[i].bytes_left;
+      if (m > data_len - n) m = data_len - n;
+      // m is the bytes to scan in the current chunk
+      crc = f->scan[i].crc_so_far;
+      for (j=0; j < m; ++j)
+         crc = crc32_update(crc, data[n+j]);
+      f->scan[i].bytes_left -= m;
+      f->scan[i].crc_so_far = crc;
+      if (f->scan[i].bytes_left == 0) {
+         // does it match?
+         if (f->scan[i].crc_so_far == f->scan[i].goal_crc) {
+            // Houston, we have page
+            data_len = n+m; // consumption amount is wherever that scan ended
+            f->page_crc_tests = -1; // drop out of page scan mode
+            f->previous_length = 0; // decode-but-don't-output one frame
+            f->next_seg = -1;       // start a new page
+            f->current_loc = f->scan[i].sample_loc; // set the current sample location
+                                    // to the amount we'd have decoded had we decoded this page
+            f->current_loc_valid = f->current_loc != ~0U;
+            return data_len;
+         }
+         // delete entry
+         f->scan[i] = f->scan[--f->page_crc_tests];
+      } else {
+         ++i;
+      }
+   }
+
+   return data_len;
+}
+
+// return value: number of bytes we used
+int stb_vorbis_decode_frame_pushdata(
+         stb_vorbis *f,                   // the file we're decoding
+         const uint8 *data, int data_len, // the memory available for decoding
+         int *channels,                   // place to write number of float * buffers
+         float ***output,                 // place to write float ** array of float * buffers
+         int *samples                     // place to write number of output samples
+     )
+{
+   int i;
+   int len,right,left;
+
+   if (!IS_PUSH_MODE(f)) return error(f, VORBIS_invalid_api_mixing);
+
+   if (f->page_crc_tests >= 0) {
+      *samples = 0;
+      return vorbis_search_for_page_pushdata(f, (uint8 *) data, data_len);
+   }
+
+   f->stream     = (uint8 *) data;
+   f->stream_end = (uint8 *) data + data_len;
+   f->error      = VORBIS__no_error;
+
+   // check that we have the entire packet in memory
+   if (!is_whole_packet_present(f)) {
+      *samples = 0;
+      return 0;
+   }
+
+   if (!vorbis_decode_packet(f, &len, &left, &right)) {
+      // save the actual error we encountered
+      enum STBVorbisError error = f->error;
+      if (error == VORBIS_bad_packet_type) {
+         // flush and resynch
+         f->error = VORBIS__no_error;
+         while (get8_packet(f) != EOP)
+            if (f->eof) break;
+         *samples = 0;
+         return (int) (f->stream - data);
+      }
+      if (error == VORBIS_continued_packet_flag_invalid) {
+         if (f->previous_length == 0) {
+            // we may be resynching, in which case it's ok to hit one
+            // of these; just discard the packet
+            f->error = VORBIS__no_error;
+            while (get8_packet(f) != EOP)
+               if (f->eof) break;
+            *samples = 0;
+            return (int) (f->stream - data);
+         }
+      }
+      // if we get an error while parsing, what to do?
+      // well, it DEFINITELY won't work to continue from where we are!
+      stb_vorbis_flush_pushdata(f);
+      // restore the error that actually made us bail
+      f->error = error;
+      *samples = 0;
+      return 1;
+   }
+
+   // success!
+   len = vorbis_finish_frame(f, len, left, right);
+   for (i=0; i < f->channels; ++i)
+      f->outputs[i] = f->channel_buffers[i] + left;
+
+   if (channels) *channels = f->channels;
+   *samples = len;
+   *output = f->outputs;
+   return (int) (f->stream - data);
+}
+
+stb_vorbis *stb_vorbis_open_pushdata(
+         const unsigned char *data, int data_len, // the memory available for decoding
+         int *data_used,              // only defined if result is not NULL
+         int *error, const stb_vorbis_alloc *alloc)
+{
+   stb_vorbis *f, p;
+   vorbis_init(&p, alloc);
+   p.stream     = (uint8 *) data;
+   p.stream_end = (uint8 *) data + data_len;
+   p.push_mode  = TRUE;
+   if (!start_decoder(&p)) {
+      if (p.eof)
+         *error = VORBIS_need_more_data;
+      else
+         *error = p.error;
+      vorbis_deinit(&p);
+      return NULL;
+   }
+   f = vorbis_alloc(&p);
+   if (f) {
+      *f = p;
+      *data_used = (int) (f->stream - data);
+      *error = 0;
+      return f;
+   } else {
+      vorbis_deinit(&p);
+      return NULL;
+   }
+}
+#endif // STB_VORBIS_NO_PUSHDATA_API
+
+unsigned int stb_vorbis_get_file_offset(stb_vorbis *f)
+{
+   #ifndef STB_VORBIS_NO_PUSHDATA_API
+   if (f->push_mode) return 0;
+   #endif
+   if (USE_MEMORY(f)) return (unsigned int) (f->stream - f->stream_start);
+   #ifndef STB_VORBIS_NO_STDIO
+   return (unsigned int) (ftell(f->f) - f->f_start);
+   #endif
+}
+
+#ifndef STB_VORBIS_NO_PULLDATA_API
+//
+// DATA-PULLING API
+//
+
+static uint32 vorbis_find_page(stb_vorbis *f, uint32 *end, uint32 *last)
+{
+   for(;;) {
+      int n;
+      if (f->eof) return 0;
+      n = get8(f);
+      if (n == 0x4f) { // page header candidate
+         unsigned int retry_loc = stb_vorbis_get_file_offset(f);
+         int i;
+         // check if we're off the end of a file_section stream
+         if (retry_loc - 25 > f->stream_len)
+            return 0;
+         // check the rest of the header
+         for (i=1; i < 4; ++i)
+            if (get8(f) != ogg_page_header[i])
+               break;
+         if (f->eof) return 0;
+         if (i == 4) {
+            uint8 header[27];
+            uint32 i, crc, goal, len;
+            for (i=0; i < 4; ++i)
+               header[i] = ogg_page_header[i];
+            for (; i < 27; ++i)
+               header[i] = get8(f);
+            if (f->eof) return 0;
+            if (header[4] != 0) goto invalid;
+            goal = header[22] + (header[23] << 8) + (header[24]<<16) + ((uint32)header[25]<<24);
+            for (i=22; i < 26; ++i)
+               header[i] = 0;
+            crc = 0;
+            for (i=0; i < 27; ++i)
+               crc = crc32_update(crc, header[i]);
+            len = 0;
+            for (i=0; i < header[26]; ++i) {
+               int s = get8(f);
+               crc = crc32_update(crc, s);
+               len += s;
+            }
+            if (len && f->eof) return 0;
+            for (i=0; i < len; ++i)
+               crc = crc32_update(crc, get8(f));
+            // finished parsing probable page
+            if (crc == goal) {
+               // we could now check that it's either got the last
+               // page flag set, OR it's followed by the capture
+               // pattern, but I guess TECHNICALLY you could have
+               // a file with garbage between each ogg page and recover
+               // from it automatically? So even though that paranoia
+               // might decrease the chance of an invalid decode by
+               // another 2^32, not worth it since it would hose those
+               // invalid-but-useful files?
+               if (end)
+                  *end = stb_vorbis_get_file_offset(f);
+               if (last) {
+                  if (header[5] & 0x04)
+                     *last = 1;
+                  else
+                     *last = 0;
+               }
+               set_file_offset(f, retry_loc-1);
+               return 1;
+            }
+         }
+        invalid:
+         // not a valid page, so rewind and look for next one
+         set_file_offset(f, retry_loc);
+      }
+   }
+}
+
+
+#define SAMPLE_unknown  0xffffffff
+
+// seeking is implemented with a binary search, which narrows down the range to
+// 64K, before using a linear search (because finding the synchronization
+// pattern can be expensive, and the chance we'd find the end page again is
+// relatively high for small ranges)
+//
+// two initial interpolation-style probes are used at the start of the search
+// to try to bound either side of the binary search sensibly, while still
+// working in O(log n) time if they fail.
+
+static int get_seek_page_info(stb_vorbis *f, ProbedPage *z)
+{
+   uint8 header[27], lacing[255];
+   int i,len;
+
+   // record where the page starts
+   z->page_start = stb_vorbis_get_file_offset(f);
+
+   // parse the header
+   getn(f, header, 27);
+   if (header[0] != 'O' || header[1] != 'g' || header[2] != 'g' || header[3] != 'S')
+      return 0;
+   getn(f, lacing, header[26]);
+
+   // determine the length of the payload
+   len = 0;
+   for (i=0; i < header[26]; ++i)
+      len += lacing[i];
+
+   // this implies where the page ends
+   z->page_end = z->page_start + 27 + header[26] + len;
+
+   // read the last-decoded sample out of the data
+   z->last_decoded_sample = header[6] + (header[7] << 8) + (header[8] << 16) + (header[9] << 24);
+
+   // restore file state to where we were
+   set_file_offset(f, z->page_start);
+   return 1;
+}
+
+// rarely used function to seek back to the preceding page while finding the
+// start of a packet
+static int go_to_page_before(stb_vorbis *f, unsigned int limit_offset)
+{
+   unsigned int previous_safe, end;
+
+   // now we want to seek back 64K from the limit
+   if (limit_offset >= 65536 && limit_offset-65536 >= f->first_audio_page_offset)
+      previous_safe = limit_offset - 65536;
+   else
+      previous_safe = f->first_audio_page_offset;
+
+   set_file_offset(f, previous_safe);
+
+   while (vorbis_find_page(f, &end, NULL)) {
+      if (end >= limit_offset && stb_vorbis_get_file_offset(f) < limit_offset)
+         return 1;
+      set_file_offset(f, end);
+   }
+
+   return 0;
+}
+
+// implements the search logic for finding a page and starting decoding. if
+// the function succeeds, current_loc_valid will be true and current_loc will
+// be less than or equal to the provided sample number (the closer the
+// better).
+static int seek_to_sample_coarse(stb_vorbis *f, uint32 sample_number)
+{
+   ProbedPage left, right, mid;
+   int i, start_seg_with_known_loc, end_pos, page_start;
+   uint32 delta, stream_length, padding, last_sample_limit;
+   double offset = 0.0, bytes_per_sample = 0.0;
+   int probe = 0;
+
+   // find the last page and validate the target sample
+   stream_length = stb_vorbis_stream_length_in_samples(f);
+   if (stream_length == 0)            return error(f, VORBIS_seek_without_length);
+   if (sample_number > stream_length) return error(f, VORBIS_seek_invalid);
+
+   // this is the maximum difference between the window-center (which is the
+   // actual granule position value), and the right-start (which the spec
+   // indicates should be the granule position (give or take one)).
+   padding = ((f->blocksize_1 - f->blocksize_0) >> 2);
+   if (sample_number < padding)
+      last_sample_limit = 0;
+   else
+      last_sample_limit = sample_number - padding;
+
+   left = f->p_first;
+   while (left.last_decoded_sample == ~0U) {
+      // (untested) the first page does not have a 'last_decoded_sample'
+      set_file_offset(f, left.page_end);
+      if (!get_seek_page_info(f, &left)) goto error;
+   }
+
+   right = f->p_last;
+   assert(right.last_decoded_sample != ~0U);
+
+   // starting from the start is handled differently
+   if (last_sample_limit <= left.last_decoded_sample) {
+      if (stb_vorbis_seek_start(f)) {
+         if (f->current_loc > sample_number)
+            return error(f, VORBIS_seek_failed);
+         return 1;
+      }
+      return 0;
+   }
+
+   while (left.page_end != right.page_start) {
+      assert(left.page_end < right.page_start);
+      // search range in bytes
+      delta = right.page_start - left.page_end;
+      if (delta <= 65536) {
+         // there's only 64K left to search - handle it linearly
+         set_file_offset(f, left.page_end);
+      } else {
+         if (probe < 2) {
+            if (probe == 0) {
+               // first probe (interpolate)
+               double data_bytes = right.page_end - left.page_start;
+               bytes_per_sample = data_bytes / right.last_decoded_sample;
+               offset = left.page_start + bytes_per_sample * (last_sample_limit - left.last_decoded_sample);
+            } else {
+               // second probe (try to bound the other side)
+               double error = ((double) last_sample_limit - mid.last_decoded_sample) * bytes_per_sample;
+               if (error >= 0 && error <  8000) error =  8000;
+               if (error <  0 && error > -8000) error = -8000;
+               offset += error * 2;
+            }
+
+            // ensure the offset is valid
+            if (offset < left.page_end)
+               offset = left.page_end;
+            if (offset > right.page_start - 65536)
+               offset = right.page_start - 65536;
+
+            set_file_offset(f, (unsigned int) offset);
+         } else {
+            // binary search for large ranges (offset by 32K to ensure
+            // we don't hit the right page)
+            set_file_offset(f, left.page_end + (delta / 2) - 32768);
+         }
+
+         if (!vorbis_find_page(f, NULL, NULL)) goto error;
+      }
+
+      for (;;) {
+         if (!get_seek_page_info(f, &mid)) goto error;
+         if (mid.last_decoded_sample != ~0U) break;
+         // (untested) no frames end on this page
+         set_file_offset(f, mid.page_end);
+         assert(mid.page_start < right.page_start);
+      }
+
+      // if we've just found the last page again then we're in a tricky file,
+      // and we're close enough (if it wasn't an interpolation probe).
+      if (mid.page_start == right.page_start) {
+         if (probe >= 2 || delta <= 65536)
+            break;
+      } else {
+         if (last_sample_limit < mid.last_decoded_sample)
+            right = mid;
+         else
+            left = mid;
+      }
+
+      ++probe;
+   }
+
+   // seek back to start of the last packet
+   page_start = left.page_start;
+   set_file_offset(f, page_start);
+   if (!start_page(f)) return error(f, VORBIS_seek_failed);
+   end_pos = f->end_seg_with_known_loc;
+   assert(end_pos >= 0);
+
+   for (;;) {
+      for (i = end_pos; i > 0; --i)
+         if (f->segments[i-1] != 255)
+            break;
+
+      start_seg_with_known_loc = i;
+
+      if (start_seg_with_known_loc > 0 || !(f->page_flag & PAGEFLAG_continued_packet))
+         break;
+
+      // (untested) the final packet begins on an earlier page
+      if (!go_to_page_before(f, page_start))
+         goto error;
+
+      page_start = stb_vorbis_get_file_offset(f);
+      if (!start_page(f)) goto error;
+      end_pos = f->segment_count - 1;
+   }
+
+   // prepare to start decoding
+   f->current_loc_valid = FALSE;
+   f->last_seg = FALSE;
+   f->valid_bits = 0;
+   f->packet_bytes = 0;
+   f->bytes_in_seg = 0;
+   f->previous_length = 0;
+   f->next_seg = start_seg_with_known_loc;
+
+   for (i = 0; i < start_seg_with_known_loc; i++)
+      skip(f, f->segments[i]);
+
+   // start decoding (optimizable - this frame is generally discarded)
+   if (!vorbis_pump_first_frame(f))
+      return 0;
+   if (f->current_loc > sample_number)
+      return error(f, VORBIS_seek_failed);
+   return 1;
+
+error:
+   // try to restore the file to a valid state
+   stb_vorbis_seek_start(f);
+   return error(f, VORBIS_seek_failed);
+}
+
+// the same as vorbis_decode_initial, but without advancing
+static int peek_decode_initial(vorb *f, int *p_left_start, int *p_left_end, int *p_right_start, int *p_right_end, int *mode)
+{
+   int bits_read, bytes_read;
+
+   if (!vorbis_decode_initial(f, p_left_start, p_left_end, p_right_start, p_right_end, mode))
+      return 0;
+
+   // either 1 or 2 bytes were read, figure out which so we can rewind
+   bits_read = 1 + ilog(f->mode_count-1);
+   if (f->mode_config[*mode].blockflag)
+      bits_read += 2;
+   bytes_read = (bits_read + 7) / 8;
+
+   f->bytes_in_seg += bytes_read;
+   f->packet_bytes -= bytes_read;
+   skip(f, -bytes_read);
+   if (f->next_seg == -1)
+      f->next_seg = f->segment_count - 1;
+   else
+      f->next_seg--;
+   f->valid_bits = 0;
+
+   return 1;
+}
+
+int stb_vorbis_seek_frame(stb_vorbis *f, unsigned int sample_number)
+{
+   uint32 max_frame_samples;
+
+   if (IS_PUSH_MODE(f)) return error(f, VORBIS_invalid_api_mixing);
+
+   // fast page-level search
+   if (!seek_to_sample_coarse(f, sample_number))
+      return 0;
+
+   assert(f->current_loc_valid);
+   assert(f->current_loc <= sample_number);
+
+   // linear search for the relevant packet
+   max_frame_samples = (f->blocksize_1*3 - f->blocksize_0) >> 2;
+   while (f->current_loc < sample_number) {
+      int left_start, left_end, right_start, right_end, mode, frame_samples;
+      if (!peek_decode_initial(f, &left_start, &left_end, &right_start, &right_end, &mode))
+         return error(f, VORBIS_seek_failed);
+      // calculate the number of samples returned by the next frame
+      frame_samples = right_start - left_start;
+      if (f->current_loc + frame_samples > sample_number) {
+         return 1; // the next frame will contain the sample
+      } else if (f->current_loc + frame_samples + max_frame_samples > sample_number) {
+         // there's a chance the frame after this could contain the sample
+         vorbis_pump_first_frame(f);
+      } else {
+         // this frame is too early to be relevant
+         f->current_loc += frame_samples;
+         f->previous_length = 0;
+         maybe_start_packet(f);
+         flush_packet(f);
+      }
+   }
+   // the next frame should start with the sample
+   if (f->current_loc != sample_number) return error(f, VORBIS_seek_failed);
+   return 1;
+}
+
+int stb_vorbis_seek(stb_vorbis *f, unsigned int sample_number)
+{
+   if (!stb_vorbis_seek_frame(f, sample_number))
+      return 0;
+
+   if (sample_number != f->current_loc) {
+      int n;
+      uint32 frame_start = f->current_loc;
+      stb_vorbis_get_frame_float(f, &n, NULL);
+      assert(sample_number > frame_start);
+      assert(f->channel_buffer_start + (int) (sample_number-frame_start) <= f->channel_buffer_end);
+      f->channel_buffer_start += (sample_number - frame_start);
+   }
+
+   return 1;
+}
+
+int stb_vorbis_seek_start(stb_vorbis *f)
+{
+   if (IS_PUSH_MODE(f)) { return error(f, VORBIS_invalid_api_mixing); }
+   set_file_offset(f, f->first_audio_page_offset);
+   f->previous_length = 0;
+   f->first_decode = TRUE;
+   f->next_seg = -1;
+   return vorbis_pump_first_frame(f);
+}
+
+unsigned int stb_vorbis_stream_length_in_samples(stb_vorbis *f)
+{
+   unsigned int restore_offset, previous_safe;
+   unsigned int end, last_page_loc;
+
+   if (IS_PUSH_MODE(f)) return error(f, VORBIS_invalid_api_mixing);
+   if (!f->total_samples) {
+      unsigned int last;
+      uint32 lo,hi;
+      char header[6];
+
+      // first, store the current decode position so we can restore it
+      restore_offset = stb_vorbis_get_file_offset(f);
+
+      // now we want to seek back 64K from the end (the last page must
+      // be at most a little less than 64K, but let's allow a little slop)
+      if (f->stream_len >= 65536 && f->stream_len-65536 >= f->first_audio_page_offset)
+         previous_safe = f->stream_len - 65536;
+      else
+         previous_safe = f->first_audio_page_offset;
+
+      set_file_offset(f, previous_safe);
+      // previous_safe is now our candidate 'earliest known place that seeking
+      // to will lead to the final page'
+
+      if (!vorbis_find_page(f, &end, &last)) {
+         // if we can't find a page, we're hosed!
+         f->error = VORBIS_cant_find_last_page;
+         f->total_samples = 0xffffffff;
+         goto done;
+      }
+
+      // check if there are more pages
+      last_page_loc = stb_vorbis_get_file_offset(f);
+
+      // stop when the last_page flag is set, not when we reach eof;
+      // this allows us to stop short of a 'file_section' end without
+      // explicitly checking the length of the section
+      while (!last) {
+         set_file_offset(f, end);
+         if (!vorbis_find_page(f, &end, &last)) {
+            // the last page we found didn't have the 'last page' flag
+            // set. whoops!
+            break;
+         }
+         //previous_safe = last_page_loc+1; // NOTE: not used after this point, but note for debugging
+         last_page_loc = stb_vorbis_get_file_offset(f);
+      }
+
+      set_file_offset(f, last_page_loc);
+
+      // parse the header
+      getn(f, (unsigned char *)header, 6);
+      // extract the absolute granule position
+      lo = get32(f);
+      hi = get32(f);
+      if (lo == 0xffffffff && hi == 0xffffffff) {
+         f->error = VORBIS_cant_find_last_page;
+         f->total_samples = SAMPLE_unknown;
+         goto done;
+      }
+      if (hi)
+         lo = 0xfffffffe; // saturate
+      f->total_samples = lo;
+
+      f->p_last.page_start = last_page_loc;
+      f->p_last.page_end   = end;
+      f->p_last.last_decoded_sample = lo;
+
+     done:
+      set_file_offset(f, restore_offset);
+   }
+   return f->total_samples == SAMPLE_unknown ? 0 : f->total_samples;
+}
+
+float stb_vorbis_stream_length_in_seconds(stb_vorbis *f)
+{
+   return stb_vorbis_stream_length_in_samples(f) / (float) f->sample_rate;
+}
+
+
+
+int stb_vorbis_get_frame_float(stb_vorbis *f, int *channels, float ***output)
+{
+   int len, right,left,i;
+   if (IS_PUSH_MODE(f)) return error(f, VORBIS_invalid_api_mixing);
+
+   if (!vorbis_decode_packet(f, &len, &left, &right)) {
+      f->channel_buffer_start = f->channel_buffer_end = 0;
+      return 0;
+   }
+
+   len = vorbis_finish_frame(f, len, left, right);
+   for (i=0; i < f->channels; ++i)
+      f->outputs[i] = f->channel_buffers[i] + left;
+
+   f->channel_buffer_start = left;
+   f->channel_buffer_end   = left+len;
+
+   if (channels) *channels = f->channels;
+   if (output)   *output = f->outputs;
+   return len;
+}
+
+#ifndef STB_VORBIS_NO_STDIO
+
+stb_vorbis * stb_vorbis_open_file_section(FILE *file, int close_on_free, int *error, const stb_vorbis_alloc *alloc, unsigned int length)
+{
+   stb_vorbis *f, p;
+   vorbis_init(&p, alloc);
+   p.f = file;
+   p.f_start = (uint32) ftell(file);
+   p.stream_len   = length;
+   p.close_on_free = close_on_free;
+   if (start_decoder(&p)) {
+      f = vorbis_alloc(&p);
+      if (f) {
+         *f = p;
+         vorbis_pump_first_frame(f);
+         return f;
+      }
+   }
+   if (error) *error = p.error;
+   vorbis_deinit(&p);
+   return NULL;
+}
+
+stb_vorbis * stb_vorbis_open_file(FILE *file, int close_on_free, int *error, const stb_vorbis_alloc *alloc)
+{
+   unsigned int len, start;
+   start = (unsigned int) ftell(file);
+   fseek(file, 0, SEEK_END);
+   len = (unsigned int) (ftell(file) - start);
+   fseek(file, start, SEEK_SET);
+   return stb_vorbis_open_file_section(file, close_on_free, error, alloc, len);
+}
+
+stb_vorbis * stb_vorbis_open_filename(const char *filename, int *error, const stb_vorbis_alloc *alloc)
+{
+   FILE *f;
+#if defined(_WIN32) && defined(__STDC_WANT_SECURE_LIB__)
+   if (0 != fopen_s(&f, filename, "rb"))
+      f = NULL;
+#else
+   f = fopen(filename, "rb");
+#endif
+   if (f)
+      return stb_vorbis_open_file(f, TRUE, error, alloc);
+   if (error) *error = VORBIS_file_open_failure;
+   return NULL;
+}
+#endif // STB_VORBIS_NO_STDIO
+
+stb_vorbis * stb_vorbis_open_memory(const unsigned char *data, int len, int *error, const stb_vorbis_alloc *alloc)
+{
+   stb_vorbis *f, p;
+   if (!data) {
+      if (error) *error = VORBIS_unexpected_eof;
+      return NULL;
+   }
+   vorbis_init(&p, alloc);
+   p.stream = (uint8 *) data;
+   p.stream_end = (uint8 *) data + len;
+   p.stream_start = (uint8 *) p.stream;
+   p.stream_len = len;
+   p.push_mode = FALSE;
+   if (start_decoder(&p)) {
+      f = vorbis_alloc(&p);
+      if (f) {
+         *f = p;
+         vorbis_pump_first_frame(f);
+         if (error) *error = VORBIS__no_error;
+         return f;
+      }
+   }
+   if (error) *error = p.error;
+   vorbis_deinit(&p);
+   return NULL;
+}
+
+#ifndef STB_VORBIS_NO_INTEGER_CONVERSION
+#define PLAYBACK_MONO     1
+#define PLAYBACK_LEFT     2
+#define PLAYBACK_RIGHT    4
+
+#define L  (PLAYBACK_LEFT  | PLAYBACK_MONO)
+#define C  (PLAYBACK_LEFT  | PLAYBACK_RIGHT | PLAYBACK_MONO)
+#define R  (PLAYBACK_RIGHT | PLAYBACK_MONO)
+
+static int8 channel_position[7][6] =
+{
+   { 0 },
+   { C },
+   { L, R },
+   { L, C, R },
+   { L, R, L, R },
+   { L, C, R, L, R },
+   { L, C, R, L, R, C },
+};
+
+
+#ifndef STB_VORBIS_NO_FAST_SCALED_FLOAT
+   typedef union {
+      float f;
+      int i;
+   } float_conv;
+   typedef char stb_vorbis_float_size_test[sizeof(float)==4 && sizeof(int) == 4];
+   #define FASTDEF(x) float_conv x
+   // add (1<<23) to convert to int, then divide by 2^SHIFT, then add 0.5/2^SHIFT to round
+   #define MAGIC(SHIFT) (1.5f * (1 << (23-SHIFT)) + 0.5f/(1 << SHIFT))
+   #define ADDEND(SHIFT) (((150-SHIFT) << 23) + (1 << 22))
+   #define FAST_SCALED_FLOAT_TO_INT(temp,x,s) (temp.f = (x) + MAGIC(s), temp.i - ADDEND(s))
+   #define check_endianness()
+#else
+   #define FAST_SCALED_FLOAT_TO_INT(temp,x,s) ((int) ((x) * (1 << (s))))
+   #define check_endianness()
+   #define FASTDEF(x)
+#endif
+
+static void copy_samples(short *dest, float *src, int len)
+{
+   int i;
+   check_endianness();
+   for (i=0; i < len; ++i) {
+      FASTDEF(temp);
+      int v = FAST_SCALED_FLOAT_TO_INT(temp, src[i],15);
+      if ((unsigned int) (v + 32768) > 65535)
+         v = v < 0 ? -32768 : 32767;
+      dest[i] = v;
+   }
+}
+
+static void compute_samples(int mask, short *output, int num_c, float **data, int d_offset, int len)
+{
+   #define STB_BUFFER_SIZE  32
+   float buffer[STB_BUFFER_SIZE];
+   int i,j,o,n = STB_BUFFER_SIZE;
+   check_endianness();
+   for (o = 0; o < len; o += STB_BUFFER_SIZE) {
+      memset(buffer, 0, sizeof(buffer));
+      if (o + n > len) n = len - o;
+      for (j=0; j < num_c; ++j) {
+         if (channel_position[num_c][j] & mask) {
+            for (i=0; i < n; ++i)
+               buffer[i] += data[j][d_offset+o+i];
+         }
+      }
+      for (i=0; i < n; ++i) {
+         FASTDEF(temp);
+         int v = FAST_SCALED_FLOAT_TO_INT(temp,buffer[i],15);
+         if ((unsigned int) (v + 32768) > 65535)
+            v = v < 0 ? -32768 : 32767;
+         output[o+i] = v;
+      }
+   }
+   #undef STB_BUFFER_SIZE
+}
+
+static void compute_stereo_samples(short *output, int num_c, float **data, int d_offset, int len)
+{
+   #define STB_BUFFER_SIZE  32
+   float buffer[STB_BUFFER_SIZE];
+   int i,j,o,n = STB_BUFFER_SIZE >> 1;
+   // o is the offset in the source data
+   check_endianness();
+   for (o = 0; o < len; o += STB_BUFFER_SIZE >> 1) {
+      // o2 is the offset in the output data
+      int o2 = o << 1;
+      memset(buffer, 0, sizeof(buffer));
+      if (o + n > len) n = len - o;
+      for (j=0; j < num_c; ++j) {
+         int m = channel_position[num_c][j] & (PLAYBACK_LEFT | PLAYBACK_RIGHT);
+         if (m == (PLAYBACK_LEFT | PLAYBACK_RIGHT)) {
+            for (i=0; i < n; ++i) {
+               buffer[i*2+0] += data[j][d_offset+o+i];
+               buffer[i*2+1] += data[j][d_offset+o+i];
+            }
+         } else if (m == PLAYBACK_LEFT) {
+            for (i=0; i < n; ++i) {
+               buffer[i*2+0] += data[j][d_offset+o+i];
+            }
+         } else if (m == PLAYBACK_RIGHT) {
+            for (i=0; i < n; ++i) {
+               buffer[i*2+1] += data[j][d_offset+o+i];
+            }
+         }
+      }
+      for (i=0; i < (n<<1); ++i) {
+         FASTDEF(temp);
+         int v = FAST_SCALED_FLOAT_TO_INT(temp,buffer[i],15);
+         if ((unsigned int) (v + 32768) > 65535)
+            v = v < 0 ? -32768 : 32767;
+         output[o2+i] = v;
+      }
+   }
+   #undef STB_BUFFER_SIZE
+}
+
+static void convert_samples_short(int buf_c, short **buffer, int b_offset, int data_c, float **data, int d_offset, int samples)
+{
+   int i;
+   if (buf_c != data_c && buf_c <= 2 && data_c <= 6) {
+      static int channel_selector[3][2] = { {0}, {PLAYBACK_MONO}, {PLAYBACK_LEFT, PLAYBACK_RIGHT} };
+      for (i=0; i < buf_c; ++i)
+         compute_samples(channel_selector[buf_c][i], buffer[i]+b_offset, data_c, data, d_offset, samples);
+   } else {
+      int limit = buf_c < data_c ? buf_c : data_c;
+      for (i=0; i < limit; ++i)
+         copy_samples(buffer[i]+b_offset, data[i]+d_offset, samples);
+      for (   ; i < buf_c; ++i)
+         memset(buffer[i]+b_offset, 0, sizeof(short) * samples);
+   }
+}
+
+int stb_vorbis_get_frame_short(stb_vorbis *f, int num_c, short **buffer, int num_samples)
+{
+   float **output = NULL;
+   int len = stb_vorbis_get_frame_float(f, NULL, &output);
+   if (len > num_samples) len = num_samples;
+   if (len)
+      convert_samples_short(num_c, buffer, 0, f->channels, output, 0, len);
+   return len;
+}
+
+static void convert_channels_short_interleaved(int buf_c, short *buffer, int data_c, float **data, int d_offset, int len)
+{
+   int i;
+   check_endianness();
+   if (buf_c != data_c && buf_c <= 2 && data_c <= 6) {
+      assert(buf_c == 2);
+      for (i=0; i < buf_c; ++i)
+         compute_stereo_samples(buffer, data_c, data, d_offset, len);
+   } else {
+      int limit = buf_c < data_c ? buf_c : data_c;
+      int j;
+      for (j=0; j < len; ++j) {
+         for (i=0; i < limit; ++i) {
+            FASTDEF(temp);
+            float f = data[i][d_offset+j];
+            int v = FAST_SCALED_FLOAT_TO_INT(temp, f,15);//data[i][d_offset+j],15);
+            if ((unsigned int) (v + 32768) > 65535)
+               v = v < 0 ? -32768 : 32767;
+            *buffer++ = v;
+         }
+         for (   ; i < buf_c; ++i)
+            *buffer++ = 0;
+      }
+   }
+}
+
+int stb_vorbis_get_frame_short_interleaved(stb_vorbis *f, int num_c, short *buffer, int num_shorts)
+{
+   float **output;
+   int len;
+   if (num_c == 1) return stb_vorbis_get_frame_short(f,num_c,&buffer, num_shorts);
+   len = stb_vorbis_get_frame_float(f, NULL, &output);
+   if (len) {
+      if (len*num_c > num_shorts) len = num_shorts / num_c;
+      convert_channels_short_interleaved(num_c, buffer, f->channels, output, 0, len);
+   }
+   return len;
+}
+
+int stb_vorbis_get_samples_short_interleaved(stb_vorbis *f, int channels, short *buffer, int num_shorts)
+{
+   float **outputs;
+   int len = num_shorts / channels;
+   int n=0;
+   while (n < len) {
+      int k = f->channel_buffer_end - f->channel_buffer_start;
+      if (n+k >= len) k = len - n;
+      if (k)
+         convert_channels_short_interleaved(channels, buffer, f->channels, f->channel_buffers, f->channel_buffer_start, k);
+      buffer += k*channels;
+      n += k;
+      f->channel_buffer_start += k;
+      if (n == len) break;
+      if (!stb_vorbis_get_frame_float(f, NULL, &outputs)) break;
+   }
+   return n;
+}
+
+int stb_vorbis_get_samples_short(stb_vorbis *f, int channels, short **buffer, int len)
+{
+   float **outputs;
+   int n=0;
+   while (n < len) {
+      int k = f->channel_buffer_end - f->channel_buffer_start;
+      if (n+k >= len) k = len - n;
+      if (k)
+         convert_samples_short(channels, buffer, n, f->channels, f->channel_buffers, f->channel_buffer_start, k);
+      n += k;
+      f->channel_buffer_start += k;
+      if (n == len) break;
+      if (!stb_vorbis_get_frame_float(f, NULL, &outputs)) break;
+   }
+   return n;
+}
+
+#ifndef STB_VORBIS_NO_STDIO
+int stb_vorbis_decode_filename(const char *filename, int *channels, int *sample_rate, short **output)
+{
+   int data_len, offset, total, limit, error;
+   short *data;
+   stb_vorbis *v = stb_vorbis_open_filename(filename, &error, NULL);
+   if (v == NULL) return -1;
+   limit = v->channels * 4096;
+   *channels = v->channels;
+   if (sample_rate)
+      *sample_rate = v->sample_rate;
+   offset = data_len = 0;
+   total = limit;
+   data = (short *) malloc(total * sizeof(*data));
+   if (data == NULL) {
+      stb_vorbis_close(v);
+      return -2;
+   }
+   for (;;) {
+      int n = stb_vorbis_get_frame_short_interleaved(v, v->channels, data+offset, total-offset);
+      if (n == 0) break;
+      data_len += n;
+      offset += n * v->channels;
+      if (offset + limit > total) {
+         short *data2;
+         total *= 2;
+         data2 = (short *) realloc(data, total * sizeof(*data));
+         if (data2 == NULL) {
+            free(data);
+            stb_vorbis_close(v);
+            return -2;
+         }
+         data = data2;
+      }
+   }
+   *output = data;
+   stb_vorbis_close(v);
+   return data_len;
+}
+#endif // NO_STDIO
+
+int stb_vorbis_decode_memory(const uint8 *mem, int len, int *channels, int *sample_rate, short **output)
+{
+   int data_len, offset, total, limit, error;
+   short *data;
+   stb_vorbis *v = stb_vorbis_open_memory(mem, len, &error, NULL);
+   if (v == NULL) return -1;
+   limit = v->channels * 4096;
+   *channels = v->channels;
+   if (sample_rate)
+      *sample_rate = v->sample_rate;
+   offset = data_len = 0;
+   total = limit;
+   data = (short *) malloc(total * sizeof(*data));
+   if (data == NULL) {
+      stb_vorbis_close(v);
+      return -2;
+   }
+   for (;;) {
+      int n = stb_vorbis_get_frame_short_interleaved(v, v->channels, data+offset, total-offset);
+      if (n == 0) break;
+      data_len += n;
+      offset += n * v->channels;
+      if (offset + limit > total) {
+         short *data2;
+         total *= 2;
+         data2 = (short *) realloc(data, total * sizeof(*data));
+         if (data2 == NULL) {
+            free(data);
+            stb_vorbis_close(v);
+            return -2;
+         }
+         data = data2;
+      }
+   }
+   *output = data;
+   stb_vorbis_close(v);
+   return data_len;
+}
+#endif // STB_VORBIS_NO_INTEGER_CONVERSION
+
+int stb_vorbis_get_samples_float_interleaved(stb_vorbis *f, int channels, float *buffer, int num_floats)
+{
+   float **outputs;
+   int len = num_floats / channels;
+   int n=0;
+   int z = f->channels;
+   if (z > channels) z = channels;
+   while (n < len) {
+      int i,j;
+      int k = f->channel_buffer_end - f->channel_buffer_start;
+      if (n+k >= len) k = len - n;
+      for (j=0; j < k; ++j) {
+         for (i=0; i < z; ++i)
+            *buffer++ = f->channel_buffers[i][f->channel_buffer_start+j];
+         for (   ; i < channels; ++i)
+            *buffer++ = 0;
+      }
+      n += k;
+      f->channel_buffer_start += k;
+      if (n == len)
+         break;
+      if (!stb_vorbis_get_frame_float(f, NULL, &outputs))
+         break;
+   }
+   return n;
+}
+
+int stb_vorbis_get_samples_float(stb_vorbis *f, int channels, float **buffer, int num_samples)
+{
+   float **outputs;
+   int n=0;
+   int z = f->channels;
+   if (z > channels) z = channels;
+   while (n < num_samples) {
+      int i;
+      int k = f->channel_buffer_end - f->channel_buffer_start;
+      if (n+k >= num_samples) k = num_samples - n;
+      if (k) {
+         for (i=0; i < z; ++i)
+            memcpy(buffer[i]+n, f->channel_buffers[i]+f->channel_buffer_start, sizeof(float)*k);
+         for (   ; i < channels; ++i)
+            memset(buffer[i]+n, 0, sizeof(float) * k);
+      }
+      n += k;
+      f->channel_buffer_start += k;
+      if (n == num_samples)
+         break;
+      if (!stb_vorbis_get_frame_float(f, NULL, &outputs))
+         break;
+   }
+   return n;
+}
+#endif // STB_VORBIS_NO_PULLDATA_API
+
+/* Version history
+    1.17    - 2019-07-08 - fix CVE-2019-13217, -13218, -13219, -13220, -13221, -13222, -13223
+                           found with Mayhem by ForAllSecure
+    1.16    - 2019-03-04 - fix warnings
+    1.15    - 2019-02-07 - explicit failure if Ogg Skeleton data is found
+    1.14    - 2018-02-11 - delete bogus dealloca usage
+    1.13    - 2018-01-29 - fix truncation of last frame (hopefully)
+    1.12    - 2017-11-21 - limit residue begin/end to blocksize/2 to avoid large temp allocs in bad/corrupt files
+    1.11    - 2017-07-23 - fix MinGW compilation
+    1.10    - 2017-03-03 - more robust seeking; fix negative ilog(); clear error in open_memory
+    1.09    - 2016-04-04 - back out 'avoid discarding last frame' fix from previous version
+    1.08    - 2016-04-02 - fixed multiple warnings; fix setup memory leaks;
+                           avoid discarding last frame of audio data
+    1.07    - 2015-01-16 - fixed some warnings, fix mingw, const-correct API
+                           some more crash fixes when out of memory or with corrupt files
+    1.06    - 2015-08-31 - full, correct support for seeking API (Dougall Johnson)
+                           some crash fixes when out of memory or with corrupt files
+    1.05    - 2015-04-19 - don't define __forceinline if it's redundant
+    1.04    - 2014-08-27 - fix missing const-correct case in API
+    1.03    - 2014-08-07 - Warning fixes
+    1.02    - 2014-07-09 - Declare qsort compare function _cdecl on windows
+    1.01    - 2014-06-18 - fix stb_vorbis_get_samples_float
+    1.0     - 2014-05-26 - fix memory leaks; fix warnings; fix bugs in multichannel
+                           (API change) report sample rate for decode-full-file funcs
+    0.99996 - bracket #include <malloc.h> for macintosh compilation by Laurent Gomila
+    0.99995 - use union instead of pointer-cast for fast-float-to-int to avoid alias-optimization problem
+    0.99994 - change fast-float-to-int to work in single-precision FPU mode, remove endian-dependence
+    0.99993 - remove assert that fired on legal files with empty tables
+    0.99992 - rewind-to-start
+    0.99991 - bugfix to stb_vorbis_get_samples_short by Bernhard Wodo
+    0.9999 - (should have been 0.99990) fix no-CRT support, compiling as C++
+    0.9998 - add a full-decode function with a memory source
+    0.9997 - fix a bug in the read-from-FILE case in 0.9996 addition
+    0.9996 - query length of vorbis stream in samples/seconds
+    0.9995 - bugfix to another optimization that only happened in certain files
+    0.9994 - bugfix to one of the optimizations that caused significant (but inaudible?) errors
+    0.9993 - performance improvements; runs in 99% to 104% of time of reference implementation
+    0.9992 - performance improvement of IMDCT; now performs close to reference implementation
+    0.9991 - performance improvement of IMDCT
+    0.999 - (should have been 0.9990) performance improvement of IMDCT
+    0.998 - no-CRT support from Casey Muratori
+    0.997 - bugfixes for bugs found by Terje Mathisen
+    0.996 - bugfix: fast-huffman decode initialized incorrectly for sparse codebooks; fixing gives 10% speedup - found by Terje Mathisen
+    0.995 - bugfix: fix to 'effective' overrun detection - found by Terje Mathisen
+    0.994 - bugfix: garbage decode on final VQ symbol of a non-multiple - found by Terje Mathisen
+    0.993 - bugfix: pushdata API required 1 extra byte for empty page (failed to consume final page if empty) - found by Terje Mathisen
+    0.992 - fixes for MinGW warning
+    0.991 - turn fast-float-conversion on by default
+    0.990 - fix push-mode seek recovery if you seek into the headers
+    0.98b - fix to bad release of 0.98
+    0.98 - fix push-mode seek recovery; robustify float-to-int and support non-fast mode
+    0.97 - builds under c++ (typecasting, don't use 'class' keyword)
+    0.96 - somehow MY 0.95 was right, but the web one was wrong, so here's my 0.95 rereleased as 0.96, fixes a typo in the clamping code
+    0.95 - clamping code for 16-bit functions
+    0.94 - not publically released
+    0.93 - fixed all-zero-floor case (was decoding garbage)
+    0.92 - fixed a memory leak
+    0.91 - conditional compiles to omit parts of the API and the infrastructure to support them: STB_VORBIS_NO_PULLDATA_API, STB_VORBIS_NO_PUSHDATA_API, STB_VORBIS_NO_STDIO, STB_VORBIS_NO_INTEGER_CONVERSION
+    0.90 - first public release
+*/
+
+#endif // STB_VORBIS_HEADER_ONLY
+
+
+/*
+------------------------------------------------------------------------------
+This software is available under 2 licenses -- choose whichever you prefer.
+------------------------------------------------------------------------------
+ALTERNATIVE A - MIT License
+Copyright (c) 2017 Sean Barrett
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+------------------------------------------------------------------------------
+ALTERNATIVE B - Public Domain (www.unlicense.org)
+This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+------------------------------------------------------------------------------
+*/

--- a/LIB386/AIL/SDL/stb_vorbis.h
+++ b/LIB386/AIL/SDL/stb_vorbis.h
@@ -1,0 +1,16 @@
+#ifndef STB_VORBIS_INCLUDE_STB_VORBIS_H
+#define STB_VORBIS_INCLUDE_STB_VORBIS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Decode entire file to 16-bit interleaved PCM. Returns samples per channel, or -1 on error.
+   *output is malloc'd; caller must free() it. */
+extern int stb_vorbis_decode_filename(const char *filename, int *channels, int *sample_rate, short **output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/LIB386/CMakeLists.txt
+++ b/LIB386/CMakeLists.txt
@@ -8,3 +8,7 @@ add_subdirectory(OBJECT)
 add_subdirectory(pol_work)
 add_subdirectory(SVGA)
 add_subdirectory(SYSTEM)
+
+if(MVIDEO_BACKEND STREQUAL "smacker")
+  add_subdirectory(libsmacker)
+endif()

--- a/LIB386/H/AIL/VIDEO_AUDIO.H
+++ b/LIB386/H/AIL/VIDEO_AUDIO.H
@@ -1,0 +1,33 @@
+//--------------------------------------------------------------------------
+#ifndef LIB_AIL_VIDEO_AUDIO
+#define LIB_AIL_VIDEO_AUDIO
+
+//--------------------------------------------------------------------------
+#include <SYSTEM/ADELINE_TYPES.H>
+
+//--------------------------------------------------------------------------
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Start a dedicated audio stream for video playback (e.g. Smacker track).
+// Stream is created paused; call ResumeVideoAudio() after pre-filling so playback doesn't stutter.
+// freq: sample rate (e.g. 22050), channels: 1 or 2, is16bit: 1 for 16-bit PCM, 0 for 8-bit.
+// Returns 1 on success, 0 on failure.
+S32 StartVideoAudio(S32 freq, S32 channels, S32 is16bit);
+
+// Start playback (call after pushing initial buffer so device doesn't underrun).
+void ResumeVideoAudio(void);
+
+// Push PCM data to the video audio stream. data is sizeBytes bytes.
+void PushVideoAudio(const void *data, U32 sizeBytes);
+
+// Stop and destroy the video audio stream.
+void StopVideoAudio(void);
+
+//--------------------------------------------------------------------------
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/LIB386/H/SMACKER.H
+++ b/LIB386/H/SMACKER.H
@@ -1,14 +1,5 @@
-//──────────────────────────────────────────────────────────────────────────
+// Redirect to wrapper so <smacker.h> resolves to libsmacker on case-insensitive FS.
 #ifndef	LIB_SMACKER
 #define	LIB_SMACKER
-
-//──────────────────────────────────────────────────────────────────────────
-#ifdef MVIDEO_USE_SMACKER
-#include	<SMACKER/SMACK.H>
-#include	<SMACKER/SMACKER.H>
-#endif
-
-//──────────────────────────────────────────────────────────────────────────
+#include	<SMACKER_ADELINE.H>
 #endif//LIB_SMACKER
-
-//──────────────────────────────────────────────────────────────────────────

--- a/LIB386/H/SMACKER_ADELINE.H
+++ b/LIB386/H/SMACKER_ADELINE.H
@@ -1,0 +1,37 @@
+//──────────────────────────────────────────────────────────────────────────
+#ifndef	LIB_SMACKER_ADELINE
+#define	LIB_SMACKER_ADELINE
+
+// Wrapper for InitAcf SmackRegisterMemory stubs and libsmacker (LGPL) include.
+// Named SMACKER_ADELINE.H so that #include <smacker.h> below resolves to
+// libsmacker/smacker.h on case-insensitive filesystems (e.g. macOS).
+//──────────────────────────────────────────────────────────────────────────
+#ifdef USE_MVIDEO_SMACKER
+#include	<smacker.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+extern void SmackRegisterMemory(void *ptr, U32 size);
+extern void SmackResetMemory(void);
+#ifdef __cplusplus
+}
+#endif
+#elif defined(MVIDEO_USE_SMACKER)
+#include	<SMACKER/SMACK.H>
+#include	<SMACKER/SMACKER.H>
+#else
+/* No video backend: no-ops for InitAcf when LBA_EDITOR */
+#ifdef __cplusplus
+extern "C" {
+#endif
+static inline void SmackRegisterMemory(void *ptr, U32 size) { (void)ptr; (void)size; }
+static inline void SmackResetMemory(void) {}
+#ifdef __cplusplus
+}
+#endif
+#endif
+
+//──────────────────────────────────────────────────────────────────────────
+#endif//LIB_SMACKER_ADELINE
+
+//──────────────────────────────────────────────────────────────────────────

--- a/LIB386/libsmacker/CMakeLists.txt
+++ b/LIB386/libsmacker/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(libsmacker STATIC
+  smacker.c
+  smk_bitstream.c
+  smk_hufftree.c
+  smacker_compat.c
+)
+target_include_directories(libsmacker PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/LIB386/libsmacker/COPYING.txt
+++ b/LIB386/libsmacker/COPYING.txt
@@ -1,0 +1,502 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/LIB386/libsmacker/README.md
+++ b/LIB386/libsmacker/README.md
@@ -1,0 +1,8 @@
+# libsmacker
+
+C library for decoding .smk Smacker Video files (as used in LBA2).
+
+- **License:** GNU LGPL 2.1. See [COPYING.txt](COPYING.txt).
+- **Origin:** [libsmacker](https://github.com/digitalcreations/smacker) by Greg Kennedy (and others).
+
+This replaces the proprietary RAD Game Tools Smacker SDK for video playback in the community build.

--- a/LIB386/libsmacker/smacker.c
+++ b/LIB386/libsmacker/smacker.c
@@ -1,0 +1,1427 @@
+/**
+	libsmacker - A C library for decoding .smk Smacker Video files
+	Copyright (C) 2012-2017 Greg Kennedy
+
+	See smacker.h for more information.
+
+	smacker.c
+		Main implementation file of libsmacker.
+		Open, close, query, render, advance and seek an smk
+*/
+
+#include "smacker.h"
+
+/* safe malloc and free */
+#include "smk_malloc.h"
+
+/* data structures */
+#include "smk_bitstream.h"
+#include "smk_hufftree.h"
+
+/* GLOBALS */
+/* tree processing order */
+#define SMK_TREE_MMAP	0
+#define SMK_TREE_MCLR	1
+#define SMK_TREE_FULL	2
+#define SMK_TREE_TYPE	3
+
+/* SMACKER DATA STRUCTURES */
+struct smk_t
+{
+	/* meta-info */
+	/* file mode: see flags, smacker.h */
+	unsigned char	mode;
+
+	/* microsec per frame - stored as a double to handle scaling
+		(large positive millisec / frame values may overflow a ul) */
+	double	usf;
+
+	/* total frames */
+	unsigned long	f;
+	/* does file have a ring frame? (in other words, does file loop?) */
+	unsigned char	ring_frame;
+
+	/* Index of current frame */
+	unsigned long	cur_frame;
+
+	/* SOURCE union.
+		Where the data is going to be read from (or be stored),
+		depending on the file mode. */
+	union
+	{
+		struct
+		{
+			/* on-disk mode */
+			FILE* fp;
+			unsigned long* chunk_offset;
+		} file;
+
+		/* in-memory mode: unprocessed chunks */
+		unsigned char** chunk_data;
+	} source;
+
+	/* shared array of "chunk sizes"*/
+	unsigned long* chunk_size;
+
+	/* Holds per-frame flags (i.e. 'keyframe') */
+	unsigned char* keyframe;
+	/* Holds per-frame type mask (e.g. 'audio track 3, 2, and palette swap') */
+	unsigned char* frame_type;
+
+	/* video and audio structures */
+	/* Video data type: enable/disable decode switch,
+		video info and flags,
+		pointer to last-decoded-palette */
+	struct smk_video_t
+	{
+		/* enable/disable decode switch */
+		unsigned char enable;
+
+		/* video info */
+		unsigned long	w;
+		unsigned long	h;
+		/* Y scale mode (constants defined in smacker.h)
+			0: unscaled
+			1: doubled
+			2: interlaced */
+		unsigned char	y_scale_mode;
+
+		/* version ('2' or '4') */
+		unsigned char	v;
+
+		/* Huffman trees */
+		/* unsigned long tree_size[4]; */
+		struct smk_huff16_t* tree[4];
+
+		/* Palette data type: pointer to last-decoded-palette */
+		unsigned char palette[256][3];
+		/* Last-unpacked frame */
+		unsigned char* frame;
+	} video;
+
+	/* audio structure */
+	struct smk_audio_t
+	{
+		/* set if track exists in file */
+		unsigned char exists;
+
+		/* enable/disable switch (per track) */
+		unsigned char enable;
+
+		/* Info */
+		unsigned char	channels;
+		unsigned char	bitdepth;
+		unsigned long	rate;
+		long	max_buffer;
+
+		/* compression type
+			0: raw PCM
+			1: SMK DPCM
+			2: Bink (Perceptual), unsupported */
+		unsigned char	compress;
+
+		/* pointer to last-decoded-audio-buffer */
+		void* buffer;
+		unsigned long	buffer_size;
+	} audio[7];
+};
+
+union smk_read_t
+{
+	FILE* file;
+	unsigned char* ram;
+};
+
+/* An fread wrapper: consumes N bytes, or returns -1
+	on failure (when size doesn't match expected) */
+static char smk_read_file(void* buf, const size_t size, FILE* fp)
+{
+	/* don't bother checking buf or fp, fread does it for us */
+	size_t bytesRead = fread(buf,1,size,fp);
+	if (bytesRead != size)
+	{
+		fprintf(stderr, "libsmacker::smk_read_file(buf,%lu,fp) - ERROR: Short read, %lu bytes returned\n\tReason: %s\n", (unsigned long)size, (unsigned long)bytesRead, strerror(errno));
+		return -1;
+	}
+	return 0;
+}
+
+/* A memcpy wrapper: consumes N bytes, or returns -1
+	on failure (when size too low) */
+static char smk_read_memory(void* buf, const unsigned long size, unsigned char** p, unsigned long* p_size)
+{
+	if (size > *p_size)
+	{
+		fprintf(stderr,"libsmacker::smk_read_memory(buf,%lu,p,%lu) - ERROR: Short read\n",(unsigned long)size, (unsigned long)*p_size);
+		return -1;
+	}
+	memcpy(buf,*p,size);
+	*p += size;
+	*p_size -= size;
+	return 0;
+}
+
+/* Helper functions to do the reading, plus
+	byteswap from LE to host order */
+/* read n bytes from (source) into ret */
+#define smk_read(ret,n) \
+{ \
+	if (m) \
+	{ \
+		r = (smk_read_file(ret,n,fp.file)); \
+	} \
+	else \
+	{ \
+		r = (smk_read_memory(ret,n,&fp.ram,&size)); \
+	} \
+	if (r < 0) \
+	{ \
+		fprintf(stderr,"libsmacker::smk_read(...) - Errors encountered on read, bailing out (file: %s, line: %lu)\n", __FILE__, (unsigned long)__LINE__); \
+		goto error; \
+	} \
+}
+
+/* Calls smk_read, but returns a ul */
+#define smk_read_ul(p) \
+{ \
+	smk_read(buf,4); \
+	p = ((unsigned long) buf[3] << 24) | \
+		((unsigned long) buf[2] << 16) | \
+		((unsigned long) buf[1] << 8) | \
+		((unsigned long) buf[0]); \
+}
+
+/* PUBLIC FUNCTIONS */
+/* open an smk (from a generic Source) */
+static smk smk_open_generic(const unsigned char m, union smk_read_t fp, unsigned long size, const unsigned char process_mode)
+{
+	smk s = NULL;
+
+	/* Temporary variables */
+	long temp_l;
+	unsigned long temp_u;
+
+	/* r is used by macros above for return code */
+	char r;
+	unsigned char buf[4] = {'\0'};
+
+	/* video hufftrees are stored as a large chunk (bitstream)
+		these vars are used to load, then decode them */
+	unsigned char* hufftree_chunk = NULL;
+	unsigned long tree_size;
+	/* a bitstream struct */
+	struct smk_bit_t* bs = NULL;
+
+	/* safe malloc the structure */
+	smk_malloc(s,sizeof (struct smk_t));
+
+	/* Check for a valid signature */
+	smk_read(buf,3);
+	if (buf[0] != 'S' || buf[1] != 'M' || buf[2] != 'K')
+	{
+		fprintf(stderr,"libsmacker::smk_open_generic - ERROR: invalid SMKn signature (got: %s)\n",buf);
+		goto error;
+	}
+
+	/* Read .smk file version */
+	smk_read(&s->video.v,1);
+	if (s->video.v != '2' && s->video.v != '4')
+	{
+		fprintf(stderr,"libsmacker::smk_open_generic - Warning: invalid SMK version %c (expected: 2 or 4)\n",s->video.v);
+		/* take a guess */
+		if (s->video.v < '4')
+			s->video.v = '2';
+		else
+			s->video.v = '4';
+		fprintf(stderr,"\tProcessing will continue as type %c\n",s->video.v);
+	}
+
+	/* width, height, total num frames */
+	smk_read_ul(s->video.w);
+	smk_read_ul(s->video.h);
+
+	smk_read_ul(s->f);
+
+	/* frames per second calculation */
+	smk_read_ul(temp_u);
+	temp_l = (int)temp_u;
+	if (temp_l > 0)
+	{
+		/* millisec per frame */
+		s->usf = temp_l * 1000;
+	}
+	else if (temp_l < 0)
+	{
+		/* 10 microsec per frame */
+		s->usf = temp_l * -10;
+	}
+	else
+	{
+		/* defaults to 10 usf (= 100000 microseconds) */
+		s->usf = 100000;
+	}
+
+	/* Video flags follow.
+		Ring frame is important to libsmacker.
+		Y scale / Y interlace go in the Video flags.
+		The user should scale appropriately. */
+	smk_read_ul(temp_u);
+	if (temp_u & 0x01)
+	{
+		s->ring_frame = 1;
+	}
+	if (temp_u & 0x02)
+	{
+		s->video.y_scale_mode = SMK_FLAG_Y_DOUBLE;
+	}
+	if (temp_u & 0x04)
+	{
+		if (s->video.y_scale_mode == SMK_FLAG_Y_DOUBLE)
+		{
+			fputs("libsmacker::smk_open_generic - Warning: SMK file specifies both Y-Double AND Y-Interlace.\n",stderr);
+		}
+		s->video.y_scale_mode = SMK_FLAG_Y_INTERLACE;
+	}
+
+	/* Max buffer size for each audio track - used to pre-allocate buffers */
+	for (temp_l = 0; temp_l < 7; temp_l ++)
+	{
+		smk_read_ul(s->audio[temp_l].max_buffer);
+	}
+
+	/* Read size of "hufftree chunk" - save for later. */
+	smk_read_ul(tree_size);
+
+	/* "unpacked" sizes of each huff tree - we don't use
+		but calling application might. */
+	for (temp_l = 0; temp_l < 4; temp_l ++)
+	{
+/*		smk_read_ul(s->video.tree_size[temp_u]); */
+		smk_read_ul(temp_u);
+	}
+
+	/* read audio rate data */
+	for (temp_l = 0; temp_l < 7; temp_l ++)
+	{
+		smk_read_ul(temp_u);
+		if (temp_u & 0x40000000)
+		{
+			/* Audio track specifies "exists" flag, malloc structure and copy components. */
+			s->audio[temp_l].exists = 1;
+
+			/* and for all audio tracks */
+			smk_malloc(s->audio[temp_l].buffer, s->audio[temp_l].max_buffer);
+
+			if (temp_u & 0x80000000)
+			{
+				s->audio[temp_l].compress = 1;
+			}
+			s->audio[temp_l].bitdepth = ((temp_u & 0x20000000) ? 16 : 8);
+			s->audio[temp_l].channels = ((temp_u & 0x10000000) ? 2 : 1);
+			if (temp_u & 0x0c000000)
+			{
+				fprintf(stderr,"libsmacker::smk_open_generic - Warning: audio track %ld is compressed with Bink (perceptual) Audio Codec: this is currently unsupported by libsmacker\n",temp_l);
+				s->audio[temp_l].compress = 2;
+			}
+			/* Bits 25 & 24 are unused. */
+			s->audio[temp_l].rate = (temp_u & 0x00FFFFFF);
+		}
+	}
+
+	/* Skip over Dummy field */
+	smk_read_ul(temp_u);
+
+	/* FrameSizes and Keyframe marker are stored together. */
+	smk_malloc(s->keyframe,(s->f + s->ring_frame));
+	smk_malloc(s->chunk_size,(s->f + s->ring_frame) * sizeof(unsigned long));
+
+	for (temp_u = 0; temp_u < (s->f + s->ring_frame); temp_u ++)
+	{
+		smk_read_ul(s->chunk_size[temp_u]);
+
+		/* Set Keyframe */
+		if (s->chunk_size[temp_u] & 0x01)
+		{
+			s->keyframe[temp_u] = 1;
+		}
+		/* Bits 1 is used, but the purpose is unknown. */
+		s->chunk_size[temp_u] &= 0xFFFFFFFC;
+	}
+
+	/* That was easy... Now read FrameTypes! */
+	smk_malloc(s->frame_type,(s->f + s->ring_frame));
+	for (temp_u = 0; temp_u < (s->f + s->ring_frame); temp_u ++)
+	{
+		smk_read(&s->frame_type[temp_u],1);
+	}
+
+	/* HuffmanTrees
+		We know the sizes already: read and assemble into
+		something actually parse-able at run-time */
+	smk_malloc(hufftree_chunk,tree_size);
+	smk_read(hufftree_chunk,tree_size);
+
+	/* set up a Bitstream */
+	bs = smk_bs_init(hufftree_chunk, tree_size);
+	/* create some tables */
+	for (temp_u = 0; temp_u < 4; temp_u ++)
+	{
+		smk_huff16_build(bs,s->video.tree[temp_u]);
+	}
+
+	/* clean up */
+	smk_free(bs);
+	smk_free(hufftree_chunk);
+
+	/* Go ahead and malloc storage for the video frame */
+	smk_malloc(s->video.frame,s->video.w * s->video.h);
+
+	/* final processing: depending on ProcessMode, handle what to do with rest of file data */
+	s->mode = process_mode;
+
+	/* Handle the rest of the data.
+		For MODE_MEMORY, read the chunks and store */
+	if (s->mode == SMK_MODE_MEMORY)
+	{
+		smk_malloc(s->source.chunk_data,(s->f + s->ring_frame) * sizeof(unsigned char*));
+		for (temp_u = 0; temp_u < (s->f + s->ring_frame); temp_u ++)
+		{
+			smk_malloc(s->source.chunk_data[temp_u],s->chunk_size[temp_u]);
+			smk_read(s->source.chunk_data[temp_u],s->chunk_size[temp_u]);
+		}
+	}
+	else
+	{
+		/* MODE_STREAM: don't read anything now, just precompute offsets.
+			use fseek to verify that the file is "complete" */
+		smk_malloc(s->source.file.chunk_offset,(s->f + s->ring_frame) * sizeof(unsigned long));
+		for (temp_u = 0; temp_u < (s->f + s->ring_frame); temp_u ++)
+		{
+			s->source.file.chunk_offset[temp_u] = ftell(fp.file);
+			if (fseek(fp.file,s->chunk_size[temp_u],SEEK_CUR))
+			{
+				fprintf(stderr,"libsmacker::smk_open - ERROR: fseek to frame %lu not OK.\n",temp_u);
+				perror ("\tError reported was");
+				goto error;
+			}
+		}
+	}
+
+	return s;
+
+error:
+	smk_free(bs);
+	smk_free(hufftree_chunk);
+	smk_close(s);
+	return NULL;
+}
+
+/* open an smk (from a memory buffer) */
+smk smk_open_memory(const unsigned char* buffer, const unsigned long size)
+{
+	smk s = NULL;
+
+	union smk_read_t fp;
+
+	smk_assert(buffer);
+
+	/* set up the read union for Memory mode */
+	fp.ram = (unsigned char*)buffer;
+
+	if (!(s = smk_open_generic(0,fp,size,SMK_MODE_MEMORY)))
+	{
+		fprintf(stderr,"libsmacker::smk_open_memory(buffer,%lu) - ERROR: Fatal error in smk_open_generic, returning NULL.\n",size);
+	}
+
+	/* fall through, return s or null */
+error:
+	return s;
+}
+
+/* open an smk (from a file) */
+smk smk_open_filepointer(FILE* file, const unsigned char mode)
+{
+	smk s = NULL;
+	union smk_read_t fp;
+
+	smk_assert(file);
+
+	/* Copy file ptr to internal union */
+	fp.file = file;
+
+	if (!(s = smk_open_generic(1,fp,0,mode)))
+	{
+		fprintf(stderr,"libsmacker::smk_open_filepointer(file,%u) - ERROR: Fatal error in smk_open_generic, returning NULL.\n",mode);
+		fclose(fp.file);
+		goto error;
+	}
+
+	if (mode == SMK_MODE_MEMORY)
+	{
+		fclose(fp.file);
+	}
+	else
+	{
+		s->source.file.fp = fp.file;
+	}
+
+	/* fall through, return s or null */
+error:
+	return s;
+}
+
+/* open an smk (from a file) */
+smk smk_open_file(const char* filename, const unsigned char mode)
+{
+	FILE* fp;
+
+	smk_assert(filename);
+
+	if (!(fp = fopen(filename,"rb")))
+	{
+		fprintf(stderr,"libsmacker::smk_open_file(%s,%u) - ERROR: could not open file (errno: %d)\n",filename,mode,errno);
+		perror ("\tError reported was");
+		goto error;
+	}
+
+	/* kick processing to smk_open_filepointer */
+	return smk_open_filepointer(fp,mode);
+
+	/* fall through, return s or null */
+error:
+	return NULL;
+}
+
+/* close out an smk file and clean up memory */
+void smk_close(smk s)
+{
+	unsigned long u;
+
+	smk_assert(s);
+
+	/* free video sub-components */
+	{
+		for (u = 0; u < 4; u ++)
+		{
+			if (s->video.tree[u]) smk_huff16_free(s->video.tree[u]);
+		}
+		smk_free(s->video.frame);
+	}
+
+	/* free audio sub-components */
+	for (u=0; u<7; u++)
+	{
+		smk_free(s->audio[u].buffer);
+	}
+
+	smk_free(s->keyframe);
+	smk_free(s->frame_type);
+
+	if (s->mode == SMK_MODE_DISK)
+	{
+		/* disk-mode */
+		if (s->source.file.fp)
+		{
+			fclose(s->source.file.fp);
+		}
+		smk_free(s->source.file.chunk_offset);
+	}
+	else
+	{
+		/* mem-mode */
+		if (s->source.chunk_data != NULL)
+		{
+			for (u=0; u<(s->f + s->ring_frame); u++)
+			{
+				smk_free(s->source.chunk_data[u]);
+			}
+			smk_free(s->source.chunk_data);
+		}
+	}
+	smk_free(s->chunk_size);
+
+	smk_free(s);
+
+error: ;
+}
+
+/* tell some info about the file */
+char smk_info_all(const smk object, unsigned long* frame, unsigned long* frame_count, double* usf)
+{
+	/* sanity check */
+	smk_assert(object);
+	if (!frame && !frame_count && !usf) {
+		fputs("libsmacker::smk_info_all(object,frame,frame_count,usf) - ERROR: Request for info with all-NULL return references\n",stderr);
+		goto error;
+	}
+	if (frame)
+		*frame = (object->cur_frame % object->f);
+
+	if (frame_count)
+		*frame_count = object->f;
+
+	if (usf)
+		*usf = object->usf;
+
+	return 0;
+
+error:
+	return -1;
+}
+
+char smk_info_video(const smk object, unsigned long* w, unsigned long* h, unsigned char* y_scale_mode)
+{
+	/* sanity check */
+	smk_assert(object);
+	if (!w && !h && !y_scale_mode)
+	{
+		fputs("libsmacker::smk_info_all(object,w,h,y_scale_mode) - ERROR: Request for info with all-NULL return references\n",stderr);
+		return -1;
+	}
+
+	if (w)
+		*w = object->video.w;
+
+	if (h)
+		*h = object->video.h;
+
+	if (y_scale_mode)
+		*y_scale_mode = object->video.y_scale_mode;
+
+	return 0;
+
+error:
+	return -1;
+}
+
+char smk_info_audio(const smk object, unsigned char* track_mask, unsigned char channels[7], unsigned char bitdepth[7], unsigned long audio_rate[7])
+{
+	unsigned char i;
+
+	/* sanity check */
+	smk_assert(object);
+
+	if (!track_mask && !channels && !bitdepth && !audio_rate)
+	{
+		fputs("libsmacker::smk_info_audio(object,track_mask,channels,bitdepth,audio_rate) - ERROR: Request for info with all-NULL return references\n",stderr);
+		return -1;
+	}
+	if (track_mask)
+	{
+		*track_mask = ( (object->audio[0].exists) |
+			 ( (object->audio[1].exists) << 1 ) |
+			 ( (object->audio[2].exists) << 2 ) |
+			 ( (object->audio[3].exists) << 3 ) |
+			 ( (object->audio[4].exists) << 4 ) |
+			 ( (object->audio[5].exists) << 5 ) |
+			 ( (object->audio[6].exists) << 6 ) );
+	}
+	if (channels)
+	{
+		for (i = 0; i < 7; i ++)
+		{
+			channels[i] = object->audio[i].channels;
+		}
+	}
+	if (bitdepth)
+	{
+		for (i = 0; i < 7; i ++)
+		{
+			bitdepth[i] = object->audio[i].bitdepth;
+		}
+	}
+	if (audio_rate)
+	{
+		for (i = 0; i < 7; i ++)
+		{
+			audio_rate[i] = object->audio[i].rate;
+		}
+	}
+	return 0;
+
+error:
+	return -1;
+}
+
+/* Enable-disable switches */
+char smk_enable_all(smk object, const unsigned char mask)
+{
+	unsigned char i;
+
+	/* sanity check */
+	smk_assert(object);
+
+	/* set video-enable */
+	object->video.enable = (mask & 0x80);
+
+	for (i = 0; i < 7; i ++)
+	{
+		if (object->audio[i].exists)
+		{
+			object->audio[i].enable = (mask & (1 << i));
+		}
+	}
+
+	return 0;
+
+error:
+	return -1;
+}
+
+char smk_enable_video(smk object, const unsigned char enable)
+{
+	/* sanity check */
+	smk_assert(object);
+
+	object->video.enable = enable;
+	return 0;
+
+error:
+	return -1;
+}
+
+char smk_enable_audio(smk object, const unsigned char track, const unsigned char enable)
+{
+	/* sanity check */
+	smk_assert(object);
+
+	object->audio[track].enable = enable;
+	return 0;
+
+error:
+	return -1;
+}
+
+const unsigned char* smk_get_palette(const smk object)
+{
+	smk_assert(object);
+
+	return (unsigned char*)object->video.palette;
+
+error:
+	return NULL;
+}
+const unsigned char* smk_get_video(const smk object)
+{
+	smk_assert(object);
+
+	return object->video.frame;
+
+error:
+	return NULL;
+}
+const unsigned char* smk_get_audio(const smk object, const unsigned char t)
+{
+	smk_assert(object);
+
+	return object->audio[t].buffer;
+
+error:
+	return NULL;
+}
+unsigned long smk_get_audio_size(const smk object, const unsigned char t)
+{
+	smk_assert(object);
+
+	return object->audio[t].buffer_size;
+
+error:
+	return 0;
+}
+
+/* Decompresses a palette-frame. */
+static char smk_render_palette(struct smk_video_t* s, unsigned char* p, unsigned long size)
+{
+	/* Index into palette */
+	unsigned short i = 0;
+	/* Helper variables */
+	unsigned short count, src;
+
+	static unsigned char oldPalette[256][3];
+
+	/* Smacker palette map: smk colors are 6-bit, this table expands them to 8. */
+	const unsigned char palmap[64] =
+	{
+		0x00, 0x04, 0x08, 0x0C, 0x10, 0x14, 0x18, 0x1C,
+		0x20, 0x24, 0x28, 0x2C, 0x30, 0x34, 0x38, 0x3C,
+		0x41, 0x45, 0x49, 0x4D, 0x51, 0x55, 0x59, 0x5D,
+		0x61, 0x65, 0x69, 0x6D, 0x71, 0x75, 0x79, 0x7D,
+		0x82, 0x86, 0x8A, 0x8E, 0x92, 0x96, 0x9A, 0x9E,
+		0xA2, 0xA6, 0xAA, 0xAE, 0xB2, 0xB6, 0xBA, 0xBE,
+		0xC3, 0xC7, 0xCB, 0xCF, 0xD3, 0xD7, 0xDB, 0xDF,
+		0xE3, 0xE7, 0xEB, 0xEF, 0xF3, 0xF7, 0xFB, 0xFF
+	};
+
+	/* sanity check */
+	smk_assert(s);
+	smk_assert(p);
+
+	// Copy palette to old palette
+	memcpy(oldPalette, s->palette, 256 * 3);
+
+	/* Loop until palette is complete, or we are out of bytes to process */
+	while ( (i < 256) && (size > 0) )
+	{
+		if ((*p) & 0x80)
+		{
+			/* 0x80: Skip block
+				(preserve C+1 palette entries from previous palette) */
+			count = ((*p) & 0x7F) + 1;
+			p ++; size --;
+
+			/* check for overflow condition */
+			if (i + count > 256)
+			{
+				fprintf(stderr,"libsmacker::palette_render(s,p,size) - ERROR: overflow, 0x80 attempt to skip %d entries from %d\n",count,i);
+				goto error;
+			}
+
+			/* finally: advance the index. */
+			i += count;
+		}
+		else if ((*p) & 0x40)
+		{
+			/* 0x40: Color-shift block
+				Copy (c + 1) color entries of the previous palette,
+				starting from entry (s),
+				to the next entries of the new palette. */
+			if (size < 2)
+			{
+				fputs("libsmacker::palette_render(s,p,size) - ERROR: 0x40 ran out of bytes for copy\n",stderr);
+				goto error;
+			}
+
+			/* pick "count" items to copy */
+			count = ((*p) & 0x3F) + 1;
+			p ++; size --;
+
+			/* start offset of old palette */
+			src = *p;
+			p ++; size --;
+
+			/* overflow: see if we write/read beyond 256colors, or overwrite own palette */
+			if (i + count > 256 || src + count > 256 ||
+				(src < i && src + count > i) )
+			{
+				fprintf(stderr,"libsmacker::palette_render(s,p,size) - ERROR: overflow, 0x40 attempt to copy %d entries from %d to %d\n",count,src,i);
+				goto error;
+			}
+
+			/* OK!  Copy the color-palette entries. */
+			memmove(&s->palette[i][0],&oldPalette[src][0],count * 3);
+
+			i += count;
+		}
+		else
+		{
+			/* 0x00: Set Color block
+				Direct-set the next 3 bytes for palette index */
+			if (size < 3)
+			{
+				fprintf(stderr,"libsmacker::palette_render - ERROR: 0x3F ran out of bytes for copy, size=%lu\n", size);
+				goto error;
+			}
+
+			for (count = 0; count < 3; count ++)
+			{
+				if (*p > 0x3F)
+				{
+					fprintf(stderr,"libsmacker::palette_render - ERROR: palette index exceeds 0x3F (entry [%u][%u])\n", i, count);
+					goto error;
+				}
+				s->palette[i][count] = palmap[*p];
+				p++; size --;
+			}
+			i ++;
+		}
+	}
+
+	if (i < 256)
+	{
+		fprintf(stderr,"libsmacker::palette_render - ERROR: did not completely fill palette (idx=%u)\n",i);
+		goto error;
+	}
+
+	return 0;
+
+error:
+	/* Error, return -1
+		The new palette probably has errors but is preferrable to a black screen */
+	return -1;
+}
+
+static char smk_render_video(struct smk_video_t* s, unsigned char* p, unsigned int size)
+{
+	unsigned char* t = s->frame;
+	unsigned char s1,s2;
+	unsigned short temp;
+	unsigned long i,j,k, row, col,skip;
+
+	/* used for video decoding */
+	struct smk_bit_t* bs = NULL;
+
+	/* results from a tree lookup */
+	long unpack;
+
+	/* unpack, broken into pieces */
+	unsigned char type;
+	unsigned char blocklen;
+	unsigned char typedata;
+	char bit;
+
+	const unsigned short sizetable[64] = {
+		1,	 2,	3,	4,	5,	6,	7,	8,
+		9,	10,	11,	12,	13,	14,	15,	16,
+		17,	18,	19,	20,	21,	22,	23,	24,
+		25,	26,	27,	28,	29,	30,	31,	32,
+		33,	34,	35,	36,	37,	38,	39,	40,
+		41,	42,	43,	44,	45,	46,	47,	48,
+		49,	50,	51,	52,	53,	54,	55,	56,
+		57,	58,	59,	128,	256,	512,	1024,	2048
+	};
+
+	/* sanity check */
+	smk_assert(s);
+	smk_assert(p);
+
+	row = 0;
+	col = 0;
+
+	/* Set up a bitstream for video unpacking */
+	/* We could check the return code but it will only fail if p is null and we already verified that. */
+	bs = smk_bs_init (p, size);
+
+	/* Reset the cache on all bigtrees */
+	smk_huff16_reset(s->tree[0]);
+	smk_huff16_reset(s->tree[1]);
+	smk_huff16_reset(s->tree[2]);
+	smk_huff16_reset(s->tree[3]);
+
+	while ( row < s->h )
+	{
+		smk_huff16_lookup(bs,s->tree[SMK_TREE_TYPE],unpack);
+
+		type = ((unpack & 0x0003));
+		blocklen = ((unpack & 0x00FC) >> 2);
+		typedata = ((unpack & 0xFF00) >> 8);
+
+		/* support for v4 full-blocks */
+		if (type == 1 && s->v == '4')
+		{
+			smk_bs_read_1(bs, bit);
+			if (bit)
+			{
+				type = 4;
+			} else {
+				smk_bs_read_1(bs, bit);
+				if (bit)
+				{
+					type = 5;
+				}
+			}
+		}
+
+		for (j = 0; (j < sizetable[blocklen]) && (row < s->h); j ++)
+		{
+			skip = (row * s->w) + col;
+			switch(type)
+			{
+				case 0:
+					smk_huff16_lookup(bs,s->tree[SMK_TREE_MCLR],unpack);
+					s1 = (unpack & 0xFF00) >> 8;
+					s2 = (unpack & 0x00FF);
+					smk_huff16_lookup(bs,s->tree[SMK_TREE_MMAP],unpack);
+
+					temp = 0x01;
+					for (k = 0; k < 4; k ++)
+					{
+						for (i = 0; i < 4; i ++)
+						{
+							if (unpack & temp)
+							{
+								t[skip + i] = s1;
+							}
+							else
+							{
+								t[skip + i] = s2;
+							}
+							temp = temp << 1;
+						}
+						skip += s->w;
+					}
+					break;
+
+				case 1: /* FULL BLOCK */
+					for (k = 0; k < 4; k ++)
+					{
+						smk_huff16_lookup(bs,s->tree[SMK_TREE_FULL],unpack);
+						t[skip + 3] = ((unpack & 0xFF00) >> 8);
+						t[skip + 2] = (unpack & 0x00FF);
+						smk_huff16_lookup(bs,s->tree[SMK_TREE_FULL],unpack);
+						t[skip + 1] = ((unpack & 0xFF00) >> 8);
+						t[skip] = (unpack & 0x00FF);
+						skip += s->w;
+					}
+					break;
+				case 2: /* VOID BLOCK */
+					/* break;
+					if (s->frame)
+					{
+						memcpy(&t[skip], &s->frame[skip], 4);
+						skip += s->w;
+						memcpy(&t[skip], &s->frame[skip], 4);
+						skip += s->w;
+						memcpy(&t[skip], &s->frame[skip], 4);
+						skip += s->w;
+						memcpy(&t[skip], &s->frame[skip], 4);
+					} */
+					break;
+				case 3: /* SOLID BLOCK */
+					memset(&t[skip],typedata,4);
+					skip += s->w;
+					memset(&t[skip],typedata,4);
+					skip += s->w;
+					memset(&t[skip],typedata,4);
+					skip += s->w;
+					memset(&t[skip],typedata,4);
+					break;
+				case 4: /* V4 DOUBLE BLOCK */
+					for (k = 0; k < 2; k ++)
+					{
+						smk_huff16_lookup(bs,s->tree[SMK_TREE_FULL],unpack);
+						for (i = 0; i < 2; i ++)
+						{
+							memset(&t[skip + 2],(unpack & 0xFF00) >> 8,2);
+							memset(&t[skip],(unpack & 0x00FF),2);
+							skip += s->w;
+						}
+					}
+					break;
+				case 5: /* V4 HALF BLOCK */
+					for (k = 0; k < 2; k ++)
+					{
+						smk_huff16_lookup(bs,s->tree[SMK_TREE_FULL],unpack);
+						t[skip + 3] = ((unpack & 0xFF00) >> 8);
+						t[skip + 2] = (unpack & 0x00FF);
+						t[skip + s->w + 3] = ((unpack & 0xFF00) >> 8);
+						t[skip + s->w + 2] = (unpack & 0x00FF);
+						smk_huff16_lookup(bs,s->tree[SMK_TREE_FULL],unpack);
+						t[skip + 1] = ((unpack & 0xFF00) >> 8);
+						t[skip] = (unpack & 0x00FF);
+						t[skip + s->w + 1] = ((unpack & 0xFF00) >> 8);
+						t[skip + s->w] = (unpack & 0x00FF);
+						skip += (s->w << 1);
+					}
+					break;
+			}
+			col += 4;
+			if (col >= s->w)
+			{
+				col = 0;
+				row += 4;
+			}
+		}
+	}
+
+	smk_free(bs);
+
+	return 0;
+
+error:
+	smk_free(bs);
+	return -1;
+}
+
+/* Decompress audio track i. */
+static char smk_render_audio(struct smk_audio_t* s, unsigned char* p, unsigned long size)
+{
+	unsigned int j,k;
+	unsigned char* t = s->buffer;
+	struct smk_bit_t* bs = NULL;
+
+	char bit;
+	short unpack, unpack2;
+
+	/* used for audio decoding */
+	struct smk_huff8_t* aud_tree[4] = {NULL,NULL,NULL,NULL};
+
+	/* sanity check */
+	smk_assert(s);
+	smk_assert(p);
+
+	if (!s->compress)
+	{
+		/* Raw PCM data, update buffer size and malloc */
+		s->buffer_size = size;
+
+		memcpy(t,p,size);
+	}
+	else if (s->compress == 1)
+	{
+		/* SMACKER DPCM compression */
+		/* need at least 4 bytes to process */
+		if (size < 4)
+		{
+			fputs("libsmacker::smk_render_audio() - ERROR: need 4 bytes to get unpacked output buffer size.\n",stderr);
+			goto error;
+		}
+		/* chunk is compressed (huff-compressed dpcm), retrieve unpacked buffer size */
+		s->buffer_size = ((unsigned int) p[3] << 24) |
+						((unsigned int) p[2] << 16) |
+						((unsigned int) p[1] << 8) |
+						((unsigned int) p[0]);
+
+		p += 4;
+		size -= 4;
+
+		/* Compressed audio: must unpack here */
+		/*  Set up a bitstream */
+		bs = smk_bs_init (p, size);
+
+		smk_bs_read_1(bs,bit);
+
+		if (!bit)
+		{
+			fputs("libsmacker::smk_render_audio - ERROR: initial get_bit returned 0\n",stderr);
+			goto error;
+		}
+
+		smk_bs_read_1(bs,bit);
+		if (s->channels != (bit == 1 ? 2 : 1))
+		{
+			fputs("libsmacker::smk_render - ERROR: mono/stereo mismatch\n",stderr);
+		}
+		smk_bs_read_1(bs,bit);
+		if (s->bitdepth != (bit == 1 ? 16 : 8))
+		{
+			fputs("libsmacker::smk_render - ERROR: 8-/16-bit mismatch\n",stderr);
+		}
+
+		/* build the trees */
+		smk_huff8_build(bs,aud_tree[0]);
+		j = 1;
+		k = 1;
+		if (s->bitdepth == 16)
+		{
+			smk_huff8_build(bs,aud_tree[1]);
+			k = 2;
+		}
+		if (s->channels == 2)
+		{
+			smk_huff8_build(bs,aud_tree[2]);
+			j = 2;
+			k = 2;
+			if (s->bitdepth == 16)
+			{
+				smk_huff8_build(bs,aud_tree[3]);
+				k = 4;
+			}
+		}
+
+		/* read initial sound level */
+		if (s->channels == 2)
+		{
+			smk_bs_read_8(bs,unpack);
+			if (s->bitdepth == 16)
+			{
+				smk_bs_read_8(bs,((short*)t)[1])
+				((short*)t)[1] |= (unpack << 8);
+			}
+			else
+			{
+				((unsigned char*)t)[1] = (unsigned char)unpack;
+			}
+		}
+		smk_bs_read_8(bs,unpack);
+		if (s->bitdepth == 16)
+		{
+				smk_bs_read_8(bs,((short*)t)[0])
+				((short*)t)[0] |= (unpack << 8);
+		}
+		else
+		{
+			((unsigned char*)t)[0] = (unsigned char)unpack;
+		}
+
+		/* All set: let's read some DATA! */
+		while (k < s->buffer_size)
+		{
+			if (s->bitdepth == 8)
+			{
+				smk_huff8_lookup(bs,aud_tree[0],unpack);
+				((unsigned char*)t)[j] = (char)unpack + ((unsigned char*)t)[j - s->channels];
+				j ++;
+				k++;
+			}
+			else
+			{
+				smk_huff8_lookup(bs,aud_tree[0],unpack);
+				smk_huff8_lookup(bs,aud_tree[1],unpack2);
+				((short*)t)[j] = (short) ( unpack | (unpack2 << 8) ) + ((short*)t)[j - s->channels];
+				j ++;
+				k+=2;
+			}
+			if (s->channels == 2)
+			{
+				if (s->bitdepth == 8)
+				{
+					smk_huff8_lookup(bs,aud_tree[2],unpack);
+					((unsigned char*)t)[j] = (char)unpack + ((unsigned char*)t)[j - 2];
+					j ++;
+					k++;
+				}
+				else
+				{
+					smk_huff8_lookup(bs,aud_tree[2],unpack);
+					smk_huff8_lookup(bs,aud_tree[3],unpack2);
+					((short*)t)[j] = (short) ( unpack | (unpack2 << 8) ) + ((short*)t)[j - 2];
+					j ++;
+					k+=2;
+				}
+			}
+		}
+
+		/* All done with the trees, free them. */
+		for (j = 0; j < 4; j ++)
+		{
+			if (aud_tree[j])
+			{
+				smk_huff8_free(aud_tree[j]);
+			}
+		}
+
+		/* free bitstream */
+		smk_free(bs);
+	}
+
+	return 0;
+
+error:
+	/* All done with the trees, free them. */
+	for (j = 0; j < 4; j ++)
+	{
+		if (aud_tree[j])
+		{
+			smk_huff8_free(aud_tree[j]);
+		}
+	}
+
+	smk_free(bs);
+
+	return -1;
+}
+
+/* "Renders" (unpacks) the frame at cur_frame
+	Preps all the image and audio pointers */
+static char smk_render(smk s)
+{
+	unsigned long i,size;
+	unsigned char* buffer = NULL,* p,track;
+
+	/* sanity check */
+	smk_assert(s);
+
+	/* Retrieve current chunk_size for this frame. */
+	if (!(i = s->chunk_size[s->cur_frame]))
+	{
+		fprintf(stderr,"libsmacker::smk_render(s) - Warning: frame %lu: chunk_size is 0.\n",s->cur_frame);
+		goto error;
+	}
+
+	if (s->mode == SMK_MODE_DISK)
+	{
+		/* Skip to frame in file */
+		if (fseek(s->source.file.fp,s->source.file.chunk_offset[s->cur_frame],SEEK_SET))
+		{
+			fprintf(stderr,"libsmacker::smk_render(s) - ERROR: fseek to frame %lu (offset %lu) failed.\n",s->cur_frame,s->source.file.chunk_offset[s->cur_frame]);
+			perror ("\tError reported was");
+			goto error;
+		}
+
+		/* In disk-streaming mode: make way for our incoming chunk buffer */
+		smk_malloc(buffer, i);
+
+		/* Read into buffer */
+		if ( smk_read_file(buffer,s->chunk_size[s->cur_frame],s->source.file.fp) < 0)
+		{
+			fprintf(stderr,"libsmacker::smk_render(s) - ERROR: frame %lu (offset %lu): smk_read had errors.\n",s->cur_frame,s->source.file.chunk_offset[s->cur_frame]);
+			goto error;
+		}
+	}
+	else
+	{
+		/* Just point buffer at the right place */
+		if (!s->source.chunk_data[s->cur_frame])
+		{
+			fprintf(stderr,"libsmacker::smk_render(s) - ERROR: frame %lu: memory chunk is a NULL pointer.\n",s->cur_frame);
+			goto error;
+		}
+		buffer = s->source.chunk_data[s->cur_frame];
+	}
+
+	p = buffer;
+
+	/* Palette record first */
+	if (s->frame_type[s->cur_frame] & 0x01)
+	{
+		/* need at least 1 byte to process */
+		if (!i)
+		{
+			fprintf(stderr,"libsmacker::smk_render(s) - ERROR: frame %lu: insufficient data for a palette rec.\n",s->cur_frame);
+			goto error;
+		}
+
+		/* Byte 1 in block, times 4, tells how many
+			subsequent bytes are present */
+		size = 4 * (*p);
+
+		/* If video rendering enabled, kick this off for decode. */
+		if (s->video.enable)
+		{
+			smk_render_palette(&(s->video),p + 1,size - 1);
+		}
+		p += size;
+		i -= size;
+	}
+
+	/* Unpack audio chunks */
+	for (track = 0; track < 7; track ++)
+	{
+		if (s->frame_type[s->cur_frame] & (0x02 << track))
+		{
+			/* need at least 4 byte to process */
+			if (i < 4)
+			{
+				fprintf(stderr,"libsmacker::smk_render(s) - ERROR: frame %lu: insufficient data for audio[%u] rec.\n",s->cur_frame,track);
+				goto error;
+			}
+
+			/* First 4 bytes in block tell how many
+				subsequent bytes are present */
+			size = (((unsigned int) p[3] << 24) |
+					((unsigned int) p[2] << 16) |
+					((unsigned int) p[1] << 8) |
+					((unsigned int) p[0]));
+
+			/* If audio rendering enabled, kick this off for decode. */
+			if (s->audio[track].enable)
+			{
+				smk_render_audio(&s->audio[track],p + 4,size - 4);
+			}
+			p += size;
+			i -= size;
+		}
+		else
+		{
+			s->audio[track].buffer_size = 0;
+		}
+	}
+
+	/* Unpack video chunk */
+	if (s->video.enable)
+	{
+		smk_render_video(&(s->video), p,i);
+	}
+
+	if (s->mode == SMK_MODE_DISK)
+	{
+		/* Remember that buffer we allocated?  Trash it */
+		smk_free(buffer);
+	}
+
+	return 0;
+
+error:
+	if (s->mode == SMK_MODE_DISK)
+	{
+		/* Remember that buffer we allocated?  Trash it */
+		smk_free(buffer);
+	}
+
+	return -1;
+}
+
+/* rewind to first frame and unpack */
+char smk_first(smk s)
+{
+	smk_assert(s);
+
+	s->cur_frame = 0;
+	if ( smk_render(s) < 0)
+	{
+		fprintf(stderr,"libsmacker::smk_first(s) - Warning: frame %lu: smk_render returned errors.\n",s->cur_frame);
+		goto error;
+	}
+
+	if (s->f == 1) return SMK_LAST;
+	return SMK_MORE;
+
+error:
+	return -1;
+}
+
+/* advance to next frame */
+char smk_next(smk s)
+{
+	smk_assert(s);
+
+	if (s->cur_frame + 1 < (s->f + s->ring_frame))
+	{
+		s->cur_frame ++;
+		if ( smk_render(s) < 0)
+		{
+			fprintf(stderr,"libsmacker::smk_next(s) - Warning: frame %lu: smk_render returned errors.\n",s->cur_frame);
+			goto error;
+		}
+		if (s->cur_frame + 1 == (s->f + s->ring_frame))
+		{
+			return SMK_LAST;
+		}
+		return SMK_MORE;
+	}
+	else if (s->ring_frame)
+	{
+		s->cur_frame = 1;
+		if ( smk_render(s) < 0)
+		{
+			fprintf(stderr,"libsmacker::smk_next(s) - Warning: frame %lu: smk_render returned errors.\n",s->cur_frame);
+			goto error;
+		}
+		if (s->cur_frame + 1 == (s->f + s->ring_frame))
+		{
+			return SMK_LAST;
+		}
+		return SMK_MORE;
+	}
+	return SMK_DONE;
+
+error:
+	return -1;
+}
+
+/* seek to a keyframe in an smk */
+char smk_seek_keyframe(smk s, unsigned long f)
+{
+	smk_assert(s);
+
+	/* rewind (or fast forward!) exactly to f */
+	s->cur_frame = f;
+
+	/* roll back to previous keyframe in stream, or 0 if no keyframes exist */
+	while (s->cur_frame > 0 && !(s->keyframe[s->cur_frame]))
+	{
+		s->cur_frame --;
+	}
+
+	/* render the frame: we're ready */
+	if (smk_render(s) < 0)
+	{
+		fprintf(stderr,"libsmacker::smk_seek_keyframe(s,%lu) - Warning: frame %lu: smk_render returned errors.\n",f,s->cur_frame);
+		goto error;
+	}
+
+	return 0;
+
+error:
+	return -1;
+}

--- a/LIB386/libsmacker/smacker.h
+++ b/LIB386/libsmacker/smacker.h
@@ -1,0 +1,103 @@
+/**
+	libsmacker - A C library for decoding .smk Smacker Video files
+	Copyright (C) 2012-2020 Greg Kennedy
+
+	libsmacker is a cross-platform C library which can be used for
+	decoding Smacker Video files produced by RAD Game Tools.
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published by
+	the Free Software Foundation, either version 2.1 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SMACKER_H
+#define SMACKER_H
+
+/* includes - needed for FILE* here */
+#include <stdio.h>
+
+/** forward-declaration for an struct */
+typedef struct smk_t* smk;
+
+/** a few defines as return codes from smk_next() */
+#define SMK_DONE	0x00
+#define SMK_MORE	0x01
+#define SMK_LAST	0x02
+#define SMK_ERROR	-1
+
+/** file-processing mode, pass to smk_open_file */
+#define SMK_MODE_DISK	0x00
+#define SMK_MODE_MEMORY	0x01
+
+/** Y-scale meanings */
+#define	SMK_FLAG_Y_NONE	0x00
+#define	SMK_FLAG_Y_INTERLACE	0x01
+#define	SMK_FLAG_Y_DOUBLE	0x02
+
+/** track mask and enable bits */
+#define	SMK_AUDIO_TRACK_0	0x01
+#define	SMK_AUDIO_TRACK_1	0x02
+#define	SMK_AUDIO_TRACK_2	0x04
+#define	SMK_AUDIO_TRACK_3	0x08
+#define	SMK_AUDIO_TRACK_4	0x10
+#define	SMK_AUDIO_TRACK_5	0x20
+#define	SMK_AUDIO_TRACK_6	0x40
+#define	SMK_VIDEO_TRACK	0x80
+
+/* PUBLIC FUNCTIONS */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* OPEN OPERATIONS */
+/** open an smk (from a file) */
+smk smk_open_file(const char* filename, unsigned char mode);
+/** open an smk (from a file pointer) */
+smk smk_open_filepointer(FILE* file, unsigned char mode);
+/** read an smk (from a memory buffer) */
+smk smk_open_memory(const unsigned char* buffer, unsigned long size);
+
+/* CLOSE OPERATIONS */
+/** close out an smk file and clean up memory */
+void smk_close(smk object);
+
+/* GET FILE INFO OPERATIONS */
+char smk_info_all(const smk object, unsigned long* frame, unsigned long* frame_count, double* usf);
+char smk_info_video(const smk object, unsigned long* w, unsigned long* h, unsigned char* y_scale_mode);
+char smk_info_audio(const smk object, unsigned char* track_mask, unsigned char channels[7], unsigned char bitdepth[7], unsigned long audio_rate[7]);
+
+/* ENABLE/DISABLE Switches */
+char smk_enable_all(smk object, unsigned char mask);
+char smk_enable_video(smk object, unsigned char enable);
+char smk_enable_audio(smk object, unsigned char track, unsigned char enable);
+
+/** Retrieve palette */
+const unsigned char* smk_get_palette(const smk object);
+/** Retrieve video frame, as a buffer of size w*h */
+const unsigned char* smk_get_video(const smk object);
+/** Retrieve decoded audio chunk, track N */
+const unsigned char* smk_get_audio(const smk object, unsigned char track);
+/** Get size of currently pointed decoded audio chunk, track N */
+unsigned long smk_get_audio_size(const smk object, unsigned char track);
+
+/** rewind to first frame and unpack */
+char smk_first(smk object);
+/** advance to next frame and unpack */
+char smk_next(smk object);
+/** seek to first keyframe before/at N in an smk */
+char smk_seek_keyframe(smk object, unsigned long frame);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/LIB386/libsmacker/smacker_compat.c
+++ b/LIB386/libsmacker/smacker_compat.c
@@ -1,0 +1,19 @@
+/**
+ * Compatibility stubs for game code that still calls RAD Smacker API names.
+ * When using libsmacker, these are no-ops (libsmacker does not use registered memory).
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void SmackRegisterMemory(void *ptr, unsigned long size) {
+  (void)ptr;
+  (void)size;
+}
+
+void SmackResetMemory(void) {
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/LIB386/libsmacker/smk_bitstream.c
+++ b/LIB386/libsmacker/smk_bitstream.c
@@ -1,0 +1,119 @@
+/**
+	libsmacker - A C library for decoding .smk Smacker Video files
+	Copyright (C) 2012-2017 Greg Kennedy
+
+	See smacker.h for more information.
+
+	smk_bitstream.c
+		Implements a bitstream structure, which can extract and
+		return a bit at a time from a raw block of bytes.
+*/
+
+#include "smk_bitstream.h"
+
+/* malloc and friends */
+#include "smk_malloc.h"
+
+/*
+	Bitstream structure
+	Pointer to raw block of data and a size limit.
+	Maintains internal pointers to byte_num and bit_number.
+*/
+struct smk_bit_t
+{
+	const unsigned char* buffer;
+	unsigned long size;
+
+	unsigned long byte_num;
+	char bit_num;
+};
+
+/* BITSTREAM Functions */
+struct smk_bit_t* smk_bs_init(const unsigned char* b, const unsigned long size)
+{
+	struct smk_bit_t* ret = NULL;
+
+	/* sanity check */
+	smk_assert(b);
+
+	/* allocate a bitstream struct */
+	smk_malloc(ret, sizeof(struct smk_bit_t));
+
+	/* set up the pointer to bitstream, and the size counter */
+	ret->buffer = b;
+	ret->size = size;
+
+	/* point to initial byte: note, smk_malloc already sets these to 0 */
+	/* ret->byte_num = 0;
+	ret->bit_num = 0; */
+
+	/* return ret or NULL if error : ) */
+error:
+	return ret;
+}
+
+/* Reads a bit
+	Returns -1 if error encountered */
+char _smk_bs_read_1(struct smk_bit_t* bs)
+{
+	unsigned char ret = -1;
+
+	/* sanity check */
+	smk_assert(bs);
+
+	/* don't die when running out of bits, but signal */
+	if (bs->byte_num >= bs->size)
+	{
+		fprintf(stderr, "libsmacker::_smk_bs_read_1(bs): ERROR: bitstream (length=%lu) exhausted.\n", bs->size);
+		goto error;
+	}
+
+	/* get next bit and return */
+	ret = (((bs->buffer[bs->byte_num]) & (1 << bs->bit_num)) != 0);
+
+	/* advance to next bit */
+	bs->bit_num ++;
+
+	/* Out of bits in this byte: next! */
+	if (bs->bit_num > 7)
+	{
+		bs->byte_num ++;
+		bs->bit_num = 0;
+	}
+
+	/* return ret, or (default) -1 if error */
+error:
+	return ret;
+}
+
+/* Reads a byte
+	Returns -1 if error. */
+short _smk_bs_read_8(struct smk_bit_t* bs)
+{
+	unsigned char ret = -1;
+
+	/* sanity check */
+	smk_assert(bs);
+
+	/* don't die when running out of bits, but signal */
+	if (bs->byte_num + (bs->bit_num > 0) >= bs->size)
+	{
+		fprintf(stderr, "libsmacker::_smk_bs_read_8(bs): ERROR: bitstream (length=%lu) exhausted.\n", bs->size);
+		goto error;
+	}
+
+	if (bs->bit_num)
+	{
+		/* unaligned read */
+		ret = bs->buffer[bs->byte_num] >> bs->bit_num;
+		bs->byte_num ++;
+		ret |= (bs->buffer[bs->byte_num] << (8 - bs->bit_num));
+	} else {
+		/* aligned read */
+		ret = bs->buffer[bs->byte_num ++];
+	}
+
+	/* return ret, or (default) -1 if error */
+error:
+	return ret;
+}

--- a/LIB386/libsmacker/smk_bitstream.h
+++ b/LIB386/libsmacker/smk_bitstream.h
@@ -1,0 +1,50 @@
+/**
+	libsmacker - A C library for decoding .smk Smacker Video files
+	Copyright (C) 2012-2017 Greg Kennedy
+
+	See smacker.h for more information.
+
+	smk_bitstream.h
+		SMK bitstream structure. Presents a block of raw bytes one
+		bit at a time, and protects against over-read.
+*/
+
+#ifndef SMK_BITSTREAM_H
+#define SMK_BITSTREAM_H
+
+/** Bitstream structure, Forward declaration */
+struct smk_bit_t;
+
+/* BITSTREAM Functions */
+/** Initialize a bitstream */
+struct smk_bit_t* smk_bs_init(const unsigned char* b, unsigned long size);
+
+/** This macro checks return code from _smk_bs_read_1 and
+	jumps to error label if problems occur. */
+#define smk_bs_read_1(t,uc) \
+{ \
+	if ((char)(uc = _smk_bs_read_1(t)) < 0) \
+	{ \
+		fprintf(stderr, "libsmacker::smk_bs_read_1(" #t ", " #uc ") - ERROR (file: %s, line: %lu)\n", __FILE__, (unsigned long)__LINE__); \
+		goto error; \
+	} \
+}
+/** Read a single bit from the bitstream, and advance.
+	Returns -1 on error. */
+char _smk_bs_read_1(struct smk_bit_t* bs);
+
+/** This macro checks return code from _smk_bs_read_8 and
+	jumps to error label if problems occur. */
+#define smk_bs_read_8(t,s) \
+{ \
+	if ((short)(s = _smk_bs_read_8(t)) < 0) \
+	{ \
+		fprintf(stderr, "libsmacker::smk_bs_read_8(" #t ", " #s ") - ERROR (file: %s, line: %lu)\n", __FILE__, (unsigned long)__LINE__); \
+		goto error; \
+	} \
+}
+/** Read eight bits from the bitstream (one byte), and advance.
+	Returns -1 on error. */
+short _smk_bs_read_8(struct smk_bit_t* bs);
+
+#endif

--- a/LIB386/libsmacker/smk_hufftree.c
+++ b/LIB386/libsmacker/smk_hufftree.c
@@ -1,0 +1,425 @@
+/**
+	libsmacker - A C library for decoding .smk Smacker Video files
+	Copyright (C) 2012-2017 Greg Kennedy
+
+	See smacker.h for more information.
+
+	smk_hufftree.c
+		Implementation of Smacker Huffman coding trees.
+*/
+
+#include "smk_hufftree.h"
+
+/* malloc and friends */
+#include "smk_malloc.h"
+
+/**
+	8-bit Tree node structure.
+	If b0 is non-null, this is a branch, and b1 from the union should be used.
+	If b0 is null, this is a leaf, and val / escape code from union should be used.
+*/
+struct smk_huff8_t
+{
+	struct smk_huff8_t* b0;
+	union
+	{
+		struct smk_huff8_t* b1;
+		struct
+		{
+			unsigned short value;
+			unsigned char escapecode;
+		} leaf;
+	} u;
+};
+
+/**
+	16-bit Tree root struct: holds a huff8_t structure,
+	as well as a cache of three 16-bit values.
+*/
+struct smk_huff16_t
+{
+	struct smk_huff8_t* t;
+	unsigned short cache[3];
+};
+
+/*********************** 8-BIT HUFF-TREE FUNCTIONS ***********************/
+/** safe build with built-in error jump */
+#define smk_huff8_build_rec(bs,p) \
+{ \
+	if (!(p = _smk_huff8_build_rec(bs))) \
+	{ \
+		fprintf(stderr, "libsmacker::smk_huff8_build_rec(" #bs ", " #p ") - ERROR (file: %s, line: %lu)\n", __FILE__, (unsigned long)__LINE__); \
+		goto error; \
+	} \
+}
+/** Recursive tree-building function. */
+static struct smk_huff8_t* _smk_huff8_build_rec(struct smk_bit_t* bs)
+{
+	struct smk_huff8_t* ret = NULL;
+	char bit;
+
+	/* sanity check - removed: bs cannot be null, because it was checked at smk_huff8_build below */
+	/* smk_assert(bs); */
+
+	/* Read the bit */
+	smk_bs_read_1(bs, bit);
+
+	/* Malloc a structure. */
+	smk_malloc(ret, sizeof(struct smk_huff8_t));
+
+	if (bit)
+	{
+		/* Bit set: this forms a Branch node. */
+		/* Recursively attempt to build the Left branch. */
+		smk_huff8_build_rec(bs, ret->b0);
+
+		/* Everything is still OK: attempt to build the Right branch. */
+		smk_huff8_build_rec(bs, ret->u.b1);
+
+		/* return branch pointer here */
+		return ret;
+	}
+
+	/* Bit unset signifies a Leaf node. */
+	/* Attempt to read value */
+	smk_bs_read_8(bs, ret->u.leaf.value);
+
+	/* smk_malloc sets entries to 0 by default */
+	/* ret->b0 = NULL; */
+	ret->u.leaf.escapecode = 0xFF;
+
+	return ret;
+
+error:
+	/* In case of error, undo the subtree we were building, and return NULL. */
+	smk_huff8_free(ret);
+	return NULL;
+}
+
+/* Look up an 8-bit value from a basic huff tree.
+	Return -1 on error. */
+short _smk_huff8_lookup(struct smk_bit_t* bs, const struct smk_huff8_t* t)
+{
+	char bit;
+
+	/* sanity check */
+	smk_assert(bs);
+	smk_assert(t);
+
+	if (!t->b0)
+	{
+		/* Reached a Leaf node. Return its value. */
+		return t->u.leaf.value;
+	}
+
+	/* Read the next bit from bitstream to determine path */
+	smk_bs_read_1(bs, bit);
+
+	if (bit)
+	{
+		/* get_bit returned Set, follow Right branch. */
+		return _smk_huff8_lookup(bs, t->u.b1);
+	}
+
+	/* follow Left branch */
+	return _smk_huff8_lookup(bs, t->b0);
+
+error:
+	return -1;
+}
+
+/**
+	Entry point for huff8 build. Basically just checks the start/end tags
+	and calls smk_huff8_build_rec recursive function.
+*/
+struct smk_huff8_t* _smk_huff8_build(struct smk_bit_t* bs)
+{
+	struct smk_huff8_t* ret = NULL;
+	char bit;
+
+	/* sanity check */
+	smk_assert(bs);
+
+	/* Smacker huff trees begin with a set-bit. */
+	smk_bs_read_1(bs, bit);
+
+	if (!bit)
+	{
+		/* Got a bit, but it was not 1. In theory, there could be a smk file
+			without this particular tree. */
+		fputs("libsmacker::_smk_huff8_build(bs) - Warning: initial get_bit returned 0\n", stderr);
+		goto error;
+	}
+
+	/* Begin parsing the tree data. */
+	smk_huff8_build_rec(bs, ret);
+
+	/* huff trees end with an unset-bit */
+	smk_bs_read_1(bs, bit);
+
+	if (bit)
+	{
+		fputs("libsmacker::_smk_huff8_build(bs) - ERROR: final get_bit returned 1\n", stderr);
+		goto error;
+	}
+
+	return ret;
+
+error:
+	smk_huff8_free(ret);
+	return NULL;
+}
+
+/* function to recursively delete a huffman tree */
+void smk_huff8_free(struct smk_huff8_t* t)
+{
+	/* Sanity check: do not double-free */
+	smk_assert(t);
+
+	/* If this is not a leaf node, free child trees first */
+	if (t->b0)
+	{
+		smk_huff8_free(t->b0);
+		smk_huff8_free(t->u.b1);
+	}
+
+	/* Safe-delete tree node. */
+	smk_free(t);
+
+error: ;
+}
+
+/*********************** 16-BIT HUFF-TREE FUNCTIONS ***********************/
+/* safe bigtree build with built-in error jump */
+#define smk_huff16_build_rec(bs,cache,low8,hi8,p) \
+{ \
+	if (!(p = _smk_huff16_build_rec(bs, cache, low8, hi8))) \
+	{ \
+		fprintf(stderr, "libsmacker::smk_huff16_build_rec(" #bs ", " #cache ", " #low8 ", " #hi8 ", " #p ") - ERROR (file: %s, line: %lu)\n", __FILE__, (unsigned long)__LINE__); \
+		goto error; \
+	} \
+}
+/* Recursively builds a Big tree. */
+static struct smk_huff8_t* _smk_huff16_build_rec(struct smk_bit_t* bs, const unsigned short cache[3], const struct smk_huff8_t* low8, const struct smk_huff8_t* hi8)
+{
+	struct smk_huff8_t* ret = NULL;
+
+	char bit;
+	short lowval;
+
+	/* sanity check - removed: these cannot be null, because they were checked at smk_huff16_build below */
+	/* smk_assert(bs);
+	smk_assert(cache);
+	smk_assert(low8);
+	smk_assert(hi8); */
+
+	/* Get the first bit */
+	smk_bs_read_1(bs, bit);
+
+	/* Malloc a structure. */
+	smk_malloc(ret, sizeof(struct smk_huff8_t));
+
+	if (bit)
+	{
+		/* Recursively attempt to build the Left branch. */
+		smk_huff16_build_rec(bs, cache, low8, hi8, ret->b0);
+
+		/* Recursively attempt to build the Left branch. */
+		smk_huff16_build_rec(bs, cache, low8, hi8, ret->u.b1);
+
+		/* return branch pointer here */
+		return ret;
+	}
+
+	/* Bit unset signifies a Leaf node. */
+	smk_huff8_lookup(bs, low8, lowval);
+	smk_huff8_lookup(bs, hi8, ret->u.leaf.value);
+
+	/* Looks OK: we got low and hi values. Return a new LEAF */
+	/* ret->b0 = NULL; */
+	ret->u.leaf.value = lowval | (ret->u.leaf.value << 8);
+
+	/* Last: when building the tree, some Values may correspond to cache positions.
+		Identify these values and set the Escape code byte accordingly. */
+	if (ret->u.leaf.value == cache[0])
+	{
+		ret->u.leaf.escapecode = 0;
+	}
+	else if (ret->u.leaf.value == cache[1])
+	{
+		ret->u.leaf.escapecode = 1;
+	}
+	else if (ret->u.leaf.value == cache[2])
+	{
+		ret->u.leaf.escapecode = 2;
+	}
+	else
+	{
+		ret->u.leaf.escapecode = 0xFF;
+	}
+
+	return ret;
+
+error:
+	smk_huff8_free(ret);
+	return NULL;
+}
+
+/* Entry point for building a big 16-bit tree. */
+struct smk_huff16_t* _smk_huff16_build(struct smk_bit_t* bs)
+{
+	struct smk_huff16_t* big = NULL;
+
+	struct smk_huff8_t* low8 = NULL;
+	struct smk_huff8_t* hi8 = NULL;
+
+	short lowval;
+
+	char bit;
+	unsigned char i;
+
+	/* sanity check */
+	smk_assert(bs);
+
+	/* Smacker huff trees begin with a set-bit. */
+	smk_bs_read_1(bs, bit);
+
+	if (!bit)
+	{
+		fputs("libsmacker::smk_huff16_build(bs) - ERROR: initial get_bit returned 0\n", stderr);
+		goto error;
+	}
+
+	/* build low-8-bits tree */
+	smk_huff8_build(bs, low8);
+	/* build hi-8-bits tree */
+	smk_huff8_build(bs, hi8);
+
+	/* Everything looks OK so far. Time to malloc structure. */
+	smk_malloc(big, sizeof(struct smk_huff16_t));
+
+	/* Init the escape code cache. */
+	for (i = 0; i < 3; i ++)
+	{
+		smk_bs_read_8(bs, lowval);
+		smk_bs_read_8(bs, big->cache[i]);
+		big->cache[i] = lowval | (big->cache[i] << 8);
+	}
+
+	/* Finally, call recursive function to retrieve the Bigtree. */
+	smk_huff16_build_rec(bs, big->cache, low8, hi8, big->t);
+
+	/* Done with 8-bit hufftrees, free them. */
+	smk_huff8_free(hi8);
+	smk_huff8_free(low8);
+
+	/* Check final end tag. */
+	smk_bs_read_1(bs, bit);
+
+	if (bit)
+	{
+		fputs("libsmacker::smk_huff16_build(bs) - ERROR: final get_bit returned 1\n", stderr);
+		goto error;
+	}
+
+	return big;
+
+error:
+	smk_huff16_free(big);
+	smk_huff8_free(hi8);
+	smk_huff8_free(low8);
+	return NULL;
+}
+
+static int _smk_huff16_lookup_rec(struct smk_bit_t* bs, unsigned short cache[3], const struct smk_huff8_t* t)
+{
+	unsigned short val;
+	char bit;
+
+	/* sanity check */
+	/* smk_assert(bs);
+	smk_assert(cache);
+	smk_assert(t); */
+
+	/* Reached a Leaf node */
+	if (!t->b0)
+	{
+		if (t->u.leaf.escapecode != 0xFF)
+		{
+			/* Found escape code. Retrieve value from Cache. */
+			val = cache[t->u.leaf.escapecode];
+		}
+		else
+		{
+			/* Use value directly. */
+			val = t->u.leaf.value;
+		}
+
+		if (cache[0] != val)
+		{
+			/* Update the cache, by moving val to the front of the queue,
+				if it isn't already there. */
+			cache[2] = cache[1];
+			cache[1] = cache[0];
+			cache[0] = val;
+		}
+
+		return val;
+	}
+
+	/* Read the next bit from bitstream to determine path */
+	smk_bs_read_1(bs, bit);
+
+	if (bit)
+	{
+		/* get_bit returned Set, follow Right branch. */
+		return _smk_huff16_lookup_rec(bs, cache, t->u.b1);
+	}
+
+	return _smk_huff16_lookup_rec(bs, cache, t->b0);
+
+error:
+	return -1;
+}
+
+/* Convenience call-out for recursive bigtree lookup function */
+long _smk_huff16_lookup(struct smk_bit_t* bs, struct smk_huff16_t* big)
+{
+	/* sanity check */
+	smk_assert(bs);
+	smk_assert(big);
+
+	return _smk_huff16_lookup_rec(bs, big->cache, big->t);
+
+error:
+	return -1;
+}
+
+/* Resets a Big hufftree cache */
+void smk_huff16_reset(struct smk_huff16_t* big)
+{
+	/* sanity check */
+	smk_assert(big);
+
+	big->cache[0] = 0;
+	big->cache[1] = 0;
+	big->cache[2] = 0;
+
+error: ;
+}
+
+/* delete a (big) huffman tree */
+void smk_huff16_free(struct smk_huff16_t* big)
+{
+	/* Sanity check: do not double-free */
+	smk_assert(big);
+ 
+	/* free the subtree */
+	if (big->t)
+		smk_huff8_free(big->t);
+
+	/* free the bigtree */
+	smk_free(big);
+
+error: ;
+};

--- a/LIB386/libsmacker/smk_hufftree.h
+++ b/LIB386/libsmacker/smk_hufftree.h
@@ -1,0 +1,88 @@
+/**
+	libsmacker - A C library for decoding .smk Smacker Video files
+	Copyright (C) 2012-2017 Greg Kennedy
+
+	See smacker.h for more information.
+
+	smk_hufftree.h
+		SMK huffmann trees.  There are two types:
+		- a basic 8-bit tree, and
+		- a "big" 16-bit tree which includes a cache for recently
+			searched values.
+*/
+
+#ifndef SMK_HUFFTREE_H
+#define SMK_HUFFTREE_H
+
+#include "smk_bitstream.h"
+
+/** Tree node structures - Forward declaration */
+struct smk_huff8_t;
+struct smk_huff16_t;
+
+/*********************** 8-BIT HUFF-TREE FUNCTIONS ***********************/
+/** This macro checks return code from _smk_huff8_build and
+	jumps to error label if problems occur. */
+#define smk_huff8_build(bs,t) \
+{ \
+	if (!(t = _smk_huff8_build(bs))) \
+	{ \
+		fprintf(stderr, "libsmacker::smk_huff8_build(" #bs ", " #t ") - ERROR (file: %s, line: %lu)\n", __FILE__, (unsigned long)__LINE__); \
+		goto error; \
+	} \
+}
+/** Build an 8-bit tree from a bitstream */
+struct smk_huff8_t* _smk_huff8_build(struct smk_bit_t* bs);
+
+/** This macro checks return code from _smk_huff8_lookup and
+	jumps to error label if problems occur. */
+#define smk_huff8_lookup(bs,t,s) \
+{ \
+	if ((short)(s = _smk_huff8_lookup(bs, t)) < 0) \
+	{ \
+		fprintf(stderr, "libsmacker::smk_huff8_lookup(" #bs ", " #t ", " #s ") - ERROR (file: %s, line: %lu)\n", __FILE__, (unsigned long)__LINE__); \
+		goto error; \
+	} \
+}
+/** Look up an 8-bit value in the referenced tree by following a bitstream
+	returns -1 on error */
+short _smk_huff8_lookup(struct smk_bit_t* bs, const struct smk_huff8_t* t);
+
+/** function to recursively delete an 8-bit huffman tree */
+void smk_huff8_free(struct smk_huff8_t* t);
+
+/************************ 16-BIT HUFF-TREE FUNCTIONS ************************/
+/** This macro checks return code from _smk_huff16_build and
+	jumps to error label if problems occur. */
+#define smk_huff16_build(bs,t) \
+{ \
+	if (!(t = _smk_huff16_build(bs))) \
+	{ \
+		fprintf(stderr, "libsmacker::smk_huff16_build(" #bs ", " #t ") - ERROR (file: %s, line: %lu)\n", __FILE__, (unsigned long)__LINE__); \
+		goto error; \
+	} \
+}
+/** Build a 16-bit tree from a bitstream */
+struct smk_huff16_t* _smk_huff16_build(struct smk_bit_t* bs);
+
+/** This macro checks return code from smk_huff16_lookup and
+	jumps to error label if problems occur. */
+#define smk_huff16_lookup(bs,t,s) \
+{ \
+	if ((s = _smk_huff16_lookup(bs, t)) < 0) \
+	{ \
+		fprintf(stderr, "libsmacker::smk_huff16_lookup(" #bs ", " #t ", " #s ") - ERROR (file: %s, line: %lu)\n", __FILE__, (unsigned long)__LINE__); \
+		goto error; \
+	} \
+}
+/** Look up a 16-bit value in the bigtree by following a bitstream
+	returns -1 on error */
+long _smk_huff16_lookup(struct smk_bit_t* bs, struct smk_huff16_t* big);
+
+/** Reset the cache in a 16-bit tree */
+void smk_huff16_reset(struct smk_huff16_t* big);
+
+/** function to recursively delete a 16-bit huffman tree */
+void smk_huff16_free(struct smk_huff16_t* big);
+
+#endif

--- a/LIB386/libsmacker/smk_malloc.h
+++ b/LIB386/libsmacker/smk_malloc.h
@@ -1,0 +1,77 @@
+/**
+	libsmacker - A C library for decoding .smk Smacker Video files
+	Copyright (C) 2012-2017 Greg Kennedy
+
+	See smacker.h for more information.
+
+	smk_malloc.h
+		"Safe" implementations of malloc and free.
+		Verbose implementation of assert.
+*/
+
+#ifndef SMK_MALLOC_H
+#define SMK_MALLOC_H
+
+/* calloc */
+#include <stdlib.h>
+/* fprintf */
+#include <stdio.h>
+
+/* Error messages from calloc */
+#include <errno.h>
+#include <string.h>
+
+/**
+	Verbose assert:
+		branches to an error block if pointer is null
+*/
+#define smk_assert(p) \
+{ \
+	if (!p) \
+	{ \
+		fprintf(stderr, "libsmacker::smk_assert(" #p "): ERROR: NULL POINTER at line %lu, file %s\n", (unsigned long)__LINE__, __FILE__); \
+		goto error; \
+	} \
+}
+
+/**
+	Safe free: attempts to prevent double-free by setting pointer to NULL.
+		Optionally warns on attempts to free a NULL pointer.
+*/
+#define smk_free(p) \
+{ \
+	if (p) \
+	{ \
+		free(p); \
+		p = NULL; \
+	} \
+/*	else \
+	{ \
+		fprintf(stderr, "libsmacker::smk_free(" #p ") - Warning: attempt to free NULL pointer (file: %s, line: %lu)\n", __FILE__, (unsigned long)__LINE__); \
+	} */ \
+}
+
+/**
+	Safe malloc: exits if calloc() returns NULL.
+		Also initializes blocks to 0.
+	Optionally warns on attempts to malloc over an existing pointer.
+	Ideally, one should not exit() in a library. However, if you cannot
+		calloc(), you probably have bigger problems.
+*/
+#define smk_malloc(p, x) \
+{ \
+/*	if (p) \
+	{ \
+		fprintf(stderr, "libsmacker::smk_malloc(" #p ", %lu) - Warning: freeing non-NULL pointer before calloc (file: %s, line: %lu)\n", (unsigned long) (x), __FILE__, (unsigned long)__LINE__); \
+		free(p); \
+	} */ \
+	p = calloc(1, x); \
+	if (!p) \
+	{ \
+		fprintf(stderr, "libsmacker::smk_malloc(" #p ", %lu) - ERROR: calloc() returned NULL (file: %s, line: %lu)\n\tReason: [%d] %s\n", \
+			(unsigned long) (x), __FILE__, (unsigned long)__LINE__, errno, strerror(errno)); \
+		exit(EXIT_FAILURE); \
+	} \
+}
+
+#endif

--- a/SOURCES/CMakeLists.txt
+++ b/SOURCES/CMakeLists.txt
@@ -25,11 +25,17 @@ if (WIN32)
     target_link_libraries(lba2 PRIVATE gdi32 user32 ddraw winmm kernel32)
 endif ()
 
-target_include_directories(lba2 PRIVATE ../LIB386/H)
+# Put libsmacker before LIB386/H so <smacker.h> resolves to libsmacker on case-insensitive FS (e.g. macOS)
+target_include_directories(lba2 PRIVATE
+        $<$<STREQUAL:${MVIDEO_BACKEND},smacker>:${CMAKE_SOURCE_DIR}/LIB386/libsmacker>
+        ../LIB386/H)
 target_compile_definitions(lba2 PRIVATE ONE_GAME_DIRECTORY LBA_GAME CDROM
-        $<$<STREQUAL:MVIDEO_BACKEND,null>:USE_MVIDEO_NULL>
-        $<$<STREQUAL:MVIDEO_BACKEND,smacker>:USE_MVIDEO_SMACKER>
+        $<$<STREQUAL:${MVIDEO_BACKEND},null>:USE_MVIDEO_NULL>
+        $<$<STREQUAL:${MVIDEO_BACKEND},smacker>:USE_MVIDEO_SMACKER>
         SDL_DISABLE_OLD_NAMES)
+if(MVIDEO_BACKEND STREQUAL "smacker")
+  target_link_libraries(lba2 PRIVATE libsmacker)
+endif()
 
 # Configure all ASM files to be recognized as such (workaround for bug where .ASM uppercase extension is not recognized)
 # foreach (FILE_ASM IN LISTS SOURCES_FILES_ASM SOURCES_FILES_ASM_DOS)

--- a/SOURCES/COMMON.H
+++ b/SOURCES/COMMON.H
@@ -1328,6 +1328,7 @@ extern	T_MENU_COMP	ListMenuComp[MAX_MENUS_COMP] ;
 #define PROGRAM_OK              2
 #define NAME_NOT_FOUND          3
 #define ERROR_FILE_NOT_CREATED  4
+#define PROGRAM_FAIL            5
 
 /*---------------- Headers ------------------*/
 

--- a/SOURCES/DEFINES.H
+++ b/SOURCES/DEFINES.H
@@ -162,7 +162,7 @@
 #include	<OBJECT.H>
 #include	<ANIM.H>
 #include	<AIL.H>
-#include	<SMACKER.H>
+#include	<SMACKER_ADELINE.H>
 
 #include	<FILEIO.H>
 

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -2450,7 +2450,9 @@ S32     MainGameMenu( S32 load )
                                         InitDial( START_FILE_ISLAND+Island ) ;
                                         HQ_ResumeSamples() ;
 
+#ifdef  CDROM
                                         StopMusic() ;
+#endif
 
                                         RestoreClipWindow() ;
                                         FlagFade = FALSE ;

--- a/SOURCES/MUSIC.CPP
+++ b/SOURCES/MUSIC.CPP
@@ -362,9 +362,8 @@ void	ResumeMusic( S32 fade )
 		SetVolumeJingle( 0 ) ;
 	}
 
-	StopMusic() ;
-
 #ifdef	CDROM
+	StopMusic() ;
 	ResumeCD() ;
 #endif
 	ResumeStream()  ;

--- a/SOURCES/PLAYACF.CPP
+++ b/SOURCES/PLAYACF.CPP
@@ -2,6 +2,19 @@
 
 #include "DIRECTORIES.H"
 
+#ifdef USE_MVIDEO_SMACKER
+#include "INPUT.H"
+#include "MESSAGE.H"
+#include <AIL/VIDEO_AUDIO.H>
+#include <SVGA/SCREEN.H>
+#include <SVGA/VIDEO.H>
+#include <SYSTEM/KEYBOARD_KEYS.H>
+#include <SYSTEM/LOGPRINT.H>
+#include <SDL3/SDL.h>
+#include <stdio.h>
+#include <string.h>
+#endif
+
 char		PathAcf[ADELINE_MAX_PATH] ;
 
 char		*ListAcf ;
@@ -189,271 +202,334 @@ void	PlayAllAcf( void )
 |*									   *|
 \***************************************************************************/
 
-// TODO: Implement SMACK video playback
+#ifdef USE_MVIDEO_SMACKER
+static void ReadNextVideoFrame(smk smkObject, U8 *buffer, U8 **pal) {
+  const U32 width = 320;
+  const U32 height = 200;
+  const U32 screenWidth = 640;
+  const U32 videoStartY = 40;
+  U8 *frame = (U8 *)smk_get_video(smkObject);
+  *pal = (U8 *)smk_get_palette(smkObject);
+  memset(buffer, 0, screenWidth * 480);
+  U8 *targetRow = buffer + videoStartY * screenWidth;
+  for (U32 y = 0; y < height; y++) {
+    const U8 *sourceRow = frame + y * width;
+    for (U32 x = 0; x < width; x++) {
+      targetRow[2 * x] = sourceRow[x];
+      targetRow[2 * x + 1] = sourceRow[x];
+    }
+    memcpy(targetRow + screenWidth, targetRow, screenWidth);
+    targetRow += screenWidth * 2;
+  }
+}
+
+/* Resample chunk to exactly mixSamples (one frame at stream rate) and add into mix. Uses fractional indexing so pitch/duration stay correct. */
+static void ResampleAndAddToMix(unsigned long srcRate, unsigned long targetRate, const void *srcPtr, unsigned long srcBytes,
+    void *mixPtr, unsigned long mixSamples, int is16) {
+  if (srcRate == 0 || targetRate == 0 || mixSamples == 0) return;
+  unsigned long srcSamples = srcBytes / (is16 ? 2u : 1u);
+  if (srcSamples == 0) return;
+
+  if (srcRate == targetRate) {
+    unsigned long n = (srcSamples < mixSamples) ? srcSamples : mixSamples;
+    if (is16) {
+      const short *src = (const short *)srcPtr;
+      short *mix = (short *)mixPtr;
+      for (unsigned long j = 0; j < n; j++) {
+        int s = (int)mix[j] + (int)src[j];
+        if (s > 32767) s = 32767;
+        if (s < -32768) s = -32768;
+        mix[j] = (short)s;
+      }
+    } else {
+      const U8 *src = (const U8 *)srcPtr;
+      U8 *mix = (U8 *)mixPtr;
+      for (unsigned long j = 0; j < n; j++) {
+        int s = (int)(mix[j]) - 128 + (int)(src[j]) - 128;
+        if (s > 127) s = 127;
+        if (s < -128) s = -128;
+        mix[j] = (U8)(s + 128);
+      }
+    }
+    return;
+  }
+
+  /* Resample to exactly mixSamples with linear interpolation to reduce grain. */
+  if (is16) {
+    const short *src = (const short *)srcPtr;
+    short *mix = (short *)mixPtr;
+    for (unsigned long k = 0; k < mixSamples; k++) {
+      double idx = (double)k * (double)srcSamples / (double)mixSamples;
+      unsigned long idx0 = (unsigned long)idx;
+      if (idx0 >= srcSamples) idx0 = srcSamples - 1;
+      unsigned long idx1 = idx0 + 1;
+      if (idx1 >= srcSamples) idx1 = srcSamples - 1;
+      double frac = idx - (double)idx0;
+      int sample = (int)((1.0 - frac) * (double)src[idx0] + frac * (double)src[idx1]);
+      int s = (int)mix[k] + sample;
+      if (s > 32767) s = 32767;
+      if (s < -32768) s = -32768;
+      mix[k] = (short)s;
+    }
+  } else {
+    const U8 *src = (const U8 *)srcPtr;
+    U8 *mix = (U8 *)mixPtr;
+    for (unsigned long k = 0; k < mixSamples; k++) {
+      double idx = (double)k * (double)srcSamples / (double)mixSamples;
+      unsigned long idx0 = (unsigned long)idx;
+      if (idx0 >= srcSamples) idx0 = srcSamples - 1;
+      unsigned long idx1 = idx0 + 1;
+      if (idx1 >= srcSamples) idx1 = srcSamples - 1;
+      double frac = idx - (double)idx0;
+      int sample = (int)((1.0 - frac) * ((int)(src[idx0]) - 128) + frac * ((int)(src[idx1]) - 128));
+      int s = (int)(mix[k]) - 128 + sample;
+      if (s > 127) s = 127;
+      if (s < -128) s = -128;
+      mix[k] = (U8)(s + 128);
+    }
+  }
+}
+
+/* LBA2 intro: voice tracks 1/2/3 often have header rate=22050 but are actually 11025 Hz. Return effective rate for resampling. */
+static unsigned long GetEffectiveTrackRate(int t, const unsigned long *a_r, const U8 *a_c, unsigned long targetRate) {
+  unsigned long r = a_r[t];
+  if (t >= 1 && t <= 3 && r == 22050 && (a_c[t] == 1) && targetRate == 22050)
+    return 11025u;
+  return r;
+}
+
+/* Push current frame's audio for requested tracks; mix if numTracks > 1. Resample to stream rate with duration-correct resampling. */
+static void PushCurrentFrameVideoAudio(smk smkObject, const int *tracksToPlay, int numTracks, const U8 *a_d, const unsigned long *a_r, const U8 *a_c, double usf) {
+  if (numTracks <= 0) return;
+  const unsigned long kMaxFrameBytes = 128 * 1024;
+  static U8 mixBuf[128 * 1024];
+  unsigned long sizeBytes[7];
+  const unsigned char *chunk[7];
+  int first = tracksToPlay[0];
+  unsigned long targetRate = a_r[first];
+  if (targetRate == 0) return;
+  int chans = (a_c[first] >= 2) ? 2 : 1;
+  int is16 = (a_d[first] == 16) ? 1 : 0;
+  /* Bytes per frame at stream rate (fallback when a frame has no audio) */
+  double frameSec = (usf > 0.0) ? (usf / 1e6) : (1.0 / 30.0);
+  unsigned long expectedBytes = (unsigned long)((double)targetRate * frameSec * (double)chans * (is16 ? 2.0 : 1.0));
+  if (expectedBytes > kMaxFrameBytes) expectedBytes = kMaxFrameBytes;
+
+  unsigned long maxSize = 0;
+  for (int i = 0; i < numTracks; i++) {
+    int t = tracksToPlay[i];
+    sizeBytes[i] = smk_get_audio_size(smkObject, (unsigned char)t);
+    chunk[i] = smk_get_audio(smkObject, (unsigned char)t);
+    if (chunk[i] && sizeBytes[i] > 0) {
+      unsigned long srcRate = GetEffectiveTrackRate(t, a_r, a_c, targetRate);
+      unsigned long effectiveBytes = (srcRate == targetRate) ? sizeBytes[i] : (unsigned long)((double)sizeBytes[i] * (double)targetRate / (double)srcRate);
+      if (effectiveBytes > maxSize) maxSize = effectiveBytes;
+    }
+  }
+  /* Use chunk-based size so we push actual data; fall back to expected size if frame is silent */
+  if (maxSize == 0) maxSize = expectedBytes;
+  if (maxSize == 0) return;
+  if (maxSize > kMaxFrameBytes) maxSize = kMaxFrameBytes;
+
+  unsigned long mixSamples = maxSize / (is16 ? 2u : 1u);
+
+  memset(mixBuf, is16 ? 0 : 128, (size_t)maxSize);
+  int numAdded = 0;
+  for (int i = 0; i < numTracks; i++) {
+    if (!chunk[i] || sizeBytes[i] == 0) continue;
+    ResampleAndAddToMix(GetEffectiveTrackRate(tracksToPlay[i], a_r, a_c, targetRate), targetRate, chunk[i], sizeBytes[i], mixBuf, mixSamples, is16);
+    numAdded++;
+  }
+  /* Scale mix when multiple tracks were added to avoid clipping distortion (grain). Use rounding to reduce ticking from truncation. */
+  if (numAdded > 1) {
+    int half = numAdded / 2;
+    if (is16) {
+      short *mix = (short *)mixBuf;
+      for (unsigned long j = 0; j < mixSamples; j++) {
+        int s = (int)mix[j];
+        s = (s + (s >= 0 ? half : -half)) / numAdded;
+        if (s > 32767) s = 32767;
+        if (s < -32768) s = -32768;
+        mix[j] = (short)s;
+      }
+    } else {
+      U8 *mix = mixBuf;
+      for (unsigned long j = 0; j < mixSamples; j++) {
+        int s = (int)(mix[j]) - 128;
+        s = (s + (s >= 0 ? half : -half)) / numAdded + 128;
+        if (s < 0) s = 0;
+        if (s > 255) s = 255;
+        mix[j] = (U8)s;
+      }
+    }
+  }
+  PushVideoAudio(mixBuf, (U32)maxSize);
+}
+#endif
+
+//---------------------------------------------------------------------------
+
 S32	PlayAcf( const char *name )
 {
+#ifdef USE_MVIDEO_SMACKER
+  {
+    S32 n = GetNumAcf(name);
+    if (n == -1) {
+      LogPrintf("PlayAcf: video name '%s' not found in ACF list (GetNumAcf returned -1)\n", name);
+      return 0;
+    }
+
+    LogPrintf("PlayAcf: playing '%s' index %d from %s\n", name, (int)n, PathAcf);
+
+    ListVarGame[FLAG_ACF + (n / 16)] |= (S16)(1 << (n & 15));
+
+    StopMusic();
+
+    U8 *decompbuf = (U8 *)LoadMalloc_HQR(PathAcf, n);
+    U32 size = LoadMallocFileSize;
+    if (!size) {
+      LogPrintf("PlayAcf: LoadMalloc_HQR failed for index %d\n", (int)n);
+      TheEnd(PROGRAM_OK, MessageNoCD);
+    }
+
+    smk smkObject = smk_open_memory(decompbuf, (unsigned long)size);
+    if (!smkObject) {
+      LogPrintf("PlayAcf: smk_open_memory failed for index %d (size %u)\n", (int)n, (unsigned)size);
+      Free(decompbuf);
+      TheEnd(PROGRAM_OK, MessageNoCD);
+    }
+
+    SetBlackPal();
+    BoxReset();
+    Cls();
+    BoxUpdate();
+    InitWaitNoKey();
+    InitWaitNoInput(I_JOY | I_FIRE | I_MENUS);
+
+    unsigned long w = 0, h = 0;
+    unsigned long f = 0;
+    double usf = 0.0;
+    smk_info_all(smkObject, NULL, &f, &usf);
+    smk_info_video(smkObject, &w, &h, NULL);
+    if (w != 320 || h != 200) {
+      smk_close(smkObject);
+      Free(decompbuf);
+      TheEnd(PROGRAM_FAIL, "Unsupported video format (320x200 only)");
+    }
+
+    U8 a_t = 0, a_c[7] = {0}, a_d[7] = {0};
+    unsigned long a_r[7] = {0};
+    smk_info_audio(smkObject, &a_t, a_c, a_d, a_r);
+
+    S32 smackflags = SMK_AUDIO_TRACK_0;
+    if (!strncasecmp(name, "INTRO", 5) && FlagSpeak) {
+      switch (LanguageCD) {
+        case 0: smackflags |= SMK_AUDIO_TRACK_3; break;
+        case 1: smackflags |= SMK_AUDIO_TRACK_1; break;
+        case 2: smackflags |= SMK_AUDIO_TRACK_2; break;
+        default: smackflags |= SMK_AUDIO_TRACK_3; break;
+      }
+    }
+
+    /* .smk uses track 0 = music, tracks 1/2/3 = FR/DE/EN voice; we mix all requested tracks into one stream so intro has both music and voice. */
+    int tracksToPlay[7];
+    int numTracks = 0;
+    for (int i = 0; i < 7; i++) {
+      if ((a_t & (1 << i)) && (smackflags & (1 << i)))
+        tracksToPlay[numTracks++] = i;
+    }
+    if (numTracks > 0) {
+      int first = tracksToPlay[0];
+      S32 chans = (a_c[first] >= 2) ? 2 : 1;
+      S32 is16 = (a_d[first] == 16) ? 1 : 0;
+      if (!StartVideoAudio((S32)(U32)a_r[first], chans, is16)) {
+        /* non-fatal: continue without video audio */
+        numTracks = 0;
+      }
+    }
+
+    smk_enable_all(smkObject, SMK_VIDEO_TRACK | a_t);
+    smk_first(smkObject);
+
+    U8 *dest = (U8 *)malloc(640 * 480);
+    if (!dest) {
+      StopVideoAudio();
+      smk_close(smkObject);
+      Free(decompbuf);
+      return 0;
+    }
+
+    /* Frame interval in ms from file (usf = microseconds per frame) for accurate pacing */
+    U32 frameMs = (U32)(usf / 1000.0);
+    if (frameMs == 0)
+      frameMs = 67;  /* ~15 fps */
+
+    /* Pre-fill audio buffer before starting playback (like lba2-classic-ida's SoLoud deque).
+     * Stream is created paused; we fill it then resume so the device never underruns. */
+    unsigned long prebufFrames = 0;
+    if (numTracks > 0 && f > 8u) {
+      /* ~2 seconds of audio so playback stays smooth */
+      prebufFrames = (f > 60u) ? 30u : (f > 30u) ? 25u : (f > 15u) ? 15u : (unsigned long)(f / 2);
+      if (prebufFrames > f)
+        prebufFrames = f;
+      for (unsigned long p = 0; p < prebufFrames; p++) {
+        PushCurrentFrameVideoAudio(smkObject, tracksToPlay, numTracks, a_d, a_r, a_c, usf);
+        smk_next(smkObject);
+      }
+      smk_first(smkObject);
+      ResumeVideoAudio();
+    } else if (numTracks > 0) {
+      ResumeVideoAudio();
+    }
+
+    U8 *pal = NULL;
+    U32 videoStartTicks = 0;
+    for (unsigned long c = 0; c < f; c++) {
+      /* Push this frame's audio (skip for c < prebufFrames, already in stream from pre-fill) */
+      if (numTracks > 0 && c >= prebufFrames) {
+        PushCurrentFrameVideoAudio(smkObject, tracksToPlay, numTracks, a_d, a_r, a_c, usf);
+      }
+
+      ReadNextVideoFrame(smkObject, dest, &pal);
+      CopyBlock(0, 0, 640, 480, dest, 0, 0, Log);
+      if (pal)
+        PaletteSync(pal);
+
+      /* Pace to real time with SDL so speed is correct and sleep reduces stutter */
+      if (c == 0)
+        videoStartTicks = SDL_GetTicks();
+      U32 now = SDL_GetTicks();
+      U32 nextAt = videoStartTicks + (c + 1) * frameMs;
+      for (;;) {
+        MyGetInput();
+        ManageTime();
+        if (MyKey == K_ESC || (Input & I_MENUS))
+          goto fin_play;
+        now = SDL_GetTicks();
+        if (now >= nextAt)
+          break;
+        SDL_Delay(1);  /* sleep 1ms to avoid busy-spin, re-check input each time */
+      }
+
+      smk_next(smkObject);
+    }
+
+fin_play:
+    Cls();
+    BoxStaticFullflip();
+    SetBlackPal();
+    StopVideoAudio();
+    smk_close(smkObject);
+    free(dest);
+    Free(decompbuf);
+    InitWaitNoKey();
+    InitWaitNoInput(I_MENUS);
+    return MyKey;
+  }
+#else
+  fprintf(stderr, "PlayAcf: '%s' skipped (video backend is null; build with -DMVIDEO_BACKEND=smacker for video)\n", name);
   return 0;
-//	Smack		*smk	      	;
-//	U32		frame	      	;
-//	S32		n 		;
-//	S32		ret 		;
-//	U8		*decompbuf	;
-//	U32		smackflags	;
-//#ifdef	LBA_EDITOR
-//	char		name_acf[256] 	;
-//
-//	ShowMouse( false ) ;
-//
-//	smackflags = SMACKTRACK1|SMACKNEEDVOLUME ;
-//#else
-//	smackflags = SMACKFILEHANDLE|SMACKTRACK1|SMACKNEEDVOLUME ;
-//#endif
-//
-//	// si c'est l'intro, on joue la track de la langue choisie
-//	if( !strncasecmp(name,"INTRO",5) )
-//	{
-//#ifdef	CDROM
-//		if( FlagSpeak )
-//		{
-//			switch( LanguageCD )
-//			{
-//				case 0:  // English
-//					smackflags |= SMACKTRACK4 ;
-//					break ;
-//
-//				case 1:	// Français
-//					smackflags |= SMACKTRACK2 ;
-//					break ;
-//
-//				case 2:	// Deutsch
-//					smackflags |= SMACKTRACK3 ;
-//					break ;
-//
-////				default:// other ...
-//					// no spoken track
-//			}
-//		}
-//#else
-//		smackflags |= SMACKTRACK4 ;// English and other ...
-//#endif
-//	}
-//
-//	// Ah ? pas de son ? tiens donc ... gicle-moi les tracks !
-///*	if( !Sample_Driver_Enabled )
-//	{
-//		smackflags &= ~(SMACKTRACKS|SMACKNEEDVOLUME) ;
-//	}
-//*/
-//	n = GetNumAcf( name ) ;
-//
-//	if( n==-1 )	return 0 ;
-//
-//	{
-//		S32	var	;
-//		S32	bit	;
-//
-//		var = n/16	;
-//		if( n>=32 )
-//		{
-//			var = FLAG_ACF2 ;
-//			bit = 1<<(n-32) ;
-//		}
-//		else
-//		{
-//			var = FLAG_ACF 	;
-//			bit = 1<<n 	;
-//		}
-//
-//#ifdef	LBA_EDITOR
-//		ListVarGame[FLAG_ACF+(n/16)].Value |= (S16)(1<<(n&15)) ;
-//#else
-//		ListVarGame[FLAG_ACF+(n/16)] |= (S16)(1<<(n&15)) ;
-//#endif
-//	}
-//
-//	StopMusic() ;
-//
-//	SmackResetMemory() ;
-//
-//#ifdef	LBA_EDITOR
-//	strcpy( name_acf, PathAcf ) ;
-//	strcat( name_acf, name ) ;
-//	AddExt( name_acf, ".SMK" ) ;
-//
-//	smk = SmackOpen( name_acf, smackflags, SMACKAUTOEXTRA ) ;
-//#else
-////	Fd = OpenRead(name_acf)	;// Ouvrir ressource + Seek
-//
-//	// ouvre la ressource et positionne le handle à l'offet ou se trouve
-//	// la sequence
-//	if( !HQF_Init( PathAcf, n ) )
-//#if defined(DEBUG_TOOLS)||defined(TEST_TOOLS)||!defined(CDROM)
-//		return 0 ;
-//#else
-//		TheEnd( PROGRAM_OK, MessageNoCD ) ;
-//#endif
-//
-//	smk = SmackOpen( (char*)HQF_File, smackflags, SMACKAUTOEXTRA ) ;
-//#endif
-//
-//	if( !smk )
-//#if defined(DEBUG_TOOLS)||defined(TEST_TOOLS)||!defined(CDROM)
-//		return 0 ;
-//#else
-//		TheEnd( PROGRAM_OK, MessageNoCD ) ;
-//#endif
-//
-//	decompbuf = (U8*)radmalloc( 320*200 )	;
-//
-//	if( !decompbuf )
-//	{
-//		SmackClose( smk ) ;
-//#ifndef	LBA_EDITOR
-//		HQF_Close() ;
-//#endif
-//		return 0 ;
-//	}
-//
-//	memset( decompbuf, 0, 320*200 ) ;
-//
-//	SmackToBuffer( smk, 0, 0, 320, 200, decompbuf, FALSE ) ;
-//
-////	if( Sample_Driver_Enabled )
-//	{
-//		S32	vol ;
-//
-//		if( UseWaveMixer )
-//		{
-//			vol = SampleVolume ;
-//		}
-//		else
-//		{
-//#ifdef	LBA_EDITOR
-//			vol = SampleVolume ;
-//#else
-//			vol = BoundRegleTrois( 0, MasterVolume, 127, SampleVolume ) ;
-//#endif
-//		}
-//
-//		vol = (vol==0?vol:(vol+1))*512 ;// 0..65536
-//
-//		SmackVolumePan( smk, SMACKTRACKS, vol, 32768 ) ;
-//	}
-//
-//	SetBlackPal();
-//
-//	BoxReset()  ;// pour etre sûr de ne pas utiliser Screen !
-//	Cls() ;
-//	BoxUpdate() ;
-//
-//	InitWaitNoKey()			;
-//	InitWaitNoInput( I_JOY|I_FIRE|I_MENUS ) ;
-//
-//	for( frame=0; frame<smk->Frames; frame++ )
-//	{
-//		SmackDoFrame( smk ) ;
-//
-//#ifndef	LBA_EDITOR
-//		if( !VideoFullScreen )
-//		{
-//			if( smk->NewPalette )
-//			{
-//#ifndef	LBA_EDITOR
-//				FlagBlackPal = FALSE ;
-//#endif
-//				Palette(smk->Palette) ;
-//			}
-//			BlitBox( (void*)Phys, (void*)decompbuf ) ;
-//		}
-//		else
-//#endif
-//		{
-//			CopyFrameDoubleXY( (void*)decompbuf ) ;
-//			BoxStaticAdd( 0, 40, 639, 439 ) ;
-//		}
-//
-//#ifdef	LBA_EDITOR
-//		if( FlagInfos & INFO_FRAME_SPEED )
-//		{
-//			GraphPrintf(FALSE, 0,0, "Frame: %d", frame++);
-//		}
-//#endif
-//
-//#ifndef	LBA_EDITOR
-//		if( VideoFullScreen )
-//#endif
-//		{
-//			if( smk->NewPalette )
-//			{
-//#ifndef	LBA_EDITOR
-//				FlagBlackPal = FALSE ;
-//#endif
-//				// Pour eviter flash sur frame precedente
-////				Cls()  ;
-////				BoxUpdate() ;
-//
-//				Palette(smk->Palette) ;
-//			}
-//
-//			BoxUpdate() ;
-//		}
-//
-//		if( frame!=smk->Frames )
-//		{
-//			SmackNextFrame( smk ) ;
-//		}
-//
-//		do
-//		{
-//			MyGetInput() ;
-//			ManageTime() ;
-//
-//#ifndef	LBA_EDITOR
-//			CheckSaveLogPcx( smk->Palette ) ;// F9: Sauve Screen
-//#endif
-//
-//			if( (MyKey==K_ESC OR (Input&I_MENUS))
-//#ifndef	LBA_EDITOR
-//			AND (!FlagPlayAcf OR frame>290)
-//#endif
-//			)
-//			{
-//				goto fin_play ;
-//			}
-//		}
-//		while( SmackWait( smk ) ) ;
-//	}
-//
-//fin_play:
-//
-//	SmackClose( smk ) ;
-//
-//#ifndef	LBA_EDITOR
-//	HQF_Close() ;
-//	LastIdxPalette = 0 ;// pour reforcer le chargement du .XPL (cf ChoicePalette())
-//#endif
-//
-//	radfree( decompbuf ) ;
-//
-//	FadeToBlack( smk->Palette ) ;
-//	Cls() ;
-//	BoxStaticFullflip() ;
-//	SetBlackPal() ;
-//
-//	ret = MyKey ;
-//
-//#ifdef	LBA_EDITOR
-//	SetMouseBox( 0,0, 639,479 ) ;
-//#endif
-//
-//	InitWaitNoKey()			;
-//	InitWaitNoInput( I_MENUS ) ;
-//
-//#ifdef	LBA_EDITOR
-//	ShowMouse( true ) ;
-//#endif
-//
-//	return ret ;
+#endif
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Implements Smacker video playback using libsmacker.
Intro and in-game cutscenes now play with video, music, and voice.

Depends on https://github.com/LBALab/lba2-classic-community/pull/9 (audio PR).

Enable at configure time (example uses macOS preset):
```bash
cmake --preset macos_arm64 -DSOUND_BACKEND=sdl -DMVIDEO_BACKEND=smacker
```

Tested on macOS (Apple Silicon). Should work on any platform with SDL3. The default remains null (no video) to preserve existing behavior.

## What was implemented
- Adds libsmacker (LGPL 2.1) for Smacker decoding.
- Multi-track audio mixing: music (track 0) and voice (language track) play simultaneously
- Frame pacing synced to real time via SDL ticks
- Audio pre-buffering to prevent stutter at playback start
- Works with or without the SDL sound backend (`SOUND_BACKEND=null` still builds)