### PR TITLE
fix(credits): endgame segfault + safe console invocation (#65) 

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -312,6 +312,15 @@ static void cmd_credits(int argc, const char *argv[]) {
         mode = (S32)strtol(argv[1], NULL, 0);
     Console_Close();
     Credits(mode);
+    /* Credits leaves the palette black on exit. Existing engine call sites
+       (endgame win path → PlayAcf, demo-timeout → fade-to-black + return to
+       menu) intentionally rely on that; doing the fade-in inside Credits
+       would regress them. From the console we want the screen visible
+       immediately on return, so handle it here for mode=0. */
+    if (mode == 0) {
+        FadeToPal(PtrPalNormal);
+        PtrPal = PtrPalNormal;
+    }
     Console_Print("Credits done (mode=%d)", (int)mode);
 }
 

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -305,22 +305,51 @@ static void cmd_playvideo(int argc, const char *argv[]) {
 }
 
 static void cmd_credits(int argc, const char *argv[]) {
-    /* Mode: 0 = bad end (loads menu screen after), 1 = good end (Twinsen+Zoey).
-       Default to 0; pass `credits 1` for the win-path variant. */
+    /* Mode: 0 = "demo wrap" variant (no actors), 1 = "win" variant
+       (Twinsen+Zoey). Default to 0. The original engine only invokes Credits
+       on win or after the auto-demo, never returning to its prior state, so
+       Credits() leaves several global side effects behind (GameInProgress=
+       TRUE, main menu screen blitted to Log/Screen, palette black). To make
+       console invocation transparent — usable from both the main menu and
+       live gameplay without flashing menu graphics or flipping the menu
+       into pause-mode — snapshot what Credits will mutate, then restore. */
     S32 mode = 0;
     if (argc >= 2)
         mode = (S32)strtol(argv[1], NULL, 0);
     Console_Close();
+
+    const S32 savedGameInProgress = GameInProgress;
+    const U32 bufSize = (U32)(ModeDesiredX * ModeDesiredY);
+    U8 *savedLog = (U8 *)malloc(bufSize);
+    U8 *savedScreen = (U8 *)malloc(bufSize);
+    if (savedLog && Log)
+        memcpy(savedLog, Log, bufSize);
+    if (savedScreen && Screen)
+        memcpy(savedScreen, Screen, bufSize);
+
     Credits(mode);
-    /* Credits leaves the palette black on exit. Existing engine call sites
-       (endgame win path → PlayAcf, demo-timeout → fade-to-black + return to
-       menu) intentionally rely on that; doing the fade-in inside Credits
-       would regress them. From the console we want the screen visible
-       immediately on return, so handle it here for mode=0. */
+
+    GameInProgress = savedGameInProgress;
+    if (savedLog) {
+        if (Log)
+            memcpy(Log, savedLog, bufSize);
+        free(savedLog);
+    }
+    if (savedScreen) {
+        if (Screen)
+            memcpy(Screen, savedScreen, bufSize);
+        free(savedScreen);
+    }
+
     if (mode == 0) {
         FadeToPal(PtrPalNormal);
         PtrPal = PtrPalNormal;
     }
+    /* Push the restored back-buffer to display so the next render (menu draw
+       or MainLoop AffScene) starts from the pre-credits frame instead of
+       briefly flashing the main menu image Credits left in Log. */
+    BoxStaticFullflip();
+
     Console_Print("Credits done (mode=%d)", (int)mode);
 }
 

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -4,6 +4,7 @@
 #include "../COMMON.H"
 #include "../DIRECTORIES.H"
 #include "../PLAYACF.H"
+#include "../GAMEMENU.H"
 #include "../MUSIC.H"
 #include "../AMBIANCE.H"
 #include <AIL/SAMPLE.H>
@@ -301,6 +302,17 @@ static void cmd_playvideo(int argc, const char *argv[]) {
         Console_Print("Playing video: %s", argv[1]);
     else
         Console_Print("Video not found: %s", argv[1]);
+}
+
+static void cmd_credits(int argc, const char *argv[]) {
+    /* Mode: 0 = bad end (loads menu screen after), 1 = good end (Twinsen+Zoey).
+       Default to 0; pass `credits 1` for the win-path variant. */
+    S32 mode = 0;
+    if (argc >= 2)
+        mode = (S32)strtol(argv[1], NULL, 0);
+    Console_Close();
+    Credits(mode);
+    Console_Print("Credits done (mode=%d)", (int)mode);
 }
 
 static void cmd_listvideos(int argc, const char *argv[]) {
@@ -666,6 +678,8 @@ void Console_RegisterAll(void) {
                               "Requires in-game loaded cube (not during video).");
     Console_RegisterCommandEx("playvideo", cmd_playvideo, "Play ACF video by name", "playvideo <name>",
                               "Closes console; plays video if found.");
+    Console_RegisterCommandEx("credits", cmd_credits, "Play credits sequence", "credits [0|1]",
+                              "Closes console. Mode: 0=bad end (default), 1=good end. Press any key to skip.");
     Console_RegisterCommandEx("listvideos", cmd_listvideos, "List available ACF video names", "(no args)",
                               "Scans game ACF list.");
     Console_RegisterCommandEx("playjingle", cmd_playjingle, "Play jingle 1-26", "playjingle <1-26>", "Plays jingle by index.");

--- a/SOURCES/CREDITS.CPP
+++ b/SOURCES/CREDITS.CPP
@@ -123,9 +123,6 @@ S32 GamePlayCredits(const char *file_name, S32 mode) {
     S_CRED_OBJ_2 *ptrcrdobj;
     S_CRED_OBJ_2 *ptrobj;
 
-    fprintf(stderr, "[credits] entry mode=%d PtrPal=%p ScreenAux=%p PtrZBuffer=%p\n",
-            (int)mode, (void *)PtrPal, (void *)ScreenAux, (void *)PtrZBuffer);
-
     if (!ScreenAux) {
         fprintf(stderr, "[credits] aborting: ScreenAux is NULL\n");
         return TRUE;

--- a/SOURCES/CREDITS.CPP
+++ b/SOURCES/CREDITS.CPP
@@ -123,6 +123,14 @@ S32 GamePlayCredits(const char *file_name, S32 mode) {
     S_CRED_OBJ_2 *ptrcrdobj;
     S_CRED_OBJ_2 *ptrobj;
 
+    fprintf(stderr, "[credits] entry mode=%d PtrPal=%p ScreenAux=%p PtrZBuffer=%p\n",
+            (int)mode, (void *)PtrPal, (void *)ScreenAux, (void *)PtrZBuffer);
+
+    if (!ScreenAux) {
+        fprintf(stderr, "[credits] aborting: ScreenAux is NULL\n");
+        return TRUE;
+    }
+
     // chargement de la ressource
     if ((HQF_ResSize(file_name, 0) + RECOVER_AREA) > (ModeDesiredX * ModeDesiredY + RECOVER_AREA) * 2) {
 #if defined(DEBUG_TOOLS) || defined(TEST_TOOLS)
@@ -146,8 +154,45 @@ S32 GamePlayCredits(const char *file_name, S32 mode) {
 
     NbObjects = ptrinfos->NbObjects;
 
-    ptrcrdobj = (S_CRED_OBJ_2 *)ptr;
-    ptr += sizeof(S_CRED_OBJ_2) * NbObjects;
+    /* The credits HQR was authored with the original 32-bit struct layout, but
+       on 64-bit T_OBJ_3D (embedded in S_CRED_OBJ_2) grew because T_PTR_NUM,
+       void*, and PTR_U32 fields are 8 bytes instead of 4. Walking the on-disk
+       array at sizeof(S_CRED_OBJ_2) stride therefore mis-reads OffBody/OffAnim.
+       Parse each disk record at its own stride (derived from OffTxt) and only
+       copy the fields we actually consume — the embedded T_OBJ_3D is reset by
+       ObjectClear() before use anyway. (issue #65) */
+    static S_CRED_OBJ_2 s_cred_objects[CRED_MAX_OBJECTS];
+    if (NbObjects < 0 || NbObjects > CRED_MAX_OBJECTS) {
+        fprintf(stderr, "[credits] aborting: NbObjects=%d exceeds CRED_MAX_OBJECTS=%d\n",
+                (int)NbObjects, CRED_MAX_OBJECTS);
+        return TRUE;
+    }
+    {
+        const S32 disk_block = ptrinfos->OffTxt - (S32)sizeof(S_CRED_INFOS_2);
+        if (NbObjects == 0 || disk_block <= 0 || (disk_block % NbObjects) != 0) {
+            fprintf(stderr, "[credits] aborting: bad disk layout NbObjects=%d disk_block=%d\n",
+                    (int)NbObjects, (int)disk_block);
+            return TRUE;
+        }
+        const S32 disk_stride = disk_block / NbObjects;
+        memset(s_cred_objects, 0, sizeof(S_CRED_OBJ_2) * NbObjects);
+        U8 *disk_base = ptr; /* first disk record */
+        for (S32 i = 0; i < NbObjects; i++) {
+            U8 *rec = disk_base + (S32)i * disk_stride;
+            /* Trailing fields, in order: Flag, DestX, DestZ, OffBody, OffAnim[2].
+               Only OffBody/OffAnim[] are actually read from disk; the others get
+               (re)written by the runtime. */
+            U8 *tail = rec + disk_stride;
+            S32 OffBody, OffAnim0, OffAnim1;
+            memcpy(&OffAnim1, tail - 4, sizeof(S32));
+            memcpy(&OffAnim0, tail - 8, sizeof(S32));
+            memcpy(&OffBody, tail - 12, sizeof(S32));
+            s_cred_objects[i].OffBody = OffBody;
+            s_cred_objects[i].OffAnim[0] = OffAnim0;
+            s_cred_objects[i].OffAnim[1] = OffAnim1;
+        }
+        ptrcrdobj = s_cred_objects;
+    }
 
     InitObjects(BufferAnim, SIZE_BUFFER_ANIM, NULL, NULL);
 
@@ -161,7 +206,8 @@ S32 GamePlayCredits(const char *file_name, S32 mode) {
 
     InitXplPalette(PtrCredits + ptrinfos->OffXpl);
     //	Palette( PalCredits ) ;
-    FadeToBlackAndSamples(PtrPal);
+    if (PtrPal)
+        FadeToBlackAndSamples(PtrPal);
     HQ_StopSample();
 
     x0 = 0;

--- a/SOURCES/CREDITS.H
+++ b/SOURCES/CREDITS.H
@@ -1,6 +1,10 @@
 #ifndef CREDITS_H
 #define CREDITS_H
 
+/* Cap for the static parsed-objects array. Retail credits HQR has 29 entries;
+   64 leaves headroom and keeps the static buffer size modest. */
+#define CRED_MAX_OBJECTS 64
+
 typedef struct {
     S32 NbObjects;
     S32 OffTxt;

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -3730,8 +3730,64 @@ void Credits(S32 mode) {
     if (!PtrPal)
         PtrPal = PtrPalNormal;
 
+    /* GamePlayCredits stomps several gameplay-relevant buffers because the
+       original game never returned to play after credits. To make console
+       invocation safe mid-game, save/restore them around the call. (issue #65)
+
+         * PtrZBuffer's backing buffer aliases BufCube + BufferBrick (the cube
+           grid and brick library — see MEM.CPP:187). Credits memsets it and
+           renders Z into it, destroying the cube state.
+         * BufferAnim holds animation frame state for ALL game objects.
+           InitObjects() resets it; credits writes its own animation state
+           into the buffer, so any in-game T_OBJ_3D with LastOfsIsPtr=1 holds
+           pointers into now-stale data.
+
+       GameInProgress is FALSE during MainLoop (set TRUE only after this
+       function), so it is not a usable gate. Always save; cost is one malloc
+       + memcpy round trip per buffer, ~1 ms total. */
+    U8 *zbufSave = NULL;
+    U32 zbufSize = (U32)ListMem[MEM_PTR_ZBUFFER].Size;
+    if (zbufSize && PtrZBuffer) {
+        zbufSave = (U8 *)malloc(zbufSize);
+        if (zbufSave)
+            memcpy(zbufSave, PtrZBuffer, zbufSize);
+    }
+    extern U8 *PtrLib3DBufferAnim; /* LIB386/ANIM/LIBINIT — local extern to avoid header churn */
+    U8 *animSave = NULL;
+    U8 *animCursorSave = NULL;
+    if (BufferAnim) {
+        animSave = (U8 *)malloc(SIZE_BUFFER_ANIM);
+        if (animSave)
+            memcpy(animSave, BufferAnim, SIZE_BUFFER_ANIM);
+        animCursorSave = PtrLib3DBufferAnim;
+    }
+
     GetResPath(tmpFilePath, ADELINE_MAX_PATH, CREDITS_HQR_NAME);
     GamePlayCredits(tmpFilePath, mode);
+
+    if (zbufSave) {
+        memcpy(PtrZBuffer, zbufSave, zbufSize);
+        free(zbufSave);
+    }
+    if (animSave) {
+        memcpy(BufferAnim, animSave, SIZE_BUFFER_ANIM);
+        free(animSave);
+        /* end_credits already re-installed the game's body/anim callbacks via
+           InitObjects(BufferAnim, …) but reset the bump cursor to the start.
+           Restore the cursor too, so subsequent ObjectInitAnim allocations
+           don't alias frame slots already referenced by in-game T_OBJ_3D's
+           with LastOfsIsPtr=1. */
+        PtrLib3DBufferAnim = animCursorSave;
+    }
+
+    /* Mirror HoloMap's gameplay-restore tail (HOLOGLOB.CPP:1186-1199): re-bind
+       the per-cube 3D function-pointer table (PtrWorldColBrick, PtrDoAnim, …)
+       and force a full screen flip on the next frame. Without this, returning
+       to MainLoop renders against credits' projection/fog/filler globals and
+       the player character does not appear. */
+    PtrInit3DGame();
+    FlagFade = TRUE;
+    FirstTime = AFF_ALL_FLIP;
 
     RestoreCamera();
 

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -3798,12 +3798,6 @@ void Credits(S32 mode) {
         Load_HQR(tmpFilePath, Screen, PCR_MENU);
         CopyScreen(Screen, Log);
         BoxStaticFullflip();
-        /* Fade the restored palette in here. DoGameMenu only consumes
-           FadeMenu inside its flag==1 branch, so callers that re-enter the
-           menu loop without a selection event (e.g. console-invoked credits)
-           would otherwise stay on a black screen until the next arrow press. */
-        FadeToPal(PtrPalNormal);
-        PtrPal = PtrPalNormal;
     }
 
     FadeMenu = TRUE;

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -3742,6 +3742,12 @@ void Credits(S32 mode) {
         Load_HQR(tmpFilePath, Screen, PCR_MENU);
         CopyScreen(Screen, Log);
         BoxStaticFullflip();
+        /* Fade the restored palette in here. DoGameMenu only consumes
+           FadeMenu inside its flag==1 branch, so callers that re-enter the
+           menu loop without a selection event (e.g. console-invoked credits)
+           would otherwise stay on a black screen until the next arrow press. */
+        FadeToPal(PtrPalNormal);
+        PtrPal = PtrPalNormal;
     }
 
     FadeMenu = TRUE;

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -3722,6 +3722,14 @@ void Credits(S32 mode) {
 
     SaveCamera();
 
+    /* Endgame transition can leave audio playing and PtrPal unset (issue #65).
+       Mirror the safety prologue PlayAcf uses so GamePlayCredits has valid
+       prerequisites regardless of caller (endgame win path or console). */
+    StopMusic();
+    HQ_PauseSamples();
+    if (!PtrPal)
+        PtrPal = PtrPalNormal;
+
     GetResPath(tmpFilePath, ADELINE_MAX_PATH, CREDITS_HQR_NAME);
     GamePlayCredits(tmpFilePath, mode);
 

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -3762,8 +3762,16 @@ void Credits(S32 mode) {
         animCursorSave = PtrLib3DBufferAnim;
     }
 
+    /* Suppress console toggle for the duration of the credits sequence:
+       opening the console mid-credits side-effects palette and screen state
+       Credits doesn't expect, and there's no useful interaction during a
+       cinematic. Mirrors the gating already in place around SlideShow(). */
+    Console_SetSlideShowActive(1);
+
     GetResPath(tmpFilePath, ADELINE_MAX_PATH, CREDITS_HQR_NAME);
     GamePlayCredits(tmpFilePath, mode);
+
+    Console_SetSlideShowActive(0);
 
     if (zbufSave) {
         memcpy(PtrZBuffer, zbufSave, zbufSize);


### PR DESCRIPTION
## Summary
Closes #65. The game segfaulted at the very end of the win sequence, just after the Twinsen/Zoé/pram scene, before any credits could appear. Root cause was a 32→64-bit ABI mismatch in the credits HQR record layout. Along the way I also added a `credits` console command and hardened `Credits()` so it's safe to invoke at any point — both from the menu and live gameplay — without trashing engine state.

## Why it crashed
`S_CRED_OBJ_2` (the on-disk credits-objects record) embeds `T_OBJ_3D`, which contains pointer-sized fields (`T_PTR_NUM` union, `void*`, `PTR_U32`). On 64-bit those grow from 4 to 8 bytes each, so `sizeof(S_CRED_OBJ_2)` in memory is **448 bytes** while the on-disk records were authored at **420 bytes**. Walking the array at the in-memory stride mis-read every `OffBody` / `OffAnim[]` as `0`, and `ObjectInitAnim` then walked off the heap reading garbage `NbGroups` from what it thought was anim data.

Fix: parse each record at its on-disk stride (derived from `OffTxt`) into a static in-memory array, copying only the trailing offset fields actually consumed. The embedded `T_OBJ_3D` is reset by `ObjectClear()` before use anyway.

## What changed
- **Disk-stride parser** for credits records (`SOURCES/CREDITS.CPP`) — fixes the segfault.
- **`credits [0|1]` console command** — defaults to 0 ("demo wrap" variant), `credits 1` for the win-path variant. Mirrors `cmd_playvideo`.
- **Defensive prologue in `Credits()`** — `StopMusic` + `HQ_PauseSamples` + `PtrPal` fallback to `PtrPalNormal`, so no caller can leave `GamePlayCredits` with stale audio or a NULL palette.
- **Save/restore engine state across the credits call**:
- `PtrZBuffer` region (aliased to `BufCube` + `BufferBrick`, see `MEM.CPP:187`) — was getting stomped by credits' `memset` and Z renders, leaving the cube grid full of `0xFF` and crashing `WorldCodeBrick` on return.
- `BufferAnim` contents + `PtrLib3DBufferAnim` cursor — credits resets these and overwrites slots, leaving in-game `T_OBJ_3D`s with `LastOfsIsPtr=1` pointing at stale frame data (this is what caused Twinsen to be invisible after the segfault was fixed; opening + closing the holomap masked it because `HoloMap` runs `PtrInit3DGame`).
- **HoloMap-style gameplay-restore tail** — `PtrInit3DGame()` + `FlagFade=TRUE` + `FirstTime=AFF_ALL_FLIP` after credits returns, so the per-cube 3D function-pointer table is rebound and the next frame does a full flip.
- **Console-invocation transparency** (`cmd_credits`) — snapshots `GameInProgress` + `Log` + `Screen` and restores them, so calling `credits` from the main menu doesn't flip into pause-mode ("Resume Game" only) and calling it in-game doesn't flash the main-menu image before MainLoop redraws.
- **Mode=0 fade-in** — handled at the console caller, not inside `Credits()`, so the demo-attract path (`GAMEMENU.CPP:2252`) keeps its original "exit palette black" contract and doesn't get an extra flicker.
- **Suppress console toggle during credits** — reuses the existing `Console_SetSlideShowActive` gate around `GamePlayCredits` so opening the console mid-cinematic can't side-effect palette/screen state.

## Test plan
- [x] Linux build: `make build` clean, `clang-format` clean.
- [x] **Endgame segfault** — played to completion, win → credits → BABY video, no crash.
- [x] **Console from main menu** — `credits` plays, key skips, menu fades back in cleanly (no "Resume Game only" flash).
- [x] **Console from in-game** — `credits` plays, key skips, gameplay resumes with no menu-image flash and no `WorldCodeBrick` crash.
- [x] **`credits 1`** — Twinsen + Zoé happy-end variant plays.
- [x] **Console toggle during credits** — F12 ignored while credits play.
- [x] Demo-attract path (60s idle on main menu) — credits roll after key press in demo.

Files touched:
- `SOURCES/CREDITS.CPP`, `SOURCES/CREDITS.H` — disk-stride parser, error-bail prints.
- `SOURCES/GAMEMENU.CPP` — `Credits()` prologue + state save/restore + `PtrInit3DGame` tail + console gate.
- `SOURCES/CONSOLE/CONSOLE_CMD.CPP` — `cmd_credits` handler, registration, transparency wrapper.