### PR TITLE
Add portable Windows build support via MSYS2

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,43 @@
+name: Windows
+on: [push, pull_request, workflow_dispatch]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-toolchain
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-ninja
+            mingw-w64-ucrt-x86_64-sdl3
+
+      - name: Code Checkout
+        uses: actions/checkout@v5
+
+      - name: Configure
+        run: cmake --preset windows_ucrt64 -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+      - name: Build
+        run: cmake --build --preset windows_ucrt64
+
+      - name: Verify Binary
+        run: |
+          test -f out/build/windows_ucrt64/SOURCES/lba2.exe && echo "Build successful"
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,16 +2,23 @@ cmake_minimum_required(VERSION 3.23)
 
 project(LBA2)
 
-# Bruteforce setup of UASM assembly compiler (must happen before enable_language)
-set(CMAKE_ASM_MASM_COMPILER uasm)
-set(CMAKE_ASM_MASM_FLAGS_INIT "-D_WIN32 -Zm -c -Cx -Cp -W4 -nologo -Sg -Sa -Zd")
-if (WIN32)
-    set(CMAKE_ASM_MASM_FLAGS_INIT ${CMAKE_ASM_MASM_FLAGS_INIT}" -coff")
-else ()
-    set(CMAKE_ASM_MASM_FLAGS_INIT ${CMAKE_ASM_MASM_FLAGS_INIT}" -elf -zcw")
-endif ()
+# Option to enable x86 assembly (requires UASM). Default OFF since all ASM is ported to C++.
+option(ENABLE_ASM "Enable x86 assembly (requires UASM assembler)" OFF)
 
-enable_language(C CXX ASM_MASM)
+if(ENABLE_ASM)
+    # UASM assembly compiler setup (must happen before enable_language)
+    set(CMAKE_ASM_MASM_COMPILER uasm)
+    set(CMAKE_ASM_MASM_FLAGS_INIT "-D_WIN32 -Zm -c -Cx -Cp -W4 -nologo -Sg -Sa -Zd")
+    if(WIN32)
+        set(CMAKE_ASM_MASM_FLAGS_INIT ${CMAKE_ASM_MASM_FLAGS_INIT}" -coff")
+    else()
+        set(CMAKE_ASM_MASM_FLAGS_INIT ${CMAKE_ASM_MASM_FLAGS_INIT}" -elf -zcw")
+    endif()
+    enable_language(C CXX ASM_MASM)
+else()
+    enable_language(C CXX)
+endif()
+
 set(CMAKE_CXX_STANDARD 98)
 
 # Compilation options

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -41,8 +41,8 @@
     {
       "name": "windows",
       "inherits": "default",
-      "displayName": "GCC 12.2.0 x86_64-w64-mingw32",
-      "description": "Using compilers: C = C:/msys64/mingw32/bin/gcc.exe, CXX = C:/msys64/mingw32/bin/g++.exe",
+      "displayName": "Windows MinGW32 (32-bit legacy)",
+      "description": "32-bit build using MSYS2 MinGW32. For modern 64-bit builds, use windows_ucrt64 instead.",
       "binaryDir": "${sourceDir}/out/build/${presetName}",
       "cacheVariables": {
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
@@ -60,6 +60,32 @@
       }
     },
     {
+      "name": "windows_ucrt64",
+      "inherits": "default",
+      "displayName": "Windows UCRT64 (64-bit)",
+      "description": "Native 64-bit build using MSYS2 UCRT64 (recommended for Windows 10+)",
+      "binaryDir": "${sourceDir}/out/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
+        "CMAKE_BUILD_TYPE": "Release",
+        "SOUND_BACKEND": "sdl",
+        "MVIDEO_BACKEND": "smacker"
+      }
+    },
+    {
+      "name": "windows_mingw64",
+      "inherits": "default",
+      "displayName": "Windows MinGW64 (64-bit)",
+      "description": "Native 64-bit build using MSYS2 MinGW64 (for Windows 7/8 compatibility)",
+      "binaryDir": "${sourceDir}/out/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
+        "CMAKE_BUILD_TYPE": "Release",
+        "SOUND_BACKEND": "sdl",
+        "MVIDEO_BACKEND": "smacker"
+      }
+    },
+    {
       "name": "macOS_x86_64",
       "displayName": "macOS x86_64",
       "description": "Using compilers: C = /usr/bin/clang, CXX = /usr/bin/clang++",
@@ -70,6 +96,16 @@
         "CMAKE_CXX_COMPILER": "/usr/bin/clang++",
         "CMAKE_BUILD_TYPE": "Debug"
       }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "windows_ucrt64",
+      "configurePreset": "windows_ucrt64"
+    },
+    {
+      "name": "windows_mingw64",
+      "configurePreset": "windows_mingw64"
     }
   ]
 }

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -1,0 +1,151 @@
+# Building on Windows
+
+This guide covers building LBA2 on Windows using MSYS2.
+
+## Prerequisites
+
+1. **MSYS2** - Download and install from [msys2.org](https://www.msys2.org/)
+2. After installation, update the package database:
+   ```bash
+   pacman -Syu
+   ```
+   (You may need to restart the terminal and run it again.)
+
+## Choosing an Environment
+
+MSYS2 provides multiple environments. Choose based on your needs:
+
+| Environment | Architecture | C Runtime | Windows Compatibility | Recommendation |
+|-------------|--------------|-----------|----------------------|----------------|
+| **UCRT64** | 64-bit | UCRT | Windows 10+ (built-in) | **Recommended** for most users |
+| **MINGW64** | 64-bit | MSVCRT | All Windows versions | Use for Windows 7/8 compatibility |
+| **MINGW32** | 32-bit | MSVCRT | All Windows versions | Legacy only |
+
+**Important:** Launch the correct shell for your chosen environment:
+- Start Menu → "MSYS2 UCRT64" (or MINGW64, MINGW32)
+
+## Installing Dependencies
+
+From the appropriate MSYS2 shell:
+
+### UCRT64 (Recommended)
+
+```bash
+pacman -S mingw-w64-ucrt-x86_64-toolchain \
+          mingw-w64-ucrt-x86_64-cmake \
+          mingw-w64-ucrt-x86_64-ninja \
+          mingw-w64-ucrt-x86_64-sdl3
+```
+
+### MINGW64
+
+```bash
+pacman -S mingw-w64-x86_64-toolchain \
+          mingw-w64-x86_64-cmake \
+          mingw-w64-x86_64-ninja \
+          mingw-w64-x86_64-sdl3
+```
+
+### MINGW32 (Legacy)
+
+```bash
+pacman -S mingw-w64-i686-toolchain \
+          mingw-w64-i686-cmake \
+          mingw-w64-i686-ninja \
+          mingw-w64-i686-sdl3
+```
+
+> **Note:** The package name is lowercase `sdl3`, not `SDL3`.
+
+## Building
+
+### Using CMake Presets (Recommended)
+
+```bash
+# UCRT64
+cmake --preset windows_ucrt64
+cmake --build --preset windows_ucrt64
+
+# MINGW64
+cmake --preset windows_mingw64
+cmake --build --preset windows_mingw64
+```
+
+### Manual Build
+
+```bash
+cmake -B build -G Ninja -DSOUND_BACKEND=sdl -DMVIDEO_BACKEND=smacker
+cmake --build build
+```
+
+The executable will be at `out/build/windows_ucrt64/SOURCES/lba2.exe` (preset) or `build/SOURCES/lba2.exe` (manual).
+
+## Running
+
+### Game Assets Required
+
+LBA2 requires the original game files to run. These are **not** included in this repository. You need a legitimate copy of the game from [GOG](https://www.gog.com/game/little_big_adventure_2) or [Steam](https://store.steampowered.com/app/398000/Little_Big_Adventure_2/).
+
+### SDL3.dll
+
+When running **outside** the MSYS2 environment:
+- Copy `SDL3.dll` to the same directory as `lba2.exe`
+- Or add the MSYS2 bin directory to your PATH
+
+The DLL is located at:
+- UCRT64: `C:\msys64\ucrt64\bin\SDL3.dll`
+- MINGW64: `C:\msys64\mingw64\bin\SDL3.dll`
+- MINGW32: `C:\msys64\mingw32\bin\SDL3.dll`
+
+## Troubleshooting
+
+### "command not found" for cmake/ninja/gcc
+
+Make sure you're using the correct MSYS2 shell (UCRT64/MINGW64/MINGW32), not the generic MSYS shell. The compilers are only available in the MinGW-based shells.
+
+### Package not found
+
+Update your package database:
+```bash
+pacman -Syu
+```
+
+### SDL3 not found during cmake
+
+Ensure you installed the SDL3 package for your specific environment (e.g., `mingw-w64-ucrt-x86_64-sdl3` for UCRT64).
+
+### Build fails with ASM/UASM errors
+
+This project no longer requires UASM. The x86 assembly has been ported to C++. If you see ASM-related errors, ensure you're using the latest code and haven't set `-DENABLE_ASM=ON`.
+
+### Binary crashes immediately
+
+- Verify SDL3.dll is accessible (see above)
+- Make sure you have the game assets in the expected location
+- Run from a command prompt to see error messages
+
+## Legacy 32-bit Build
+
+For 32-bit builds (required for the original ASM code path), use the `windows` preset:
+
+```bash
+cmake --preset windows
+cmake --build out/build/windows
+```
+
+This requires MSYS2 MINGW32 and produces a 32-bit executable.
+
+## Known Issues
+
+### Release build crashes on startup (64-bit)
+
+The 64-bit Release build may crash with a segmentation fault during scene rendering (in `GetShadow`). This appears to be a pre-existing issue with uninitialized memory or undefined behavior that is only exposed by Windows Release optimizations. Linux and macOS builds are not affected.
+
+**Workaround:** Build in Debug mode:
+
+```bash
+cmake --preset windows_ucrt64 -DCMAKE_BUILD_TYPE=Debug
+cmake --build --preset windows_ucrt64
+```
+
+The Debug build runs correctly, though with reduced performance.


### PR DESCRIPTION
## Summary

- Add support for 64-bit Windows builds using MSYS2 (UCRT64/MINGW64)
- Make UASM assembler optional since all x86 assembly has been ported to C++
- Add Windows CI workflow for automated build verification

## Changes

- **CMakeLists.txt**: Add `ENABLE_ASM` option (default OFF) to make UASM conditional
- **CMakePresets.json**: Add `windows_ucrt64` and `windows_mingw64` presets for 64-bit builds, clarify existing `windows` preset as 32-bit legacy
- **.github/workflows/windows.yml**: New CI workflow using MSYS2 UCRT64
- **docs/WINDOWS.md**: Comprehensive guide for Windows developers (prerequisites, environment selection, building, troubleshooting)

## Known Issues

The 64-bit Release build has a crash in shadow rendering (`GetShadow`) that appears to be pre-existing undefined behavior exposed by Windows Release optimizations. Debug builds work correctly. This does not affect Linux or macOS. Documented in docs/WINDOWS.md with workaround.

## Test Plan

- [x] Build completes on MSYS2 UCRT64 (Debug mode)
- [x] Game runs and plays intro video. You can also run demo mode (SHIFT + D) from the menu.
- [ ] CI workflow passes on push