### PR TITLE
ci: rolling latest pre-release on push to main

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -1,0 +1,194 @@
+name: Release latest (rolling)
+
+# Rolling pre-release for community testers who want bleeding-edge main builds
+# without cloning + building. Triggers on every push to main; force-overwrites
+# a `latest` GitHub Release with the just-built artifacts.
+#
+# Distinct from the tag-triggered release-{linux-appimage,windows,macos}.yml
+# workflows in trigger only — same packaging scripts, same artifact shape, so
+# `latest` is functionally a tag-release at HEAD-of-main with a rolling tag
+# instead of a versioned one.
+#
+# Marked prerelease: true and make_latest: false so the v0.x.y stable tag
+# stays as the GitHub-promoted "Latest" on the Releases page; this workflow's
+# release sits below it labeled as a rolling pre-release.
+#
+# See docs/RELEASING.md "Rolling latest pre-release" for the full rationale
+# and how this fits with the cross-platform release standard.
+
+on:
+  push:
+    branches: [main]
+
+# Two pushes back-to-back shouldn't queue — cancel any in-flight rolling
+# build, the newest commit wins. Tag-triggered release workflows don't
+# share this concurrency group (different lifecycle).
+concurrency:
+  group: release-latest
+  cancel-in-progress: true
+
+jobs:
+  build-linux:
+    name: "Build Linux AppImage (${{ matrix.arch }})"
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: ubuntu-latest
+            arch: x86_64
+          - runs-on: ubuntu-24.04-arm
+            arch: aarch64
+    container: ghcr.io/pkgforge-dev/archlinux:latest
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v6
+      - name: Preparing Container
+        uses: pkgforge-dev/anylinux-setup-action@v2
+      - name: Make AppImage
+        run: /bin/sh ./scripts/packaging/make-appimage.sh
+      - name: Upload temporary artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: latest-linux-${{ matrix.arch }}
+          path: dist
+
+  build-windows:
+    name: "Build Windows ZIP"
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Set up MSYS2 (UCRT64)
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-ninja
+            mingw-w64-ucrt-x86_64-sdl3
+            zip
+      - name: Configure (static-link release build)
+        run: |
+          cmake --preset windows_ucrt64 \
+                -DLBA2_LINK_STATIC=ON \
+                -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: cmake --build --preset windows_ucrt64
+      - name: Bundle ZIP
+        run: |
+          BUILD_DIR=out/build/windows_ucrt64
+          VERSION=$(cat "$BUILD_DIR/VERSION.txt")
+          mkdir -p dist
+          bash scripts/packaging/bundle-windows.sh \
+            --exe "$BUILD_DIR/SOURCES/lba2cc.exe" \
+            --version "$VERSION" \
+            --arch x64 \
+            --build-dir "$BUILD_DIR" \
+            --output-dir dist
+      - name: Upload temporary artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: latest-windows-x64
+          path: dist
+
+  build-macos:
+    name: "Build macOS DMG"
+    runs-on: macos-latest
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Install SDL3 (static build)
+        uses: libsdl-org/setup-sdl@main
+        id: sdl
+        with:
+          version: 3-latest
+          build-type: Release
+          cmake-arguments: "-DSDL_STATIC=ON -DSDL_SHARED=OFF"
+      - name: Configure (static-link release build)
+        run: |
+          cmake --preset macos_arm64 \
+                -DCMAKE_PREFIX_PATH="${{ steps.sdl.outputs.prefix }}" \
+                -DLBA2_LINK_STATIC=ON \
+                -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: cmake --build --preset macos_arm64
+      - name: Bundle DMG
+        run: |
+          BUILD_DIR=out/build/macos_arm64
+          VERSION=$(cat "$BUILD_DIR/VERSION.txt")
+          mkdir -p dist
+          bash scripts/packaging/bundle-macos.sh \
+            --app "$BUILD_DIR/SOURCES/lba2cc.app" \
+            --version "$VERSION" \
+            --arch arm64 \
+            --build-dir "$BUILD_DIR" \
+            --output-dir dist
+      - name: Upload temporary artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: latest-macos-arm64
+          path: dist
+
+  release:
+    name: Update rolling latest release
+    needs: [build-linux, build-windows, build-macos]
+    # Run even if a build leg failed — partial release with whatever
+    # platforms succeeded is more useful for community testers than
+    # blocking the whole rolling release on one flaky leg. Don't run if
+    # the workflow itself was cancelled.
+    if: always() && !cancelled()
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all platform artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: latest-*
+          merge-multiple: true
+
+      - name: Compose release body
+        run: |
+          SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
+          cat > release-body.md <<EOF
+          **Rolling pre-release.** Built from \`main\` on every push. For stable releases see [the Releases page](https://github.com/${{ github.repository }}/releases).
+
+          - Commit: [\`${SHA_SHORT}\`](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
+          - Built: ${TIMESTAMP}
+
+          Same artifact shape as tagged releases — Linux AppImage (x86_64, aarch64), Windows portable ZIP (x64), macOS DMG (arm64). May contain in-progress changes that haven't been play-tested. If you're chasing a specific bug or sharing with others, prefer a tagged release.
+
+          If a particular platform's artifact is missing below, that platform's build leg failed for this commit; the other platforms still updated. Earlier rolling builds remain accessible via the [commit history](https://github.com/${{ github.repository }}/commits/main).
+          EOF
+
+      - name: Update rolling release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: latest
+          name: "Latest (rolling pre-release)"
+          body_path: release-body.md
+          files: |
+            *.AppImage
+            *.AppImage.zsync
+            lba2cc-*-windows-x64.zip
+            lba2cc-*-macos-arm64.dmg
+          # Keep the most recent stable v0.x.y tag as GitHub's "Latest"
+          # badge. This rolling release sits below it as a clearly-labeled
+          # pre-release.
+          prerelease: true
+          make_latest: false
+          # softprops/action-gh-release@v2 moves the existing tag to the
+          # current commit and updates the release in place. No manual
+          # delete-then-create needed.
+          fail_on_unmatched_files: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Intel-Mac users can produce a local DMG via
   `scripts/dev/build-macos-release.sh --preset macos_x86_64` while
   hosted Intel runners are unreliable.
-
-## [0.9.0] - 2026-05-09
+- Rolling `latest` pre-release: every push to `main` triggers a CI build
+  of all three platforms (Linux AppImages, Windows ZIP, macOS DMG) and
+  force-updates a `latest`-tagged GitHub Release. Marked pre-release; the
+  most recent stable tag keeps GitHub's "Latest" promotion. Lets community
+  testers grab bleeding-edge main builds without cloning + building.
+  See `docs/RELEASING.md` "Rolling latest pre-release".
 
 The list below is hand-curated from merged PRs and tells the story of the
 fork's evolution.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -330,6 +330,35 @@ When adding a new platform, copy the closest existing workflow, swap the
 runner / toolchain / packaging script, and the rest of the shape carries
 over.
 
+## Rolling latest pre-release
+
+`.github/workflows/release-latest.yml` is a deliberate exception to the
+"tags only" convention above. It triggers on every `push: branches: [main]`
+and force-overwrites a `latest` GitHub Release with the just-built
+artifacts. Marked `prerelease: true` and `make_latest: false` so the most
+recent stable tag (e.g. `v0.9.0`) keeps GitHub's "Latest" badge — the
+rolling release sits below it, clearly labeled.
+
+| Aspect | Difference from the per-tag releases |
+|---|---|
+| **Trigger** | `push: branches: [main]` (vs `push: tags: ['v*']`) |
+| **Tag** | Static `latest`, force-moved to current commit on every push |
+| **Pre-release flag** | Always `true` (vs always `false` for versioned tags) |
+| **`make_latest`** | `false` (vs default — versioned tags get GitHub's "Latest" promotion) |
+| **Concurrency** | Single `release-latest` group, `cancel-in-progress: true`. Back-to-back commits don't queue; newest wins. |
+| **Partial release on failure** | `if: always() && !cancelled()` on the release job. If one platform's build leg fails, the rolling release still updates with the platforms that succeeded. Tag releases are stricter (`if: startsWith(github.ref, 'refs/tags/')`) because a tagged release is meant to be complete. |
+
+Same packaging scripts (`make-appimage.sh`, `bundle-windows.sh`,
+`bundle-macos.sh`), same artifact shape, same naming. The rolling
+release is functionally a tag-release at HEAD-of-main with a moving
+tag instead of a fixed semver.
+
+**When to point users at it:** for community testers who want to
+verify a fix on `main` without building from source, or for "does this
+reproduce on the latest main?" bug-report triage. Otherwise prefer
+linking to a versioned release (stable, immutable, won't change under
+their feet between two clicks).
+
 ## macOS release artifact (local dry-run)
 
 On a macOS box (Apple Silicon or Intel):


### PR DESCRIPTION
## Summary

Adds a rolling `latest` pre-release that triggers on every push to `main`. Same artifact shape as the tag-triggered releases (Linux AppImages x86_64+aarch64, Windows portable ZIP, macOS DMG arm64) — same packaging scripts, same naming, same conventions. Just a moving tag instead of a fixed semver.

Use case: community testers who want bleeding-edge main builds without cloning + building. Bug-report triage: "does this reproduce on the latest main?"

## Pushback baked into the design

The original ask was to append a `release` job to "the existing build.yml". Pushed back on this in conversation because:

1. **There isn't a `build.yml`.** There are three (`linux.yml`, `macos.yml`, `windows.yml`). Appending to one only covers one platform; appending to all three creates a race for the same `latest` tag.
2. **PR-validation builds aren't release-quality.** Default flags, no static-link, no curated packaging. Tacking a release on those would publish raw `build/SOURCES/lba2cc[.exe]` files that need DLLs/`.dylib` on PATH at runtime. Users opening the Releases page would see `latest` next to v0.9.0 and reasonably expect a newer version of what v0.9.0 ships, not raw build outputs that don't run.
3. **We just established a release standard.** The `docs/RELEASING.md` "Release workflow conventions" table says every release lives in its own `release-*.yml`. Appending mid-`linux.yml` breaks the standard the same day we wrote it.

So this PR adds **`release-latest.yml`** as a new file, calling into the same `make-appimage.sh` / `bundle-windows.sh` / `bundle-macos.sh` the tag releases use. Documented as a deliberate exception to the "tags only" convention (different trigger, prerelease flag, concurrency group).

## What `latest` looks like

- Tag: `latest`, force-moved to current commit on every push.
- Title: `Latest (rolling pre-release)`.
- `prerelease: true` — yellow pre-release banner on GitHub.
- `make_latest: false` — keeps the most recent semver tag (currently `v0.9.0`) as GitHub's promoted "Latest" entry. The rolling release sits below it.
- Body: short SHA + commit link + UTC timestamp + a "for stable see Releases" note + caveat about partial releases when one platform's build fails.
- Files: `lba2cc-*-anylinux-{x86_64,aarch64}.AppImage(.zsync)`, `lba2cc-*-windows-x64.zip`, `lba2cc-*-macos-arm64.dmg`.

## Behaviors worth knowing

- **`concurrency: { group: release-latest, cancel-in-progress: true }`** — back-to-back commits don't queue; the newest wins. The tag-triggered release workflows don't share this group, so a tag push during a rolling build doesn't get cancelled.
- **`if: always() && !cancelled()` on the release job** — partial release if one platform fails. A flaky macOS-13 runner moment doesn't gate the whole rolling release. Tag releases stay stricter (`if: startsWith(github.ref, 'refs/tags/')`) because they're meant to be complete.
- **Body explicitly notes partial releases** — readers will see "macOS DMG missing this build, will return next push" rather than wondering if the platform's been dropped.

## What's NOT changing

- `linux.yml`, `macos.yml`, `windows.yml` — PR validation, untouched. Different purpose, different artifact shape.
- `release-linux-appimage.yml`, `release-windows.yml`, `release-macos.yml` — tag-triggered, untouched. Stable release path.
- Existing release standard in `docs/RELEASING.md` — extended with a new "Rolling latest pre-release" section that frames this workflow as a deliberate exception, not a replacement.

## Test plan

- [x] `release-latest.yml` parses as YAML.
- [x] `bash ./scripts/ci/check-format.sh` clean.
- [x] **PR-time validation runs (linux/macos/windows.yml)** — these still fire on this branch's push (untouched workflows). Confirms no regression to PR validation.
- [x] **First merge to main** — triggers the rolling workflow. Expectations:
  - All three build legs run in parallel (or whichever leg's runner is healthy).
  - `latest` tag created/moved to the merge commit.
  - GitHub Release at `/releases/tag/latest` with title "Latest (rolling pre-release)", yellow pre-release badge, files attached.
  - `v0.9.0` keeps the green "Latest" badge on the Releases page.
- [x] **Second push to main** (any small commit) — confirms the tag force-moves, the release updates, and the build doesn't queue (concurrency cancels any in-flight prior run).

## Future cleanup (deferred, not blocking)

The build steps in `release-latest.yml` duplicate `release-linux-appimage.yml` / `release-windows.yml` / `release-macos.yml`. Could DRY via reusable workflows (`workflow_call`) so each platform's build is a single shared definition called by both the tag-triggered and rolling workflows. Worth doing once the shape is settled across all four workflows; for now explicit duplication is the right call (~3 weeks of release-workflow churn behind us, want to make sure the convention is stable before extracting it).

Filed as informal future work in the commit message.
