### PR TITLE
feat(tools): extract media from GOG Original Edition LBA2.GOG (#119)

### DIFF
--- a/docs/GAME_DATA.md
+++ b/docs/GAME_DATA.md
@@ -96,6 +96,27 @@ or `make run` (see [Makefile](../Makefile)). Set `LBA2_BUILD_DIR` if you do not 
 
 Windows without Bash: configure CMake as in [WINDOWS.md](WINDOWS.md), then run `lba2cc.exe` with `--game-dir` or set `LBA2_GAME_DIR` in the environment.
 
+## GOG DRM-free "Original Edition" packages
+
+The GOG DRM-free standalone product (and the equivalent content inside the GOG Galaxy "Original Edition" DLC under `Speedrun/Windows/`) ships the 1997 retail CD-ROM as a raw BIN image (`LBA2.GOG`) rather than extracted files. HQRs are duplicated at the install root so gameplay loads, but `VIDEO.HQR`, music WAVs, and `.VOX` voices live only inside the BIN. The modern engine can't see them.
+
+To make our engine work against one of these installs, extract the media files once:
+
+```
+python3 scripts/dev/extract_lba2_gog_media.py /path/to/gog-install/
+```
+
+This walks the ISO9660 filesystem inside `LBA2.GOG`, extracts everything under `/LBA2/VIDEO/`, `/LBA2/VOX/`, and `/LBA2/MUSIC/`, and writes them next to the existing HQRs (~522 MB total: 1× `VIDEO.HQR`, 39× `.VOX`, 24× ADPCM `.WAV`). Files extracted by this script are byte-identical to what the GOG Galaxy / Steam Classic SKUs ship in `Common/` — verified by md5.
+
+The script is idempotent (re-runs skip files already at the expected size; pass `--force` to overwrite). Python 3 stdlib only, no dependencies. After extraction, point the engine at the install root as usual.
+
+Not affected by this:
+
+- GOG Galaxy or Steam buyers of *TLBA2 Classic* (with or without the Original Edition DLC) — both already ship the assets extracted under `Common/`.
+- Anyone with a 1997 LBA2 retail CD can rip it (`cdrdao read-cd …`) into a BIN/CUE pair that the same script handles.
+
+See issue [#119](https://github.com/LBALab/lba2-classic-community/issues/119) for the analysis behind this and the in-engine-reader follow-up option.
+
 ## Config file
 
 See [CONFIG.md](CONFIG.md). If `lba2.cfg` is missing from the user config folder, the engine copies from the asset directory when present; if the asset directory has no `lba2.cfg`, an embedded template (from the build) is written instead.

--- a/scripts/dev/extract_lba2_gog_media.py
+++ b/scripts/dev/extract_lba2_gog_media.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Extract the missing media files (VIDEO.HQR, VOX, music WAVs) from a
+GOG DRM-free LBA2 install's `LBA2.GOG` BIN image into the install
+directory, so the modern engine can load them at filesystem level.
+
+See issue #119 for why this exists. In short: GOG ships the 1997 retail
+disc as a raw Mode-1 BIN image (`LBA2.GOG`). HQRs are duplicated at
+filesystem level so gameplay works, but FMVs, voices, and music live
+only inside the BIN. This script extracts them once.
+
+After running, point the engine at the install dir:
+
+    ./lba2 --game-dir /path/to/LBA2-GOG
+
+Usage:
+    python3 scripts/dev/extract_lba2_gog_media.py <gog-install-dir>
+
+Idempotent: skips files that already exist at the destination with the
+expected size. Pass `--force` to overwrite.
+"""
+import argparse
+import os
+import struct
+import sys
+
+SECTOR = 2352
+DATA_OFFSET = 16
+DATA_SIZE = 2048
+
+
+def read_sector(f, lba):
+    f.seek(lba * SECTOR + DATA_OFFSET)
+    return f.read(DATA_SIZE)
+
+
+def parse_dir(buf):
+    out = []
+    i = 0
+    while i < len(buf):
+        rec_len = buf[i] if i < len(buf) else 0
+        if rec_len == 0:
+            i = (i // DATA_SIZE + 1) * DATA_SIZE
+            if i >= len(buf):
+                break
+            continue
+        lba = struct.unpack_from("<I", buf, i + 2)[0]
+        size = struct.unpack_from("<I", buf, i + 10)[0]
+        flags = buf[i + 25]
+        nl = buf[i + 32]
+        name = buf[i + 33 : i + 33 + nl].decode("latin-1", errors="replace").split(";")[0]
+        if name not in ("\x00", "\x01"):
+            out.append((name, lba, size, bool(flags & 0x02)))
+        i += rec_len
+    return out
+
+
+def read_data(f, lba, size):
+    chunks = []
+    rem = size
+    s = lba
+    while rem > 0:
+        d = read_sector(f, s)
+        chunks.append(d[: min(DATA_SIZE, rem)])
+        rem -= DATA_SIZE
+        s += 1
+    return b"".join(chunks)
+
+
+def find(f, lba, size, parts):
+    raw = read_data(f, lba, size)
+    for name, clba, csize, isdir in parse_dir(raw):
+        if name.upper() == parts[0].upper():
+            if len(parts) == 1:
+                return (clba, csize, isdir)
+            if isdir:
+                return find(f, clba, csize, parts[1:])
+    return None
+
+
+def list_dir(f, lba, size):
+    return parse_dir(read_data(f, lba, size))
+
+
+def extract_file(f, lba, size, dest, force):
+    if os.path.exists(dest) and os.path.getsize(dest) == size and not force:
+        return False
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    data = read_data(f, lba, size)
+    with open(dest, "wb") as o:
+        o.write(data)
+    return True
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("install_dir", help="GOG install dir containing LBA2.GOG")
+    ap.add_argument("--force", action="store_true", help="re-extract even if dest exists at expected size")
+    args = ap.parse_args()
+
+    bin_path = os.path.join(args.install_dir, "LBA2.GOG")
+    if not os.path.isfile(bin_path):
+        sys.exit(f"error: {bin_path} not found — is this a GOG install dir?")
+
+    with open(bin_path, "rb") as f:
+        pvd = read_sector(f, 16)
+        if pvd[1:6] != b"CD001":
+            sys.exit("error: LBA2.GOG is not an ISO9660 image")
+        root_lba = struct.unpack_from("<I", pvd, 156 + 2)[0]
+        root_size = struct.unpack_from("<I", pvd, 156 + 10)[0]
+
+        lba2_dir = find(f, root_lba, root_size, ["LBA2"])
+        if not lba2_dir:
+            sys.exit("error: /LBA2/ directory not found inside image")
+        lba2_lba, lba2_size, _ = lba2_dir
+
+        # Plan: VIDEO/VIDEO.HQR (1 file), VOX/* (39 files), MUSIC/* (24 files)
+        plan = []
+        for subdir in ("VIDEO", "VOX", "MUSIC"):
+            res = find(f, lba2_lba, lba2_size, [subdir])
+            if not res:
+                print(f"warning: /LBA2/{subdir}/ not found, skipping")
+                continue
+            sub_lba, sub_size, _ = res
+            for name, lba, size, isdir in list_dir(f, sub_lba, sub_size):
+                if isdir:
+                    continue
+                # Destination: install_dir/<subdir>/<name> (e.g. .../VOX/EN_000.VOX)
+                # except MUSIC → Music to match modern Classic layout
+                top = "Music" if subdir == "MUSIC" else subdir
+                dest = os.path.join(args.install_dir, top, name)
+                plan.append((name, lba, size, dest))
+
+        total_bytes = sum(size for _, _, size, _ in plan)
+        print(f"Planning to extract {len(plan)} files, {total_bytes / 1024 / 1024:.1f} MB total")
+
+        extracted = 0
+        skipped = 0
+        for name, lba, size, dest in plan:
+            wrote = extract_file(f, lba, size, dest, args.force)
+            if wrote:
+                extracted += 1
+                print(f"  extracted  {size:>11}  {dest}")
+            else:
+                skipped += 1
+
+        print()
+        print(f"Done. Extracted {extracted}, skipped {skipped} (already present).")
+        if extracted:
+            print(f"\nYou can now run the engine against {args.install_dir}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/iso_bin_extract.py
+++ b/scripts/dev/iso_bin_extract.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Extract a single file from a raw Mode-1 BIN ISO9660 image.
+
+Companion to `iso_bin_reader.py` — same on-disk format assumptions
+(2352-byte sectors with 16-byte sync+header + 2048 bytes user data +
+288 bytes ECC/EDC). Once `iso_bin_reader.py` has shown the file path
+inside the image, use this to pull a single file out for inspection.
+
+Used originally to extract `SETUP.MID` from GOG's `LBA2.GOG` to confirm
+it was a real Standard MIDI File (it is — see issue #119 and
+docs/AUDIO.md). Useful for any "what's in this BIN" debugging.
+
+Usage:
+    python3 scripts/dev/iso_bin_extract.py <image.bin> <iso-path> <output>
+
+Example:
+    python3 scripts/dev/iso_bin_extract.py LBA2.GOG /LBA2/SETUP.MID /tmp/SETUP.MID
+
+Path lookup is case-insensitive (matches ISO9660 conventions on most
+DOS-era discs).
+"""
+import sys, struct
+
+BIN = sys.argv[1]
+TARGET = sys.argv[2]
+OUTPATH = sys.argv[3]
+
+SECTOR = 2352
+DATA_OFFSET = 16
+DATA_SIZE = 2048
+
+def read_sector(f, lba):
+    f.seek(lba * SECTOR + DATA_OFFSET)
+    return f.read(DATA_SIZE)
+
+def parse_dir(buf):
+    out = []
+    i = 0
+    while i < len(buf):
+        rec_len = buf[i] if i < len(buf) else 0
+        if rec_len == 0:
+            i = (i // DATA_SIZE + 1) * DATA_SIZE
+            if i >= len(buf):
+                break
+            continue
+        lba = struct.unpack_from("<I", buf, i+2)[0]
+        size = struct.unpack_from("<I", buf, i+10)[0]
+        flags = buf[i+25]
+        nl = buf[i+32]
+        name = buf[i+33:i+33+nl].decode("latin-1", errors="replace").split(";")[0]
+        if name not in ("\x00", "\x01"):
+            out.append((name, lba, size, bool(flags & 0x02)))
+        i += rec_len
+    return out
+
+def read_data(f, lba, size):
+    chunks = []
+    rem = size
+    s = lba
+    while rem > 0:
+        d = read_sector(f, s)
+        chunks.append(d[:min(DATA_SIZE, rem)])
+        rem -= DATA_SIZE
+        s += 1
+    return b"".join(chunks)
+
+def find(f, lba, size, parts):
+    raw = read_data(f, lba, size)
+    for name, clba, csize, isdir in parse_dir(raw):
+        if name.upper() == parts[0].upper():
+            if len(parts) == 1:
+                return (clba, csize)
+            if isdir:
+                return find(f, clba, csize, parts[1:])
+    return None
+
+with open(BIN, "rb") as f:
+    pvd = read_sector(f, 16)
+    rl = struct.unpack_from("<I", pvd, 156+2)[0]
+    rs = struct.unpack_from("<I", pvd, 156+10)[0]
+    parts = TARGET.strip("/").split("/")
+    res = find(f, rl, rs, parts)
+    if not res:
+        print("not found")
+        sys.exit(1)
+    lba, size = res
+    data = read_data(f, lba, size)
+    with open(OUTPATH, "wb") as o:
+        o.write(data)
+    print(f"wrote {size} bytes")

--- a/scripts/dev/iso_bin_reader.py
+++ b/scripts/dev/iso_bin_reader.py
@@ -5,11 +5,12 @@ Walks the ISO9660 filesystem inside a raw CD-ROM image (BIN format with
 2352-byte sectors: 16-byte sync+header + 2048 bytes user data + 288
 bytes ECC/EDC). Lists every file with size and path.
 
-Used originally to map the contents of GOG's `LBA2.GOG` (the bit-identical
-1997 retail CD image). See issue #119 for the broader context — this
-script is the working spec for an in-engine ISO9660-from-BIN reader that
-would let the engine read media files directly from the GOG package
-without an extraction step.
+Used originally to map the contents of GOG's `LBA2.GOG` — the bit-exact
+preservation of the 1997 retail CD's *data track* (the disc's CD-DA audio
+track is not in the BIN; GOG ships it separately as `LBA2.OGG`). See
+issue #119 for the broader context — this script is the working spec
+for an in-engine ISO9660-from-BIN reader that would let the engine read
+media files directly from the GOG package without an extraction step.
 
 Usage:
     python3 scripts/dev/iso_bin_reader.py /path/to/image.bin

--- a/scripts/dev/iso_bin_reader.py
+++ b/scripts/dev/iso_bin_reader.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Minimal ISO9660 reader for raw Mode-1 BIN images (2352-byte sectors).
+
+Walks the ISO9660 filesystem inside a raw CD-ROM image (BIN format with
+2352-byte sectors: 16-byte sync+header + 2048 bytes user data + 288
+bytes ECC/EDC). Lists every file with size and path.
+
+Used originally to map the contents of GOG's `LBA2.GOG` (the bit-identical
+1997 retail CD image). See issue #119 for the broader context — this
+script is the working spec for an in-engine ISO9660-from-BIN reader that
+would let the engine read media files directly from the GOG package
+without an extraction step.
+
+Usage:
+    python3 scripts/dev/iso_bin_reader.py /path/to/image.bin
+
+The output is a flat sorted listing: `<size>  /path/to/file`. Pipe to grep
+to find specific resources, e.g.:
+
+    python3 scripts/dev/iso_bin_reader.py LBA2.GOG | grep -i '\\.HQR$'
+"""
+import sys, struct
+
+BIN = sys.argv[1]
+
+SECTOR = 2352
+DATA_OFFSET = 16   # sync(12) + header(4)
+DATA_SIZE = 2048
+
+def read_sector(f, lba):
+    f.seek(lba * SECTOR + DATA_OFFSET)
+    return f.read(DATA_SIZE)
+
+def parse_dir(buf):
+    """Parse one ISO9660 directory data block. Returns list of (name, lba, size, is_dir)."""
+    out = []
+    i = 0
+    while i < len(buf):
+        rec_len = buf[i] if i < len(buf) else 0
+        if rec_len == 0:
+            # padding to next 2048 boundary
+            i = (i // DATA_SIZE + 1) * DATA_SIZE
+            if i >= len(buf):
+                break
+            continue
+        lba = struct.unpack_from("<I", buf, i+2)[0]
+        size = struct.unpack_from("<I", buf, i+10)[0]
+        flags = buf[i+25]
+        name_len = buf[i+32]
+        name = buf[i+33 : i+33+name_len].decode("latin-1", errors="replace")
+        # strip ;1 version suffix
+        if ";" in name:
+            name = name.split(";", 1)[0]
+        # skip . and ..
+        if name not in ("\x00", "\x01"):
+            out.append((name, lba, size, bool(flags & 0x02)))
+        i += rec_len
+    return out
+
+def read_file_data(f, lba, size):
+    chunks = []
+    remaining = size
+    s = lba
+    while remaining > 0:
+        d = read_sector(f, s)
+        chunks.append(d[:min(DATA_SIZE, remaining)])
+        remaining -= DATA_SIZE
+        s += 1
+    return b"".join(chunks)
+
+def walk(f, lba, size, path=""):
+    """Recursively walk directory at given extent."""
+    raw = read_file_data(f, lba, size)
+    entries = parse_dir(raw)
+    files = []
+    for name, child_lba, child_size, is_dir in entries:
+        full = path + "/" + name
+        if is_dir:
+            files.extend(walk(f, child_lba, child_size, full))
+        else:
+            files.append((full, child_lba, child_size))
+    return files
+
+with open(BIN, "rb") as f:
+    pvd = read_sector(f, 16)
+    assert pvd[1:6] == b"CD001", "not ISO9660"
+    # root directory record at offset 156 in PVD user data, length 34
+    root_rec = pvd[156:156+34]
+    root_lba = struct.unpack_from("<I", root_rec, 2)[0]
+    root_size = struct.unpack_from("<I", root_rec, 10)[0]
+    print(f"Volume ID: {pvd[40:72].decode('latin-1').rstrip()}")
+    print(f"Root LBA={root_lba}, size={root_size}")
+    print()
+    files = walk(f, root_lba, root_size)
+    files.sort(key=lambda x: x[0].lower())
+    for name, lba, size in files:
+        print(f"  {size:>11}  {name}")
+    print()
+    print(f"Total: {len(files)} files")


### PR DESCRIPTION
## Summary

Three Python tools (stdlib only) under `scripts/dev/` for working with the raw BIN image GOG ships as `LBA2.GOG`:

- `iso_bin_reader.py` — lists every file inside the ISO9660 filesystem
- `iso_bin_extract.py` — extracts a single file
- `extract_lba2_gog_media.py` — one-shot wrapper that pulls `VIDEO.HQR`, all `.VOX` voices, and all music WAVs (~522 MB) into the install dir, so the modern engine sees them at filesystem level

Documented in `docs/GAME_DATA.md` with scope: only affects the GOG DRM-free Original Edition product (standalone, or inside Galaxy's `Speedrun/Windows/`). GOG Galaxy / Steam Classic owners already have assets extracted under `Common/`.

Context and analysis in #119.

## Test plan

- [x] Extracted files md5-verified byte-identical to GOG Galaxy's `Common/VIDEO/VIDEO.HQR` and `Common/VOX/EN_000.VOX`
- [x] Music WAVs verified as IMA ADPCM stereo 22050 Hz (matches `docs/AUDIO.md`)
- [x] Idempotent — 2nd run skips files at expected size
- [x] Engine smoke test against extracted dir + copied HQRs: reaches event loop cleanly