### PR TITLE
chore: introduce changelog, versioning, and contribution principles

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!--
+PR title format: `<type>(<scope>): <summary>`
+Types: feat | fix | port | perf | refactor | docs | test | build | ci | chore
+Scope is optional. Example: `fix(credits): preserve gameplay state across console-invoked credits`
+The PR title becomes the squash-merged commit on main, so it lands in the changelog as-is.
+See AGENTS.md "Commit & PR conventions".
+-->
+
+## What & why
+
+<!-- One or two sentences. What does this change and why does it matter? -->
+
+## Notes for reviewers
+
+<!-- Optional: tradeoffs considered, follow-ups, anything non-obvious. -->
+
+## Checklist
+
+- [ ] Build passes on my platform (Linux / macOS / Windows — pick one or more)
+- [ ] If LIB386 / 3DEXT touched: ASM equivalence tests pass (`./run_tests_docker.sh`)
+- [ ] If behavior changes: opt-in via flag/cvar/config (preserves default game feel)
+- [ ] Docs updated in the same PR if behavior or workflow changed
+- [ ] French comments and ASCII art preserved in any modified files

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,44 @@
+name: PR title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Conventional Commit format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Allowed types. `port` is fork-specific: ASM -> C++ port work.
+          # See AGENTS.md "Commit & PR conventions" and cliff.toml.
+          types: |
+            feat
+            fix
+            port
+            perf
+            refactor
+            docs
+            test
+            build
+            ci
+            chore
+          requireScope: false
+          # Title must start with a type prefix; squash-merge turns the PR
+          # title into the single commit on main, so this is the only
+          # convention contributors need to follow.
+          subjectPattern: '^[A-Za-z0-9].+$'
+          subjectPatternError: |
+            The PR title subject (after the type prefix) must not be empty
+            and should start with a letter or digit. Example:
+              fix(credits): preserve gameplay state across console-invoked credits

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,39 @@ Apply these behavior rules on every non-trivial task:
 - Types: S32, U32 from `LIB386/H/SYSTEM/ADELINE_TYPES.H`
 - C++98 for game code; tests may use C11/C++11
 
+## Commit & PR conventions
+
+The repo uses **squash-merge**, so the **PR title** becomes the single
+commit on `main`. That title drives the changelog (`git-cliff` reads it),
+so it has to follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<optional scope>): <summary>
+```
+
+Allowed types:
+
+| Type       | Use for                                                     |
+|------------|-------------------------------------------------------------|
+| `feat`     | New feature visible to players or contributors              |
+| `fix`      | Bug fix                                                     |
+| `port`     | ASM → C++ port work (fork-specific, distinct from refactor) |
+| `perf`     | Performance improvement, no behavior change                 |
+| `refactor` | Code restructuring, no behavior change                      |
+| `docs`     | Documentation only                                          |
+| `test`     | Adding or tightening tests                                  |
+| `build`    | Build system, CMake, presets                                |
+| `ci`       | CI workflows                                                |
+| `chore`    | Internal housekeeping                                       |
+
+Scope is optional but useful (`fix(credits): ...`, `port(SORT): ...`).
+
+A lightweight CI check (`.github/workflows/pr-title.yml`) verifies the PR
+title format. **Individual commits inside the PR can be messy** — only the
+final squashed title matters. Contributors do not need to edit
+`CHANGELOG.md`; it is regenerated at release time. See
+[docs/RELEASING.md](docs/RELEASING.md).
+
 ## Further Reading
 
 - [LICENSE](LICENSE) — GPL v2; project license

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ This document helps AI coding assistants (Cursor, Copilot, Claude, etc.) work ef
 - **Verify before claiming:** Run build or tests to confirm changes work; do not claim something works without verification.
 - **Search before adding:** Check for existing implementations before adding new code; avoid duplication.
 - **Say when unsure:** If uncertain whether a change is correct, say so. Prefer "I'm not certain" over confident but wrong.
+- **Pin fixes with a test or a repro hook.** When fixing a bug, first ask whether the affected logic is pure-data (parsing, serialization, math, projection, sort) — if yes, extracting it into a pure function and adding a host test is usually a small additional refactor and should be done as part of the fix. When automation is impractical (state, timing, UI), ship a manual repro hook instead (a console command, debug menu entry, or build flag). See [CONTRIBUTING.md "Doing good work here"](CONTRIBUTING.md#doing-good-work-here) for the rationale.
 
 ## Execution Style (Karpathy-Inspired)
 
@@ -83,6 +84,7 @@ Apply these behavior rules on every non-trivial task:
 | File with French comments or ASCII art | Preserve; add new comments alongside | docs/FRENCH_COMMENTS.md, docs/ASCII_ART.md |
 | New subsystem or doc | Create docs/<name>.md; add to docs/README.md; update in same commit | docs/README.md |
 | Any code that affects documented behavior | Update the doc in the same commit | Principle 2 |
+| Fixing a bug | If the affected logic is pure-data, extract it to a pure function and add a host test. Otherwise add a manual repro hook (console command, debug flag) | CONTRIBUTING.md "Doing good work here" |
 
 ## Code Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,165 @@
+# Changelog
+
+All notable changes to the LBA2 Classic Community engine fork.
+
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> Engine semver is independent from `NUM_VERSION` (save-file on-disk format,
+> see `SOURCES/COMMON.H`). Save-format changes are tracked there, not here.
+
+## [Unreleased]
+
+_Changes accumulated since the fork was created. The first tagged release
+will move this section to a dated heading. See
+[docs/RELEASING.md](docs/RELEASING.md) for the cut recipe._
+
+The list below is hand-curated from merged PRs and tells the story of the
+fork's evolution. Future entries are auto-generated from conventional
+commits by [`git-cliff`](https://git-cliff.org/).
+
+### Stability & 64-bit hardening
+
+- Endgame credits segfault on 64-bit hosts — fixed
+  ([#65](https://github.com/LBALab/lba2-classic-community/issues/65),
+  [#66](https://github.com/LBALab/lba2-classic-community/pull/66))
+- Legacy 32-bit `.lba` saves load safely on 64-bit builds, with a corpus
+  harness to prevent regressions
+  ([#62](https://github.com/LBALab/lba2-classic-community/issues/62),
+  [#63](https://github.com/LBALab/lba2-classic-community/pull/63))
+- 32-bit on-disk ABI rule and credits HQR layout codified in docs
+  ([#67](https://github.com/LBALab/lba2-classic-community/pull/67))
+- Linux exterior draw-order bug — `SinTab`/`CosTab` arrays merged into a
+  single contiguous block to match the original ASM layout
+  ([#55](https://github.com/LBALab/lba2-classic-community/pull/55))
+- Compiler warnings cleaned up across GCC, Clang, and MinGW
+  ([#52](https://github.com/LBALab/lba2-classic-community/pull/52))
+- Bezier C++ memory corruption — fixed
+  ([#8](https://github.com/LBALab/lba2-classic-community/pull/8))
+
+### New features (opt-in)
+
+All new features default-off or default-to-original-behavior, in line with
+[AGENTS.md Principle 4](AGENTS.md#principles).
+
+- Quake-style debug console: built-in, always available, configurable
+  toggle key, host-tested
+  ([#23](https://github.com/LBALab/lba2-classic-community/issues/23),
+  [#24](https://github.com/LBALab/lba2-classic-community/pull/24),
+  [#60](https://github.com/LBALab/lba2-classic-community/pull/60)) —
+  see [docs/CONSOLE.md](docs/CONSOLE.md)
+- SDL3 gamepad support
+  ([#38](https://github.com/LBALab/lba2-classic-community/issues/38),
+  [#58](https://github.com/LBALab/lba2-classic-community/pull/58))
+- Optional exterior auto-camera centering (`FollowCamera`)
+  ([#37](https://github.com/LBALab/lba2-classic-community/issues/37),
+  [#50](https://github.com/LBALab/lba2-classic-community/pull/50)) —
+  see [docs/CAMERA.md](docs/CAMERA.md)
+- Menu mouse QoL: hover, selection, marquee for long text, keyboard
+  takes priority over mouse hover
+  ([#41](https://github.com/LBALab/lba2-classic-community/pull/41),
+  [#53](https://github.com/LBALab/lba2-classic-community/pull/53),
+  [#56](https://github.com/LBALab/lba2-classic-community/pull/56))
+- Original Adeline debug tools re-enabled behind `DEBUG_TOOLS=ON`
+  ([#17](https://github.com/LBALab/lba2-classic-community/issues/17),
+  [#22](https://github.com/LBALab/lba2-classic-community/pull/22)) —
+  see [docs/DEBUG.md](docs/DEBUG.md)
+
+### Game data, config, and UX
+
+- Auto-discovery of retail game data (`./data`, `../LBA2`,
+  `LBA2_GAME_DIR`, `--game-dir`); embedded default config; clearer
+  startup errors
+  ([#54](https://github.com/LBALab/lba2-classic-community/pull/54)) —
+  see [docs/GAME_DATA.md](docs/GAME_DATA.md)
+- Menus reorganized to match LBA2 Original from GOG
+  ([#42](https://github.com/LBALab/lba2-classic-community/pull/42))
+- Menu language selection
+  ([#42](https://github.com/LBALab/lba2-classic-community/pull/42))
+- Menu music and jingle handling — fixed
+  ([#43](https://github.com/LBALab/lba2-classic-community/issues/43))
+- Case-sensitive music paths on Linux — fixed
+  ([#12](https://github.com/LBALab/lba2-classic-community/pull/12))
+
+### Ported (ASM → C++)
+
+- Object display, rendering helpers, and supporting math via the
+  ASM-validation framework, with byte-for-byte equivalence tests
+  ([#31](https://github.com/LBALab/lba2-classic-community/pull/31),
+  [#32](https://github.com/LBALab/lba2-classic-community/pull/32))
+- SDL audio backend with Miles parity gap tracking
+  ([#27](https://github.com/LBALab/lba2-classic-community/issues/27),
+  [#28](https://github.com/LBALab/lba2-classic-community/pull/28),
+  [#9](https://github.com/LBALab/lba2-classic-community/pull/9))
+- SDL renderer presentation path with LTO and inline rotates
+  ([#11](https://github.com/LBALab/lba2-classic-community/pull/11),
+  [#51](https://github.com/LBALab/lba2-classic-community/pull/51))
+- Smacker FMV via libsmacker; video audio routed through the AIL backend
+  ([#10](https://github.com/LBALab/lba2-classic-community/pull/10),
+  [#29](https://github.com/LBALab/lba2-classic-community/issues/29),
+  [#35](https://github.com/LBALab/lba2-classic-community/pull/35))
+- See [docs/ASM_TO_CPP_REFERENCE.md](docs/ASM_TO_CPP_REFERENCE.md) for the
+  full port-status table.
+
+### Cross-platform & build
+
+- macOS CI build (arm64); macOS x86_64 preset
+  ([#52](https://github.com/LBALab/lba2-classic-community/pull/52))
+- Portable Windows build via MSYS2 UCRT64
+  ([#14](https://github.com/LBALab/lba2-classic-community/pull/14)) —
+  see [docs/WINDOWS.md](docs/WINDOWS.md)
+- CMake presets for Linux, macOS arm64/x86_64, Windows UCRT64, and
+  cross-compile Linux→Windows
+  ([#21](https://github.com/LBALab/lba2-classic-community/pull/21))
+- SDL3 throughout (audio, video, renderer)
+- Default Windows preset switched to Release
+- `clang-format` with checked-in config; ASM and `LIB386/libsmacker/`
+  excluded
+  ([#36](https://github.com/LBALab/lba2-classic-community/pull/36))
+- Host-only discovery tests run on Linux/macOS/Windows in CI without
+  Docker or retail files
+  ([#54](https://github.com/LBALab/lba2-classic-community/pull/54))
+
+### Tests
+
+- ASM↔CPP equivalence test framework with byte-for-byte assertions and
+  randomized stress rounds
+  ([#31](https://github.com/LBALab/lba2-classic-community/pull/31)) —
+  see [docs/TESTING.md](docs/TESTING.md)
+- Polyrec replay with `--bisect` for finding the first divergent draw
+  call between ASM and CPP renderers
+- Tightened assertions across `POLYFLAT`, `POLYGOUR`, `POLYDISC`,
+  `POLYTEXT`, `POLYGTEX`, `AFF_OBJ`, FPU precision, and the resampler
+  ([#44](https://github.com/LBALab/lba2-classic-community/pull/44))
+
+### Documentation
+
+- [AGENTS.md](AGENTS.md) — principles, "never" list, "when modifying X
+  do Y" table for AI assistants and human contributors
+  ([#40](https://github.com/LBALab/lba2-classic-community/pull/40))
+- [docs/GLOSSARY.md](docs/GLOSSARY.md),
+  [docs/LIFECYCLES.md](docs/LIFECYCLES.md),
+  [docs/SCENES.md](docs/SCENES.md) — engine reference
+  ([#25](https://github.com/LBALab/lba2-classic-community/pull/25),
+  [#26](https://github.com/LBALab/lba2-classic-community/issues/26))
+- [docs/MENU.md](docs/MENU.md), [docs/CONFIG.md](docs/CONFIG.md),
+  [docs/SAVEGAME.md](docs/SAVEGAME.md) — subsystem references
+  ([#30](https://github.com/LBALab/lba2-classic-community/pull/30))
+- [docs/CONSOLE.md](docs/CONSOLE.md), [docs/DEBUG.md](docs/DEBUG.md),
+  [docs/CAMERA.md](docs/CAMERA.md),
+  [docs/FEATURE_WORKFLOW.md](docs/FEATURE_WORKFLOW.md)
+- [docs/FRENCH_COMMENTS.md](docs/FRENCH_COMMENTS.md) and
+  [docs/ASCII_ART.md](docs/ASCII_ART.md) — preservation catalogs
+
+### Earliest fork work
+
+- File encoding preservation
+  ([#1](https://github.com/LBALab/lba2-classic-community/pull/1))
+- SDL audio, Smacker FMV, SDL renderer first land
+  ([#9](https://github.com/LBALab/lba2-classic-community/pull/9),
+  [#10](https://github.com/LBALab/lba2-classic-community/pull/10),
+  [#11](https://github.com/LBALab/lba2-classic-community/pull/11))
+- Preservation docs and build configuration clarity
+  ([#13](https://github.com/LBALab/lba2-classic-community/pull/13))
+
+[Unreleased]: https://github.com/LBALab/lba2-classic-community/compare/main...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,25 @@
 # How to Contribute
 
-If you'd like to contribute to the project, there are several ways you can help.
+This is a hobby project. Maintainers and contributors come and go as life
+allows — that's fine and expected. The goal is a sustainable, friendly
+place to work on an old game we love. Pick something that interests you,
+move at your own pace, and ship it when it's ready.
 
-If you use an AI assistant (Cursor, Copilot, Claude), point it at [AGENTS.md](AGENTS.md) for project context.
+A few notes that keep it sustainable:
 
-If you need help getting started, join us on [Discord](https://discord.gg/gfzna5SfZ5).
+- **Keep PRs focused.** One topic per PR. Sweeping rewrites or
+  whole-subsystem changes (e.g. "port everything to Rust", reorganizing a
+  whole subdirectory) deserve a heads-up on
+  [Discord](https://discord.gg/jsTPWYXHsh) or an issue *before* you start
+  — reviewer time is the scarce resource, not code.
+- **AI assistants are welcome** (Cursor, Copilot, Claude, etc.). The bar
+  is the same as for any contributor: the code has to be correct, the
+  scope has to match what the PR title claims, and ASM equivalence still
+  has to hold. Point your assistant at [AGENTS.md](AGENTS.md) for project
+  context, principles, and the "never" list.
+- **Ask early when in doubt.** A short question on
+  [Discord](https://discord.gg/jsTPWYXHsh) beats a week of work in the
+  wrong direction.
 
 ## Reporting Crashes and Bugs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,20 @@ high *without* anyone having to police it.
   maintenance cost. Resist "while I'm here" cleanups; open a separate PR
   instead.
 
+- **Ship a test, or ship a repro hook.** Bugs in pure-data code paths
+  (parsing, serialization, math, projection, sort) are almost always
+  cheap to test once you extract the affected logic into a pure function
+  — that small refactor is usually worth doing as part of the fix, with
+  a host test pinning it. See `tests/3D/test_sintab.cpp` and the
+  savegame corpus harness as patterns. When automation genuinely isn't
+  realistic (state machines, input timing, UI flow), at least ship a
+  **manual repro hook** alongside the fix: a console command, a debug
+  menu entry, or a build flag that re-triggers the affected path. PR
+  #66's `credits [0|1]` console command is the canonical example.
+  *Why:* future you (or someone else) will debug this same area again.
+  A test pins it forever; a repro hook saves an hour of figuring out
+  how to re-trigger the bug. Both beat nothing.
+
 ## Reporting Crashes and Bugs
 
 If you observe a bug you can report it [here](https://github.com/LBALab/lba2-classic-community/issues/new).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,53 @@ A few notes that keep it sustainable:
   [Discord](https://discord.gg/jsTPWYXHsh) beats a week of work in the
   wrong direction.
 
+## Doing good work here
+
+A few principles. The *why* matters more than the rule — once you
+understand the why, you can apply judgment in cases the rule doesn't
+cover. None of this is unique to this project; it's how good engineering
+works generally. It's written down because this is a small hobby project
+where reviewer time is scarce, and these habits are what keep quality
+high *without* anyone having to police it.
+
+- **Own what you ship.** If you used an AI assistant, you are still the
+  author. Read the diff yourself before opening the PR; you should be
+  able to explain every line and defend every decision under review.
+  *Why:* outsourcing typing is fine — outsourcing *understanding* is how
+  subtle bugs land in old code. Your name on the PR is a commitment.
+
+- **Actually test your change.** Build it. Run the game (or the relevant
+  test). Walk through the path your change touches. Then try one path it
+  doesn't touch, in case you broke something next door. *Why:* "the
+  automated tests pass" is necessary, not sufficient. This codebase is
+  25 years old and full of failure modes nothing has ever automated. You
+  are the last pair of eyes before review.
+
+- **Write tests when you reasonably can.** Especially for new logic,
+  regressions you just fixed, and anything in `LIB386/` where ASM
+  equivalence is the bar. *Why:* a test you write today catches the bug
+  your future self introduces in six months, on a platform you don't
+  own, for a contributor you've never met. That's a great trade.
+
+- **CI is on your side.** When it fails, read the log and fix the cause.
+  Don't disable a check, skip a hook (`--no-verify`), or work around the
+  failure to "unblock" yourself. *Why:* CI catches what you forgot to
+  check on your machine — that's its whole job, and it's free. Fighting
+  it just defers the same problem to whoever merges after you, often on
+  a platform you didn't test.
+
+- **Explain *why*, not *what*.** In PR descriptions, commit messages,
+  and code comments alike. *Why:* the diff already shows what changed.
+  What it can't show is why this approach over the obvious alternative,
+  what constraint you hit, or what you considered and rejected. That's
+  the part future contributors (and your future self) will need.
+
+- **Smaller is better.** The smallest change that solves the problem is
+  easier to review, easier to revert if it turns out to be wrong, and
+  easier to come back to after a break. *Why:* every line is a
+  maintenance cost. Resist "while I'm here" cleanups; open a separate PR
+  instead.
+
 ## Reporting Crashes and Bugs
 
 If you observe a bug you can report it [here](https://github.com/LBALab/lba2-classic-community/issues/new).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,11 @@ If you need help getting started, join us on [Discord](https://discord.gg/gfzna5
 
 ## Reporting Crashes and Bugs
 
-If you observe a bug you can report it [here](https://github.com/2point21/lba2-classic-community/issues/new).
+If you observe a bug you can report it [here](https://github.com/LBALab/lba2-classic-community/issues/new).
 
 ## Proposing Features
 
-If you have an idea, you can [create a feature request](https://github.com/2point21/lba2-classic-community/issues/new) to suggest a new feature.
+If you have an idea, you can [create a feature request](https://github.com/LBALab/lba2-classic-community/issues/new) to suggest a new feature.
 
 ## Contributing Code
 
@@ -21,6 +21,17 @@ If you have an idea, you can [create a feature request](https://github.com/2poin
 3. Make your changes
 4. Run `./run_tests_docker.sh` before submitting (or N/A if docs-only). CI will catch failures, but local run saves round-trips. PRs also run **host** discovery tests (`test_res_discovery`) on **Linux, macOS, and Windows** plus **format**; full ASM equivalence is the Docker workflow on Linux.
 5. Submit a pull request
+
+### PR titles
+
+The repo uses **squash-merge**, so your PR title becomes the commit on
+`main` and lands in the changelog as-is. Format it as
+`<type>(<scope>): <summary>` — for example
+`fix(credits): preserve gameplay state across console-invoked credits`.
+The full type list and rationale live in
+[AGENTS.md](AGENTS.md#commit--pr-conventions). A CI check verifies the
+title format. You do **not** need to edit `CHANGELOG.md` — it is
+regenerated at release time.
 
 PRs and pushes run build checks on **Linux**, **Windows** (MSYS2 UCRT64), and **macOS** (arm64); see `.github/workflows/`. Equivalence tests still run in Docker on Linux only (`test.yml`).
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Read our [Contribution Guidelines](https://github.com/2point21/lba2-classic-comm
 
 **Official Website:** https://twinsenslittlebigadventure.com/
 
-**Discord:** https://discord.gg/gfzna5SfZ5
+**Discord:** https://discord.gg/jsTPWYXHsh
 
 **Docs:** https://lba-classic-doc.readthedocs.io/
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,65 @@
+# git-cliff configuration for lba2-classic-community
+# See https://git-cliff.org/docs for the full reference.
+#
+# Two version concepts in this repo, do not confuse them:
+#   * Engine version (semver, e.g. v0.9.0) — what cliff manages.
+#   * NUM_VERSION (SOURCES/COMMON.H) — the save-file on-disk format version.
+# They are independent. Bumping engine semver does not bump NUM_VERSION,
+# and vice versa.
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to the LBA2 Classic Community engine fork.
+
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> Engine semver is independent from `NUM_VERSION` (save-file on-disk format,
+> see `SOURCES/COMMON.H`). Save-format changes are tracked there, not here.
+
+"""
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}\
+- {{ commit.message | split(pat="\\n") | first | upper_first }}\
+{% if commit.scope %} (*{{ commit.scope }}*){% endif %} \
+([{{ commit.id | truncate(length=7, end="") }}](https://github.com/LBALab/lba2-classic-community/commit/{{ commit.id }}))
+{% endfor %}
+{% endfor %}
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+protect_breaking_commits = true
+tag_pattern = "v[0-9]*"
+sort_commits = "newest"
+topo_order = false
+
+# Order matters: first match wins. Skips run before groupings.
+commit_parsers = [
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^Merge ", skip = true },
+    { message = "^feat",        group = "Added" },
+    { message = "^port",        group = "Ported (ASM → C++)" },
+    { message = "^fix",         group = "Fixed" },
+    { message = "^perf",        group = "Performance" },
+    { message = "^refactor",    group = "Changed" },
+    { message = "^docs",        group = "Documentation" },
+    { message = "^test",        group = "Tests" },
+    { message = "^build",       group = "Build" },
+    { message = "^ci",          group = "Internal" },
+    { message = "^chore",       group = "Internal" },
+    { message = ".*",           group = "Other" },
+]

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ Index of documentation in this repository.
 | [GAME_DATA.md](GAME_DATA.md) | Retail game files: `LBA2_GAME_DIR`, `--game-dir`, discovery order, dev layouts. |
 | [DEBUG.md](DEBUG.md) | Original Adeline debug tools (DEBUG_TOOLS=ON): overlay, F9 screenshot, bug save/load, cheats, scene selection. |
 | [CONSOLE.md](CONSOLE.md) | Quake-style debug console (always available): backtick/F12, commands and cvars. |
+| [RELEASING.md](RELEASING.md) | Maintainer recipe for cutting a release: versioning, the `1.0` bar, `git-cliff`, engine version vs `NUM_VERSION`. |
 
 
 ## Testing

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,86 @@
+# Releasing
+
+Short maintainer recipe for cutting a release.
+
+## Versioning
+
+The engine uses [Semantic Versioning](https://semver.org/). The fork is
+**pre-1.0** while crashes are still being ironed out.
+
+| Bump  | When                                                                |
+|-------|---------------------------------------------------------------------|
+| MAJOR | Save-format break, hard removal of a build option, or `1.0` itself  |
+| MINOR | New feature, new platform support, opt-in behavior change           |
+| PATCH | Bugfix or doc-only release                                          |
+
+### `1.0.0` bar
+
+`1.0.0` is reached when all of the following hold:
+
+- Main story completable on **Linux, macOS, and Windows** without known crashes.
+- Save / load round-trip stable across a full playthrough.
+- Equivalence and host-discovery tests pass on all three platforms in CI.
+- Memory-safety hardening (issue
+  [#47](https://github.com/LBALab/lba2-classic-community/issues/47)) closed
+  for the main-story code paths.
+
+Until then, MINOR releases ship features and platform progress; PATCH
+releases ship fixes.
+
+### Engine version vs `NUM_VERSION`
+
+These are **independent**:
+
+- **Engine version** (`v0.9.0`, `v1.0.0`, ...) — the semver tag this doc is about.
+- **`NUM_VERSION`** in `SOURCES/COMMON.H` — the save-file on-disk format
+  version (currently `36`). Bumping the engine version does **not** bump
+  `NUM_VERSION`, and vice versa. See
+  [issue #64](https://github.com/LBALab/lba2-classic-community/issues/64) for
+  the canonical save-format work tracked separately.
+
+## Cutting a release
+
+Prerequisites: [`git-cliff`](https://git-cliff.org/) installed locally.
+
+```bash
+# 1. Pick the version. Pre-1.0 examples: v0.9.0, v0.9.1, v0.10.0
+VERSION=v0.9.0
+
+# 2. Regenerate CHANGELOG.md from history. The [Unreleased] section
+#    becomes the new version's section.
+git cliff --tag "$VERSION" -o CHANGELOG.md
+
+# 3. Review the diff. Hand-curate the top of the new section if useful
+#    (group highlights, link to docs).
+git diff CHANGELOG.md
+
+# 4. Commit and tag.
+git add CHANGELOG.md
+git commit -m "chore(release): $VERSION"
+git tag -a "$VERSION" -m "Release $VERSION"
+
+# 5. Push.
+git push origin main
+git push origin "$VERSION"
+```
+
+## GitHub Release
+
+Creating a GitHub Release with attached binaries is tracked separately in
+[issue #46](https://github.com/LBALab/lba2-classic-community/issues/46).
+Until that workflow lands, push the tag (above) and optionally draft a
+plain Release on GitHub with the relevant CHANGELOG section pasted as the
+body. Source-only releases are valid; players build from source per the
+[README](../README.md).
+
+## What `git-cliff` reads
+
+- Commit messages on `main` since the previous tag.
+- Conventional-commit prefixes (`feat:`, `fix:`, `port:`, `docs:`, ...) drive
+  the section grouping. See `cliff.toml` and the
+  [Commit & PR conventions](../AGENTS.md#commit--pr-conventions) section in
+  AGENTS.md.
+- The repo uses **squash-merge**, so each PR contributes exactly one commit
+  to `main`, and the PR title is that commit's message. The PR-title CI
+  check (`.github/workflows/pr-title.yml`) is what keeps the log clean
+  enough for cliff to parse.


### PR DESCRIPTION
## TL;DR

Sets up a low-friction changelog and release flow, codifies the project's hobby-project tone in `CONTRIBUTING.md`, and adds a "Doing good work here" principles section so contributors (human and AI) have the *why* behind the bar we hold each other to. Deliberately defers the binary-release workflow to #46 — that's a separate design conversation.

## What's in this PR

**Release & versioning infrastructure**
- `cliff.toml` — [`git-cliff`](https://git-cliff.org/) config. Uses conventional-commit prefixes from PR titles to auto-generate changelog sections. Includes a fork-specific `port:` type for ASM→C++ work so we don't lump it under generic `refactor:`.
- `.github/workflows/pr-title.yml` — lints PR titles via `amannn/action-semantic-pull-request`. Squash-merge means the PR title becomes the single commit on `main`, so this is the **only** convention contributors need to follow. Individual commits inside a PR can be messy.
- `.github/PULL_REQUEST_TEMPLATE.md` — minimal checklist (build, equivalence tests, opt-in flags, docs, preservation).
- `CHANGELOG.md` — hand-curated narrative of the fork's evolution since creation, organized as "Unreleased" until the first tag. Tries to surface the work that's happened in the last months that contributors and players may not have realized was in here (console module, gamepad, auto-camera, save hardening, draw-order fix, full ASM↔CPP equivalence framework, etc.). Future entries will be auto-generated by `git-cliff` from conventional-commit PR titles.
- `docs/RELEASING.md` — short maintainer recipe. Defines the `1.0` bar (links to #47), explicitly separates engine semver from `NUM_VERSION` so they don't get confused (#64 is the `NUM_VERSION 37+` work, tracked separately), and defers binary releases to #46.

**Contribution culture**
- `CONTRIBUTING.md` — reshaped intro to set tone explicitly: hobby project, contributors come and go, low friction wins, focused PRs, sweeping changes get a Discord heads-up first, AI assistants welcome at the same quality bar. Added "Doing good work here" — six principles with the *why* alongside each rule (own what you ship, actually test your change, write tests, embrace CI, explain why-not-what, smaller is better, ship a test or a repro hook).
- Fixed stale `2point21/lba2-classic-community` URLs and Discord invite (`gfzna5SfZ5` → `jsTPWYXHsh`, the actual LBALab server).
- `AGENTS.md` — added a "Commit & PR conventions" section, a Golden Rule for pinning bug fixes (test or repro hook), and a row in the "When Modifying X, Do Y" table for "Fixing a bug" so AI-assisted PRs catch the pattern.

## What's deliberately NOT in this PR

- **Binary release workflow** — defers to #46. Code-signing, artifact format, and CI lift are their own conversation.
- **CODEOWNERS** — multi-maintainer decision, not a single-author proposal.
- **Issue templates** — small follow-up; not required for this system to work.
- **Repo settings change to enforce squash-merge-only** — that's a one-click admin setting (Settings → General → Pull Requests). Listed below as question #2.

## Three questions for maintainers

1. **Starting version: `v0.9.0`?** The fork has 1054 commits, zero tags. `v0.9.0` reflects "playable, pre-1.0" given the recent endgame crash fix is fresh. Open to `v0.1.0` or another starting number — say what feels right.
2. **Enable squash-merge-only in repo settings?** The PR-title CI check only delivers value if the title becomes the commit on `main`. Without this, merge commits would let messy commit messages through and `git-cliff` would produce noise. (Settings → General → Pull Requests, uncheck "Allow merge commits" and "Allow rebase merging".)
3. **Is the `1.0` bar the right one?** Currently: main story completable on Linux + macOS + Windows, no known crashes, save round-trip stable, equivalence + host-discovery tests passing in CI, and the memory-safety umbrella (#47) closed for main-story paths. Adjust as you see fit.

## Honesty notes

- **This PR itself is a multi-topic bundle**, which our own new "smaller is better" principle would normally push back on. Justification: the four commits build on the same conversation and are most useful reviewed together as a single coherent process proposal. I tried to make them each separately readable (see "How to review" below) so reviewers can comment on parts independently.
- **The principles section is partially aspirational vs recent practice.** An honest audit of the last 12 merged PRs found we're strong on "explain why not what" and "embrace CI" (zero `--no-verify` in history), but mixed on "write tests for bug fixes" — #66's parse fix is the canonical example of a unit-testable bug we shipped without a test. The new principle ("ship a test or a repro hook") and AGENTS.md guidance are aimed at catching that pattern in future PRs.

## How to review

```bash
gh pr checkout <this-PR>
git log main..HEAD --oneline                  # 4 commits, each separately reviewable
git show 7ad5a85   # the main proposal (cliff/CI/CHANGELOG/RELEASING/AGENTS/CONTRIBUTING)
git show e7af50d   # Discord URL + hobby-project tone
git show cb7a641   # "Doing good work here" principles
git show 0eb7a26   # Test or repro-hook principle
```

Most of the value is in the prose — `CHANGELOG.md`, `docs/RELEASING.md`, and the new sections of `CONTRIBUTING.md` and `AGENTS.md` are where to spend reading time. The CI workflow is the only file that *acts*; the rest is policy.

## Test plan

- [ ] PR-title check appears in this PR's checks list and passes against the title above
- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-title.yml'))"` parses cleanly
- [ ] Maintainers read `CHANGELOG.md` end-to-end and flag any factual inaccuracies in the milestone narrative
- [ ] Maintainers answer the three questions above