### PR TITLE
ci: bundle-windows.sh — derive REPO_ROOT from script path, not git

### DIFF
--- a/scripts/packaging/bundle-windows.sh
+++ b/scripts/packaging/bundle-windows.sh
@@ -56,7 +56,12 @@ if [[ ! -f "$EXE_PATH" ]]; then
     exit 1
 fi
 
-REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+# Derive REPO_ROOT from the script's own path rather than `git rev-parse`
+# so this script works in environments without git on PATH (the MSYS2
+# shell on GitHub-hosted Windows runners is one — git is host-side, not
+# inside the MSYS2 prefix). The script lives at
+# scripts/packaging/bundle-windows.sh, so two `..` reach the repo root.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 EXE_NAME="$(basename "$EXE_PATH")"           # lba2cc.exe (or override)
 EXE_STEM="${EXE_NAME%.exe}"                  # lba2cc
 ARTIFACT_NAME="${EXE_STEM}-${VERSION}-windows-${ARCH}"


### PR DESCRIPTION
## Summary

Re-applies the small fix that didn't reach main when PR #98/#99 merged. The bundle step on the Windows release workflow currently dies with:

\`\`\`
scripts/packaging/bundle-windows.sh: line 59: git: command not found
\`\`\`

`git` lives host-side on GitHub-hosted Windows runners, not inside the MSYS2 prefix that `shell: msys2 {0}` opens jobs in.

## Fix

Replace \`git rev-parse --show-toplevel\` with a path-derived \`REPO_ROOT\`:

\`\`\`bash
REPO_ROOT=\"\$(cd \"\$(dirname \"\${BASH_SOURCE[0]}\")/../..\" && pwd)\"
\`\`\`

The script lives at \`scripts/packaging/bundle-windows.sh\`, so two \`..\` always land at the repo root regardless of shell, environment, or whether \`git\` is on PATH. Same approach \`scripts/dev/build-and-run.sh\` already uses for cross-shell portability. Removes a dependency the script never actually needed.

## Test plan

- [x] Local dry-run via \`scripts/dev/build-windows-release.sh\` still produces a valid ZIP with the new derivation.
- [x] YAML still parses.
- [ ] Re-dispatch \`Release Windows\` workflow on this branch — bundle step should now reach completion.

## Out of scope

- \`actionlint\` integration to catch this kind of issue offline before pushing — separate small dev-tooling improvement worth doing in a follow-up.