### PR TITLE
docs(releasing): cross-link smoke test from recipe and announcement steps

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -180,6 +180,12 @@ For future releases, `gh release create --generate-notes` auto-fills
 the body from PR titles since the previous tag — useful as a sanity
 check against the cliff-generated CHANGELOG section.
 
+Once the binary attachments have landed (the per-platform release
+workflows finish on a tag in a few minutes each), run the
+[post-release smoke test](#post-release-smoke-test) before announcing
+the release. A 30-second sanity check that confirms the artifacts
+GitHub serves are actually runnable on a clean box.
+
 ## Post-release smoke test
 
 After a tag-driven release publishes its artifacts, run:
@@ -207,8 +213,9 @@ local verifier is safe to announce on Discord.
 
 ## After the release
 
-Tell people. A short Discord post in the LBALab community channel
-helps the release land:
+Don't announce until the [smoke test](#post-release-smoke-test) passes.
+Then tell people — a short Discord post in the LBALab community
+channel helps the release land:
 
 ```
 v0.9.0 is out — first tagged release of the fork.


### PR DESCRIPTION
## Summary

The post-release smoke test section already lives between *GitHub release* and *After the release*, in the right place by ordering — but a maintainer scanning the numbered recipe wouldn't necessarily know to pause and run it. Two short cross-links:

- End of *Drafting the release* → \"Once the binary attachments have landed, run the [smoke test](...) before announcing.\"
- Top of *After the release* → \"Don't announce until the [smoke test](...) passes.\"

No new content; just makes the flow discoverable in either reading direction (top-down via recipe, or jumping to the announcement template).

## Test plan

- [x] Markdown renders correctly.
- [x] Both anchor links resolve to `#post-release-smoke-test`.