### PR TITLE
chore(config): modernize lba2.cfg defaults

### DIFF
--- a/SOURCES/LBA2.CFG
+++ b/SOURCES/LBA2.CFG
@@ -131,6 +131,7 @@ Input34_2: 0
 Input35_1: 33
 Input35_2: 0
 FullScreen: 1
+DisplayFullScreen: 1
 
 ; Gamepad (SDL3 positional mapping; 0 = unbound)
 ; Virtual scancodes start at K_GAMEPAD_BASE = 1024 (see KEYBOARD_KEYS.H).

--- a/SOURCES/LBA2.CFG
+++ b/SOURCES/LBA2.CFG
@@ -9,7 +9,7 @@
 ; Italiano
 ; Portugues
 
-Language: Français
+Language: English
 
 
 
@@ -19,7 +19,7 @@ Language: Français
 ; Français
 ; Deutsch
 
-LanguageCD: Français
+LanguageCD: English
 
 
 
@@ -50,17 +50,14 @@ MasterVolume: 127
 
 CompressSave: 1
 WinMode: 0
-LastSave: frantz
-Shadow: 2
+LastSave:
+Shadow: 3
 AllCameras: 1
 ReverseStereo: 0
-DetailLevel: 1
+DetailLevel: 3
 
-Version: 3
+Version: 0
 
-LanguageInstall:
-Demo:
-PathInstall: Z:\LBA2\
 Input0_1: 200
 Input0_2: 72
 Input1_1: 208
@@ -133,7 +130,7 @@ Input34_1: 46
 Input34_2: 0
 Input35_1: 33
 Input35_2: 0
-FullScreen: 0
+FullScreen: 1
 
 ; Gamepad (SDL3 positional mapping; 0 = unbound)
 ; Virtual scancodes start at K_GAMEPAD_BASE = 1024 (see KEYBOARD_KEYS.H).

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -44,9 +44,9 @@ lba2.cfg stores user preferences and last-save info. Read at startup, written at
 | Input0_1..Input35_2 | int | Key scancodes | DefKeysDefault95 | 36 inputs × 2 keys each (`MAX_INPUT` in INPUT.H). Only read when WinMode=1 |
 | WinMode | int | 0, 1 | 0 | 0=ignore Input* keys, use defaults; 1=read Input* keys. WriteInputConfig always writes WinMode=1 |
 | CompressSave | int | 0, 1 | 1 | 0=uncompressed saves, 1=compressed |
-| Version, Version_US | int | Distributor ID | 3 (EA) from template; 0 (UNKNOWN_VERSION) if key missing | Activision, EA, Virgin, regional variants. Set via `distrib` console command. |
-| Language | string | English, Français, Deutsch, Español, Italiano, Portugues | Français | Must match `TabLanguage[]` exactly (case-insensitive) |
-| LanguageCD | string | Same as Language | Français | Voice CD language; only used with CDROM build |
+| Version, Version_US | int | Distributor ID | 0 (UNKNOWN_VERSION) | Activision, EA, Virgin, regional variants. Set via `distrib` console command. |
+| Language | string | English, Français, Deutsch, Español, Italiano, Portugues | English | Must match `TabLanguage[]` exactly (case-insensitive) |
+| LanguageCD | string | Same as Language | English | Voice CD language; only used with CDROM build |
 | FlagKeepVoice | string | ON, OFF | ON | Keep voice files on HD |
 | MenuMouse | int | 0, 1 | 1 | 1 = menu cursor, hover/left-click confirm, wheel for sliders and save list; 0 = keyboard/joystick only (classic) |
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -34,7 +34,7 @@ lba2.cfg stores user preferences and last-save info. Read at startup, written at
 | ReverseStereo | int | 0, 1 | 0 | 0=OFF, 1=ON |
 | DetailLevel | int | 0–3 | 3 | 0=min (no rain, no sea, no horizon), 1=486, 2=base Pentium, 3=max. Drives Shadow, RainEnable, MaxPolySea, FlagDrawHorizon |
 | FullScreen | int | 0, 1 | 1 | 0=small videos, 1=fullscreen videos. Invalid values → 1 |
-| DisplayFullScreen | int | 0, 1 | 0 | 0=windowed display, 1=fullscreen display. Invalid values → 0 |
+| DisplayFullScreen | int | 0, 1 | 1 | 0=windowed display, 1=fullscreen display. Invalid values → 0 |
 | FlagDisplayText | string | ON, OFF | ON | Case-insensitive. Any other value → ON |
 | WaveVolume | int | 0–127 | 97 | Sample/SFX volume |
 | VoiceVolume | int | 0–127 | 112 | Voice volume |


### PR DESCRIPTION
## Summary

The embedded `SOURCES/LBA2.CFG` template was Adeline's 1997 French-game profile. Brings it in line with what `docs/CONFIG.md` already documented in most rows, plus a few editorial calls for an open-source English-distributed fork.

**Stale**: `LastSave: frantz` (dev's name in the public template), `PathInstall: Z:\LBA2\` + `LanguageInstall:` + `Demo:` (vestigial installer keys), `Shadow: 2` and `DetailLevel: 1` (documented as 3 already).

**Editorial**: `Language` / `LanguageCD` `Français` → `English` (fork is hosted/documented in English; Options menu still works for everyone else), `FullScreen: 0` → `1` (modern launcher expectation; documented as 1 already), `Version: 3` (EA) → `0` (UNKNOWN — community fork shouldn't ship with a 1997 publisher's branding as the default; UNKNOWN cleanly skips `DistribLogo` on launch).

`docs/CONFIG.md` `Language`/`LanguageCD` default cells bumped to match. Other rows were already aligned.

No code change. Data + docs only.

## Test plan

- [x] Fresh launch (delete user `lba2.cfg`) shows English UI text + voice
- [x] No distributor slide on startup (Version 0 → DistribLogo no-op)
- [x] Game launches fullscreen
- [x] Options menu can still flip every changed default