### PR TITLE
docs(changelog): credit foundational contributors and refresh body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,9 @@ All new features default-off or default-to-original-behavior, in line with
 
 ### Cross-platform & build
 
+- First Linux release artifact: AppImage built in CI from an any-linux
+  base, packaged as a single portable binary
+  ([#74](https://github.com/LBALab/lba2-classic-community/pull/74))
 - macOS CI build (arm64); macOS x86_64 preset
   ([#52](https://github.com/LBALab/lba2-classic-community/pull/52))
 - Portable Windows build via MSYS2 UCRT64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,15 +20,13 @@ fork's evolution.
 > **Highlights since the fork**
 >
 > The biggest architectural shift is portability. The playable game now
-> builds **without an ASM toolchain** — pure C/C++ on the build path,
-> linked against SDL3 and `libsmacker`. The original 16/32-bit x86
-> assembly is still in the tree (it remains the source of truth and is
-> required to run the ASM↔C++ equivalence tests), but it is **no longer
-> in the build path of the playable binary**. Combined with the SDL3
-> port, this unlocked native builds for **Linux x86_64**, **macOS
-> arm64/x86_64**, and **Windows (MSYS2 UCRT64)**, and keeps the door
-> open to other SDL platforms. Community members have already started
-> building it on handheld devices in the wild.
+> builds as pure C/C++ against SDL3 and `libsmacker`, with no ASM
+> toolchain on the build path. The original 16/32-bit x86 assembly is
+> still in the tree as the source of truth and powers the ASM↔C++
+> equivalence tests, but it no longer runs in the playable binary.
+> Native builds for Linux x86_64, macOS arm64/x86_64, and Windows
+> (MSYS2 UCRT64). Community members are already running it on handheld
+> devices in the wild.
 
 ### Stability & 64-bit hardening
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,20 @@ fork's evolution.
 
 ### Stability & 64-bit hardening
 
+- Magic-school grand-wizard crash on 64-bit hosts — fixed
+  ([#78](https://github.com/LBALab/lba2-classic-community/issues/78),
+  [#84](https://github.com/LBALab/lba2-classic-community/pull/84)).
+  U32+pointer-wraparound trap in `CopyMask`, pinned by a host-only
+  regression test.
+- Renderer-side U32+pointer-wrap class named, documented, and swept
+  across ~80 files in SVGA, pol_work, 3D, 3DEXT, GRILLE, INTEXT — one
+  bug fixed (above), six "safe by convention" latent traps recorded
+  ([#85](https://github.com/LBALab/lba2-classic-community/pull/85),
+  [#86](https://github.com/LBALab/lba2-classic-community/pull/86),
+  [#87](https://github.com/LBALab/lba2-classic-community/pull/87),
+  [#88](https://github.com/LBALab/lba2-classic-community/pull/88),
+  [#89](https://github.com/LBALab/lba2-classic-community/pull/89),
+  [#90](https://github.com/LBALab/lba2-classic-community/pull/90))
 - Endgame credits segfault on 64-bit hosts — fixed
   ([#65](https://github.com/LBALab/lba2-classic-community/issues/65),
   [#66](https://github.com/LBALab/lba2-classic-community/pull/66))
@@ -172,32 +186,61 @@ All new features default-off or default-to-original-behavior, in line with
 - [docs/CONSOLE.md](docs/CONSOLE.md), [docs/DEBUG.md](docs/DEBUG.md),
   [docs/CAMERA.md](docs/CAMERA.md),
   [docs/FEATURE_WORKFLOW.md](docs/FEATURE_WORKFLOW.md)
+- [docs/PLATFORM.md](docs/PLATFORM.md) — host-assumptions map
+  (pointer width, endianness, FPU semantics, OS boundaries),
+  [docs/PLATFORM_AUDITS.md](docs/PLATFORM_AUDITS.md) — per-file audit
+  logs hung off it
+  ([#85](https://github.com/LBALab/lba2-classic-community/pull/85),
+  [#88](https://github.com/LBALab/lba2-classic-community/pull/88))
+- [docs/ABI.md](docs/ABI.md) — disk-layout patterns for fat structs
+  on 64-bit ([#67](https://github.com/LBALab/lba2-classic-community/pull/67))
+- [docs/CRASH_INVESTIGATION.md](docs/CRASH_INVESTIGATION.md) —
+  AddressSanitizer + gdb runbook
+  ([#85](https://github.com/LBALab/lba2-classic-community/pull/85))
+- [docs/COMPILER_NOTES.md](docs/COMPILER_NOTES.md),
+  [docs/TESTING.md](docs/TESTING.md)
 - [docs/FRENCH_COMMENTS.md](docs/FRENCH_COMMENTS.md) and
   [docs/ASCII_ART.md](docs/ASCII_ART.md) — preservation catalogs
 
-### Earliest fork work
+### Pre-PR foundations
+
+Most of what made this fork buildable and cross-platform predates the
+PR workflow. The themes from that direct-commit era — CMake build
+system and MinGW cross-compile to Windows ([@leokolln](https://github.com/leokolln)),
+macOS M1 build, the bulk of the LIB386 ASM→C++ port, and the ASM↔CPP
+equivalence test infrastructure ([@sergiou87](https://github.com/sergiou87)),
+early renderer/SVGA/object-display ASM→CPP ports ([@xesf](https://github.com/xesf)),
+all building on [@yaz0r](https://github.com/yaz0r)'s original buildable
+prototype — are credited under Contributors below.
+
+The earliest PR-tracked entries that sit alongside that work:
 
 - File encoding preservation
   ([#1](https://github.com/LBALab/lba2-classic-community/pull/1))
-- SDL audio, Smacker FMV, SDL renderer first land
-  ([#9](https://github.com/LBALab/lba2-classic-community/pull/9),
-  [#10](https://github.com/LBALab/lba2-classic-community/pull/10),
-  [#11](https://github.com/LBALab/lba2-classic-community/pull/11))
 - Preservation docs and build configuration clarity
   ([#13](https://github.com/LBALab/lba2-classic-community/pull/13))
 
 ### Contributors
 
 Thanks to everyone who's worked on this fork to date:
+[@gwen-gg](https://github.com/gwen-gg),
 [@innerbytes](https://github.com/innerbytes),
+[@leokolln](https://github.com/leokolln),
+[@Link4Electronics](https://github.com/Link4Electronics),
 [@noctonca](https://github.com/noctonca),
 [@sergiou87](https://github.com/sergiou87),
-[@xesf](https://github.com/xesf).
+[@xesf](https://github.com/xesf),
+[@yaz0r](https://github.com/yaz0r).
 
 
-Special thanks to [@xesf](https://github.com/xesf), one of the owners of LBALab, for foundational early ASM→C++ renderer/SVGA/object-display porting work that helped establish the modern cross-platform baseline of this fork.
+Special thanks to the contributors whose foundational work this fork stands on:
 
-A big thank you to [2.21](https://discord.gg/e2ZXpzrM) for open-sourcing the original code and the original Adeline
+- [@sergiou87](https://github.com/sergiou87) — macOS M1 build, the bulk of the LIB386 ASM→C++ port, and the ASM↔CPP equivalence test infrastructure that makes the cross-platform port verifiable.
+- [@leokolln](https://github.com/leokolln) — the cross-platform build foundation: CMake build system and presets, MinGW cross-compile to Windows, UASM ASM modernisation, 64-bit Linux preset, AIL sound backend structure, and Linux CI.
+- [@xesf](https://github.com/xesf) — implementation work across SVGA, 3D object rendering, brick handling, and `AffString`, plus the CopyMask Tavern crash fix and widescreen Steam Deck work.
+- [@yaz0r](https://github.com/yaz0r) — the original buildable prototype that the cross-platform fork was built on.
+
+A big thank you to Gwen Gourevich ([@gwen-gg](https://github.com/gwen-gg)) and [2.21](https://discord.gg/e2ZXpzrM) for open-sourcing the original code, and to the original Adeline
 Software team whose code this builds on.
 
 [Unreleased]: https://github.com/LBALab/lba2-classic-community/compare/main...HEAD


### PR DESCRIPTION
## What & why

Three threads in one update — all "make the changelog tell the truth".

### 1. Stability & 64-bit hardening

The most recent and structurally biggest hardening work was missing entirely. Adds:

- The magic-school grand-wizard crash fix (#78 / #84) — `CopyMask` U32+pointer-wraparound, pinned by host-only regression test.
- The renderer-side U32-wrap audit sweep (#85, #86, #87, #88, #89, #90) — ~80 files across SVGA, pol_work, 3D, 3DEXT, GRILLE, INTEXT.

### 2. Documentation

The platform/hardening doc spine that's built up over recent work wasn't listed. Adds:

- `PLATFORM.md` + `PLATFORM_AUDITS.md` (#85, #88)
- `ABI.md` (#67)
- `CRASH_INVESTIGATION.md` (#85)
- `COMPILER_NOTES.md`, `TESTING.md`

### 3. "Earliest fork work" → "Pre-PR foundations"

The PR-only view of contributors was missing the bulk of what made this fork buildable and cross-platform. Renames the section, adds a short prose paragraph naming the direct-commit themes from the pre-PR era — CMake build system + MinGW cross-compile (@leokolln), macOS M1 build + the bulk of the LIB386 ASM→C++ port + ASM↔CPP equivalence test infrastructure (@sergiou87), early renderer/SVGA/object-display ASM→CPP ports (@xesf), all building on @yaz0r's original prototype.

Drops the "SDL audio, Smacker FMV, SDL renderer first land" bullet from this section since #9/#10/#11 are already cited under Audio/video backends above.

### Contributors

- Adds @gwen-gg, @leokolln, @Link4Electronics, @yaz0r, and Alexandre Fontoura to the list.
- Replaces the single-line special-thanks paragraph (which only named @xesf) with per-contributor bullets accurate to actual commits.
- Names Gwen Gourevich alongside 2.21 in the open-source thank-you line.
- Drops the LBALab-ownership blurb on @xesf per project preference.

## Notes for reviewers

- All claims about who did what are derived from `git log` analysis (commit counts, file-touch areas, message themes), not memory. Worth a sanity check from anyone who lived through the pre-PR era.
- The two confirmations that drove this:
  - Andriy Tevelyev = `@innerbytes` (already in list; no separate entry needed).
  - @yaz0r is the originator of the buildable prototype, per @leokolln's own commit message: *"Buildable but not linkable executable 'lba2'. This code is almost entirely based on modifications done by @yaz0r on his own fork."*

## Checklist

- [x] No code changes
- [x] No behavior change
- [x] Docs updated — this *is* the docs update
