### PR TITLE
docs(platform): SVGA U32-wrap audit — 17 files swept, 1 fixed, 0 new bugs

### DIFF
--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -52,12 +52,34 @@ Audit candidates (not yet swept):
 
 #### Audit log
 
+Verdicts:
+- **fixed** — bug was present; PR landed.
+- **safe** — defensive clipping precedes the pointer math in this function. Negative inputs cannot reach the U32 conversion.
+- **safe (convention)** — no defensive clipping, but every caller in the tree passes non-negative coordinates. Latent trap if a future caller ever passes negative — worth a comment in-source pointing at this audit if you touch one of these.
+
 | File | Function | Verdict | Notes |
 |---|---|---|---|
-| `LIB386/SVGA/COPYMASK.CPP` | `CopyMask` | fixed | PR #84 |
-| `LIB386/SVGA/MASK.CPP` | `ClippingMask` | safe | Geometry locals already `S32`; clipping is explicit before pointer math. |
+| `LIB386/SVGA/AFFSTR.CPP` | `AffString`, `AffStringToBuffer` | safe (convention) | Pointer math uses `Log + TabOffLine[y] + x`; signed `+ x` is correct, but `TabOffLine[y]` would OOB-read for negative `y`. All callers are UI/menu code with non-negative coords. |
+| `LIB386/SVGA/BLITBOXF.CPP` | `BlitBoxF` | safe | Fixed coordinates (160, 140); no signed input. |
+| `LIB386/SVGA/BOX.CPP` | `Box` | safe | Signed clipping clamps `x0/y0/x1/y1` into the clip rect before any U32 math. |
+| `LIB386/SVGA/CALCMASK.CPP` | `CalcGraphMsk` | safe | Operates on bank data; no screen-pointer math. |
+| `LIB386/SVGA/CLRBOXF.CPP` | `ClearBox` | safe (convention) | Indexes `TabOffDst[y]` with `S16` from a `T_BOX`. All callers populate the box with non-negative bounds. |
+| `LIB386/SVGA/COPYMASK.CPP` | `CopyMask` | fixed | PR #84. |
+| `LIB386/SVGA/CPYBLOCI.CPP` | `CopyBlockIncrust` | safe | Signed clipping precedes pointer math; both source and destination clipped. |
+| `LIB386/SVGA/CPYBLOCK.CPP` | `CopyBlock` | safe | Same pattern as `CopyBlockIncrust`. |
+| `LIB386/SVGA/FONT.CPP` | `Font`, `CarFont`, `SizeFont` | safe | Delegates to `AffMask` (in `MASK.CPP`). |
+| `LIB386/SVGA/GRAPH.CPP` | `AffGraph`, `ClippingGraph` | safe | Fast-path `AffGraph` dispatches negative-or-overhanging cases to `ClippingGraph`. Both compute pointers as `Log + TabOffLine[y] + x` (pointer + S32, not pointer + U32 — the failing pattern). |
+| `LIB386/SVGA/MASK.CPP` | `AffMask`, `ClippingMask` | safe | Geometry locals already `S32`; clipping explicit before pointer math. |
+| `LIB386/SVGA/PLOT.CPP` | `Plot`, `GetPlot` | safe | Hard signed clip-rect check at entry; returns early on out-of-range. |
+| `LIB386/SVGA/RESBLOCK.CPP` | `RestoreBlock` | safe (convention) | No defensive clipping; mirrored with `SaveBlock` so callers pair the two with the same coords. All call sites use non-negative menu/UI coords. |
+| `LIB386/SVGA/SAVBLOCK.CPP` | `SaveBlock` | safe (convention) | Same pattern and caller set as `RestoreBlock`. |
+| `LIB386/SVGA/SCALEBOX.CPP` | `ScaleBox` | safe (convention) | No defensive clipping. All call sites pass full-screen or hard-coded non-negative source rects. |
+| `LIB386/SVGA/SCALESPI.CPP` | `ScaleSprite` | safe | All-S32 clipping clamps `sx/sy/end_x/end_y` to the clip rect before pointer math. |
+| `LIB386/SVGA/SCALESPT.CPP` | `ScaleSpriteTransp` | safe | Both fast (1:1) and scaled paths clip with signed compares before pointer math. |
 
-**Next:** Sweep the candidate list above. Each hit gets either a fix-with-test PR or an in-source justification for why no negative coordinate ever reaches the pointer math.
+**Status:** SVGA group swept. Only `CopyMask` had the bug. Five files are "safe by convention" — they would break if any future caller passed a negative coordinate; flagged here so the next person who touches them sees the trap.
+
+**Next:** Sweep `LIB386/pol_work/`, `LIB386/3D/` + `SOURCES/3DEXT/`, then `SOURCES/GRILLE.CPP` + `SOURCES/INTEXT.CPP`. `LIB386/pol_work/POLYLINE.CPP` is reachable from SVGA via `Rect` → `Line`, so the pol_work sweep also covers that edge.
 
 ---
 


### PR DESCRIPTION
## What & why

First sweep PR following the framework set up in #85. Audits `LIB386/SVGA/` for the same U32-wrap-plus-failed-clip pattern that caused #78 in `CopyMask`.

**Result: CopyMask was the only bug in this group.** Seventeen files swept; one already fixed (#84); twelve have proper defensive signed clipping before U32 conversion; five are "safe by convention" — no defensive clipping, but every caller in the tree passes non-negative coordinates today.

The audit log table in `PLATFORM.md` §1 "Renderer-side wraparound" gains the per-file rows. Verdict legend added so the three categories (`fixed`, `safe`, `safe (convention)`) read unambiguously.

## Notes for reviewers

- Docs only. No code touched.
- The "safe (convention)" rows are interesting: `AFFSTR`, `CLRBOXF`, `RESBLOCK`, `SAVBLOCK`, `SCALEBOX` have no defensive clipping. They work today only because every caller passes non-negative coords. If a future change ever makes one of those callers compute coords from a signed source that could go negative, you'd reproduce #78 in a new spot. Recording the convention here means the next person to touch them sees the trap.
- `LIB386/pol_work/POLYLINE.CPP` is reachable from this group via `Rect()` → `Line()` but lives in `pol_work/`. Will get covered in the pol_work sweep PR.

## Checklist

- [x] No code changes
- [x] No behavior change
- [x] Docs updated — this *is* the docs update
