### PR TITLE
docs: fix stale Discord invite and 2point21/ org URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,15 +4,15 @@ If you'd like to contribute to the project, there are several ways you can help.
 
 If you use an AI assistant (Cursor, Copilot, Claude), point it at [AGENTS.md](AGENTS.md) for project context.
 
-If you need help getting started, join us on [Discord](https://discord.gg/gfzna5SfZ5).
+If you need help getting started, join us on [Discord](https://discord.gg/jsTPWYXHsh).
 
 ## Reporting Crashes and Bugs
 
-If you observe a bug you can report it [here](https://github.com/2point21/lba2-classic-community/issues/new).
+If you observe a bug you can report it [here](https://github.com/LBALab/lba2-classic-community/issues/new).
 
 ## Proposing Features
 
-If you have an idea, you can [create a feature request](https://github.com/2point21/lba2-classic-community/issues/new) to suggest a new feature.
+If you have an idea, you can [create a feature request](https://github.com/LBALab/lba2-classic-community/issues/new) to suggest a new feature.
 
 ## Contributing Code
 
@@ -83,4 +83,4 @@ This project values preservation. When modifying original source files:
 
 ## Contributing to the Documentation
 
-You can also help build the official documentation here: https://github.com/2point21/lba-classic-doc
+You can also help build the official documentation here: https://github.com/LBALab/lba-classic-doc

--- a/README.md
+++ b/README.md
@@ -180,19 +180,19 @@ This codebase is a window into 1990s game development at Adeline Software Intern
 
 ## Licence
 
-This source code is licensed under the [GNU General Public License](https://github.com/2point21/lba2-classic-community/blob/main/LICENSE).
+This source code is licensed under the [GNU General Public License](https://github.com/LBALab/lba2-classic-community/blob/main/LICENSE).
 
 Please note this license only applies to **Little Big Adventure 2** engine source code. **Little Big Adventure 2** game assets (art, models, textures, audio, etc.) are not open-source and therefore aren't redistributable.
 
 ## How can I contribute?
 
-Read our [Contribution Guidelines](https://github.com/2point21/lba2-classic-community/blob/main/CONTRIBUTING.md).
+Read our [Contribution Guidelines](https://github.com/LBALab/lba2-classic-community/blob/main/CONTRIBUTING.md).
 
 ## Links
 
 **Official Website:** https://twinsenslittlebigadventure.com/
 
-**Discord:** https://discord.gg/gfzna5SfZ5
+**Discord:** https://discord.gg/jsTPWYXHsh
 
 **Docs:** https://lba-classic-doc.readthedocs.io/
 


### PR DESCRIPTION
- README.md and CONTRIBUTING.md Discord links: gfzna5SfZ5 -> jsTPWYXHsh (the actual LBALab community server).
- README.md and CONTRIBUTING.md GitHub links: github.com/2point21/... -> github.com/LBALab/... (org moved; old URLs still resolve via redirects but should not be canonical).