### PR TITLE
fix: menu mouse hover no longer overrides keyboard selection

### DIFF
--- a/LIB386/H/SYSTEM/MOUSE.H
+++ b/LIB386/H/SYSTEM/MOUSE.H
@@ -24,6 +24,9 @@ extern const void *MouseSpriteGraphic; ///< Memory of graphic for mouse cursor
 /// True when the software cursor should be composited this frame (respects idle hide).
 bool MouseSpriteShouldDraw(void);
 
+/// True when mouse has moved since last call (edge-consuming).
+bool MouseConsumeMotionFlag(void);
+
 // --- Initialization ----------------------------------------------------------
 void InitMouse();
 void EndMouse();

--- a/LIB386/SYSTEM/MOUSE.CPP
+++ b/LIB386/SYSTEM/MOUSE.CPP
@@ -35,6 +35,7 @@ volatile S32 MouseWheelYAccum = 0;
 
 static bool s_showSpriteAfterFirstMotion = false;
 static Uint32 s_lastPointerActivityMs = 0;
+static bool s_mouseMotionFlag = false;
 
 static void MousePointerMarkActivity(void) {
     s_lastPointerActivityMs = SDL_GetTicks();
@@ -71,6 +72,12 @@ bool MouseSpriteShouldDraw(void) {
             return false;
     }
     return true;
+}
+
+bool MouseConsumeMotionFlag(void) {
+    bool v = s_mouseMotionFlag;
+    s_mouseMotionFlag = false;
+    return v;
 }
 
 // --- Interface ---------------------------------------------------------------
@@ -161,6 +168,7 @@ void HandleEventsMouse(const void *event) {
         SetMousePos((U32)curX, (U32)curY);
 
         MousePointerMarkActivity();
+        s_mouseMotionFlag = true;
 
         if (s_showSpriteAfterFirstMotion) {
             s_showSpriteAfterFirstMotion = false;

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -1290,8 +1290,10 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
             S32 hitSel = -1;
             S32 cur, leftDown, prevLeft, leftDownEdge, leftUpEdge, relSel;
             S32 wy;
+            bool saveMoved;
 
             GameMenuMousePollFocus();
+            saveMoved = MouseConsumeMotionFlag();
             cur = Click;
             leftDown = (cur & 1) != 0;
             prevLeft = (save_prev_click & 1) != 0;
@@ -1299,7 +1301,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
             leftUpEdge = !leftDown && prevLeft;
             save_prev_click = cur;
 
-            if (GameMenuSaveListHitTest(MouseX, MouseY, nb, start, &hitSel)) {
+            if (saveMoved && GameMenuSaveListHitTest(MouseX, MouseY, nb, start, &hitSel)) {
                 if (!leftDown && save_press < 0 && hitSel != select) {
                     select = hitSel;
                     flag = 1;

--- a/SOURCES/GAMEMENU_MOUSE.CPP
+++ b/SOURCES/GAMEMENU_MOUSE.CPP
@@ -2,7 +2,6 @@
 
 #include "C_EXTERN.H"
 
-#include <SYSTEM/HQRRESS.H>
 #include <SYSTEM/MOUSE.H>
 #include <SYSTEM/WINDOW.H>
 
@@ -24,23 +23,7 @@ void GameMenuMouseResetPress(void) {
 }
 
 void MenuMouseApplyCursorSprite(void) {
-    extern T_HQR_HEADER *HQRPtrSprite;
-
-    if (HQRPtrSprite == NULL) {
-        InitMouse();
-        return;
-    }
-
-    {
-        const U8 *g = (const U8 *)HQR_Get(HQRPtrSprite, (U32)MENU_MOUSE_SPRITE_HQR_INDEX);
-
-        if (g == NULL) {
-            InitMouse();
-            return;
-        }
-        MouseSpriteGraphic = g;
-        MouseSpriteGraphicNum = 0;
-    }
+    /* No-op: menus use the default BinGphMouse arrow set by InitMouse(). */
 }
 
 void MenuMouseAcquire(void) {
@@ -48,7 +31,6 @@ void MenuMouseAcquire(void) {
         return;
     s_menuMouseRefCount++;
     if (s_menuMouseRefCount == 1) {
-        MenuMouseApplyCursorSprite();
         ShowMouseAfterFirstMotion();
     }
 }
@@ -125,11 +107,13 @@ S32 GameMenuMouseProcessDoGameMenu(U16 *ptrmenu, S16 *selected, S32 *flag) {
     S32 leftUpEdge;
     S32 rel;
     S32 mess;
+    bool mouseMoved;
 
     if (!FlagMenuMouse || s_menuMouseRefCount <= 0)
         return -1;
 
     GameMenuMousePollFocus();
+    mouseMoved = MouseConsumeMotionFlag();
 
     cur = Click;
     leftDown = (cur & 1) != 0;
@@ -158,7 +142,8 @@ S32 GameMenuMouseProcessDoGameMenu(U16 *ptrmenu, S16 *selected, S32 *flag) {
             ptrmenu[0] = *selected;
         }
     } else if (!leftDown && s_pressRow < 0) {
-        if (row >= 0 && row != *selected) {
+        /* Hover: only update selection when the mouse actually moved. */
+        if (mouseMoved && row >= 0 && row != *selected) {
             *selected = row;
             *flag = 1;
             ptrmenu[0] = *selected;


### PR DESCRIPTION
Use the default BinGphMouse arrow instead of loading SPRITE_CURSOR from sprites.hqr.  Gate hover-selection on actual mouse movement so a stationary pointer does not snap the highlight back when navigating with the keyboard.  Idle-hide and click/wheel behavior unchanged.