### PR TITLE
Mouse camera for exterior FollowCamera

### DIFF
--- a/LIB386/H/SYSTEM/WINDOW.H
+++ b/LIB386/H/SYSTEM/WINDOW.H
@@ -25,6 +25,7 @@ void WindowToSurfaceCoords(S32 windowX, S32 windowY, S32 *surfaceX, S32 *surface
 void SetWindowFullscreen(bool fullscreen);
 bool GetWindowFullscreen();
 
+void SetWindowRelativeMouse(bool enable);
 void ManageWindow();
 void HandleEventsWindow(const void *event);
 

--- a/LIB386/SYSTEM/MOUSE.CPP
+++ b/LIB386/SYSTEM/MOUSE.CPP
@@ -179,12 +179,14 @@ void HandleEventsMouse(const void *event) {
     case SDL_EVENT_MOUSE_BUTTON_DOWN:
         MousePointerMarkActivity();
         Click |= (sdlEvent->button.button == 1) ? 1 : 0;
+        Click |= (sdlEvent->button.button == 2) ? 4 : 0;
         Click |= (sdlEvent->button.button == 3) ? 2 : 0;
         break;
 
     case SDL_EVENT_MOUSE_BUTTON_UP:
         MousePointerMarkActivity();
         Click &= (sdlEvent->button.button == 1) ? ~1 : Click;
+        Click &= (sdlEvent->button.button == 2) ? ~4 : Click;
         Click &= (sdlEvent->button.button == 3) ? ~2 : Click;
         break;
 

--- a/LIB386/SYSTEM/WINDOW.CPP
+++ b/LIB386/SYSTEM/WINDOW.CPP
@@ -275,6 +275,11 @@ void WindowToSurfaceCoords(S32 windowX, S32 windowY, S32 *surfaceX, S32 *surface
     }
 }
 
+void SetWindowRelativeMouse(bool enable) {
+    if (sdlWindow != NULL)
+        SDL_SetWindowRelativeMouseMode(sdlWindow, enable);
+}
+
 void SetWindowFullscreen(bool fullscreen) {
     windowFullscreenEnabled = fullscreen;
 

--- a/SOURCES/C_EXTERN.H
+++ b/SOURCES/C_EXTERN.H
@@ -199,6 +199,15 @@ extern S32 Planet;
 extern S32 AllCameras;
 extern S32 FollowCamera;
 extern S32 FollowCamBaseDist;
+extern S32 FlagMouseCamera;
+extern S32 FlagMouseCameraDrag;
+extern S32 MouseCameraSensX;
+extern S32 MouseCameraSensY;
+extern S32 MouseCameraInvertY;
+extern S32 MouseCameraDivisor;
+extern S32 MouseCameraSmoothing;
+extern S32 MouseCameraOrbitActive; /* set by EXTFUNC each frame mouse orbit occurs */
+extern S32 FollowCamReengageDelay;
 extern S32 ReverseStereo;
 
 extern S32 ScaleFactorSprite;

--- a/SOURCES/EXTFUNC.CPP
+++ b/SOURCES/EXTFUNC.CPP
@@ -15,6 +15,8 @@
 
 #include <SVGA/SCREEN.H>
 #include <SYSTEM/KEYBOARD_KEYS.H>
+#include <SYSTEM/MOUSE.H>
+#include <SYSTEM/WINDOW.H>
 #include "FOLLOWCAM_CFG.H"
 
 extern S32 Nxw, Nyw, Nzw;
@@ -2229,6 +2231,85 @@ S32 GereExtKeys(U32 key)
                 FollowCamBaseDist += FOLLOW_CAM_ZOOM_STEP;
             FirstTime = AFF_ALL_FLIP;
             flag = 1;
+        }
+
+        /* --- Mouse camera: orbit, elevation, zoom, recenter --- */
+        MouseCameraOrbitActive = FALSE;
+        {
+            /* Relative mouse mode: deltas keep flowing past window edge.
+             * Drag mode: active while right button held.
+             * Free mode: always active.
+             * Disabled when mouse camera conditions not met. */
+            static S32 prevRelative = 0;
+            S32 wantRelative = 0;
+            if (FlagMouseCamera AND CubeMode == CUBE_EXTERIEUR)
+                wantRelative = FlagMouseCameraDrag ? (Click & 2) : 1;
+            if (wantRelative != prevRelative) {
+                SetWindowRelativeMouse(wantRelative ? true : false);
+                prevRelative = wantRelative;
+            }
+        }
+        if (FlagMouseCamera AND CubeMode == CUBE_EXTERIEUR) {
+            ManageMouse();
+
+            {
+                S32 orbitActive = FlagMouseCameraDrag ? (Click & 2) : 1;
+
+                if (orbitActive) {
+                    S32 rawX = MouseXDep;
+                    S32 rawY = MouseYDep;
+
+                    /* Dead zone on raw pixels before scaling */
+                    if (rawX > -MOUSE_CAM_DEAD_ZONE AND rawX < MOUSE_CAM_DEAD_ZONE)
+                        rawX = 0;
+                    if (rawY > -MOUSE_CAM_DEAD_ZONE AND rawY < MOUSE_CAM_DEAD_ZONE)
+                        rawY = 0;
+
+                    S32 dx = rawX * MouseCameraSensX / MouseCameraDivisor;
+                    S32 dy = rawY * MouseCameraSensY / MouseCameraDivisor;
+
+                    if (MouseCameraInvertY)
+                        dy = -dy;
+
+                    if (dx != 0) {
+                        AddBetaCam = (AddBetaCam - dx) & 4095;
+                        MouseCameraOrbitActive = TRUE;
+                        FirstTime = AFF_ALL_FLIP;
+                        flag = 1;
+                    }
+                    if (dy != 0) {
+                        AlphaCam += dy;
+                        if (AlphaCam < FOLLOW_CAM_ALPHA_MIN)
+                            AlphaCam = FOLLOW_CAM_ALPHA_MIN;
+                        if (AlphaCam > FOLLOW_CAM_ALPHA_MAX)
+                            AlphaCam = FOLLOW_CAM_ALPHA_MAX;
+                        FirstTime = AFF_ALL_FLIP;
+                        flag = 1;
+                    }
+                    if (dx != 0 OR dy != 0)
+                        FollowCamReengageDelay = FOLLOW_CAM_REENGAGE_FRAMES;
+                }
+            }
+
+            {
+                S32 wy = ConsumeMouseWheelY();
+
+                if (wy != 0) {
+                    FollowCamBaseDist -= wy * FOLLOW_CAM_ZOOM_STEP * MOUSE_CAM_ZOOM_MULT;
+                    if (FollowCamBaseDist < FOLLOW_CAM_DIST_MIN)
+                        FollowCamBaseDist = FOLLOW_CAM_DIST_MIN;
+                    if (FollowCamBaseDist > FOLLOW_CAM_DIST_MAX)
+                        FollowCamBaseDist = FOLLOW_CAM_DIST_MAX;
+                    FirstTime = AFF_ALL_FLIP;
+                    flag = 1;
+                }
+            }
+
+            if (Click & 4) {
+                CameraCenter(1);
+                FirstTime = AFF_ALL_FLIP;
+                flag = 1;
+            }
         }
     }
 #endif

--- a/SOURCES/FOLLOWCAM_CFG.H
+++ b/SOURCES/FOLLOWCAM_CFG.H
@@ -29,3 +29,10 @@
 
 /* Horizontal pan keys [ ] ---------------------------------------------------*/
 #define FOLLOW_CAM_PAN_STEP 30 /* AddBetaCam change per [ / ] key press per frame */
+
+/* Mouse camera --------------------------------------------------------------*/
+#define MOUSE_CAM_DIVISOR_DEFAULT 4   /* pixel-to-angle scaling (lower = faster) */
+#define MOUSE_CAM_SMOOTHING_DEFAULT 2 /* BetaCam lerp divisor during orbit (1=snap, higher=laggier) */
+#define MOUSE_CAM_DEAD_ZONE 2         /* ignore deltas smaller than this (pixels, pre-scale) */
+#define MOUSE_CAM_ZOOM_MULT 1         /* wheel zoom multiplier (applied to FOLLOW_CAM_ZOOM_STEP) */
+#define MOUSE_CAM_SENS_DEFAULT 4      /* default sensitivity (1-10 range) */

--- a/SOURCES/GLOBAL.CPP
+++ b/SOURCES/GLOBAL.CPP
@@ -1,4 +1,5 @@
 #include "C_EXTERN.H"
+#include "FOLLOWCAM_CFG.H"
 
 /*══════════════════════════════════════════════════════════════════════════*
 			 █▀▀▀█ █▀▀▀▀ █▀▀▀█ ██▀▀▀ █▀▀▀█
@@ -200,6 +201,14 @@ S32 ExtraConque = -1; // Numero extra visant Twinsen (avec Conque)
 S32 AllCameras = TRUE;
 S32 FollowCamera = FALSE;
 S32 FollowCamBaseDist = 0; /* player's chosen zoom distance (0 = uninitialised) */
+S32 FlagMouseCamera = TRUE;
+S32 FlagMouseCameraDrag = TRUE; /* 0=free orbit on move, 1=require right-drag */
+S32 MouseCameraSensX = MOUSE_CAM_SENS_DEFAULT;
+S32 MouseCameraSensY = MOUSE_CAM_SENS_DEFAULT;
+S32 MouseCameraInvertY = FALSE;
+S32 MouseCameraDivisor = MOUSE_CAM_DIVISOR_DEFAULT;
+S32 MouseCameraSmoothing = MOUSE_CAM_SMOOTHING_DEFAULT;
+S32 MouseCameraOrbitActive = FALSE;
 S32 ReverseStereo = FALSE;
 S32 Island = 0;
 S32 Planet = 0;

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -68,7 +68,7 @@ static S32 FollowCamPrevHeroBeta = 0;
 static S32 FollowCamPrevAddBeta = 0;   /* dirty check: last seen AddBetaCam */
 static S32 FollowCamEffectiveDist = 0; /* spring arm: smoothed distance (0 = uninitialised) */
 static S32 FollowCamTargetBeta = 0;    /* rotation lag: desired BetaCam */
-S32 FollowCamReengageDelay = 0; /* frames before auto-center resumes after manual pan */
+S32 FollowCamReengageDelay = 0;        /* frames before auto-center resumes after manual pan */
 static S32 FollowCamPrevBaseDist = -1; /* dirty: zoom from GereExtKeys (numpad * /) */
 static S32 FollowCamPrevAlphaCam = -1; /* dirty: numpad +/- elevation while follow */
 

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -68,7 +68,7 @@ static S32 FollowCamPrevHeroBeta = 0;
 static S32 FollowCamPrevAddBeta = 0;   /* dirty check: last seen AddBetaCam */
 static S32 FollowCamEffectiveDist = 0; /* spring arm: smoothed distance (0 = uninitialised) */
 static S32 FollowCamTargetBeta = 0;    /* rotation lag: desired BetaCam */
-static S32 FollowCamReengageDelay = 0; /* frames before auto-center resumes after manual pan */
+S32 FollowCamReengageDelay = 0; /* frames before auto-center resumes after manual pan */
 static S32 FollowCamPrevBaseDist = -1; /* dirty: zoom from GereExtKeys (numpad * /) */
 static S32 FollowCamPrevAlphaCam = -1; /* dirty: numpad +/- elevation while follow */
 
@@ -1753,16 +1753,23 @@ restartloop:
 
                         if (manualPan) {
                             BetaCam = FollowCamTargetBeta;
-                        } else if (FollowCamReengageDelay == 0) {
+                        } else if (MouseCameraOrbitActive OR FollowCamReengageDelay == 0) {
                             S32 diff = FollowCamTargetBeta - BetaCam;
                             if (diff > 2048)
                                 diff -= 4096;
                             if (diff < -2048)
                                 diff += 4096;
                             if (diff > FOLLOW_CAM_ROT_THRESHOLD OR diff < -FOLLOW_CAM_ROT_THRESHOLD) {
-                                S32 dynamicDiv = FOLLOW_CAM_ROT_DIVISOR * FollowCamEffectiveDist / FollowCamBaseDist;
-                                if (dynamicDiv < FOLLOW_CAM_ROT_DIVISOR / 3)
-                                    dynamicDiv = FOLLOW_CAM_ROT_DIVISOR / 3;
+                                /* Mouse orbit: tight lerp for responsive feel.
+                                 * Auto-follow: distance-scaled inertia for cinematic drift. */
+                                S32 dynamicDiv;
+                                if (MouseCameraOrbitActive) {
+                                    dynamicDiv = MouseCameraSmoothing;
+                                } else {
+                                    dynamicDiv = FOLLOW_CAM_ROT_DIVISOR * FollowCamEffectiveDist / FollowCamBaseDist;
+                                    if (dynamicDiv < FOLLOW_CAM_ROT_DIVISOR / 3)
+                                        dynamicDiv = FOLLOW_CAM_ROT_DIVISOR / 3;
+                                }
                                 S32 step = diff / dynamicDiv;
                                 if (step > 0 AND step < FOLLOW_CAM_ROT_MIN_STEP)
                                     step = FOLLOW_CAM_ROT_MIN_STEP;
@@ -1989,6 +1996,48 @@ void ReadConfigFile(void) {
         FlagMenuMouse = TRUE;
     else
         FlagMenuMouse = FALSE;
+
+    FlagMouseCamera = DefFileBufferReadValueDefault("MouseCamera", TRUE);
+    if (FlagMouseCamera != 0)
+        FlagMouseCamera = TRUE;
+    else
+        FlagMouseCamera = FALSE;
+
+    FlagMouseCameraDrag = DefFileBufferReadValueDefault("MouseCameraDrag", TRUE);
+    if (FlagMouseCameraDrag != 0)
+        FlagMouseCameraDrag = TRUE;
+    else
+        FlagMouseCameraDrag = FALSE;
+
+    MouseCameraSensX = DefFileBufferReadValueDefault("MouseSensitivityX", MOUSE_CAM_SENS_DEFAULT);
+    if (MouseCameraSensX < 1)
+        MouseCameraSensX = 1;
+    if (MouseCameraSensX > 10)
+        MouseCameraSensX = 10;
+
+    MouseCameraSensY = DefFileBufferReadValueDefault("MouseSensitivityY", MOUSE_CAM_SENS_DEFAULT);
+    if (MouseCameraSensY < 1)
+        MouseCameraSensY = 1;
+    if (MouseCameraSensY > 10)
+        MouseCameraSensY = 10;
+
+    MouseCameraInvertY = DefFileBufferReadValueDefault("MouseInvertY", FALSE);
+    if (MouseCameraInvertY != 0)
+        MouseCameraInvertY = TRUE;
+    else
+        MouseCameraInvertY = FALSE;
+
+    MouseCameraDivisor = DefFileBufferReadValueDefault("MouseCameraDivisor", MOUSE_CAM_DIVISOR_DEFAULT);
+    if (MouseCameraDivisor < 1)
+        MouseCameraDivisor = 1;
+    if (MouseCameraDivisor > 16)
+        MouseCameraDivisor = 16;
+
+    MouseCameraSmoothing = DefFileBufferReadValueDefault("MouseCameraSmoothing", MOUSE_CAM_SMOOTHING_DEFAULT);
+    if (MouseCameraSmoothing < 1)
+        MouseCameraSmoothing = 1;
+    if (MouseCameraSmoothing > 16)
+        MouseCameraSmoothing = 16;
 }
 
 /*──────────────────────────────────────────────────────────────────────────*/
@@ -2019,6 +2068,13 @@ void WriteConfigFile(void) {
         DefFileBufferWriteString("FlagDisplayText", "OFF");
 
     DefFileBufferWriteValue("MenuMouse", FlagMenuMouse);
+    DefFileBufferWriteValue("MouseCamera", FlagMouseCamera);
+    DefFileBufferWriteValue("MouseCameraDrag", FlagMouseCameraDrag);
+    DefFileBufferWriteValue("MouseSensitivityX", MouseCameraSensX);
+    DefFileBufferWriteValue("MouseSensitivityY", MouseCameraSensY);
+    DefFileBufferWriteValue("MouseInvertY", MouseCameraInvertY);
+    DefFileBufferWriteValue("MouseCameraDivisor", MouseCameraDivisor);
+    DefFileBufferWriteValue("MouseCameraSmoothing", MouseCameraSmoothing);
 }
 
 /*══════════════════════════════════════════════════════════════════════════*

--- a/docs/CONTROLLER.md
+++ b/docs/CONTROLLER.md
@@ -1,0 +1,82 @@
+# Controller & Mouse Camera
+
+Working design document for mouse camera, gamepad, and modern input features.
+
+## Roadmap
+
+| Phase | Branch | Description | Depends on |
+|-------|--------|-------------|------------|
+| **1** | `feature/mouse-camera` | Mouse orbit, zoom, elevation in exterior FollowCamera | — |
+| **2** | `feature/gamepad-input` | SDL3 gamepad: left stick → movement, right stick → camera, triggers → zoom | Phase 1 |
+| **3** | `feature/controls-menu` | Restructure Options: Controls → Keyboard / Mouse / Controller sub-menus | Phase 1+2 |
+| **4** | `feature/camera-relative-movement` | Optional camera-relative stick / WASD movement (non-tank) | Phase 2+3 |
+
+Each phase is an independent PR behind its own config flag.
+
+---
+
+## Phase 1 — Mouse Camera
+
+Mouse orbits the camera, adjusts elevation, scroll wheel zooms.
+Only active when `FollowCamera=1` AND exterior scene.
+Reuses the same variables as the keyboard FollowCamera controls.
+
+### Input mapping
+
+| Mouse input | Variable | Keyboard equivalent |
+|-------------|----------|-------------------|
+| Move / right-drag horizontal | `AddBetaCam` | `[` / `]` |
+| Move / right-drag vertical | `AlphaCam` | Numpad `+` / `-` |
+| Scroll wheel | `FollowCamBaseDist` | Numpad `*` / `/` |
+| Middle-click | `CameraCenter(1)` | Enter |
+
+### Two orbit modes
+
+| Mode | `MouseCameraDrag` | Behaviour |
+|------|-------------------|-----------|
+| **Free** | `0` (default) | Any mouse motion orbits; dead-zone threshold filters jitter |
+| **Hold** | `1` | Right-button hold required to orbit |
+
+### Config keys (`lba2.cfg`)
+
+```
+MouseCamera: 1          ; 0=off, 1=on
+MouseCameraDrag: 0      ; 0=free orbit on move, 1=require right-drag
+MouseSensitivityX: 4    ; orbit speed (1-10)
+MouseSensitivityY: 4    ; elevation speed (1-10)
+MouseInvertY: 0         ; 0=normal, 1=inverted
+```
+
+### Implementation
+
+- Hook: `GereExtKeys()` in `SOURCES/EXTFUNC.CPP`, inside the `if (FollowCamera)` block
+- Consumes `MouseXDep`/`MouseYDep` via `ManageMouse()`
+- Sets `FollowCamReengageDelay` on orbit (same grace-period as `[`/`]` keys)
+- PERSO.CPP dirty check already reacts to `AddBetaCam`/`AlphaCam` changes
+- Tuning constants in `SOURCES/FOLLOWCAM_CFG.H`
+
+---
+
+## Phase 2 — SDL3 Gamepad (future)
+
+Rewrite `SOURCES/JOYSTICK.CPP` (currently all commented out) using SDL3 gamepad API.
+- Left stick → I_UP/DOWN/LEFT/RIGHT (tank controls, with dead zone)
+- Right stick → camera orbit/elevation (same variables as mouse)
+- L2/R2 triggers → zoom
+- Face buttons → Action, Inventory, Behavior, Menu
+- Config: `GamepadEnabled`, dead zone, invert, button mapping
+
+## Phase 3 — Controls Menu (future)
+
+Restructure Options menu:
+```
+Options → Controls → Keyboard (existing, moved)
+                   → Mouse (sensitivity, invert, enable)
+                   → Controller (dead zone, invert, button map)
+```
+
+## Phase 4 — Camera-Relative Movement (future)
+
+Optional mode where stick / WASD moves character relative to camera facing instead
+of tank controls.  Character auto-rotates toward movement direction.  Behind config
+flag `ModernMovement=0`.  Needs extensive playtesting — changes combat and platforming feel.

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ Index of documentation in this repository.
 
 | Doc | Description |
 |-----|-------------|
+| [CONTROLLER.md](CONTROLLER.md) | Mouse camera, gamepad input, controls menu, and modern movement — phased roadmap and design. |
 | [FEATURE_WORKFLOW.md](FEATURE_WORKFLOW.md) | Reasoning and docs for big features: console commands, headless mode, menu changes, camera. |
 | [AUDIO.md](AUDIO.md) | Audio system: AIL contract, SDL backend, sound scripting patterns, known issues. |
 | [ASM_TO_CPP_REFERENCE.md](ASM_TO_CPP_REFERENCE.md) | Which modules are ported from ASM to C++ in this fork. |


### PR DESCRIPTION
**WIP** This is already functional. Just need a bit more play testing. This could reveal some tightening needed on the auto camera. The thinking is that this would be transferable to the right joystick on a gamepad down the line.

## Summary

- Right-click drag orbits the camera horizontally and adjusts elevation in exterior scenes when Auto camera (`FollowCamera`) is active
- Scroll wheel zooms in/out; middle-click recenters behind the hero
- SDL relative mouse mode captures the cursor during drag so orbit continues past window edges
- All settings persist in `lba2.cfg` with sensible defaults; no config needed to use

## Config keys

| Key | Default | Description |
|-----|---------|-------------|
| `MouseCamera` | 1 | Enable mouse camera (0=off) |
| `MouseCameraDrag` | 1 | 1=right-click drag to orbit, 0=free orbit on move |
| `MouseSensitivityX` | 4 | Horizontal orbit speed (1-10) |
| `MouseSensitivityY` | 4 | Elevation speed (1-10) |
| `MouseInvertY` | 0 | Invert elevation axis |
| `MouseCameraDivisor` | 4 | Pixel-to-angle scaling (lower=faster, 1-16) |
| `MouseCameraSmoothing` | 2 | Orbit lerp (1=snap, higher=laggier, 1-16) |

## Design

- Hooks into `GereExtKeys()` alongside existing keyboard camera controls
- Maps mouse deltas to the same variables (`AddBetaCam`, `AlphaCam`, `FollowCamBaseDist`) the keyboard already drives
- Orbit uses a tight lerp (`MouseCameraSmoothing`) for smooth diagonal/compound movement, separate from the cinematic auto-follow lerp
- Dead zone on raw pixel deltas filters jitter without eating intentional movement
- No effect on interior scenes, classic camera mode, or keyboard controls
- Adds `docs/CONTROLLER.md` with phased roadmap for gamepad, controls menu, and camera-relative movement

## Test plan

- [ ] Exterior scene, right-click drag: camera orbits and shifts smoothly, including past window edges
- [ ] Diagonal drag: no jerking or stuttering
- [ ] Scroll wheel: smooth zoom in/out
- [ ] Middle-click: camera recenters behind hero
- [ ] Walk after orbiting: camera drifts back behind hero after grace period
- [ ] Interior scene: mouse does nothing to camera
- [ ] `FollowCamera=0`: mouse does nothing
- [ ] `MouseCamera=0`: mouse does nothing regardless of FollowCamera
- [ ] Keyboard `[`/`]` and numpad controls still work alongside mouse
- [ ] Config keys absent from `lba2.cfg`: defaults apply, keys written on exit
