### PR TITLE
ci: fix SDL3 MSYS2 package name (lowercase)

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -22,7 +22,11 @@ jobs:
             arch: x64
             msystem: UCRT64
             preset: windows_ucrt64
-            sdl3_pkg: mingw-w64-ucrt-x86_64-SDL3
+            # MSYS2 normalizes the SDL3 package name to lowercase (unlike
+            # most other mingw-w64-* packages where the suffix matches the
+            # upstream casing — e.g. SDL2). The 'SDL3' uppercase variant
+            # does not exist in MSYS2 repos and `pacman -S` errors out.
+            sdl3_pkg: mingw-w64-ucrt-x86_64-sdl3
     defaults:
       run:
         # Run all `run:` steps inside the MSYS2 shell so cmake, ninja, gcc,


### PR DESCRIPTION
The previous commit installed mingw-w64-ucrt-x86_64-SDL3, which doesn't exist — pacman errors out with "target not found". MSYS2 normalizes the SDL3 package name to lowercase (unlike SDL2 which preserves upstream casing). Confirmed via packages.msys2.org: mingw-w64-ucrt-x86_64-sdl3 (3.4.4-1, lowercase) is the correct package and contains both shared and static variants — same one the maintainer's local MSYS2 install uses.

Reference:
https://packages.msys2.org/packages/mingw-w64-ucrt-x86_64-sdl3

<!--
PR title format: `<type>(<scope>): <summary>`
Types: feat | fix | port | perf | refactor | docs | test | build | ci | chore
Scope is optional. Example: `fix(credits): preserve gameplay state across console-invoked credits`
The PR title becomes the squash-merged commit on main, so it lands in the changelog as-is.
See AGENTS.md "Commit & PR conventions".
-->

## What & why

<!-- One or two sentences. What does this change and why does it matter? -->

## Notes for reviewers

<!-- Optional: tradeoffs considered, follow-ups, anything non-obvious. -->

## Checklist

- [ ] Build passes on my platform (Linux / macOS / Windows — pick one or more)
- [ ] If LIB386 / 3DEXT touched: ASM equivalence tests pass (`./run_tests_docker.sh`)
- [ ] If behavior changes: opt-in via flag/cvar/config (preserves default game feel)
- [ ] Docs updated in the same PR if behavior or workflow changed
- [ ] French comments and ASCII art preserved in any modified files
