### PR TITLE
fix(menu): add gamepad D-pad navigation to save/load list

### DIFF
--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -1156,6 +1156,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
     U8 *ptr;
     S32 timerzoom;
     S32 timeranotherkey;
+    S32 padNavDir = 0;
     S32 timerdraw = 1;
     U32 draw = 1;
     U32 newcube = NewCube;
@@ -1249,6 +1250,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
     InitDial(0);
 
     InitWaitNoKey();
+    padNavDir = JoystickMenuNavOnly();
 
     MenuMouseAcquire();
     save_press = -1;
@@ -1330,17 +1332,22 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
         }
 
         /* Suppress nav keys outside the repeat window; translate gamepad
-           D-pad / stick to K_GRAY_UP/DOWN when the window is open. */
+           D-pad / stick to K_GRAY_UP/DOWN when the window is open.
+           Edge-only for gamepad: fire on direction change so a deflected
+           stick on menu entry does not auto-fire. */
         if (TimerRefHR <= timeranotherkey) {
             if (MyKey == K_GRAY_UP || MyKey == K_GRAY_DOWN)
                 MyKey = 0;
             Input &= ~(I_UP | I_DOWN);
         } else if (!MyKey) {
             S32 jdir = JoystickMenuNavOnly();
-            if (jdir == K_UP)
-                MyKey = K_GRAY_UP;
-            else if (jdir == K_DOWN)
-                MyKey = K_GRAY_DOWN;
+            if (jdir != padNavDir) {
+                padNavDir = jdir;
+                if (jdir == K_UP)
+                    MyKey = K_GRAY_UP;
+                else if (jdir == K_DOWN)
+                    MyKey = K_GRAY_DOWN;
+            }
         }
 
         if (FlagMenuMouse && MenuMouse_GetRefCount() > 0) {

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -1325,8 +1325,23 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
 
         if (FlagMenuMouse && MenuMouse_GetRefCount() > 0) {
             MyGetInput();
-        } else if (TimerRefHR > timeranotherkey)
+        } else if (TimerRefHR > timeranotherkey) {
             MyGetInput();
+        }
+
+        /* Suppress nav keys outside the repeat window; translate gamepad
+           D-pad / stick to K_GRAY_UP/DOWN when the window is open. */
+        if (TimerRefHR <= timeranotherkey) {
+            if (MyKey == K_GRAY_UP || MyKey == K_GRAY_DOWN)
+                MyKey = 0;
+            Input &= ~(I_UP | I_DOWN);
+        } else if (!MyKey) {
+            S32 jdir = JoystickMenuNavOnly();
+            if (jdir == K_UP)
+                MyKey = K_GRAY_UP;
+            else if (jdir == K_DOWN)
+                MyKey = K_GRAY_DOWN;
+        }
 
         if (FlagMenuMouse && MenuMouse_GetRefCount() > 0) {
             S32 hitSel = -1;


### PR DESCRIPTION
<!--
PR title format: `<type>(<scope>): <summary>`
Types: feat | fix | port | perf | refactor | docs | test | build | ci | chore
Scope is optional. Example: `fix(credits): preserve gameplay state across console-invoked credits`
The PR title becomes the squash-merged commit on main, so it lands in the changelog as-is.
See AGENTS.md "Commit & PR conventions".
-->

## What & why

`ChoosePlayerName()` (the save/load name picker) only checked `K_GRAY_UP/DOWN` (keyboard scancodes) for list navigation. Gamepad D-pad and left-stick input had no effect. `DoGameMenu()` already uses `JoystickMenuNavOnly()` to translate stick/dpad to those scancodes; this applies the same pattern here.

Also fixes a related issue where holding a keyboard arrow key (or D-pad) in mouse-active mode would scroll through the entire list in one pass, the mouse path called `MyGetInput()` every frame, bypassing the repeat cadence entirely.

## Notes for reviewers

- Input polling is unchanged: `MyGetInput()` still runs every frame when the mouse is active (needed for hover/click tracking). The fix adds a separate rate-limiting gate that suppresses nav keys outside the `timeranotherkey` repeat window, mouse clicks are handled below that block and are unaffected.
- Gamepad hold-to-repeat works at the same cadence as a held keyboard arrow key.

## Checklist

- [x] Build passes on my platform (Linux / macOS / Windows — pick one or more)
- [x] If LIB386 / 3DEXT touched: ASM equivalence tests pass (`./run_tests_docker.sh`)
- [x] If behavior changes: opt-in via flag/cvar/config (preserves default game feel)
- [x] Docs updated in the same PR if behavior or workflow changed
- [x] French comments and ASCII art preserved in any modified files
