### PR TITLE
ci(macos): release workflow — DMG matrix (arm64 + x86_64)

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,0 +1,105 @@
+name: Release macOS
+
+# Mirrors release-linux-appimage.yml and release-windows.yml so all release
+# workflows follow the same conventions (see "Release workflow conventions"
+# in docs/RELEASING.md).
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: "Build ${{ matrix.arch }}"
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: macos-latest   # Apple Silicon (arm64)
+            arch: arm64
+            preset: macos_arm64
+          - runs-on: macos-13       # Last reliable Intel runner
+            arch: x86_64
+            preset: macos_x86_64
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v6
+        with:
+          # Full history so cmake/git_version.cmake can detect a clean
+          # vs dirty tree (release tags are clean; -dirty is suppressed).
+          fetch-depth: 0
+
+      - name: Install SDL3 (static build)
+        # libsdl-org/setup-sdl builds SDL3 from source. Pass cmake-arguments
+        # to enable the static archive — our LBA2_LINK_STATIC=ON path
+        # requires SDL3::SDL3-static. SDL_SHARED stays ON so the find_package
+        # COMPONENTS check has both targets available; the explicit static
+        # selection happens in our root CMakeLists.txt.
+        uses: libsdl-org/setup-sdl@main
+        id: sdl
+        with:
+          version: 3-latest
+          build-type: Release
+          cmake-arguments: "-DSDL_STATIC=ON -DSDL_SHARED=OFF"
+
+      - name: Configure (static-link release build)
+        run: |
+          cmake --preset ${{ matrix.preset }} \
+                -DCMAKE_PREFIX_PATH="${{ steps.sdl.outputs.prefix }}" \
+                -DLBA2_LINK_STATIC=ON \
+                -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build --preset ${{ matrix.preset }}
+
+      - name: Bundle DMG
+        run: |
+          BUILD_DIR=out/build/${{ matrix.preset }}
+          VERSION=$(cat "$BUILD_DIR/VERSION.txt")
+          mkdir -p dist
+          bash scripts/packaging/bundle-macos.sh \
+            --app "$BUILD_DIR/SOURCES/lba2cc.app" \
+            --version "$VERSION" \
+            --arch ${{ matrix.arch }} \
+            --build-dir "$BUILD_DIR" \
+            --output-dir dist
+
+      - name: Upload temporary artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: macOS-${{ matrix.arch }}
+          path: dist
+
+  release:
+    name: Attach to GitHub Release
+    needs: [build]
+    # Only create/update a Release on tag pushes. workflow_dispatch runs
+    # produce a downloadable artifact via the build job's upload-artifact
+    # step but do not touch the Releases page (avoids attaching to a
+    # branch-named "release"). Matches release-windows.yml and the
+    # tightened release-linux-appimage.yml.
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: macOS-*
+          merge-multiple: true
+
+      - name: Release macOS DMGs
+        # softprops/action-gh-release@v2 is idempotent: creates the Release
+        # if absent, attaches/updates if present. Lets the AppImage,
+        # Windows, and macOS workflows fire in any order on the same tag
+        # and all land their artifacts on the same Release page.
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            lba2cc-*-macos-*.dmg
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,16 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-_Nothing yet._
+### Cross-platform & build
+
+- macOS native release artifact: a portable DMG with the `.app` bundle
+  inside, drag-to-Applications layout, native multi-resolution `.icns`
+  icon, and an `Info.plist` populated from the same `LBA2_*` cache vars
+  that drive the runtime window title, `.desktop` entry, AppImage labels,
+  and Windows resource. Built for arm64 (Apple Silicon) and x86_64 (Intel)
+  on tag push. Static-linked SDL3, no `.dylib` dependencies. Code signing +
+  notarization deferred — first launch on macOS requires the right-click →
+  Open Gatekeeper bypass; documented in the README inside the DMG.
 
 ## [0.9.0] - 2026-05-09
 


### PR DESCRIPTION
## Summary

Stacks on #102 (macOS-1 — packaging scaffolding). Adds the CI release workflow that calls into `scripts/packaging/bundle-macos.sh`. Shape mirrors `release-linux-appimage.yml` and `release-windows.yml` exactly per the conventions table in `docs/RELEASING.md` — third platform, no new design.

After both PRs merge, v0.10.0 (or any future tag) will produce **five artifacts** instead of three:

```
lba2cc-<version>-anylinux-x86_64.AppImage
lba2cc-<version>-anylinux-x86_64.AppImage.zsync
lba2cc-<version>-anylinux-aarch64.AppImage
lba2cc-<version>-anylinux-aarch64.AppImage.zsync
lba2cc-<version>-windows-x64.zip
lba2cc-<version>-macos-arm64.dmg          ← new
lba2cc-<version>-macos-x86_64.dmg         ← new
```

Seven files total. (Five → seven, my count above was off.)

## What it does

**Trigger:** tag push (`v*`) for real releases, `workflow_dispatch` for validation runs.

**Two jobs:**

1. **`build`** (matrix, `fail-fast: false`):
   - **arm64**: `runs-on: macos-latest` (Apple Silicon), preset `macos_arm64`.
   - **x86_64**: `runs-on: macos-13` (last reliable Intel runner), preset `macos_x86_64`.
   - `libsdl-org/setup-sdl@main` builds SDL3 from source with `-DSDL_STATIC=ON -DSDL_SHARED=OFF` so our `LBA2_LINK_STATIC=ON` path can resolve `SDL3::SDL3-static`.
   - Configures with the matching preset + `-DCMAKE_PREFIX_PATH="${{ steps.sdl.outputs.prefix }}"` + `-DLBA2_LINK_STATIC=ON`.
   - Builds — CMake's `MACOSX_BUNDLE` (wired in macOS-1) produces `lba2cc.app`.
   - Calls `scripts/packaging/bundle-macos.sh` from macOS-1, producing `lba2cc-<version>-macos-<arch>.dmg`.
   - Uploads as `macOS-<arch>` workflow artifact.

2. **`release`** (depends on `build`, **tag-only**):
   - Downloads both DMG artifacts.
   - `softprops/action-gh-release@v2` attaches them to the tag's GitHub Release. Idempotent (creates if absent, attaches if present), so AppImage, Windows, and macOS can all fire on the same tag and converge on one release page.

## Cross-platform release standard — third platform plugged in

The conventions table in `docs/RELEASING.md` claimed macOS would be copy-and-fill from the Windows pattern. This PR proves the claim:

| Concern | This workflow |
|---|---|
| Triggers | `push: tags: ['v*']` + `workflow_dispatch:` ✓ |
| Job structure | `build` matrix → `release` job ✓ |
| Artifact handoff | `upload-artifact@v7` named `macOS-<arch>` → `download-artifact@v7 pattern: 'macOS-*'` ✓ |
| Release upload | `softprops/action-gh-release@v2`, idempotent ✓ |
| Tag-only upload | `if: startsWith(github.ref, 'refs/tags/')` ✓ |
| Naming | `lba2cc-<version>-macos-<arch>.dmg` ✓ |
| Version source | `out/build/<preset>/VERSION.txt` ✓ |
| Packaging logic | `scripts/packaging/bundle-macos.sh` ✓ |

No table rows added; macOS is just another row. That's the win — the standard genuinely is reusable.

## Single-arch fallback if Intel runner drops

`macos-13` is the last reliable Intel runner; GitHub's macOS runner deprecation cadence may eventually take it offline. `fail-fast: false` means the arm64 leg still ships even if the Intel leg fails. If `macos-13` is gone for good when we cut v0.10.0, we remove the Intel matrix row and continue arm64-only — `lba2cc-<version>-macos-arm64.dmg` only. One-line workflow change.

Apple Silicon is the dominant Mac architecture in 2026; arm64-only is a defensible v0.10.x position if Intel runner availability becomes flaky.

## Test plan

- [x] **YAML parses** (`python3 -c 'import yaml; yaml.safe_load(...)'`) — clean.
- [x] **Format check** — clean.
- [x] **Local end-to-end on macOS-1's branch** — DMG produced, .app launched, packaging pipeline verified (per macOS-1 verification).
- [ ] **Workflow_dispatch validation on this branch** — go to Actions → "Release macOS" → Run workflow on `ci/macos-release-workflow`. Expectations:
  - Both build legs succeed (or at least arm64 does — Intel leg is best-effort under fail-fast: false).
  - Workflow artifact downloadable from run summary, contains `lba2cc-0.10.0-dev-macos-arm64.dmg` (and Intel sibling if that leg passed).
  - Release job is **Skipped** (correct — branch ref isn't a tag).
  - No stray `main` release shows up.
- [ ] **First real tag** — when v0.10.0 is cut, all three workflows fire in parallel; release page populates with seven files (1 ZIP + 2 AppImage + 2 zsync + 2 DMG).

## Out of scope

- **Code signing + notarization** — deferred per planning thread; needs Apple Developer Program account ($99/year). Without it, first launch requires right-click → Open. Documented in the in-DMG README from macOS-1.
- **Universal binary** (`lipo`-merged arm64+x86_64 in one `.app`) — per-arch matches the cross-platform naming convention; universal would diverge.
- **DMG visual polish** (background image, custom layout). Plain functional DMG for v0.10.0; can polish later.
- **`FetchContent` fallback for `LBA2_LINK_STATIC=ON`** when the host's SDL3 is shared-only (the brew-on-Mac issue). CI uses `setup-sdl` which provides static, so it's CI-clean. The fallback is a separate small follow-up that improves local-Mac iteration.
- **Cross-platform first-launch picker (Thread B)** — separate PR after this lands. Removes the Terminal `--game-dir` setup step from the macOS README; improves no-data UX on Linux + Windows too.
