### PR TITLE
docs(abi): codify 32-bit-on-disk rule, lock credits HQR layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ Apply these behavior rules on every non-trivial task:
 | Audio/video | AIL in LIB386/AIL/; backends SDL, Miles, null | docs/AUDIO.md |
 | Debug tools | DEBUG_TOOLS (console is always available) | docs/DEBUG.md, docs/CONSOLE.md |
 | Config / lba2.cfg | Keys, persistence, installer vs game, embedded default | docs/CONFIG.md, docs/GAME_DATA.md |
+| Code that reads retail HQR data or legacy save formats | Check the rule: never `sizeof(T)`-as-stride for fat structs; use a paired `T_DISK` or field-by-field serialization | docs/ABI.md |
 | File with French comments or ASCII art | Preserve; add new comments alongside | docs/FRENCH_COMMENTS.md, docs/ASCII_ART.md |
 | New subsystem or doc | Create docs/<name>.md; add to docs/README.md; update in same commit | docs/README.md |
 | Any code that affects documented behavior | Update the doc in the same commit | Principle 2 |

--- a/SOURCES/CREDITS.CPP
+++ b/SOURCES/CREDITS.CPP
@@ -12,9 +12,20 @@
 
 #include "C_EXTERN.H"
 
+#include <cstddef>
 #include <SVGA/SCREEN.H>
 #include <SVGA/VIDEO.H>
 #include <SYSTEM/KEYBOARD.H>
+
+/* On-disk credits HQR records are frozen at the 1997 32-bit DOS ABI. Lock the
+   sizes at compile time so the layout can never silently drift if a contributor
+   changes a field. The runtime S_CRED_OBJ_2 is intentionally larger on 64-bit
+   (T_OBJ_3D grew); the parser must walk the file at the on-disk stride —
+   never sizeof(S_CRED_OBJ_2). See docs/ABI.md and issue #65. */
+typedef char ABI_assert_S_CRED_INFOS_2_size[(sizeof(S_CRED_INFOS_2) == 12) ? 1 : -1];
+typedef char ABI_assert_S_CRED_OBJ_2_DISK_size[(sizeof(S_CRED_OBJ_2_DISK) == 420) ? 1 : -1];
+typedef char ABI_assert_S_CRED_OBJ_2_DISK_offset_OffBody[(offsetof(S_CRED_OBJ_2_DISK, OffBody) == 408) ? 1 : -1];
+typedef char ABI_assert_S_CRED_OBJ_2_DISK_offset_OffAnim[(offsetof(S_CRED_OBJ_2_DISK, OffAnim) == 412) ? 1 : -1];
 
 #define GridSizeX 40000
 #define GridSizeZ 40000
@@ -151,13 +162,12 @@ S32 GamePlayCredits(const char *file_name, S32 mode) {
 
     NbObjects = ptrinfos->NbObjects;
 
-    /* The credits HQR was authored with the original 32-bit struct layout, but
-       on 64-bit T_OBJ_3D (embedded in S_CRED_OBJ_2) grew because T_PTR_NUM,
-       void*, and PTR_U32 fields are 8 bytes instead of 4. Walking the on-disk
-       array at sizeof(S_CRED_OBJ_2) stride therefore mis-reads OffBody/OffAnim.
-       Parse each disk record at its own stride (derived from OffTxt) and only
-       copy the fields we actually consume — the embedded T_OBJ_3D is reset by
-       ObjectClear() before use anyway. (issue #65) */
+    /* Parse the on-disk array via S_CRED_OBJ_2_DISK (frozen 32-bit ABI, see
+       CREDITS.H + the static_asserts at the top of this file) into a runtime
+       S_CRED_OBJ_2 array. We only copy the fields actually consumed — the
+       embedded T_OBJ_3D is reset by ObjectClear() before use anyway. Walking
+       the file at sizeof(S_CRED_OBJ_2) is wrong on 64-bit; the disk struct
+       is what authoritatively defines the stride. (issue #65, docs/ABI.md) */
     static S_CRED_OBJ_2 s_cred_objects[CRED_MAX_OBJECTS];
     if (NbObjects < 0 || NbObjects > CRED_MAX_OBJECTS) {
         fprintf(stderr, "[credits] aborting: NbObjects=%d exceeds CRED_MAX_OBJECTS=%d\n",
@@ -166,27 +176,18 @@ S32 GamePlayCredits(const char *file_name, S32 mode) {
     }
     {
         const S32 disk_block = ptrinfos->OffTxt - (S32)sizeof(S_CRED_INFOS_2);
-        if (NbObjects == 0 || disk_block <= 0 || (disk_block % NbObjects) != 0) {
-            fprintf(stderr, "[credits] aborting: bad disk layout NbObjects=%d disk_block=%d\n",
-                    (int)NbObjects, (int)disk_block);
+        const S32 expected = (S32)sizeof(S_CRED_OBJ_2_DISK) * NbObjects;
+        if (NbObjects == 0 || disk_block != expected) {
+            fprintf(stderr, "[credits] aborting: disk_block=%d != %d × sizeof(S_CRED_OBJ_2_DISK)=%d\n",
+                    (int)disk_block, (int)NbObjects, (int)sizeof(S_CRED_OBJ_2_DISK));
             return TRUE;
         }
-        const S32 disk_stride = disk_block / NbObjects;
+        const S_CRED_OBJ_2_DISK *disk_recs = (const S_CRED_OBJ_2_DISK *)ptr;
         memset(s_cred_objects, 0, sizeof(S_CRED_OBJ_2) * NbObjects);
-        U8 *disk_base = ptr; /* first disk record */
         for (S32 i = 0; i < NbObjects; i++) {
-            U8 *rec = disk_base + (S32)i * disk_stride;
-            /* Trailing fields, in order: Flag, DestX, DestZ, OffBody, OffAnim[2].
-               Only OffBody/OffAnim[] are actually read from disk; the others get
-               (re)written by the runtime. */
-            U8 *tail = rec + disk_stride;
-            S32 OffBody, OffAnim0, OffAnim1;
-            memcpy(&OffAnim1, tail - 4, sizeof(S32));
-            memcpy(&OffAnim0, tail - 8, sizeof(S32));
-            memcpy(&OffBody, tail - 12, sizeof(S32));
-            s_cred_objects[i].OffBody = OffBody;
-            s_cred_objects[i].OffAnim[0] = OffAnim0;
-            s_cred_objects[i].OffAnim[1] = OffAnim1;
+            s_cred_objects[i].OffBody = disk_recs[i].OffBody;
+            s_cred_objects[i].OffAnim[0] = disk_recs[i].OffAnim[0];
+            s_cred_objects[i].OffAnim[1] = disk_recs[i].OffAnim[1];
         }
         ptrcrdobj = s_cred_objects;
     }

--- a/SOURCES/CREDITS.H
+++ b/SOURCES/CREDITS.H
@@ -26,6 +26,26 @@ typedef struct {
 
 } S_CRED_OBJ_2;
 
+/* On-disk layout of an S_CRED_OBJ_2 record inside lba2.hqr (CREDITS_HQR_NAME,
+   index 0). Frozen at the original 32-bit DOS ABI — the credits HQR is a
+   1997 retail asset and never changes. The runtime S_CRED_OBJ_2 above is
+   larger on 64-bit because T_OBJ_3D contains pointer-sized fields, so reading
+   the file with sizeof(S_CRED_OBJ_2) as the stride mis-aligns every record
+   (this was issue #65). Always parse via this struct or via the explicit
+   per-record stride derived from S_CRED_INFOS_2.OffTxt. See docs/ABI.md. */
+#define S_CRED_OBJ_2_DISK_OBJ_BYTES 376
+#define S_CRED_OBJ_2_DISK_REALANGLE_BYTES 20
+
+typedef struct {
+    char Obj[S_CRED_OBJ_2_DISK_OBJ_BYTES];               // 32-bit T_OBJ_3D
+    char RealAngle[S_CRED_OBJ_2_DISK_REALANGLE_BYTES];   // BOUND_MOVE (fixed-width)
+    S32 Flag;
+    S32 DestX;
+    S32 DestZ;
+    S32 OffBody;
+    S32 OffAnim[2];
+} S_CRED_OBJ_2_DISK;
+
 extern S32 GamePlayCredits(const char *file_name, S32 mode);
 
 #endif // CREDITS_H

--- a/SOURCES/CREDITS.H
+++ b/SOURCES/CREDITS.H
@@ -37,8 +37,8 @@ typedef struct {
 #define S_CRED_OBJ_2_DISK_REALANGLE_BYTES 20
 
 typedef struct {
-    char Obj[S_CRED_OBJ_2_DISK_OBJ_BYTES];               // 32-bit T_OBJ_3D
-    char RealAngle[S_CRED_OBJ_2_DISK_REALANGLE_BYTES];   // BOUND_MOVE (fixed-width)
+    char Obj[S_CRED_OBJ_2_DISK_OBJ_BYTES];             // 32-bit T_OBJ_3D
+    char RealAngle[S_CRED_OBJ_2_DISK_REALANGLE_BYTES]; // BOUND_MOVE (fixed-width)
     S32 Flag;
     S32 DestX;
     S32 DestZ;

--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -1,0 +1,75 @@
+# ABI Boundaries
+
+LBA2's retail data files (HQR resources, save games) were authored against the original 1997 32-bit DOS ABI. Modern builds run on 64-bit, where some C struct types grow because pointer-sized fields go from 4 to 8 bytes. Reading retail data through grown structs misaligns every record after the first pointer-sized field — this is what caused [issue #65](https://github.com/LBALab/lba2-classic-community/issues/65) (endgame credits segfault) and motivated [PR #63](https://github.com/LBALab/lba2-classic-community/pull/63) (legacy save-game compatibility).
+
+Truth hierarchy: **code > this document > external sources**.
+
+## The rule
+
+> **A struct whose layout is dictated by a retail file or a legacy save format must never assume `sizeof(T)` matches the on-disk record size.**
+
+Two acceptable patterns:
+
+1. **Paired on-disk type.** Define a sister `T_DISK` struct with explicit-width fields (no pointers, no embedded "fat" types) and a `static_assert`-equivalent that pins its size. Read into the disk type, then copy fields into the runtime type. Worked example: [`S_CRED_OBJ_2_DISK`](../SOURCES/CREDITS.H), used in [`SOURCES/CREDITS.CPP`](../SOURCES/CREDITS.CPP).
+2. **Field-by-field serialization.** Read or write each field at a known wire width (`LbaWriteByte`, `LbaWriteWord`, `LbaWriteLong`). The in-memory struct is irrelevant to the format. Worked example: [`SaveContexte` / `LoadContexte`](../SOURCES/SAVEGAME.CPP) — see the comments at lines 825–837 explicitly skipping `T_OBJ_3D` and pointer fields.
+
+Direct casts of file buffers to "fat" runtime structs are **always** wrong on 64-bit. The smell when this bites: two offsets that should differ read as identical, or all trailing fields read as `0`.
+
+## Catalogue of fat types
+
+These types contain pointer-sized fields and are larger on 64-bit than on 32-bit:
+
+| Type | Defined in | Why it's fat |
+|------|------------|---------------|
+| `T_OBJ_3D` | [`LIB386/H/OBJECT/AFF_OBJ.H`](../LIB386/H/OBJECT/AFF_OBJ.H) | 3× `T_PTR_NUM` + 2× `void*` + 2× `PTR_U32` = 7 pointer-sized fields. 32-bit: 376 B; 64-bit: 404 B (+28). |
+| `T_PTR_NUM` (union) | `AFF_OBJ.H:22` | `union { void* Ptr; S32 Num; }` — sized to the larger member. |
+| Any struct embedding the above by value | — | Inherits the size delta. |
+
+### Embedders of `T_OBJ_3D` (audited)
+
+| Struct | File | File-backed? | Status |
+|--------|------|--------------|--------|
+| `S_CRED_OBJ_2` | [`SOURCES/CREDITS.H`](../SOURCES/CREDITS.H) | Yes — `lba2.hqr` index 0 | Fixed (#65). On-disk variant `S_CRED_OBJ_2_DISK` exists; runtime parser uses it. |
+| `T_OBJET` | [`SOURCES/DEFINES.H:387`](../SOURCES/DEFINES.H) | No — runtime only; save uses field-by-field | Safe. |
+| `T_OBJET` (3DEXT MOUNFRAC) | [`SOURCES/3DEXT/DEFINES.H:26`](../SOURCES/3DEXT/DEFINES.H) | No — gated `#ifdef MOUNFRAC` | Safe. |
+
+If you add a new struct that embeds a fat type and intend to read it from disk, add a `T_DISK` paired type and a `static_assert`-equivalent. If you only need it at runtime, no action required.
+
+## Compile-time guards
+
+C++98 doesn't have `static_assert` as a keyword, so use the typedef-array idiom:
+
+```c
+typedef char ABI_assert_T_size[(sizeof(T) == EXPECTED_BYTES) ? 1 : -1];
+typedef char ABI_assert_T_offset[(offsetof(T, Field) == EXPECTED_OFFSET) ? 1 : -1];
+```
+
+On a violation the build fails with `array size is negative`. Existing examples in [`SOURCES/CREDITS.CPP`](../SOURCES/CREDITS.CPP) (top of file) lock `S_CRED_INFOS_2`, `S_CRED_OBJ_2_DISK`, and the `OffBody`/`OffAnim` offsets.
+
+`offsetof` requires `#include <cstddef>`.
+
+## What's in scope vs out of scope
+
+| In scope | Out of scope |
+|---|---|
+| Reading retail HQR data into typed structs | Pure runtime structs that never touch disk |
+| Reading legacy `.lba` saves authored by 32-bit binaries | Format design for *new* save versions — see [issue #64](https://github.com/LBALab/lba2-classic-community/issues/64) |
+| Cross-platform persistence of any binary blob | Text/JSON formats |
+
+## Reviewing a new file-load site
+
+Checklist when adding a `Load_HQR` / `LoadMalloc_HQR` / `fread` call site:
+
+1. What type is the buffer cast to?
+2. Does the type contain `T_PTR_NUM`, `void*`, `PTR_U32`, function pointers, or embed `T_OBJ_3D`?
+3. If yes:
+   - Define a paired `T_DISK` type with explicit-width fields and lock its size with the typedef-array assert above.
+   - Cast the file buffer to `T_DISK*`, then copy the fields you need into the runtime `T*`.
+   - Do **not** advance pointers using `sizeof(T)` — use `sizeof(T_DISK)`.
+4. If no (all fields are fixed-width integers/chars): still consider adding the size assert as a contract.
+
+## Related work
+
+- [Issue #65](https://github.com/LBALab/lba2-classic-community/issues/65) / [PR #66](https://github.com/LBALab/lba2-classic-community/pull/66) — endgame credits segfault, the worked example for pattern (1).
+- [PR #63](https://github.com/LBALab/lba2-classic-community/pull/63) — legacy save compatibility, the worked example for pattern (2).
+- [Issue #64](https://github.com/LBALab/lba2-classic-community/issues/64) — canonical portable save format, the long-term direction for serialization. This document is intended as scaffolding that #64 can extend with the canonical wire schema.

--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -8,12 +8,29 @@ Truth hierarchy: **code > this document > external sources**.
 
 > **A struct whose layout is dictated by a retail file or a legacy save format must never assume `sizeof(T)` matches the on-disk record size.**
 
-Two acceptable patterns:
+Direct casts of file buffers to fat runtime structs are **always** wrong on 64-bit. The smell when this bites: two offsets that should differ read as identical, or all trailing fields read as `0`.
 
-1. **Paired on-disk type.** Define a sister `T_DISK` struct with explicit-width fields (no pointers, no embedded "fat" types) and a `static_assert`-equivalent that pins its size. Read into the disk type, then copy fields into the runtime type. Worked example: [`S_CRED_OBJ_2_DISK`](../SOURCES/CREDITS.H), used in [`SOURCES/CREDITS.CPP`](../SOURCES/CREDITS.CPP).
-2. **Field-by-field serialization.** Read or write each field at a known wire width (`LbaWriteByte`, `LbaWriteWord`, `LbaWriteLong`). The in-memory struct is irrelevant to the format. Worked example: [`SaveContexte` / `LoadContexte`](../SOURCES/SAVEGAME.CPP) — see the comments at lines 825–837 explicitly skipping `T_OBJ_3D` and pointer fields.
+### Three patterns, each with a clear scope
 
-Direct casts of file buffers to "fat" runtime structs are **always** wrong on 64-bit. The smell when this bites: two offsets that should differ read as identical, or all trailing fields read as `0`.
+**Pattern (1) — Paired on-disk type.** Define a sister `T_DISK` (or `T_WIRE32`) struct with explicit-width fields, no pointers, no embedded fat types, and pin its size with a static-size assert. Read into the disk type, then copy fields into the runtime type. Use this when the wire format is **frozen and known** — retail HQR records, or the 32-bit-era legacy save layout.
+
+Existing examples:
+- [`S_CRED_OBJ_2_DISK`](../SOURCES/CREDITS.H) — credits HQR records, used in [`SOURCES/CREDITS.CPP`](../SOURCES/CREDITS.CPP) (#65).
+- `T_OBJ_3D_WIRE32` + `SavegameObj3dFromWire32` — embedded `T_OBJ_3D` blob in legacy saves, used in [`SOURCES/SAVEGAME.CPP`](../SOURCES/SAVEGAME.CPP) (#63).
+
+**Pattern (2) — Field-by-field serialization.** Read or write each field at a known wire width (`LbaWriteByte`, `LbaWriteWord`, `LbaWriteLong`); the in-memory struct is irrelevant to the format. Use this when **you control the writer** — new save versions, any new format you're authoring. The format becomes a wire protocol, decoupled from any C struct.
+
+Existing example: most of [`SaveContexte` / `LoadContexte`](../SOURCES/SAVEGAME.CPP) — see comments at lines 825–837 explicitly skipping `T_OBJ_3D` and pointer fields. Issue #64 extends this pattern into a fully canonical save format.
+
+**Pattern (3) — Tolerant read with stride retry.** When the writer's ABI is **fundamentally unknown at read time** — typically player-authored saves spanning eras (32-bit DOS retail, 32-bit modern, 64-bit modern) — pick a candidate stride, read at it, validate a discriminating field per record, rewind and retry the alternate stride on mismatch. Only fail if every candidate fails.
+
+Existing example: `LoadContexteReadObjectsAtStride` + `SaveLoadGuessObjectWireStride` in [`SOURCES/SAVEGAME.CPP`](../SOURCES/SAVEGAME.CPP) (#63). Validates `IndexFile3D` per object as the discriminator.
+
+This is **not a fallback for sloppy parsing** — it's the right answer when player saves authored by older binaries must remain loadable. New formats should use pattern (2) and avoid the need entirely.
+
+### Bounded reads (orthogonal safety layer)
+
+Independent of which of the three patterns you use, untrusted on-disk input must not be able to walk off the buffer. PR #63 introduced `SaveLoadSetReadLimit` + cursor-aware `LbaRead*` macros that return `SAVELOAD_CTX_ERR` on overrun instead of segfaulting, plus `MAX_*` range checks on every count field. Apply the same discipline to any new file-load site that consumes count-prefixed arrays.
 
 ## Catalogue of fat types
 
@@ -60,16 +77,18 @@ On a violation the build fails with `array size is negative`. Existing examples 
 
 Checklist when adding a `Load_HQR` / `LoadMalloc_HQR` / `fread` call site:
 
-1. What type is the buffer cast to?
-2. Does the type contain `T_PTR_NUM`, `void*`, `PTR_U32`, function pointers, or embed `T_OBJ_3D`?
-3. If yes:
-   - Define a paired `T_DISK` type with explicit-width fields and lock its size with the typedef-array assert above.
-   - Cast the file buffer to `T_DISK*`, then copy the fields you need into the runtime `T*`.
-   - Do **not** advance pointers using `sizeof(T)` — use `sizeof(T_DISK)`.
-4. If no (all fields are fixed-width integers/chars): still consider adding the size assert as a contract.
+1. **Are you reading or writing?** If writing a new format, default to pattern (2). Don't author new formats that need pattern (1) or (3).
+2. **What's the wire layout source?**
+   - Retail HQR / frozen legacy → pattern (1).
+   - You control it (new save version) → pattern (2).
+   - Player files written by binaries you don't control, possibly in different ABIs → pattern (3), with validation.
+3. **What type is the buffer cast to?** Does it contain `T_PTR_NUM`, `void*`, `PTR_U32`, function pointers, or embed `T_OBJ_3D`?
+   - If yes and pattern (1): define a paired `T_DISK` / `T_WIRE32` type, lock its size with the typedef-array assert, cast the file buffer to it, copy fields into the runtime type. Never advance pointers with `sizeof(T)` — use `sizeof(T_DISK)`.
+   - If no (all fixed-width fields): still add a size assert as a contract.
+4. **Bounded reads.** Use `SaveLoadSetReadLimit` + `LbaRead*` (or equivalent) for any count-prefixed array. Range-check counts against `MAX_*` constants before allocating.
 
 ## Related work
 
-- [Issue #65](https://github.com/LBALab/lba2-classic-community/issues/65) / [PR #66](https://github.com/LBALab/lba2-classic-community/pull/66) — endgame credits segfault, the worked example for pattern (1).
-- [PR #63](https://github.com/LBALab/lba2-classic-community/pull/63) — legacy save compatibility, the worked example for pattern (2).
-- [Issue #64](https://github.com/LBALab/lba2-classic-community/issues/64) — canonical portable save format, the long-term direction for serialization. This document is intended as scaffolding that #64 can extend with the canonical wire schema.
+- [Issue #65](https://github.com/LBALab/lba2-classic-community/issues/65) / [PR #66](https://github.com/LBALab/lba2-classic-community/pull/66) — endgame credits segfault. Worked example of pattern (1) on retail HQR data.
+- [Issue #62](https://github.com/LBALab/lba2-classic-community/issues/62) / [PR #63](https://github.com/LBALab/lba2-classic-community/pull/63) — legacy save load hardening. Demonstrates patterns (1) (`T_OBJ_3D_WIRE32`), (2) (most of `SaveContexte`), and (3) (`LoadContexteReadObjectsAtStride`) coexisting in one read path, plus the bounded-reads safety layer (`SaveLoadSetReadLimit`).
+- [Issue #64](https://github.com/LBALab/lba2-classic-community/issues/64) — canonical portable save format. The long-term direction: define `NUM_VERSION 37+` purely via pattern (2) so new saves never need pattern (3). Legacy loaders for older saves stay in place.

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@ Index of documentation in this repository.
 | [ASM_TO_CPP_REFERENCE.md](ASM_TO_CPP_REFERENCE.md) | Which modules are ported from ASM to C++ in this fork. |
 | [COMPILER_NOTES.md](COMPILER_NOTES.md) | Calling conventions and compiler-related notes. |
 | [GFX_OPTIONS.md](GFX_OPTIONS.md) | Variables and locations for graphical quality options. |
+| [ABI.md](ABI.md) | Rule for reading 32-bit DOS-era data on 64-bit hosts; catalogue of fat types; compile-time guards. |
 
 ## External resources
 


### PR DESCRIPTION
 ## Summary
  Documentation + compile-time enforcement of the rule that drove [#66](https://github.com/LBALab/lba2-classic-community/pull/66) (endgame credits) and [#63](https://github.com/LBALab/lba2-classic-community/pull/63) (legacy save load):

  > Retail HQR data and legacy `.lba` saves were authored against the 1997 32-bit DOS ABI. On 64-bit, `T_OBJ_3D` embeds pointer-sized fields and grows. Reading file data through grown structs misaligns every record after the first pointer-sized field.

  Complementary to #63 (which solved the save-side problem in code). Scaffolding for [#64](https://github.com/LBALab/lba2-classic-community/issues/64).

  ## What's in it
  - **`docs/ABI.md`** — the rule, three patterns with clear scope (paired on-disk type, field-by-field, tolerant stride retry), bounded-reads safety layer, audit catalogue, reviewer checklist.
  - **`S_CRED_OBJ_2_DISK` + static asserts** — frozen 420-byte on-disk paired struct in `CREDITS.H`; typedef-array asserts (C++98) in `CREDITS.CPP` lock size and `OffBody`/`OffAnim` offsets so #65's bug shape can't be reintroduced.
  - **`AGENTS.md` + `docs/README.md`** — one-line pointers to the rule.

  ## Audit
  Every `Load_HQR` / `LoadMalloc_HQR` site (68 total) reviewed; `S_CRED_OBJ_2` was the only at-risk struct and is fixed. Details in `docs/ABI.md`.

  ## Test plan
  - [x] Build + clang-format clean on Linux x86_64.
  - [x] Asserts pin host-invariant on-disk sizes — compile cleanly on the full CI matrix.
  - [x] Credits sequence plays end-to-end through the refactored parser.