### PR TITLE
fix(packaging): add libxtst-dev to Linux tarball build deps

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -76,7 +76,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             cmake ninja-build build-essential \
             libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxi-dev \
-            libxinerama-dev libxxf86vm-dev libxss-dev \
+            libxinerama-dev libxxf86vm-dev libxss-dev libxtst-dev \
             libwayland-dev libxkbcommon-dev libegl1-mesa-dev libgl1-mesa-dev \
             libasound2-dev libpulse-dev \
             libudev-dev libdbus-1-dev

--- a/.github/workflows/release-linux-tarball.yml
+++ b/.github/workflows/release-linux-tarball.yml
@@ -45,7 +45,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             cmake ninja-build build-essential \
             libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxi-dev \
-            libxinerama-dev libxxf86vm-dev libxss-dev \
+            libxinerama-dev libxxf86vm-dev libxss-dev libxtst-dev \
             libwayland-dev libxkbcommon-dev libegl1-mesa-dev libgl1-mesa-dev \
             libasound2-dev libpulse-dev \
             libudev-dev libdbus-1-dev


### PR DESCRIPTION
## Summary

The first rolling-release run after #124 merged failed on both x86_64 and aarch64 at the *Install SDL3 (static build)* step:

\`\`\`
CMake Error at cmake/macros.cmake:433 (message):
  Couldn't find dependency package for XTEST. Please install the needed
  packages or configure with -DSDL_X11_XTEST=OFF
\`\`\`

SDL3 needs \`libxtst-dev\` for the XTest extension (fake-input simulation, screensaver inhibition). It's in the [SDL3 README-linux build dependencies](https://wiki.libsdl.org/SDL3/README-linux#build-dependencies) and was missed in the initial apt list.

Failed run: https://github.com/LBALab/lba2-classic-community/actions/runs/25724989968

## Test plan

- [ ] Rolling \`release-latest.yml\` succeeds on next push to main (both \`build-linux-tarball\` matrix legs reach the bundle step).
- [ ] Same for tag-triggered \`release-linux-tarball.yml\` (verifiable via \`workflow_dispatch\` on this branch).