### PR TITLE
build(macos): ad-hoc codesign the .app post-build

### DIFF
--- a/SOURCES/CMakeLists.txt
+++ b/SOURCES/CMakeLists.txt
@@ -64,6 +64,20 @@ if(APPLE)
         ${CMAKE_BINARY_DIR}/packaging/${LBA2_DESKTOP_ID}.icns
         PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
     add_dependencies(${LBA2_EXECUTABLE_NAME} lba2_icns)
+
+    # Ad-hoc codesign the .app post-build. Apple Silicon (macOS 11+) refuses
+    # to launch unsigned binaries — Gatekeeper reports the app as "damaged"
+    # and offers only "Move to Bin" as a remedy, even though the binary is
+    # fine. The `-` identity is an ad-hoc self-attestation (no Apple
+    # Developer account required); it gets the .app past the on-load
+    # signature check while we wait for real Developer ID + notarization
+    # to land. --deep covers any nested frameworks (none today, but
+    # future-proof for when SDL3 might ship as a bundled .dylib).
+    add_custom_command(TARGET ${LBA2_EXECUTABLE_NAME} POST_BUILD
+        COMMAND codesign --force --deep --sign -
+                $<TARGET_BUNDLE_DIR:${LBA2_EXECUTABLE_NAME}>
+        COMMENT "Ad-hoc codesigning ${LBA2_EXECUTABLE_NAME}.app"
+        VERBATIM)
 endif()
 # GCC LTO mis-infers T_PLASMA::data_start size when ptrc writes into Malloc tail (see ANIMTEX.CPP plasma case).
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/scripts/packaging/macos-readme.txt.in
+++ b/scripts/packaging/macos-readme.txt.in
@@ -10,11 +10,19 @@ INSTALLING
 Drag @LBA2_EXECUTABLE_NAME@.app onto the Applications shortcut in this
 window. That copies it into your /Applications folder.
 
-First launch: macOS will block the app because it isn't code-signed yet
-(this is on our roadmap). To bypass: right-click @LBA2_EXECUTABLE_NAME@.app
-in /Applications and pick "Open". You'll get a "this app is from an
-unidentified developer" dialog with an Open button — click it once. After
-that, double-click works normally.
+First launch: macOS will block the app because it isn't notarized yet
+(notarization needs an Apple Developer account; on our roadmap). To
+bypass: right-click @LBA2_EXECUTABLE_NAME@.app in /Applications and pick
+"Open". You'll get a "this app is from an unidentified developer" dialog
+with an Open button — click it once. After that, double-click works.
+
+If macOS instead says "the app is damaged and can't be opened" with only
+a Move to Bin button, that's the quarantine attribute blocking launch
+even after our ad-hoc signature. Run this once in Terminal to clear it:
+
+    xattr -cr /Applications/@LBA2_EXECUTABLE_NAME@.app
+
+Then try the right-click → Open above.
 
 
 GAME DATA


### PR DESCRIPTION
Apple Silicon (macOS 11+) refuses to launch unsigned binaries. CMake's MACOSX_BUNDLE wiring builds the .app structure but doesn't codesign it, so the OS reports the app as "damaged and can't be opened" with only a Move to Bin button as a remedy — even though the binary is fine.

Add a POST_BUILD custom command that runs `codesign --force --deep --sign -`. The `-` identity is an ad-hoc self-attestation: no Apple Developer account required, no notarization, but enough to satisfy the on-load signature check that arm64 enforces. Real Developer ID + notarization remains on the roadmap.

The right-click → Open Gatekeeper bypass for unsigned-but-signed apps still applies to the first launch (the OS marks downloads from outside the App Store as "from an unidentified developer"), but the install now actually completes — the "damaged" wording was the failure mode this fix addresses.

Updated the in-DMG README:
- Distinguish the unidentified-developer flow (right-click → Open) from the damaged-and-can't-be-opened flow (xattr -cr to clear quarantine). Both can hit the user; both have a one-liner workaround. Document both rather than guessing which the user will see.