### PR TITLE
docs: codify community-project tone and contribution principles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ This document helps AI coding assistants (Cursor, Copilot, Claude, etc.) work ef
 - **Verify before claiming:** Run build or tests to confirm changes work; do not claim something works without verification.
 - **Search before adding:** Check for existing implementations before adding new code; avoid duplication.
 - **Say when unsure:** If uncertain whether a change is correct, say so. Prefer "I'm not certain" over confident but wrong.
+- **Pin fixes with a test or a repro hook.** When fixing a bug, first ask whether the affected logic is pure-data (parsing, serialization, math, projection, sort) — if yes, extracting it into a pure function and adding a host test is usually a small additional refactor and should be done as part of the fix. When automation is impractical (state, timing, UI), ship a manual repro hook instead (a console command, debug menu entry, or build flag). See [CONTRIBUTING.md "Doing good work here"](CONTRIBUTING.md#doing-good-work-here) for the rationale.
 
 ## Execution Style (Karpathy-Inspired)
 
@@ -84,6 +85,7 @@ Apply these behavior rules on every non-trivial task:
 | File with French comments or ASCII art | Preserve; add new comments alongside | docs/FRENCH_COMMENTS.md, docs/ASCII_ART.md |
 | New subsystem or doc | Create docs/<name>.md; add to docs/README.md; update in same commit | docs/README.md |
 | Any code that affects documented behavior | Update the doc in the same commit | Principle 2 |
+| Fixing a bug | If the affected logic is pure-data, extract it to a pure function and add a host test. Otherwise add a manual repro hook (console command, debug flag) | CONTRIBUTING.md "Doing good work here" |
 
 ## Code Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,86 @@
 # How to Contribute
 
-If you'd like to contribute to the project, there are several ways you can help.
+This is a community project. Maintainers and contributors come and go as life
+allows — that's fine and expected. The goal is a sustainable, friendly
+place to work on an old game we love. Pick something that interests you,
+move at your own pace, and ship it when it's ready.
 
-If you use an AI assistant (Cursor, Copilot, Claude), point it at [AGENTS.md](AGENTS.md) for project context.
+A few notes that keep it sustainable:
 
-If you need help getting started, join us on [Discord](https://discord.gg/jsTPWYXHsh).
+- **Keep PRs focused.** One topic per PR. Sweeping rewrites or
+  whole-subsystem changes (e.g. "port everything to Rust", reorganizing a
+  whole subdirectory) deserve a heads-up on
+  [Discord](https://discord.gg/jsTPWYXHsh) or an issue *before* you start
+  — reviewer time is the scarce resource, not code.
+- **AI assistants are welcome** (Cursor, Copilot, Claude, etc.). The bar
+  is the same as for any contributor: the code has to be correct, the
+  scope has to match what the PR title claims, and ASM equivalence still
+  has to hold. Point your assistant at [AGENTS.md](AGENTS.md) for project
+  context, principles, and the "never" list.
+- **Ask early when in doubt.** A short question on
+  [Discord](https://discord.gg/jsTPWYXHsh) beats a week of work in the
+  wrong direction.
+
+## Doing good work here
+
+A few principles. The *why* matters more than the rule — once you
+understand the why, you can apply judgment in cases the rule doesn't
+cover. None of this is unique to this project; it's how good engineering
+works generally. It's written down because this is a community project
+where reviewer time is scarce, and these habits are what keep quality
+high *without* anyone having to police it.
+
+- **Own what you ship.** If you used an AI assistant, you are still the
+  author. Read the diff yourself before opening the PR; you should be
+  able to explain every line and defend every decision under review.
+  *Why:* outsourcing typing is fine — outsourcing *understanding* is how
+  subtle bugs land in old code. Your name on the PR is a commitment.
+
+- **Actually test your change.** Build it. Run the game (or the relevant
+  test). Walk through the path your change touches. Then try one path it
+  doesn't touch, in case you broke something next door. *Why:* "the
+  automated tests pass" is necessary, not sufficient. This codebase is
+  25 years old and full of failure modes nothing has ever automated. You
+  are the last pair of eyes before review.
+
+- **Write tests when you reasonably can.** Especially for new logic,
+  regressions you just fixed, and anything in `LIB386/` where ASM
+  equivalence is the bar. *Why:* a test you write today catches the bug
+  your future self introduces in six months, on a platform you don't
+  own, for a contributor you've never met. That's a great trade.
+
+- **CI is on your side.** When it fails, read the log and fix the cause.
+  Don't disable a check, skip a hook (`--no-verify`), or work around the
+  failure to "unblock" yourself. *Why:* CI catches what you forgot to
+  check on your machine — that's its whole job, and it's free. Fighting
+  it just defers the same problem to whoever merges after you, often on
+  a platform you didn't test.
+
+- **Explain *why*, not *what*.** In PR descriptions, commit messages,
+  and code comments alike. *Why:* the diff already shows what changed.
+  What it can't show is why this approach over the obvious alternative,
+  what constraint you hit, or what you considered and rejected. That's
+  the part future contributors (and your future self) will need.
+
+- **Smaller is better.** The smallest change that solves the problem is
+  easier to review, easier to revert if it turns out to be wrong, and
+  easier to come back to after a break. *Why:* every line is a
+  maintenance cost. Resist "while I'm here" cleanups; open a separate PR
+  instead.
+
+- **Ship a test, or ship a repro hook.** Bugs in pure-data code paths
+  (parsing, serialization, math, projection, sort) are almost always
+  cheap to test once you extract the affected logic into a pure function
+  — that small refactor is usually worth doing as part of the fix, with
+  a host test pinning it. See `tests/3D/test_sintab.cpp` and the
+  savegame corpus harness as patterns. When automation genuinely isn't
+  realistic (state machines, input timing, UI flow), at least ship a
+  **manual repro hook** alongside the fix: a console command, a debug
+  menu entry, or a build flag that re-triggers the affected path. PR
+  #66's `credits [0|1]` console command is the canonical example.
+  *Why:* future you (or someone else) will debug this same area again.
+  A test pins it forever; a repro hook saves an hour of figuring out
+  how to re-trigger the bug. Both beat nothing.
 
 ## Reporting Crashes and Bugs
 


### PR DESCRIPTION
## What

Sets the cultural tone for sustainable contribution and gives both human contributors and AI assistants a shared vocabulary for what "good work here" means.

`CONTRIBUTING.md`:

- Reshape intro to state tone explicitly: community project, contributors come and go, low friction, focused PRs, sweeping changes need a Discord/issue heads-up first, AI assistants welcome at the same quality bar as humans.
- Add **"Doing good work here"** with seven principles, each with the *why* alongside the rule:
     1. **Own what you ship** (still the author when AI helps)
     2. **Actually test your change** (manually, beyond CI)
     3. **Write tests when you reasonably can**
     4. **CI is on your side** (no `--no-verify`, no bypass)
     5. **Explain why, not what** (in PRs, commits, comments)
     6. **Smaller is better**
     7. **Ship a test, or ship a repro hook**

`AGENTS.md`:
- New Golden Rule for pinning bug fixes with a test or repro hook, cross-referenced to `CONTRIBUTING.md`.
- New "Fixing a bug" row in the "When Modifying X, Do Y" table so AI-assisted PRs catch the pattern at task time.

## Why

This is mentorship-tone content for contributors who range widely in experience. The why-behind-each-rule is deliberate: a principle with reasoning attached teaches judgment for cases the rule doesn't cover. Keeps the project's quality bar high without anyone having to police it.

## The worked example

PR #66 (endgame credits segfault) is the canonical example for the test/repro-hook principle:

- The on-disk parse fix was unit-testable with a small extraction we didn't do.
- The state-preservation and input-timing parts genuinely need infrastructure we don't have.
- The `credits [0|1]` console command #66 added **is** the kind of repro hook this principle wants — shipped without us having a name for the pattern. This PR gives it a name.

## Note

The principles section is partially aspirational vs recent practice. An audit of the last 12 merged PRs found we're strong on "explain why not what" and "embrace CI" (zero `--no-verify` in history), but mixed on "write tests for bug fixes". The new principle ("ship a test or a repro hook") and AGENTS.md guidance are aimed at catching that pattern in future PRs — including ones I author.

## Test plan

- [ ] Read `CONTRIBUTING.md` end-to-end and flag any tone that feels preachy or off
- [ ] Read AGENTS.md additions and confirm they feel actionable for AI assistants, not just descriptive