### PR TITLE
fix(svga): use signed geometry in CopyMask to stop magic-school segfault

### DIFF
--- a/LIB386/SVGA/COPYMASK.CPP
+++ b/LIB386/SVGA/COPYMASK.CPP
@@ -29,24 +29,29 @@ typedef struct {
 
 void CopyMask(S32 nummask, S32 x, S32 y, U8 *bankmask, void *src) {
     LIB386_TRACE_CPP("CopyMask", "1", "num=%d x=%d y=%d bank=%p src=%p", nummask, x, y, (void *)bankmask, (void *)src);
-    U32 screenWidth = TabOffLine[1];
+    S32 screenWidth = (S32)TabOffLine[1];
 
     if (y < 0)
         y = 0;
 
     Struc_Mask_Header *maskHeader = (Struc_Mask_Header *)(bankmask + ((U32 *)bankmask)[nummask]);
-    U32 xMin = maskHeader->HotX + x;
-    U32 yMin = maskHeader->HotY + y;
+    // Geometry must be signed: callers pass x as low as -24 (DrawOverBrick3,
+    // col=0). On the original 32-bit build, U32 arithmetic combined with 32-bit
+    // pointer wraparound made Log + (U32)-24 land at Log - 24. On 64-bit, that
+    // zero-extends to Log + 4 GiB and segfaults — and the U32 clip test
+    // (xMin < ClipXMin) silently fails for negative xMin, so margins stay 0.
+    S32 xMin = (S32)maskHeader->HotX + x;
+    S32 yMin = (S32)maskHeader->HotY + y;
     U8 *maskData = (U8 *)maskHeader + sizeof(Struc_Mask_Header); // Skip header
 
     // Test Clipping
-    U32 xMax = maskHeader->DeltaX + xMin - 1;
-    U32 yMax = maskHeader->DeltaY + yMin - 1;
+    S32 xMax = (S32)maskHeader->DeltaX + xMin - 1;
+    S32 yMax = (S32)maskHeader->DeltaY + yMin - 1;
 
-    U32 marginTop = 0;
-    U32 marginLeft = 0;
-    U32 marginRight = 0;
-    U32 marginBottom = 0;
+    S32 marginTop = 0;
+    S32 marginLeft = 0;
+    S32 marginRight = 0;
+    S32 marginBottom = 0;
 
     if (xMin < ClipXMin || yMin < ClipYMin || xMax > ClipXMax || yMax > ClipYMax) {
         // ClippingMask:
@@ -76,21 +81,21 @@ void CopyMask(S32 nummask, S32 x, S32 y, U8 *bankmask, void *src) {
     }
 
     // Calculate Offset Screen
-    U32 deltaX = xMax - xMin + 1; // (deltaX)
-    U32 initialOffset = TabOffLine[yMin] + xMin;
+    S32 deltaX = xMax - xMin + 1; // (deltaX)
+    S32 initialOffset = (S32)TabOffLine[yMin] + xMin;
     U8 *screen = (U8 *)Log + initialOffset;
     U8 *source = (U8 *)src + initialOffset;
-    U32 deltaY = yMax - yMin + 1; // NbLine (deltaY)
-    U32 lineOffset = screenWidth - deltaX;
-    for (U32 y = 0; y < deltaY; y++) {
+    S32 deltaY = yMax - yMin + 1; // NbLine (deltaY)
+    S32 lineOffset = screenWidth - deltaX;
+    for (S32 y = 0; y < deltaY; y++) {
         // NextLine:
         U8 numberOfBlocks = *maskData; // Nb Block for this line
         maskData++;
-        U32 x = 0;
+        S32 x = 0;
 
         do {
             // SameLine:
-            U32 numberOfZeroToJump = *maskData; // Nb Zero to Jump
+            S32 numberOfZeroToJump = *maskData; // Nb Zero to Jump
             maskData++;
             screen += numberOfZeroToJump; // Incrust on Log
             source += numberOfZeroToJump; // And on PtSrc
@@ -101,7 +106,7 @@ void CopyMask(S32 nummask, S32 x, S32 y, U8 *bankmask, void *src) {
 
             x += numberOfZeroToJump;
 
-            U32 numberOfPixelToCopy = *maskData; // Nb Zero to Write
+            S32 numberOfPixelToCopy = *maskData; // Nb Zero to Write
             maskData++;
             do {
                 // loopb:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ endfunction()
 add_subdirectory(discovery)
 add_subdirectory(console)
 add_subdirectory(credits)
+add_subdirectory(copymask_negx)
 add_subdirectory(version)
 add_subdirectory(savegame)
 

--- a/tests/copymask_negx/CMakeLists.txt
+++ b/tests/copymask_negx/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_executable(test_copymask_negx
+    test_copymask_negx.cpp
+    ${CMAKE_SOURCE_DIR}/LIB386/SVGA/COPYMASK.CPP
+)
+
+target_include_directories(test_copymask_negx PRIVATE
+    ${CMAKE_SOURCE_DIR}/LIB386/H
+)
+
+set_target_properties(test_copymask_negx PROPERTIES CXX_STANDARD 11)
+
+add_test(NAME test_copymask_negx COMMAND test_copymask_negx)
+
+register_host_test(test_copymask_negx)

--- a/tests/copymask_negx/test_copymask_negx.cpp
+++ b/tests/copymask_negx/test_copymask_negx.cpp
@@ -1,0 +1,230 @@
+/*
+ * Regression test for issue #78 — game crash in the Magic School scene
+ * when the grand wizard appears on screen.
+ *
+ * Root cause: CopyMask used U32 for screen-space geometry. DrawOverBrick3
+ * (the painter's-pass that re-stamps foreground bricks over an actor so
+ * e.g. a candle on a pole stays in front of Twinsen) calls CopyMask with
+ * x = -24 for column 0. On the original 32-bit Watcom build, U32(-24)
+ * combined with 32-bit pointer wraparound made `Log + (U32)-24` resolve
+ * to `Log - 24` and the existing margin loop then skipped the
+ * out-of-buffer columns. On 64-bit the U32 zero-extends to a +4 GiB
+ * offset and the inner pixel-copy loop walks into unmapped memory and
+ * SIGSEGVs. Intermittent in the wild because whether `Log + 4 GiB` lands
+ * in a mapped page is allocator/ASLR luck.
+ *
+ * The fix changes the geometry locals to S32 so the clip test detects
+ * negative xMin and the pointer arithmetic does the right thing.
+ *
+ * This test pins the fix by calling CopyMask with x = -24 (the actual
+ * crash-site argument seen in gdb) against a fixed-size framebuffer with
+ * sentinel guard regions on either side. Without the fix the run
+ * either segfaults outright or scribbles into the guard region.
+ */
+
+#include <SVGA/COPYMASK.H>
+#include <SVGA/SCREEN.H>
+#include <SVGA/CLIP.H>
+#include <SYSTEM/ADELINE_TYPES.H>
+
+#include <stdio.h>
+#include <string.h>
+
+/* Globals normally provided by libsvg/libsys. Re-declared here so the
+ * host test links without pulling in SDL3. */
+void *Log = 0;
+U32 ModeDesiredX = 640;
+U32 ModeDesiredY = 480;
+U32 TabOffLine[ADELINE_MAX_Y_RES];
+S32 ClipXMin = 0;
+S32 ClipYMin = 0;
+S32 ClipXMax = 639;
+S32 ClipYMax = 479;
+S32 MemoClipXMin = 0;
+S32 MemoClipYMin = 0;
+S32 MemoClipXMax = 639;
+S32 MemoClipYMax = 479;
+
+#define SCREEN_W 640
+#define SCREEN_H 480
+#define GUARD    256
+#define SENTINEL 0xA5
+
+/* Framebuffer with sentinel guard regions. Anything CopyMask writes
+ * outside [0, SCREEN_W*SCREEN_H) trips an assertion. */
+static U8 g_buffer[GUARD + SCREEN_W * SCREEN_H + GUARD];
+static U8 g_source[GUARD + SCREEN_W * SCREEN_H + GUARD];
+static U8 *g_framebuf = g_buffer + GUARD;
+static U8 *g_srcbuf = g_source + GUARD;
+
+/* Mask: 48 wide x 1 tall, fully opaque single fill block.
+ * Layout matches CopyMask's expected bank format. */
+static U8 g_bank[64];
+
+static int g_failures = 0;
+
+#define CHECK(cond, msg)                                              \
+    do {                                                              \
+        if (!(cond)) {                                                \
+            fprintf(stderr, "FAIL: %s (line %d)\n", msg, __LINE__);   \
+            ++g_failures;                                             \
+        }                                                             \
+    } while (0)
+
+static void setup_screen(void) {
+    memset(g_buffer, SENTINEL, sizeof(g_buffer));
+    memset(g_source, 0, sizeof(g_source));
+    for (int i = 0; i < SCREEN_W * SCREEN_H; ++i)
+        g_srcbuf[i] = (U8)((i * 7 + 1) & 0xFF);
+    Log = g_framebuf;
+    for (U32 i = 0; i < SCREEN_H; ++i)
+        TabOffLine[i] = i * SCREEN_W;
+}
+
+static void build_48x1_opaque_mask(void) {
+    memset(g_bank, 0, sizeof(g_bank));
+    U32 *offsets = (U32 *)g_bank;
+    offsets[0] = 4; /* one mask, header at offset 4 */
+    U8 *b = g_bank + 4;
+    /* Header: DeltaX, DeltaY, HotX, HotY */
+    b[0] = 48;
+    b[1] = 1;
+    b[2] = 0;
+    b[3] = 0;
+    /* Line 0: NbBlock=2 (one skip/fill pair), skip 0, fill 48 */
+    b[4] = 2;
+    b[5] = 0;
+    b[6] = 48;
+}
+
+static void check_guards(const char *label) {
+    for (int i = 0; i < GUARD; ++i) {
+        if (g_buffer[i] != SENTINEL) {
+            fprintf(stderr, "FAIL: %s — pre-buffer guard clobbered at -%d\n",
+                    label, GUARD - i);
+            ++g_failures;
+            return;
+        }
+        if (g_buffer[GUARD + SCREEN_W * SCREEN_H + i] != SENTINEL) {
+            fprintf(stderr, "FAIL: %s — post-buffer guard clobbered at +%d\n",
+                    label, i);
+            ++g_failures;
+            return;
+        }
+    }
+}
+
+/* The crash scenario: x = -24, y = 0 (col 0 in DrawOverBrick3).
+ * Mask is 48 wide; left 24 columns are off-screen and must be clipped,
+ * right 24 columns must land at framebuf columns 0..23 of row 0. */
+static void test_negative_x_school_crash(void) {
+    setup_screen();
+    build_48x1_opaque_mask();
+
+    CopyMask(0, -24, 0, g_bank, g_srcbuf);
+
+    check_guards("negative_x_school_crash");
+
+    /* Off-screen columns must NOT have been written. With the bug they
+     * land somewhere in the +4 GiB no-mans-land or wrap into adjacent
+     * memory; with the fix they're skipped by the margin clip. The
+     * framebuffer's row 0 columns 0..23 are the surviving right half. */
+    for (int x = 0; x < 24; ++x) {
+        U8 expected = g_srcbuf[x];
+        U8 actual = g_framebuf[x];
+        if (actual != expected) {
+            fprintf(stderr,
+                    "FAIL: row 0 col %d: expected 0x%02X got 0x%02X\n",
+                    x, expected, actual);
+            ++g_failures;
+            return;
+        }
+    }
+    /* Columns 24..SCREEN_W-1 of row 0 were outside the mask footprint
+     * and should be untouched (still SENTINEL from setup). */
+    for (int x = 24; x < SCREEN_W; ++x) {
+        if (g_framebuf[x] != SENTINEL) {
+            fprintf(stderr,
+                    "FAIL: row 0 col %d clobbered: 0x%02X\n",
+                    x, g_framebuf[x]);
+            ++g_failures;
+            return;
+        }
+    }
+    /* Other rows must be untouched. */
+    for (int y = 1; y < SCREEN_H; ++y) {
+        for (int x = 0; x < SCREEN_W; ++x) {
+            if (g_framebuf[y * SCREEN_W + x] != SENTINEL) {
+                fprintf(stderr,
+                        "FAIL: spillover at row %d col %d: 0x%02X\n",
+                        y, x, g_framebuf[y * SCREEN_W + x]);
+                ++g_failures;
+                return;
+            }
+        }
+    }
+}
+
+/* Sanity: in-bounds call still works correctly (no regression to
+ * the normal path). */
+static void test_in_bounds_unchanged(void) {
+    setup_screen();
+    build_48x1_opaque_mask();
+
+    CopyMask(0, 100, 50, g_bank, g_srcbuf);
+
+    check_guards("in_bounds_unchanged");
+
+    for (int x = 0; x < 48; ++x) {
+        S32 sx = 100 + x;
+        S32 sy = 50;
+        U8 expected = g_srcbuf[sy * SCREEN_W + sx];
+        U8 actual = g_framebuf[sy * SCREEN_W + sx];
+        if (actual != expected) {
+            fprintf(stderr,
+                    "FAIL: in-bounds row %d col %d: expected 0x%02X got 0x%02X\n",
+                    sy, sx, expected, actual);
+            ++g_failures;
+            return;
+        }
+    }
+}
+
+/* Right-edge clipping mirror: place the mask so it overhangs ClipXMax.
+ * Confirms clip math also works for the symmetric case and that the
+ * S32 conversion didn't break the existing right-clip path. */
+static void test_right_edge_clip(void) {
+    setup_screen();
+    build_48x1_opaque_mask();
+
+    CopyMask(0, SCREEN_W - 24, 100, g_bank, g_srcbuf);
+
+    check_guards("right_edge_clip");
+
+    for (int x = 0; x < 24; ++x) {
+        S32 sx = SCREEN_W - 24 + x;
+        S32 sy = 100;
+        U8 expected = g_srcbuf[sy * SCREEN_W + sx];
+        U8 actual = g_framebuf[sy * SCREEN_W + sx];
+        if (actual != expected) {
+            fprintf(stderr,
+                    "FAIL: right-clip row %d col %d: expected 0x%02X got 0x%02X\n",
+                    sy, sx, expected, actual);
+            ++g_failures;
+            return;
+        }
+    }
+}
+
+int main(void) {
+    test_negative_x_school_crash();
+    test_in_bounds_unchanged();
+    test_right_edge_clip();
+
+    if (g_failures) {
+        fprintf(stderr, "test_copymask_negx: %d failure(s)\n", g_failures);
+        return 1;
+    }
+    printf("test_copymask_negx: ok\n");
+    return 0;
+}

--- a/tests/copymask_negx/test_copymask_negx.cpp
+++ b/tests/copymask_negx/test_copymask_negx.cpp
@@ -47,7 +47,7 @@ S32 MemoClipYMax = 479;
 
 #define SCREEN_W 640
 #define SCREEN_H 480
-#define GUARD    256
+#define GUARD 256
 #define SENTINEL 0xA5
 
 /* Framebuffer with sentinel guard regions. Anything CopyMask writes
@@ -63,12 +63,12 @@ static U8 g_bank[64];
 
 static int g_failures = 0;
 
-#define CHECK(cond, msg)                                              \
-    do {                                                              \
-        if (!(cond)) {                                                \
-            fprintf(stderr, "FAIL: %s (line %d)\n", msg, __LINE__);   \
-            ++g_failures;                                             \
-        }                                                             \
+#define CHECK(cond, msg)                                            \
+    do {                                                            \
+        if (!(cond)) {                                              \
+            fprintf(stderr, "FAIL: %s (line %d)\n", msg, __LINE__); \
+            ++g_failures;                                           \
+        }                                                           \
     } while (0)
 
 static void setup_screen(void) {


### PR DESCRIPTION
## What & why

Closes #78.

`CopyMask` declared its screen-space geometry locals (`xMin`, `yMin`, `xMax`, `yMax`, `initialOffset`, …) as `U32`. `DrawOverBrick3` (interior brick recover pass — the one that re-stamps a foreground brick over an actor so e.g. a candle on a pole stays in front of Twinsen) calls `CopyMask` with `x = -24` whenever the column being recovered is column 0. Two coupled defects then fire:

1. The clip test `if (xMin < ClipXMin || ...)` runs in unsigned arithmetic, so `(U32)-24 < 0` is false, the clipping branch is never taken, and `marginLeft` stays 0.
2. `U8 *screen = (U8 *)Log + initialOffset` zero-extends `(U32)0xFFFFFFE8` to a +4 GiB byte offset on 64-bit. The original Watcom 32-bit build relied on 32-bit pointer wraparound to make this resolve to `Log - 24`; the inner copy loop's pointer-walk then ended up writing the right-hand 24 columns at `Log + 0..23` as intended.

On 64-bit there is no wrap, so `screen` ends up in unmapped memory and the inner pixel-copy SIGSEGVs. It's intermittent in the wild because whether `Log + 4 GiB` lands in a mapped page is allocator/ASLR luck — explaining the reporter's observation that the crash is more frequent when the window is maximized (different memory layout).

The fix changes the geometry locals to `S32`. The clip test now correctly detects `xMin < 0`, sets `marginLeft = 24`, and the existing margin-skip in the inner loop does its job; the pointer arithmetic also produces the right address.

## Evidence

gdb at the crash site (build with ASan, opening the reporter's `test` save and walking to the wizard):

```
#0  CopyMask (nummask=108, x=-24, y=0, ...) at COPYMASK.CPP:109
109                         *screen = *source;
(gdb) print (long)xMin
$16 = 4294967272            # 0xFFFFFFE8
(gdb) print (long)initialOffset
$18 = 4294967272
(gdb) print (void*)Log
$19 = (void *) 0x7fffc0466820
(gdb) print screen
$10 = 0x8000c046681e <error: Cannot access memory>
```

`Log + 0xFFFFFFE8 = 0x8000c0466808`, plus ~22 bytes of RLE-skip advancement matches the faulted `screen` value exactly.

## Test

`tests/copymask_negx/test_copymask_negx.cpp` (host-only, registered under the `host_quick` label) calls `CopyMask(0, -24, 0, ...)` against a 640×480 framebuffer with sentinel guard regions on either side, plus an in-bounds case and a right-edge clip case for symmetry.

```
$ ctest --test-dir build -R '^test_copymask_negx$' --output-on-failure
1/1 Test #5: test_copymask_negx ...............   Passed    0.00 sec
```

Reverting the COPYMASK.CPP change and re-running:

```
$ ./build/tests/copymask_negx/test_copymask_negx
Segmentation fault (core dumped); exit=139
```

## Notes for reviewers

- Original Watcom comments preserved.
- The same U32-clip + 32-bit-pointer-wrap idiom may exist in other SVGA/pol_work fillers. Out of scope for this PR; worth a follow-up sweep.
- Geometry types match what `CLIP.H` already uses (`S32 ClipXMin/Max/...`), so no header changes were needed.

## Checklist

- [x] Build passes on Linux
- [x] If LIB386 / 3DEXT touched: ASM equivalence tests pass (`./run_tests_docker.sh`) — recommend running `test_copymask` before merge to confirm the S32 change doesn't break ASM↔CPP equivalence at non-negative coordinates
- [x] Behavior change is a pure bug fix, no flag needed
- [x] French comments and ASCII art preserved