### PR TITLE
ci: label-based host test discovery (workflows, Makefile, README, docs)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -40,10 +40,10 @@ jobs:
       - name: Build
         run: |
           cmake --build build --target lba2
-          cmake --build build --target test_res_discovery test_console_state test_credits_parse
+          cmake --build build --target host_tests
 
-      - name: Host tests (game data discovery)
-        run: cd build && ctest -R 'test_(res_discovery|console_state|credits_parse)' --output-on-failure
+      - name: Host tests
+        run: cd build && ctest -L host_quick --output-on-failure
 
       - name: Verify Binary
         run: test -f build/SOURCES/lba2 && echo "Build successful"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Build
         run: |
           cmake --build build --target lba2
-          cmake --build build --target test_res_discovery test_console_state test_credits_parse
+          cmake --build build --target host_tests
 
-      - name: Host tests (game data discovery)
-        run: cd build && ctest -R 'test_(res_discovery|console_state|credits_parse)' --output-on-failure
+      - name: Host tests
+        run: cd build && ctest -L host_quick --output-on-failure
 
       - name: Verify Binary
         run: test -f build/SOURCES/lba2 && echo "Build successful"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,10 +42,10 @@ jobs:
       - name: Build
         run: |
           cmake --build build --target lba2
-          cmake --build build --target test_res_discovery test_console_state test_credits_parse
+          cmake --build build --target host_tests
 
-      - name: Host tests (game data discovery)
-        run: cd build && ctest -R 'test_(res_discovery|console_state|credits_parse)' --output-on-failure
+      - name: Host tests
+        run: cd build && ctest -L host_quick --output-on-failure
 
       - name: Verify Binary
         run: test -f build/SOURCES/lba2.exe && echo "Build successful"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ Apply these behavior rules on every non-trivial task:
 - **Build:** `cmake -B build && cmake --build build`. Or use presets for your platform: `cmake --preset <preset> && cmake --build --preset <preset>` — `linux`, `macos_arm64`, `macos_x86_64`, `windows_ucrt64` (see `CMakePresets.json`).
 - **Game data:** Retail files are not in the repo. See `docs/GAME_DATA.md`. Set `LBA2_GAME_DIR`, use `--game-dir`, or place data in `./data` / `../LBA2` relative to the repo. From anywhere in the clone: `./scripts/dev/build-and-run.sh` or `make run` (repo root).
 - **Tests:** Run via Docker: `./run_tests_docker.sh`. Works on Linux, macOS (Docker + QEMU), and Windows (Docker Desktop). Tests require 32-bit x86 + UASM inside the container.
-- **Host discovery tests:** `make test` / `make test-discovery` (or `ctest -R test_res_discovery` after configure with `-DLBA2_BUILD_TESTS=ON -DLBA2_BUILD_ASM_EQUIV_TESTS=OFF`). No Docker, no retail files. CI runs these on Linux, macOS, and Windows (see `.github/workflows/*.yml`).
+- **Host tests:** `make test` (or `ctest -L host_quick` after configure with `-DLBA2_BUILD_TESTS=ON -DLBA2_BUILD_ASM_EQUIV_TESTS=OFF`). No Docker, no retail files. CI runs these on Linux, macOS, and Windows (see `.github/workflows/*.yml`).
 - **Filter:** `./run_tests_docker.sh test_getang2d test_lirot3df`
 - **Bisect:** `./run_tests_docker.sh --bisect` to find first divergent draw call
 - **Before considering done:** Run `./run_tests_docker.sh` (or N/A if docs-only). If modifying formatted files: `clang-format -i` on staged C/C++ files (works on all platforms), or CI runs format check.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Convenience targets — delegate to CMake and scripts (see docs/GAME_DATA.md).
-.PHONY: help clean build run build-run test-discovery test tests test-docker format-check
+.PHONY: help clean build run build-run test tests test-docker format-check
 
 MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(shell "$(MAKEFILE_DIR)scripts/dev/repo_root.sh" 2>/dev/null || echo "$(MAKEFILE_DIR)")
@@ -13,8 +13,7 @@ help:
 	@echo "  make build          - configure (Ninja) and build lba2"
 	@echo "  make run            - build and run (uses scripts/dev/build-and-run.sh)"
 	@echo "  make build-run      - same as run"
-	@echo "  make test-discovery - configure with tests, build host tests (discovery + console), run CTest"
-	@echo "  make test | tests   - same as test-discovery (host path tests; no retail files)"
+	@echo "  make test | tests   - configure with tests, build host_tests, run CTest -L host_quick (no Docker, no retail files)"
 	@echo "  make test-docker    - ./run_tests_docker.sh (ASM suite; requires Docker)"
 	@echo "  make format-check   - scripts/ci/check-format.sh"
 
@@ -28,14 +27,12 @@ build:
 run build-run:
 	@bash "$(REPO_ROOT)/scripts/dev/build-and-run.sh"
 
-test-discovery:
+test tests:
 	$(CMAKE) -S "$(REPO_ROOT)" -B "$(BUILD_DIR)" -G Ninja -DCMAKE_BUILD_TYPE=Debug \
 		-DLBA2_BUILD_TESTS=ON \
 		-DLBA2_BUILD_ASM_EQUIV_TESTS=OFF
-	$(CMAKE) --build "$(BUILD_DIR)" --target test_res_discovery test_console_state test_console_commands
-	cd "$(BUILD_DIR)" && ctest -R 'test_(res_discovery|console_state|console_commands)' --output-on-failure
-
-test tests: test-discovery
+	$(CMAKE) --build "$(BUILD_DIR)" --target host_tests
+	cd "$(BUILD_DIR)" && ctest -L host_quick --output-on-failure
 
 test-docker:
 	@cd "$(REPO_ROOT)" && ./run_tests_docker.sh

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The **original** LBA2 engine source is the **lba2-classic** codebase: it is most
 3. **`make build`** — configures `build/` (Ninja, Debug) and compiles `lba2`. Or: `cmake -B build && cmake --build build` (default generator is fine if you do not use `make build`).
 4. **Retail game data** are not in this repo. You need a directory that contains **`lba2.hqr`**. How you point the engine at it is **your choice**: `export LBA2_GAME_DIR=/path`, **`./data/`** (gitignored), **`--game-dir`**, or bounded automatic discovery — see [docs/GAME_DATA.md](docs/GAME_DATA.md). Nothing is “special-cased” except that marker file.
 5. **`make run`** or **`./scripts/dev/build-and-run.sh`** — build if needed, then run (exits with a clear message if no valid data directory was found).
-6. **`make test`** (alias for **`make test-discovery`**) — host-only tests for path resolution and embedded default config; **no** retail files or Docker required.
+6. **`make test`** — host-only tests (path resolution, embedded default config, console parser, credits parse); **no** retail files or Docker required.
 
 **Windows:** Use **MSYS2** (recommended; see [docs/WINDOWS.md](docs/WINDOWS.md)). Discovery and the game work the same (`LBA2_GAME_DIR`, `--game-dir`, paths with `\` or `/`). The root **`Makefile`** and **`scripts/dev/*.sh`** need a **Unix-like shell** (MSYS2 UCRT64, Git Bash, or WSL); alternatively run **`cmake`** and **`build/SOURCES/lba2.exe`** from **cmd.exe** / PowerShell and set the env var with `set LBA2_GAME_DIR=...`.
 
@@ -102,7 +102,7 @@ available on `PATH`.
 | `MVIDEO_BACKEND` | `null`, `smacker` | `smacker` | Motion video backend. Use `smacker` for FMV playback via the bundled open-source libsmacker. |
 | `DEBUG_TOOLS` | `ON`, `OFF` | `OFF` | Enable original Adeline developer debug tools. See [docs/DEBUG.md](docs/DEBUG.md). |
 | `LBA2_BUILD_TESTS` | `ON`, `OFF` | `OFF` | Build CTest targets (ASM equivalence + host tests such as `test_res_discovery`). |
-| `LBA2_BUILD_ASM_EQUIV_TESTS` | `ON`, `OFF` | `ON` | ASM↔CPP equivalence suite (needs `objcopy`). Set `OFF` for host-only `test_res_discovery` (e.g. macOS CI, `make test-discovery`). |
+| `LBA2_BUILD_ASM_EQUIV_TESTS` | `ON`, `OFF` | `ON` | ASM↔CPP equivalence suite (needs `objcopy`). Set `OFF` for host-only tests (e.g. macOS CI, `make test`). |
 
 When `MVIDEO_BACKEND` is set to `smacker`, the build links in `libsmacker` and the FMV player. Video audio routes through the active sound backend (SDL: real audio; NULL/MILES: silent). See `LIB386/SMACKER/README.md` and `LIB386/AIL/MILES/README.md` for details on the proprietary SDKs and their open-source replacements.
 
@@ -159,8 +159,6 @@ lba2-classic-community/
 │   ├── H/                    # Shared legacy headers/types
 │   └── libsmacker/           # Open-source Smacker decoder (LGPL 2.1)
 ├── tests/                    # Host tests + ASM↔CPP equivalence test wiring
-│   ├── console/              # Console-focused host tests
-│   └── discovery/            # Game data discovery/config tests
 ├── docs/                     # Project documentation index and subsystem docs
 └── run_tests_docker.sh       # Docker wrapper for ASM↔CPP test workflows
 ```

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -73,7 +73,7 @@ directory contains targeted ASM-vs-CPP tests for those low-level cases.
 
 ### 4. Host tests — game data discovery (`tests/discovery`)
 
-`tests/discovery/test_res_discovery.cpp` exercises **`ResolveGameDataDir`** (`LBA2_GAME_DIR`, `--game-dir` stripping), **parent-directory sibling discovery** (retail folder or `CommonClassic` next to a fake `repo_clone` via `chdir`), and **embedded default `lba2.cfg`** writing. These run **on the host** (no Docker, no 32-bit ASM). Configure with `-DLBA2_BUILD_TESTS=ON` and **`-DLBA2_BUILD_ASM_EQUIV_TESTS=OFF`** if you only need discovery tests (no `objcopy`; used by `make test-discovery` and PR host jobs).
+`tests/discovery/test_res_discovery.cpp` exercises **`ResolveGameDataDir`** (`LBA2_GAME_DIR`, `--game-dir` stripping), **parent-directory sibling discovery** (retail folder or `CommonClassic` next to a fake `repo_clone` via `chdir`), and **embedded default `lba2.cfg`** writing. These run **on the host** (no Docker, no 32-bit ASM). Configure with `-DLBA2_BUILD_TESTS=ON` and **`-DLBA2_BUILD_ASM_EQUIV_TESTS=OFF`** if you only need host tests (no `objcopy`; used by `make test` and PR host jobs).
 
 ### 5. Host tests — console (`tests/console`)
 
@@ -81,11 +81,15 @@ directory contains targeted ASM-vs-CPP tests for those low-level cases.
 
 `tests/console/test_console_commands.cpp` covers parser/output integration in **`SOURCES/CONSOLE/CONSOLE.CPP`** using host-only hooks: built-in `help` and `cmdlist`, unknown-command diagnostics, cvar set/get (`fps`), and a registered **`status`** command path that prints the same status headline format.
 
-PR host jobs and **`make test`** / **`make test-discovery`** build `test_res_discovery`, `test_console_state`, and `test_console_commands`, then:
+PR host jobs and **`make test`** build the `host_tests` aggregate target, then:
 
 ```bash
-cd build && ctest -R 'test_(res_discovery|console_state|console_commands)' --output-on-failure
+cd build && ctest -L host_quick --output-on-failure
 ```
+
+The `host_quick` label is set by `register_host_test()` in
+`tests/CMakeLists.txt`; each test's own CMakeLists opts in with one
+line. Adding a new host test requires no workflow or Makefile edits.
 
 To run only the console suite: `ctest -R test_console_ --output-on-failure`.
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,20 @@ cmake_minimum_required(VERSION 3.23)
 
 enable_testing()
 
+# Aggregate target + label for host-only tests (no Docker, no retail data;
+# run on Linux/macOS/Windows in CI). Each test registers itself via
+# register_host_test(<target>) — adding a new host test is then two lines in
+# its own CMakeLists.txt, with no workflow edits required.
+#
+#   cmake --build build --target host_tests   # builds every registered test
+#   ctest -L host_quick --output-on-failure   # runs every registered test
+add_custom_target(host_tests)
+
+function(register_host_test test_name)
+    add_dependencies(host_tests ${test_name})
+    set_tests_properties(${test_name} PROPERTIES LABELS host_quick)
+endfunction()
+
 add_subdirectory(discovery)
 add_subdirectory(console)
 add_subdirectory(credits)

--- a/tests/console/CMakeLists.txt
+++ b/tests/console/CMakeLists.txt
@@ -18,3 +18,6 @@ set_target_properties(test_console_commands PROPERTIES CXX_STANDARD 11)
 
 add_test(NAME test_console_state COMMAND test_console_state)
 add_test(NAME test_console_commands COMMAND test_console_commands)
+
+register_host_test(test_console_state)
+register_host_test(test_console_commands)

--- a/tests/credits/CMakeLists.txt
+++ b/tests/credits/CMakeLists.txt
@@ -11,3 +11,5 @@ target_include_directories(test_credits_parse PRIVATE
 set_target_properties(test_credits_parse PROPERTIES CXX_STANDARD 11)
 
 add_test(NAME test_credits_parse COMMAND test_credits_parse)
+
+register_host_test(test_credits_parse)

--- a/tests/discovery/CMakeLists.txt
+++ b/tests/discovery/CMakeLists.txt
@@ -23,3 +23,5 @@ target_compile_definitions(test_res_discovery PRIVATE
 set_target_properties(test_res_discovery PROPERTIES CXX_STANDARD 11)
 
 add_test(NAME test_res_discovery COMMAND test_res_discovery)
+
+register_host_test(test_res_discovery)


### PR DESCRIPTION
Follow-up to #72 (the credits regression test) as discussed: the previous workflow allowlists silently skipped tests not enumerated by name — exactly what the "embrace CI, no silent skips" principle warns against. The Makefile had the same drift surface.

## Change

- `tests/CMakeLists.txt` declares an aggregate `host_tests` target and a `register_host_test()` helper.
- Each host test calls `register_host_test(<target>)` to opt in.
- Workflows and the Makefile both build `host_tests` and run `ctest -L host_quick`. Adding a new host test is now zero workflow
    edits.

## Side benefit

`test_console_commands` existed in the tree but was missing from the  workflow allowlists. It now runs in CI on Linux/macOS/Windows.

## Cleanups in the same drift surface

- Dropped the misleadingly-named `make test-discovery` target — it ran more than discovery, and `make test` is the canonical UX.
- Collapsed the `tests/` subdir tree in `README.md` (it was already missing several existing subdirs).
- Updated `docs/TESTING.md`'s worked example to use the label.

## Verified

`make test` → 4/4 tests passing. Format check clean.