### PR TITLE
docs(platform,debug): document U32 wrap class and crash-investigation runbook

### DIFF
--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -4,6 +4,8 @@ LBA2's retail data files (HQR resources, save games) were authored against the o
 
 Truth hierarchy: code > this document > external sources.
 
+This doc is scoped to **on-disk** struct layout. For 32→64-bit pointer hazards in **runtime** renderer math (`U32` + pointer arithmetic that loses 32-bit address-space wrap), see [PLATFORM.md §1 — Renderer-side wraparound](PLATFORM.md#renderer-side-wraparound). For the asan + gdb workflow used to catch these, see [CRASH_INVESTIGATION.md](CRASH_INVESTIGATION.md).
+
 ## The rule
 
 > A struct whose layout is dictated by a retail file or a legacy save format must never assume `sizeof(T)` matches the on-disk record size.

--- a/docs/CRASH_INVESTIGATION.md
+++ b/docs/CRASH_INVESTIGATION.md
@@ -1,0 +1,110 @@
+# Crash investigation runbook
+
+How to investigate a native crash in this engine — the asan + gdb workflow, with the commands that have actually worked. Companion to [PLATFORM.md](PLATFORM.md), which catalogues the hazard classes; this doc is the process for finding which class a crash belongs to.
+
+## Quick path
+
+Most crashes are localised. The fast loop is:
+
+1. Reproduce under gdb to get a stack frame.
+2. If the stack alone doesn't tell you what's wrong, rebuild (or preload) with AddressSanitizer and rerun.
+3. Inspect frame state at the fault to identify what's malformed.
+
+Don't reach for ASan on a known null deref or a clean assertion failure — gdb alone is enough. Reach for ASan when the crash is intermittent, or the stack ends inside a tight inner loop where the actual cause is upstream.
+
+## Building with AddressSanitizer
+
+There are two paths. The preload trick gets you running without rebuilding the world; the static-link build is cleaner for repeat sessions.
+
+### Option A — preload at run time (no rebuild)
+
+If you have a debug build but not an ASan build, this is the quick path. Inside gdb:
+
+```
+(gdb) set exec-wrapper env LD_PRELOAD=$(gcc -print-file-name=libasan.so)
+(gdb) set environment LBA2_GAME_DIR=/path/to/data
+(gdb) run
+```
+
+Without the preload you'll see `ASan runtime does not come first in initial library list` and the process exits immediately — that error is the signal you forgot the wrapper. Use `clang -print-file-name=libclang_rt.asan-*.so` instead of `gcc` if you're on a clang build.
+
+### Option B — link statically (recommended for repeated runs)
+
+```bash
+cmake -B build-asan -DCMAKE_BUILD_TYPE=Debug \
+  -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -static-libasan -static-libubsan" \
+  -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -static-libasan -static-libubsan" \
+  -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined -static-libasan -static-libubsan"
+cmake --build build-asan -j
+```
+
+Run via `gdb --args ./build-asan/SOURCES/lba2 --game-dir /path/to/data`.
+
+### ASan options worth setting
+
+```
+(gdb) set environment ASAN_OPTIONS=abort_on_error=1:halt_on_error=1
+(gdb) set environment UBSAN_OPTIONS=print_stacktrace=1:abort_on_error=1
+```
+
+Without `abort_on_error=1`, ASan prints its report and calls `exit()`, which gdb passes through — you lose the live stack. With it, gdb stops at the moment of the bad access so you can interrogate state in place.
+
+## Inspecting state at the crash
+
+When SIGSEGV hits, the cheap interrogation:
+
+```
+(gdb) bt
+(gdb) frame N             # walk to the frame you care about
+(gdb) info locals
+(gdb) print var
+(gdb) print (long)var     # if var is unsigned, see the actual value as signed
+(gdb) print (void*)Log    # printable form of an opaque pointer
+(gdb) x/16xb maskData-16  # peek at bytes around a buffer cursor
+(gdb) info registers
+```
+
+Compute the offending pointer by hand and check it matches the faulted address — this is how you go from "crashed somewhere in a loop" to "the offset was constructed wrong before the loop ran":
+
+```
+(gdb) print (void*)(Log + (long)initialOffset)
+```
+
+If that matches `screen` (or is within a few bytes — the inner loop will have advanced it), the offset was constructed wrong upstream. Walk back up the call stack until you find where the bad value was introduced.
+
+## Reading ASan output
+
+The header line tells you what kind of bad access it was:
+
+| Header | What it usually means | Where to look |
+|---|---|---|
+| `heap-buffer-overflow` | Walked off a `malloc`'d buffer | `freed by` and `allocated at` traces show the buffer's lifetime |
+| `heap-use-after-free` | Read/wrote freed memory | The `freed by` stack tells you who freed it |
+| `stack-buffer-overflow` | Walked off a stack array | The function holding the array |
+| `global-buffer-overflow` | Walked off a static/global array | The `0x… is located N bytes (after) the variable …` line names the symbol |
+| `stack-use-after-return` | Returned a pointer to a local | The frame where the local was declared |
+| `SEGV` (ASan ran but didn't catch) | Wild pointer not in any tracked allocation | Probably bad pointer arithmetic; gdb is the better tool from here |
+
+The last row is the one that means "the bug isn't a normal overrun." That's the signal to pivot from ASan to gdb-and-arithmetic.
+
+## When the bug is a pointer-arithmetic trap
+
+If the faulted target pointer (`screen`, `dst`, etc.) lands far outside any expected buffer, and the local offset variables include a `U32` that may have come from a signed source, suspect a 32→64-bit wraparound. See [PLATFORM.md §1 — Renderer-side wraparound](PLATFORM.md#renderer-side-wraparound) for the class. Worked example with full transcript: [PR #84](https://github.com/LBALab/lba2-classic-community/pull/84).
+
+The mechanical proof for a wrap bug: at the fault site, `print (long)<offset_var>` shows a value near `0xFFFFFFE8` (or any large near-`UINT32_MAX` figure), `print (void*)Log` shows the buffer base, and `Log + that_offset` matches the faulted pointer to within a few bytes. That's the signature; once you see it, fix is to switch the geometry locals to `S32`.
+
+## After the fix: pin it
+
+Per [project policy](FEATURE_WORKFLOW.md), bug fixes land with a regression test. For host-only repros (no Docker, no retail data), the pattern is:
+
+- New `tests/<name>/` directory with `test_<name>.cpp` and `CMakeLists.txt`.
+- `register_host_test(test_<name>)` in the `CMakeLists.txt` adds it under the `host_quick` ctest label.
+- `add_subdirectory(<name>)` in `tests/CMakeLists.txt`.
+
+Working example: `tests/copymask_negx/`. Verify the test catches the regression by reverting the fix, rebuilding, and confirming the test fails — only then is it pinning anything useful.
+
+## Things that look like crashes but aren't
+
+- **`ASan runtime does not come first…`** — preload not set. See Option A above.
+- **`AddressSanitizer:DEADLYSIGNAL`** with no detail — usually means ASan caught a SEGV but couldn't symbolize. Build with `-fno-omit-frame-pointer` (or attach gdb to the running process) and re-run.
+- **`stack-overflow on …`** with a deep stack — usually unbounded recursion, not a corruption bug.

--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -33,6 +33,32 @@ Canonical sites:
 
 **Next:** A canonical `NUM_VERSION 37+` save format that does not memcpy pointer-bearing structs would remove this category for new saves entirely; legacy loaders stay in place. Tracked at [issue #64](https://github.com/LBALab/lba2-classic-community/issues/64).
 
+### Renderer-side wraparound
+
+A second, independent face of the 32→64-bit pointer transition, distinct from the disk-layout side above: pointer arithmetic with a `U32` offset that may legitimately be negative. On 32-bit, `pointer + (U32)-24` wraps in the address space and resolves to `pointer - 24`. On 64-bit it zero-extends to a +4 GiB byte offset, so the pointer lands in unmapped memory — or, worse, a mapped page belonging to something else, which is silent corruption.
+
+Coupled defect that hides the first one: clip tests written in `U32` (`if (xMin < ClipXMin)`) silently fail for negative `xMin`, so the existing margin/clip branch never fires and the corrupted offset reaches the inner loop unnoticed.
+
+Worked example — `LIB386/SVGA/COPYMASK.CPP`, called from `DrawOverBrick3` (interior brick recover pass) with `x = -24` for column 0. The school scene with the grand wizard and foreground candles triggers it on every entry. Fixed in [PR #84](https://github.com/LBALab/lba2-classic-community/pull/84) by switching the geometry locals to `S32`. Pinned by `tests/copymask_negx/`. Investigation runbook in [CRASH_INVESTIGATION.md](CRASH_INVESTIGATION.md).
+
+The smell: a renderer-adjacent function takes signed coordinates but stores them in `U32` locals before doing pointer math against `Log` / `Screen`. Crashes are intermittent because whether `pointer + 4 GiB` lands in a mapped page is allocator/ASLR luck — easy to mistake for "flaky" rather than a real bug.
+
+Audit candidates (not yet swept):
+
+- `LIB386/SVGA/` — sprite, mask, scale, font fillers
+- `LIB386/pol_work/` — flat, gouraud, textured, z-buffer, fog
+- `LIB386/3D/`, `SOURCES/3DEXT/` — projection-adjacent paths
+- `SOURCES/GRILLE.CPP`, `SOURCES/INTEXT.CPP` — interior recover pass
+
+#### Audit log
+
+| File | Function | Verdict | Notes |
+|---|---|---|---|
+| `LIB386/SVGA/COPYMASK.CPP` | `CopyMask` | fixed | PR #84 |
+| `LIB386/SVGA/MASK.CPP` | `ClippingMask` | safe | Geometry locals already `S32`; clipping is explicit before pointer math. |
+
+**Next:** Sweep the candidate list above. Each hit gets either a fix-with-test PR or an in-source justification for why no negative coordinate ever reaches the pointer math.
+
 ---
 
 ## 2. Endianness &nbsp;&nbsp;&nbsp;&nbsp; ✗ exposed


### PR DESCRIPTION
## What & why

Companion docs to PR #84. That PR fixed one instance of a 32→64-bit pointer-arithmetic trap in `CopyMask`; this PR names the class and writes down how to find more.

Two pieces:

**`PLATFORM.md` §1 gains a "Renderer-side wraparound" subsection.** Section 1 was scoped to disk-serialized structs; this adds the runtime sibling — `U32` + pointer arithmetic that loses 32-bit address-space wrap on 64-bit, paired with `U32` clip tests that silently fail for negative offsets. Includes the worked example, the smell pattern (renderer-adjacent function takes signed coords but stores them in `U32` before pointer math against `Log` / `Screen`), the audit-candidate file groups, and a per-file audit log table seeded with the two known verdicts (`COPYMASK.CPP` fixed, `MASK.CPP` already safe).

**New `CRASH_INVESTIGATION.md` is a runbook** for the asan + gdb workflow we used. Both ASan paths are covered: the `LD_PRELOAD=$(gcc -print-file-name=libasan.so)` trick when you don't want to rebuild, and the `-static-libasan` build for repeat sessions. Lists the `ASAN_OPTIONS` that keep gdb attached (`abort_on_error=1:halt_on_error=1` — without this, ASan exits and gdb passes through, losing the live stack), the gdb interrogation sequence (`bt`, `frame N`, `print (long)var` to read unsigneds as signed, `print (void*)(Log + (long)offset)` to verify the bad pointer construction), and the mechanical proof signature for a wrap bug. ASan output table for the common headers and what they mean.

`ABI.md` gets a one-line cross-link clarifying its on-disk scope vs. PLATFORM.md's runtime scope.

## Notes for reviewers

- Audit log table in PLATFORM.md is the anchor for the upcoming sweep PRs (one per file group). Each sweep PR will append rows.
- No code changes. CI runs format + tests but nothing here exercises them.
- PR #84 is referenced as the worked example — fine if it merges first or after; either ordering reads cleanly.

## Checklist

- [x] Build passes — N/A, docs only
- [x] No behavior change
- [x] Docs updated in the same PR if behavior or workflow changed — this *is* the docs PR
- [x] French comments and ASCII art preserved — N/A
