### PR TITLE
Fix music playback on case-sensitive filesystems (Linux)

### DIFF
--- a/LIB386/AIL/SDL/CD.CPP
+++ b/LIB386/AIL/SDL/CD.CPP
@@ -7,15 +7,6 @@
 #include <stdio.h>
 #include <string.h>
 
-static bool FileExists(const char *path) {
-  FILE *f = fopen(path, "rb");
-  if (f) {
-    fclose(f);
-    return true;
-  }
-  return false;
-}
-
 #ifndef ADELINE_MAX_PATH
 #define ADELINE_MAX_PATH 512
 #endif
@@ -27,16 +18,34 @@ static bool FileExists(const char *path) {
 static S32 cdVolume = 0;
 static bool cdPlaying = false;
 
-static void BuildCDTrackPath(char *outPath, S32 pathMax, S32 trackOneBased) {
+static bool FileExists(const char *path) {
+  FILE *f = fopen(path, "rb");
+  if (f) {
+    fclose(f);
+    return true;
+  }
+  return false;
+}
+
+/* Try multiple case variations of the music directory for case-sensitive
+   filesystems.  Returns true and fills outPath if a match is found. */
+static bool BuildCDTrackPath(char *outPath, S32 pathMax, S32 trackOneBased) {
+  static const char *musicDirs[] = { "music", "Music", "MUSIC" };
   char *cwd = SDL_GetCurrentDirectory();
   if (!cwd) {
     outPath[0] = '\0';
-    return;
+    return false;
   }
-  int n = snprintf(outPath, pathMax, "%s/music/Track%02d.wav", cwd, trackOneBased);
+  for (int i = 0; i < 3; i++) {
+    int n = snprintf(outPath, pathMax, "%s%s/Track%02d.wav", cwd, musicDirs[i], trackOneBased);
+    if (n >= 0 && n < pathMax && FileExists(outPath)) {
+      SDL_free(cwd);
+      return true;
+    }
+  }
   SDL_free(cwd);
-  if (n < 0 || n >= pathMax)
-    outPath[0] = '\0';
+  outPath[0] = '\0';
+  return false;
 }
 
 const char *OpenCD(char *volume_name) {
@@ -50,15 +59,13 @@ void PlayCD(S32 track) {
   char path[ADELINE_MAX_PATH];
   /* track is 0-based from the game (PtrTrackCD[num]&MUSIC - FirstCDTrack). */
   /* European: track 0 -> Track06.wav (6), track 1 -> 7, etc. US: track 0 -> Track02.wav (2). */
-  BuildCDTrackPath(path, sizeof(path), FIRST_CD_TRACK_EU + track);
-  if (path[0] && FileExists(path)) {
+  if (BuildCDTrackPath(path, sizeof(path), FIRST_CD_TRACK_EU + track)) {
     PlayStream(path);
     ChangeVolumeStream(cdVolume);
     cdPlaying = true;
     return;
   }
-  BuildCDTrackPath(path, sizeof(path), FIRST_CD_TRACK_US + track);
-  if (path[0] && FileExists(path)) {
+  if (BuildCDTrackPath(path, sizeof(path), FIRST_CD_TRACK_US + track)) {
     PlayStream(path);
     ChangeVolumeStream(cdVolume);
     cdPlaying = true;

--- a/LIB386/AIL/SDL/STREAM.CPP
+++ b/LIB386/AIL/SDL/STREAM.CPP
@@ -36,17 +36,33 @@ static void StopStreamInternal(void) {
   streamPaused = false;
 }
 
-/* Build path with extension replaced by .ogg (caller provides buffer of size pathMax). */
-static void PathToOgg(const char *wavPath, char *oggPath, int pathMax) {
+/* Build path with extension replaced and optional filename case change.
+   When lowerName is true the filename portion (after last separator) is
+   lowercased.  ext should be ".ogg" or ".OGG". */
+static void BuildOggPath(const char *wavPath, char *oggPath, int pathMax,
+                         const char *ext, bool lowerName) {
   strncpy(oggPath, wavPath, pathMax - 1);
   oggPath[pathMax - 1] = '\0';
+
+  if (lowerName) {
+    char *sep = strrchr(oggPath, '/');
+#ifdef _WIN32
+    char *bsep = strrchr(oggPath, '\\');
+    if (bsep && (!sep || bsep > sep)) sep = bsep;
+#endif
+    char *start = sep ? sep + 1 : oggPath;
+    for (char *p = start; *p; p++) {
+      if (*p >= 'A' && *p <= 'Z') *p += 32;
+    }
+  }
+
   char *dot = strrchr(oggPath, '.');
   if (dot) {
-    strcpy(dot, ".ogg");
+    strcpy(dot, ext);
   } else {
     int len = (int)strlen(oggPath);
     if (len + 5 <= pathMax)
-      strcpy(oggPath + len, ".ogg");
+      strcpy(oggPath + len, ext);
   }
 }
 
@@ -94,11 +110,18 @@ void PlayStream(char *name) {
     SDL_PutAudioStreamData(stream, wav_data, wav_data_len);
     SDL_free(wav_data);
   } else {
-    /* Try .ogg (e.g. Steam ships OGG instead of WAV). */
+    /* Try OGG with several case variations for case-sensitive filesystems. */
     char oggPath[ADELINE_MAX_PATH];
-    PathToOgg(name, oggPath, (int)sizeof(oggPath));
-    if (!TryPlayOgg(oggPath)) {
-      SDL_Log("SDL AIL: Could not load WAV '%s' or OGG '%s'", name, oggPath);
+    bool found = false;
+    static const char *exts[] = { ".ogg", ".OGG" };
+    for (int lower = 0; lower <= 1 && !found; lower++) {
+      for (int e = 0; e < 2 && !found; e++) {
+        BuildOggPath(name, oggPath, (int)sizeof(oggPath), exts[e], lower != 0);
+        found = TryPlayOgg(oggPath);
+      }
+    }
+    if (!found) {
+      SDL_Log("SDL AIL: Could not load WAV '%s' or OGG", name);
       return;
     }
   }

--- a/SOURCES/DIRECTORIES.CPP
+++ b/SOURCES/DIRECTORIES.CPP
@@ -80,7 +80,14 @@ bool Discover(char *outFound, U16 foundMaxSize, const char *baseDir,
       found = ExistsFileOrDir(fullPath);
     }
 
-    // TODO: Implement try with first letter uppercase (eg: "Music")
+    if (!found) {
+      // Try title case (first letter uppercase, rest lowercase)
+      SDL_strlwr(variation);
+      if (variation[0] >= 'a' && variation[0] <= 'z')
+        variation[0] -= 32;
+      snprintf(fullPath, ADELINE_MAX_PATH, "%s%s", baseDir, variation);
+      found = ExistsFileOrDir(fullPath);
+    }
   }
 
   // Copy to out if requested and variation was found

--- a/TODO.md
+++ b/TODO.md
@@ -4,12 +4,14 @@
 - [ ] Sky not being drawn
 - [ ] Water not being drawn
 - [ ] Can't read old saved games
+- [x] Music not playing on Linux (case-sensitive filesystem)
 
 ## General
-- [ ] Music
-- [ ] Sound Effects
-- [ ] Voices
-- [ ] Volume Control
+- [x] Music (OGG/WAV streaming, CD tracks)
+- [ ] Music (MIDI playback)
+- [x] Sound Effects
+- [x] Voices
+- [x] Volume Control
 
 ## Platforms
 - [ ] Keep Building for DOS


### PR DESCRIPTION
## Summary

Music files fail to load on Linux because file paths constructed in code don't match the case of files on disk (e.g. Steam ships "Music/" but code uses "music/", and ".OGG" vs ".ogg").

- Add title-case variation to Discover() so directories like "Music/" and "Video/" are found on case-sensitive filesystems
- Try multiple case variations of the music directory in CD.CPP (music, Music, MUSIC) instead of hardcoding a single path
- Try case variations of both filename and extension in the OGG fallback (.ogg/.OGG, lowercase/original filename)
- Update TODO.md: mark audio items as done (excluding MIDI), add Linux bug as fixed

Tested on macOS (Apple Silicon) and Ubuntu (WSL).