### PR TITLE
ci(release): pin setup-sdl SHA + add per-arch cache discriminator

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install SDL3
-        uses: libsdl-org/setup-sdl@main
+        uses: libsdl-org/setup-sdl@4ebea449684c989388fe6bcea0460e300d13a5ae # main @ 2025-12-20
         id: sdl
         with:
           install-linux-dependencies: true

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install SDL3
-        uses: libsdl-org/setup-sdl@main
+        uses: libsdl-org/setup-sdl@4ebea449684c989388fe6bcea0460e300d13a5ae # main @ 2025-12-20
         id: sdl
         with:
           install-linux-dependencies: true

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -82,12 +82,17 @@ jobs:
             libudev-dev libdbus-1-dev
 
       - name: Install SDL3 (static build)
-        uses: libsdl-org/setup-sdl@main
+        uses: libsdl-org/setup-sdl@4ebea449684c989388fe6bcea0460e300d13a5ae # main @ 2025-12-20
         id: sdl
         with:
           version: 3-latest
           build-type: Release
           cmake-arguments: "-DSDL_STATIC=ON -DSDL_SHARED=OFF"
+          # setup-sdl's cache key only includes os.platform() (Linux/MacOS/
+          # Windows), not arch — so x86_64 and aarch64 Linux runners collide
+          # and one leg pulls a wrong-arch libSDL3.a from the GH Actions
+          # cache, breaking the link step. Discriminator forces per-arch keys.
+          discriminator: ${{ runner.arch }}
 
       - name: Configure (static-link release build)
         run: |
@@ -172,7 +177,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install SDL3 (static build)
-        uses: libsdl-org/setup-sdl@main
+        uses: libsdl-org/setup-sdl@4ebea449684c989388fe6bcea0460e300d13a5ae # main @ 2025-12-20
         id: sdl
         with:
           version: 3-latest

--- a/.github/workflows/release-linux-tarball.yml
+++ b/.github/workflows/release-linux-tarball.yml
@@ -51,7 +51,7 @@ jobs:
             libudev-dev libdbus-1-dev
 
       - name: Install SDL3 (static build)
-        uses: libsdl-org/setup-sdl@main
+        uses: libsdl-org/setup-sdl@4ebea449684c989388fe6bcea0460e300d13a5ae # main @ 2025-12-20
         id: sdl
         with:
           version: 3-latest
@@ -60,6 +60,11 @@ jobs:
           # SDL3::SDL3-static and the resulting lba2cc binary doesn't link
           # libSDL3.so. Mirrors the macOS leg in release-latest.yml.
           cmake-arguments: "-DSDL_STATIC=ON -DSDL_SHARED=OFF"
+          # setup-sdl's cache key only includes os.platform() (Linux/MacOS/
+          # Windows), not arch — so x86_64 and aarch64 Linux runners collide
+          # and one leg pulls a wrong-arch libSDL3.a from the GH Actions
+          # cache, breaking the link step. Discriminator forces per-arch keys.
+          discriminator: ${{ runner.arch }}
 
       - name: Configure (static-link release build)
         run: |

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -43,7 +43,7 @@ jobs:
         # requires SDL3::SDL3-static. SDL_SHARED stays ON so the find_package
         # COMPONENTS check has both targets available; the explicit static
         # selection happens in our root CMakeLists.txt.
-        uses: libsdl-org/setup-sdl@main
+        uses: libsdl-org/setup-sdl@4ebea449684c989388fe6bcea0460e300d13a5ae # main @ 2025-12-20
         id: sdl
         with:
           version: 3-latest


### PR DESCRIPTION
## Summary

- The Linux release-tarball legs (and the linux-tarball job in release-latest) were failing at the link step with `Relocations in generic ELF (EM: 183)` — i.e. an aarch64 `libSDL3.a` was being fed to the x86_64 linker.
- Root cause: `libsdl-org/setup-sdl` builds its cache key from `SDL_BUILD_PLATFORM` (`{Linux, MacOS, Windows}`) — see [src/main.ts:670](https://github.com/libsdl-org/setup-sdl/blob/4ebea449684c989388fe6bcea0460e300d13a5ae/src/main.ts#L670) — with **no arch axis**. Our `ubuntu-latest` (x86_64) and `ubuntu-24.04-arm` (aarch64) legs therefore collide on the same cache key; whichever runs first poisons the other.
- Fix: pass `discriminator: ${{ runner.arch }}` on the two multi-arch Linux release legs so the cache splits per arch.
- Drive-by: pin all `setup-sdl@main` uses to SHA `4ebea449...` (current main as of 2025-12-20) so behaviour stops drifting silently.

Poisoned caches were purged manually (`gh cache delete` × 6) so the first run after merge rebuilds cleanly.

## Test plan
- [ ] Merge to main.
- [ ] Manually dispatch `release-latest.yml` from main; both Linux legs (x86_64, aarch64) reach `Linking CXX executable SOURCES/lba2cc` without `EM: 183`.
- [ ] Run `scripts/dev/verify-release.sh latest` once artifacts publish.