### PR TITLE
docs(changelog): three small accuracy/format fixes before tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ fork's evolution.
 > port, this unlocked native builds for **Linux x86_64**, **macOS
 > arm64/x86_64**, and **Windows (MSYS2 UCRT64)**, and keeps the door
 > open to other SDL platforms. Community members have already started
-> building it on handheld devices in the wild. 
+> building it on handheld devices in the wild.
 
 ### Stability & 64-bit hardening
 
@@ -52,7 +52,7 @@ fork's evolution.
 ### New features (opt-in)
 
 All new features default-off or default-to-original-behavior, in line with
-[AGENTS.md Principle 4](AGENTS.md#principles).
+[AGENTS.md Principle 3](AGENTS.md#principles).
 
 - Quake-style debug console: built-in, always available, configurable
   toggle key, host-tested
@@ -93,7 +93,7 @@ All new features default-off or default-to-original-behavior, in line with
 - Case-sensitive music paths on Linux — fixed
   ([#12](https://github.com/LBALab/lba2-classic-community/pull/12))
 
-### Audio/Video backends
+### Audio/video backends
 - SDL audio backend with Miles parity gap tracking
   ([#27](https://github.com/LBALab/lba2-classic-community/issues/27),
   [#28](https://github.com/LBALab/lba2-classic-community/pull/28),


### PR DESCRIPTION
## Result

Three tiny fixes to CHANGELOG's [Unreleased] section before the v0.9.0 tag.

## Changes

- **Stale Principle reference.** Line 55 read \`[AGENTS.md Principle 4](AGENTS.md#principles)\`. After PR #80 de-duplicated AGENTS.md Principles, "Optional features behind flags" moved from Principle 4 to Principle 3 (P4 is now "Quality over speed"). Updated to Principle 3.
- **Heading consistency.** \`### Audio/Video backends\` was the only heading in the file with mid-word capitalisation. Sentence-cased to \`### Audio/video backends\` to match every other heading.
- **Trailing space.** Stray trailing space at the end of the highlights blockquote ("...handheld devices in the wild. ").

## Verification

- \`git diff --stat\` shows 3 insertions, 3 deletions.
- No anchor references to the renamed heading anywhere else in the repo.