### PR TITLE
ci(macos): drop x86_64 release matrix — Intel runners stalling

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -17,13 +17,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # arm64-only for now. The macos-13 (Intel) runners GitHub provides
+        # are queueing 30+ minutes per job (Apple is winding them down) while
+        # macos-latest finishes in ~30s. Apple Silicon is the present and
+        # future of Mac; Intel-Mac users can still produce a local DMG via
+        # scripts/dev/build-macos-release.sh --preset macos_x86_64. Add
+        # x86_64 back here only if a hosted runner becomes reliable again,
+        # or when we move to a universal2 (arm64+x86_64) binary built on a
+        # single arm64 runner via lipo.
         include:
           - runs-on: macos-latest   # Apple Silicon (arm64)
             arch: arm64
             preset: macos_arm64
-          - runs-on: macos-13       # Last reliable Intel runner
-            arch: x86_64
-            preset: macos_x86_64
     steps:
       - name: Code Checkout
         uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   inside, drag-to-Applications layout, native multi-resolution `.icns`
   icon, and an `Info.plist` populated from the same `LBA2_*` cache vars
   that drive the runtime window title, `.desktop` entry, AppImage labels,
-  and Windows resource. Built for arm64 (Apple Silicon) and x86_64 (Intel)
-  on tag push. Static-linked SDL3, no `.dylib` dependencies. Code signing +
-  notarization deferred — first launch on macOS requires the right-click →
-  Open Gatekeeper bypass; documented in the README inside the DMG.
+  and Windows resource. Built for arm64 (Apple Silicon) on tag push;
+  static-linked SDL3, no `.dylib` dependencies, ad-hoc codesigned to
+  satisfy Apple Silicon's mandatory bundle integrity check. First launch
+  still needs the right-click → Open Gatekeeper bypass (Developer ID +
+  notarization deferred); documented in the README inside the DMG.
+  Intel-Mac users can produce a local DMG via
+  `scripts/dev/build-macos-release.sh --preset macos_x86_64` while
+  hosted Intel runners are unreliable.
 
 ## [0.9.0] - 2026-05-09
 


### PR DESCRIPTION
GitHub's macos-13 (Intel) hosted runners are queueing 30+ minutes per job while macos-latest (Apple Silicon) finishes in ~30s — Apple is winding the Intel runners down. Holding the release pipeline behind a runner that may never get a slot would gate every tag push on a deprecated platform.

Drop x86_64 from the release matrix for now and ship arm64-only. Apple Silicon is the present and future of Mac; Intel-Mac users can still build a local DMG via scripts/dev/build-macos-release.sh --preset macos_x86_64. The build script and bundle script both still support either arch — only the CI release matrix changes.

Keep matrix.include, fail-fast: false, and the macOS-* artifact wildcard so adding x86_64 back later is a one-line change. Comment in the workflow documents the path back: a reliable hosted Intel runner, or a universal2 binary built on a single arm64 runner via lipo.

CHANGELOG entry under [Unreleased] reflects arm64-only and points Intel-Mac users at the local build script.