### PR TITLE
docs(platform): pol_work U32-wrap audit — 13 files swept, 0 new bugs

### DIFF
--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -76,10 +76,17 @@ Verdicts:
 | `LIB386/SVGA/SCALEBOX.CPP` | `ScaleBox` | safe (convention) | No defensive clipping. All call sites pass full-screen or hard-coded non-negative source rects. |
 | `LIB386/SVGA/SCALESPI.CPP` | `ScaleSprite` | safe | All-S32 clipping clamps `sx/sy/end_x/end_y` to the clip rect before pointer math. |
 | `LIB386/SVGA/SCALESPT.CPP` | `ScaleSpriteTransp` | safe | Both fast (1:1) and scaled paths clip with signed compares before pointer math. |
+| `LIB386/pol_work/POLY.CPP` | `Fill_Poly`, `Fill_PolyClip`, `Draw_Triangle`, `Fill_Clip*` | safe | `Fill_PolyClip` computes the polygon bounding box, returns early if it doesn't overlap the clip rect, and dispatches to `Fill_ClipXMin/XMax/YMin/YMax` (Sutherland–Hodgman clippers) before any vertex reaches `Draw_Triangle`'s pointer math. By construction `Pt_XE/Pt_YE` are non-negative in the rasteriser. |
+| `LIB386/pol_work/POLYCLIP.CPP` | `ClipperZ`, `Clipping_ZFPU` | safe | Operates in 3D vertex space (`STRUC_CLIPVERTEX::V_X0/V_Y0/V_Z0`); no screen-pointer math. |
+| `LIB386/pol_work/POLYDISC.CPP` | `Fill_Sphere`, `Sph_Line_*` | safe | `Fill_Sphere` computes `Sph_XMin/XMax/YMin/YMax` with signed clipping against the clip rect before invoking any `Sph_Line_*`. The line fillers take a `U32 screenY` whose value is bounded by clipped `Sph_YMin/YMax`. |
+| `LIB386/pol_work/POLYFLAT.CPP`, `POLYGOUR.CPP`, `POLYTEXT.CPP`, `POLYTEXZ.CPP`, `POLYTZF.CPP`, `POLYTZG.CPP`, `POLYGTEX.CPP` | `Filler_*` family | safe | All take `(U32 nbLines, U32 fillCurXMin, U32 fillCurXMax)`. By construction reached only from the `Fill_PolyClip → Draw_Triangle` pipeline after polygon vertices have been clipped against the screen rect. No way for a negative coordinate to enter. |
+| `LIB386/pol_work/POLYLINE.CPP` | `Line`, `Line_Entry`, `Line_A`, `Line_ZBuffer`, `Line_ZBuffer_NZW` | safe | Heavy upfront signed clipping (DX-zero, DY-zero, and general edge cases all clamp `x0/x1/y0/y1` to the clip rect via `continue`/`return`) before any pointer math. The post-clip `U32 offset = PTR_TabOffLine[y0] + x0` and pointer-walk `dst += incrX/incrY` operate on values guaranteed non-negative. |
+| `LIB386/pol_work/POLY_JMP.CPP` | `Jmp_Solid`, `Jmp_Transparent`, `Jmp_Trame*`, etc. | safe | Pure dispatch tables; no screen-pointer math. |
+| `LIB386/pol_work/TESTVUEF.CPP` | `Test_VueF` | safe | Visibility-test helper; no screen-pointer math. |
 
-**Status:** SVGA group swept. Only `CopyMask` had the bug. Five files are "safe by convention" — they would break if any future caller passed a negative coordinate; flagged here so the next person who touches them sees the trap.
+**Status:** SVGA + pol_work groups swept. Only `CopyMask` had the bug across both. Renderer architecture insight: pol_work is safe *by construction* — `Fill_PolyClip` is the unconditional gateway that clips polygon bounding boxes against the clip rect before any vertex reaches the rasteriser, so fillers can legitimately use `U32` for `nbLines`/`fillCurXMin`/`fillCurXMax` without hazard. The same is true for `Fill_Sphere` and every `Line_*` variant. SVGA was riskier because its functions are entry points called from arbitrary UI/HUD code without a single gateway equivalent.
 
-**Next:** Sweep `LIB386/pol_work/`, `LIB386/3D/` + `SOURCES/3DEXT/`, then `SOURCES/GRILLE.CPP` + `SOURCES/INTEXT.CPP`. `LIB386/pol_work/POLYLINE.CPP` is reachable from SVGA via `Rect` → `Line`, so the pol_work sweep also covers that edge.
+**Next:** Sweep `LIB386/3D/` + `SOURCES/3DEXT/` (projection-adjacent — likely operates pre-clip in world/view space rather than screen space, but worth confirming), then `SOURCES/GRILLE.CPP` + `SOURCES/INTEXT.CPP` (interior recover pass — caller side of the original `CopyMask` bug; worth checking for off-by-one writes that corrupt `ListBrickColon` boundaries).
 
 ---
 


### PR DESCRIPTION
## What & why

Second sweep PR following #86. Audits `LIB386/pol_work/` for the U32-wrap-plus-failed-clip pattern from #78.

**Result: zero new bugs.** All 13 files in the group are safe.

The interesting finding is *why*: pol_work is safe by **construction**, not by accident. `Fill_PolyClip` (in `POLY.CPP`) is an unconditional gateway — it computes the polygon bounding box, returns early on no overlap with the clip rect, and dispatches to dedicated 2D clippers (`Fill_ClipXMin/XMax/YMin/YMax`, Sutherland–Hodgman) before any vertex reaches `Draw_Triangle`'s pointer math. So the fillers can legitimately use `U32` for `nbLines`/`fillCurXMin`/`fillCurXMax` without hazard — the values arrive non-negative by guarantee.

The same shape holds for `Fill_Sphere` (POLYDISC, signed clip then invoke `Sph_Line_*` with `U32 screenY`) and the `Line_*` family (POLYLINE, heavy upfront signed clipping for every code path before any pointer math).

POLYCLIP operates in 3D vertex space — no screen pointers. POLY_JMP and TESTVUEF have no screen-pointer math.

## Renderer architecture observation

Worth recording for the next person who wonders why this took only one PR's worth of work:

> pol_work is safe by **construction** because `Fill_PolyClip` is the unconditional gateway. SVGA was riskier (and produced #78) because its functions are entry points called from arbitrary UI/HUD code with no single gateway equivalent.

Added to the audit-log notes in `PLATFORM.md` so the architectural why is captured alongside the per-file verdicts.

## Notes for reviewers

- Docs only. No code touched.
- Next planned sweeps: `LIB386/3D/` + `SOURCES/3DEXT/` (likely safe — projection-adjacent code operates pre-clip in world/view space, not screen space), then `SOURCES/GRILLE.CPP` + `SOURCES/INTEXT.CPP` (caller side of the original CopyMask bug; worth checking for the off-by-one ListBrickColon write I noticed during initial diagnosis).

## Checklist

- [x] No code changes
- [x] No behavior change
- [x] Docs updated — this *is* the docs update
