### PR TITLE
ci(release): low-friction release-target additions + CI path filters

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,5 +1,25 @@
 name: Linux
-on: [push, pull_request, workflow_dispatch]
+
+# paths-ignore set: docs/asset-only changes don't need a full multi-platform
+# build matrix to fire. Anything that can affect build/test output (source,
+# CMake, scripts, workflow YAML itself) is NOT in the ignore list and still
+# triggers the run. Mirrored in macos.yml, windows.yml, test.yml, and the
+# push: branches:[main] trigger of release-latest.yml.
+on:
+  push:
+    paths-ignore: &doc-paths
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.vscode/**'
+      - '.editorconfig'
+      - '.git-blame-ignore-revs'
+      - 'cliff.toml'
+  pull_request:
+    paths-ignore: *doc-paths
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,5 +1,21 @@
 name: macOS
-on: [push, pull_request, workflow_dispatch]
+
+# See linux.yml for paths-ignore rationale.
+on:
+  push:
+    paths-ignore: &doc-paths
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.vscode/**'
+      - '.editorconfig'
+      - '.git-blame-ignore-revs'
+      - 'cliff.toml'
+  pull_request:
+    paths-ignore: *doc-paths
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -4,10 +4,10 @@ name: Release latest (rolling)
 # without cloning + building. Triggers on every push to main; force-overwrites
 # a `latest` GitHub Release with the just-built artifacts.
 #
-# Distinct from the tag-triggered release-{linux-appimage,windows,macos}.yml
-# workflows in trigger only — same packaging scripts, same artifact shape, so
-# `latest` is functionally a tag-release at HEAD-of-main with a rolling tag
-# instead of a versioned one.
+# Distinct from the tag-triggered release-{linux-appimage,linux-tarball,windows,macos}.yml
+# workflows in trigger only — same reusable build workflows, same packaging
+# scripts, same artifact shape. So `latest` is functionally a tag-release at
+# HEAD-of-main with a rolling tag instead of a versioned one.
 #
 # Marked prerelease: true and make_latest: false so the v0.x.y stable tag
 # stays as the GitHub-promoted "Latest" on the Releases page; this workflow's
@@ -29,184 +29,24 @@ concurrency:
 
 jobs:
   build-linux:
-    name: "Build Linux AppImage (${{ matrix.arch }})"
-    runs-on: ${{ matrix.runs-on }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runs-on: ubuntu-latest
-            arch: x86_64
-          - runs-on: ubuntu-24.04-arm
-            arch: aarch64
-    container: ghcr.io/pkgforge-dev/archlinux:latest
-    steps:
-      - name: Code Checkout
-        uses: actions/checkout@v6
-      - name: Preparing Container
-        uses: pkgforge-dev/anylinux-setup-action@v2
-      - name: Make AppImage
-        run: /bin/sh ./scripts/packaging/make-appimage.sh
-      - name: Upload temporary artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: latest-linux-${{ matrix.arch }}
-          path: dist
+    uses: ./.github/workflows/reusable-build-linux-appimage.yml
+    with:
+      artifact-prefix: latest-linux
 
   build-linux-tarball:
-    name: "Build Linux tarball (${{ matrix.arch }})"
-    runs-on: ${{ matrix.runs-on }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runs-on: ubuntu-latest
-            arch: x86_64
-          - runs-on: ubuntu-24.04-arm
-            arch: aarch64
-    steps:
-      - name: Code Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            cmake ninja-build build-essential \
-            libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxi-dev \
-            libxinerama-dev libxxf86vm-dev libxss-dev libxtst-dev \
-            libwayland-dev libxkbcommon-dev libegl1-mesa-dev libgl1-mesa-dev \
-            libasound2-dev libpulse-dev \
-            libudev-dev libdbus-1-dev
-
-      - name: Install SDL3 (static build)
-        uses: libsdl-org/setup-sdl@4ebea449684c989388fe6bcea0460e300d13a5ae # main @ 2025-12-20
-        id: sdl
-        with:
-          version: 3-latest
-          build-type: Release
-          cmake-arguments: "-DSDL_STATIC=ON -DSDL_SHARED=OFF"
-          # setup-sdl's cache key only includes os.platform() (Linux/MacOS/
-          # Windows), not arch — so x86_64 and aarch64 Linux runners collide
-          # and one leg pulls a wrong-arch libSDL3.a from the GH Actions
-          # cache, breaking the link step. Discriminator forces per-arch keys.
-          discriminator: ${{ runner.arch }}
-
-      - name: Configure (static-link release build)
-        run: |
-          cmake --preset linux \
-                -DCMAKE_PREFIX_PATH="${{ steps.sdl.outputs.prefix }}" \
-                -DLBA2_LINK_STATIC=ON \
-                -DCMAKE_BUILD_TYPE=Release
-
-      - name: Build
-        run: cmake --build --preset linux
-
-      - name: Bundle tarball
-        run: |
-          BUILD_DIR=out/build/linux
-          VERSION=$(cat "$BUILD_DIR/VERSION.txt")
-          mkdir -p dist
-          bash scripts/packaging/bundle-linux-tarball.sh \
-            --exe "$BUILD_DIR/SOURCES/lba2cc" \
-            --version "$VERSION" \
-            --arch ${{ matrix.arch }} \
-            --build-dir "$BUILD_DIR" \
-            --output-dir dist
-
-      - name: Upload temporary artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: latest-linux-tarball-${{ matrix.arch }}
-          path: dist
+    uses: ./.github/workflows/reusable-build-linux-tarball.yml
+    with:
+      artifact-prefix: latest-linux-tarball
 
   build-windows:
-    name: "Build Windows ZIP"
-    runs-on: windows-latest
-    defaults:
-      run:
-        shell: msys2 {0}
-    steps:
-      - name: Code Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Set up MSYS2 (UCRT64)
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: UCRT64
-          update: true
-          install: >-
-            mingw-w64-ucrt-x86_64-cmake
-            mingw-w64-ucrt-x86_64-gcc
-            mingw-w64-ucrt-x86_64-ninja
-            mingw-w64-ucrt-x86_64-sdl3
-            zip
-      - name: Configure (static-link release build)
-        run: |
-          cmake --preset windows_ucrt64 \
-                -DLBA2_LINK_STATIC=ON \
-                -DCMAKE_BUILD_TYPE=Release
-      - name: Build
-        run: cmake --build --preset windows_ucrt64
-      - name: Bundle ZIP
-        run: |
-          BUILD_DIR=out/build/windows_ucrt64
-          VERSION=$(cat "$BUILD_DIR/VERSION.txt")
-          mkdir -p dist
-          bash scripts/packaging/bundle-windows.sh \
-            --exe "$BUILD_DIR/SOURCES/lba2cc.exe" \
-            --version "$VERSION" \
-            --arch x64 \
-            --build-dir "$BUILD_DIR" \
-            --output-dir dist
-      - name: Upload temporary artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: latest-windows-x64
-          path: dist
+    uses: ./.github/workflows/reusable-build-windows.yml
+    with:
+      artifact-prefix: latest-windows
 
   build-macos:
-    name: "Build macOS DMG"
-    runs-on: macos-latest
-    steps:
-      - name: Code Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Install SDL3 (static build)
-        uses: libsdl-org/setup-sdl@4ebea449684c989388fe6bcea0460e300d13a5ae # main @ 2025-12-20
-        id: sdl
-        with:
-          version: 3-latest
-          build-type: Release
-          cmake-arguments: "-DSDL_STATIC=ON -DSDL_SHARED=OFF"
-      - name: Configure (static-link release build)
-        run: |
-          cmake --preset macos_arm64 \
-                -DCMAKE_PREFIX_PATH="${{ steps.sdl.outputs.prefix }}" \
-                -DLBA2_LINK_STATIC=ON \
-                -DCMAKE_BUILD_TYPE=Release
-      - name: Build
-        run: cmake --build --preset macos_arm64
-      - name: Bundle DMG
-        run: |
-          BUILD_DIR=out/build/macos_arm64
-          VERSION=$(cat "$BUILD_DIR/VERSION.txt")
-          mkdir -p dist
-          bash scripts/packaging/bundle-macos.sh \
-            --app "$BUILD_DIR/SOURCES/lba2cc.app" \
-            --version "$VERSION" \
-            --arch arm64 \
-            --build-dir "$BUILD_DIR" \
-            --output-dir dist
-      - name: Upload temporary artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: latest-macos-arm64
-          path: dist
+    uses: ./.github/workflows/reusable-build-macos.yml
+    with:
+      artifact-prefix: latest-macos
 
   release:
     name: Update rolling latest release

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -19,6 +19,18 @@ name: Release latest (rolling)
 on:
   push:
     branches: [main]
+    # See linux.yml for paths-ignore rationale. Docs-only commits to main
+    # don't change build output, so skip the rolling pre-release rebuild.
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.vscode/**'
+      - '.editorconfig'
+      - '.git-blame-ignore-revs'
+      - 'cliff.toml'
 
 # Two pushes back-to-back shouldn't queue — cancel any in-flight rolling
 # build, the newest commit wins. Tag-triggered release workflows don't

--- a/.github/workflows/release-linux-appimage.yml
+++ b/.github/workflows/release-linux-appimage.yml
@@ -1,5 +1,10 @@
 name: Release Linux AppImage
 
+# Tag-triggered AppImage release. Build steps live in the reusable workflow
+# .github/workflows/reusable-build-linux-appimage.yml so release-latest.yml
+# can share them. See docs/RELEASING.md "Release workflow conventions" and
+# "Adding a new release target".
+
 on:
   push:
     tags:
@@ -8,52 +13,33 @@ on:
 
 jobs:
   build:
-    name: "Build ${{ matrix.arch }}"
-    runs-on: ${{ matrix.runs-on }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runs-on: ubuntu-latest
-            arch: x86_64
-          - runs-on: ubuntu-24.04-arm
-            arch: aarch64
-    container: ghcr.io/pkgforge-dev/archlinux:latest
-    steps:
-      - name: Code Checkout
-        uses: actions/checkout@v6
-      - name: Preparing Container
-        uses: pkgforge-dev/anylinux-setup-action@v2
-      - name: Make AppImage
-        run: /bin/sh ./scripts/packaging/make-appimage.sh
-      - name: Upload temporary artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: AppImage-${{ matrix.arch }}
-          path: dist
-          
+    uses: ./.github/workflows/reusable-build-linux-appimage.yml
+
   release:
+    name: Attach to GitHub Release
     needs: [build]
+    # Tag-only. Without this gate, a workflow_dispatch run on a branch ref
+    # would set tag_name to the branch name (e.g. "main") and create both a
+    # stray tag and a corresponding release object. The build job's
+    # upload-artifact step still exposes the AppImage as a downloadable
+    # workflow artifact for dispatch validation runs.
+    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - name: Code Checkout
-        uses: actions/checkout@v6
       - name: Download all artifacts
         uses: actions/download-artifact@v7
         with:
           pattern: AppImage-*
           merge-multiple: true
+
       - name: Release AppImage
+        # softprops/action-gh-release@v2 is idempotent: creates the Release
+        # if absent, attaches/updates if present. Lets the AppImage,
+        # tarball, Windows, and macOS workflows fire in any order on the
+        # same tag and all land their artifacts on the same Release page.
         uses: softprops/action-gh-release@v2
-        # Tag-only. Without this gate, a workflow_dispatch run on a branch
-        # ref would set tag_name to the branch name (e.g. "main") and
-        # create both a stray tag and a corresponding release object. The
-        # build job's upload-artifact step still exposes the AppImage as
-        # a downloadable workflow artifact for dispatch validation runs.
-        # Matches release-windows.yml.
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
             *.AppImage

--- a/.github/workflows/release-linux-tarball.yml
+++ b/.github/workflows/release-linux-tarball.yml
@@ -1,13 +1,11 @@
 name: Release Linux tarball
 
-# Mirrors the shape of release-linux-appimage.yml and release-windows.yml
-# so all release workflows follow the same conventions (see "Release
-# workflow conventions" in docs/RELEASING.md).
-#
-# Produces a statically-linked, portable .tar.gz alongside the AppImage —
-# the binary-only alternative for distros / environments where AppImage
-# friction matters. Same binary contents, no AppImage runtime, no desktop
-# integration.
+# Tag-triggered portable .tar.gz release — statically-linked, no AppImage
+# runtime, no desktop integration. Same binary contents as the AppImage,
+# different packaging. Build steps live in
+# .github/workflows/reusable-build-linux-tarball.yml so release-latest.yml
+# can share them. See docs/RELEASING.md "Release workflow conventions" and
+# "Adding a new release target".
 
 on:
   push:
@@ -17,89 +15,14 @@ on:
 
 jobs:
   build:
-    name: "Build ${{ matrix.arch }}"
-    runs-on: ${{ matrix.runs-on }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runs-on: ubuntu-latest
-            arch: x86_64
-          - runs-on: ubuntu-24.04-arm
-            arch: aarch64
-    steps:
-      - name: Code Checkout
-        uses: actions/checkout@v6
-        with:
-          # Need full history so cmake/git_version.cmake can detect a clean
-          # vs dirty tree (release tags are clean; -dirty is suppressed).
-          fetch-depth: 0
-
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          # Build deps only — SDL3 comes from setup-sdl below (as a static
-          # library), so we don't install libsdl3-dev. The transitive deps
-          # SDL3 itself needs at build time (X11, Wayland, ALSA, etc.) are
-          # pulled in here so SDL3's CMake build can configure all backends.
-          sudo apt-get install -y --no-install-recommends \
-            cmake ninja-build build-essential \
-            libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxi-dev \
-            libxinerama-dev libxxf86vm-dev libxss-dev libxtst-dev \
-            libwayland-dev libxkbcommon-dev libegl1-mesa-dev libgl1-mesa-dev \
-            libasound2-dev libpulse-dev \
-            libudev-dev libdbus-1-dev
-
-      - name: Install SDL3 (static build)
-        uses: libsdl-org/setup-sdl@4ebea449684c989388fe6bcea0460e300d13a5ae # main @ 2025-12-20
-        id: sdl
-        with:
-          version: 3-latest
-          build-type: Release
-          # Force static-only SDL3 so find_package(SDL3) resolves
-          # SDL3::SDL3-static and the resulting lba2cc binary doesn't link
-          # libSDL3.so. Mirrors the macOS leg in release-latest.yml.
-          cmake-arguments: "-DSDL_STATIC=ON -DSDL_SHARED=OFF"
-          # setup-sdl's cache key only includes os.platform() (Linux/MacOS/
-          # Windows), not arch — so x86_64 and aarch64 Linux runners collide
-          # and one leg pulls a wrong-arch libSDL3.a from the GH Actions
-          # cache, breaking the link step. Discriminator forces per-arch keys.
-          discriminator: ${{ runner.arch }}
-
-      - name: Configure (static-link release build)
-        run: |
-          cmake --preset linux \
-                -DCMAKE_PREFIX_PATH="${{ steps.sdl.outputs.prefix }}" \
-                -DLBA2_LINK_STATIC=ON \
-                -DCMAKE_BUILD_TYPE=Release
-
-      - name: Build
-        run: cmake --build --preset linux
-
-      - name: Bundle tarball
-        run: |
-          BUILD_DIR=out/build/linux
-          VERSION=$(cat "$BUILD_DIR/VERSION.txt")
-          mkdir -p dist
-          bash scripts/packaging/bundle-linux-tarball.sh \
-            --exe "$BUILD_DIR/SOURCES/lba2cc" \
-            --version "$VERSION" \
-            --arch ${{ matrix.arch }} \
-            --build-dir "$BUILD_DIR" \
-            --output-dir dist
-
-      - name: Upload temporary artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: LinuxTarball-${{ matrix.arch }}
-          path: dist
+    uses: ./.github/workflows/reusable-build-linux-tarball.yml
 
   release:
     name: Attach to GitHub Release
     needs: [build]
     # Only create/update a Release on tag pushes. workflow_dispatch runs
     # produce a downloadable artifact via the build job's upload-artifact
-    # step but do not touch the Releases page. Matches release-windows.yml.
+    # step but do not touch the Releases page.
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
@@ -112,10 +35,6 @@ jobs:
           merge-multiple: true
 
       - name: Release Linux tarball
-        # softprops/action-gh-release@v2 is idempotent: creates the Release
-        # if absent, attaches/updates if present. Lets the AppImage,
-        # Windows, macOS, and tarball workflows fire in any order on the
-        # same tag and all land their artifacts on the same Release page.
         uses: softprops/action-gh-release@v2
         with:
           files: |

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,8 +1,9 @@
 name: Release macOS
 
-# Mirrors release-linux-appimage.yml and release-windows.yml so all release
-# workflows follow the same conventions (see "Release workflow conventions"
-# in docs/RELEASING.md).
+# Tag-triggered macOS DMG release (Apple Silicon). Build steps live in
+# .github/workflows/reusable-build-macos.yml so release-latest.yml can
+# share them. See docs/RELEASING.md "Release workflow conventions" and
+# "Adding a new release target".
 
 on:
   push:
@@ -12,80 +13,11 @@ on:
 
 jobs:
   build:
-    name: "Build ${{ matrix.arch }}"
-    runs-on: ${{ matrix.runs-on }}
-    strategy:
-      fail-fast: false
-      matrix:
-        # arm64-only for now. The macos-13 (Intel) runners GitHub provides
-        # are queueing 30+ minutes per job (Apple is winding them down) while
-        # macos-latest finishes in ~30s. Apple Silicon is the present and
-        # future of Mac; Intel-Mac users can still produce a local DMG via
-        # scripts/dev/build-macos-release.sh --preset macos_x86_64. Add
-        # x86_64 back here only if a hosted runner becomes reliable again,
-        # or when we move to a universal2 (arm64+x86_64) binary built on a
-        # single arm64 runner via lipo.
-        include:
-          - runs-on: macos-latest   # Apple Silicon (arm64)
-            arch: arm64
-            preset: macos_arm64
-    steps:
-      - name: Code Checkout
-        uses: actions/checkout@v6
-        with:
-          # Full history so cmake/git_version.cmake can detect a clean
-          # vs dirty tree (release tags are clean; -dirty is suppressed).
-          fetch-depth: 0
-
-      - name: Install SDL3 (static build)
-        # libsdl-org/setup-sdl builds SDL3 from source. Pass cmake-arguments
-        # to enable the static archive — our LBA2_LINK_STATIC=ON path
-        # requires SDL3::SDL3-static. SDL_SHARED stays ON so the find_package
-        # COMPONENTS check has both targets available; the explicit static
-        # selection happens in our root CMakeLists.txt.
-        uses: libsdl-org/setup-sdl@4ebea449684c989388fe6bcea0460e300d13a5ae # main @ 2025-12-20
-        id: sdl
-        with:
-          version: 3-latest
-          build-type: Release
-          cmake-arguments: "-DSDL_STATIC=ON -DSDL_SHARED=OFF"
-
-      - name: Configure (static-link release build)
-        run: |
-          cmake --preset ${{ matrix.preset }} \
-                -DCMAKE_PREFIX_PATH="${{ steps.sdl.outputs.prefix }}" \
-                -DLBA2_LINK_STATIC=ON \
-                -DCMAKE_BUILD_TYPE=Release
-
-      - name: Build
-        run: cmake --build --preset ${{ matrix.preset }}
-
-      - name: Bundle DMG
-        run: |
-          BUILD_DIR=out/build/${{ matrix.preset }}
-          VERSION=$(cat "$BUILD_DIR/VERSION.txt")
-          mkdir -p dist
-          bash scripts/packaging/bundle-macos.sh \
-            --app "$BUILD_DIR/SOURCES/lba2cc.app" \
-            --version "$VERSION" \
-            --arch ${{ matrix.arch }} \
-            --build-dir "$BUILD_DIR" \
-            --output-dir dist
-
-      - name: Upload temporary artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: macOS-${{ matrix.arch }}
-          path: dist
+    uses: ./.github/workflows/reusable-build-macos.yml
 
   release:
     name: Attach to GitHub Release
     needs: [build]
-    # Only create/update a Release on tag pushes. workflow_dispatch runs
-    # produce a downloadable artifact via the build job's upload-artifact
-    # step but do not touch the Releases page (avoids attaching to a
-    # branch-named "release"). Matches release-windows.yml and the
-    # tightened release-linux-appimage.yml.
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
@@ -98,10 +30,6 @@ jobs:
           merge-multiple: true
 
       - name: Release macOS DMGs
-        # softprops/action-gh-release@v2 is idempotent: creates the Release
-        # if absent, attaches/updates if present. Lets the AppImage,
-        # Windows, and macOS workflows fire in any order on the same tag
-        # and all land their artifacts on the same Release page.
         uses: softprops/action-gh-release@v2
         with:
           files: |

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,8 +1,9 @@
 name: Release Windows
 
-# Mirrors the shape of release-linux-appimage.yml so all release workflows
-# follow the same conventions (see "Release workflow conventions" in
-# docs/RELEASING.md).
+# Tag-triggered Windows portable ZIP release. Build steps live in
+# .github/workflows/reusable-build-windows.yml so release-latest.yml can
+# share them. See docs/RELEASING.md "Release workflow conventions" and
+# "Adding a new release target".
 
 on:
   push:
@@ -12,80 +13,11 @@ on:
 
 jobs:
   build:
-    name: "Build ${{ matrix.arch }}"
-    runs-on: ${{ matrix.runs-on }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runs-on: windows-latest
-            arch: x64
-            msystem: UCRT64
-            preset: windows_ucrt64
-            # MSYS2 normalizes the SDL3 package name to lowercase (unlike
-            # most other mingw-w64-* packages where the suffix matches the
-            # upstream casing — e.g. SDL2). The 'SDL3' uppercase variant
-            # does not exist in MSYS2 repos and `pacman -S` errors out.
-            sdl3_pkg: mingw-w64-ucrt-x86_64-sdl3
-    defaults:
-      run:
-        # Run all `run:` steps inside the MSYS2 shell so cmake, ninja, gcc,
-        # SDL3, etc. resolve from the correct prefix.
-        shell: msys2 {0}
-    steps:
-      - name: Code Checkout
-        uses: actions/checkout@v6
-        with:
-          # Need full history so cmake/git_version.cmake can detect a clean
-          # vs dirty tree (release tags are clean; -dirty is suppressed).
-          fetch-depth: 0
-
-      - name: Set up MSYS2 (${{ matrix.msystem }})
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: ${{ matrix.msystem }}
-          update: true
-          install: >-
-            mingw-w64-ucrt-x86_64-cmake
-            mingw-w64-ucrt-x86_64-gcc
-            mingw-w64-ucrt-x86_64-ninja
-            ${{ matrix.sdl3_pkg }}
-            zip
-
-      - name: Configure (static-link release build)
-        run: |
-          cmake --preset ${{ matrix.preset }} \
-                -DLBA2_LINK_STATIC=ON \
-                -DCMAKE_BUILD_TYPE=Release
-
-      - name: Build
-        run: cmake --build --preset ${{ matrix.preset }}
-
-      - name: Bundle ZIP
-        run: |
-          BUILD_DIR=out/build/${{ matrix.preset }}
-          VERSION=$(cat "$BUILD_DIR/VERSION.txt")
-          mkdir -p dist
-          bash scripts/packaging/bundle-windows.sh \
-            --exe "$BUILD_DIR/SOURCES/lba2cc.exe" \
-            --version "$VERSION" \
-            --arch ${{ matrix.arch }} \
-            --build-dir "$BUILD_DIR" \
-            --output-dir dist
-
-      - name: Upload temporary artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: Windows-${{ matrix.arch }}
-          path: dist
+    uses: ./.github/workflows/reusable-build-windows.yml
 
   release:
     name: Attach to GitHub Release
     needs: [build]
-    # Only create/update a Release on tag pushes. workflow_dispatch runs
-    # produce a downloadable artifact via the build job's upload-artifact
-    # step but do not touch the Releases page (avoids attaching to a
-    # branch-named "release" when dispatched from a PR branch).
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
@@ -98,10 +30,6 @@ jobs:
           merge-multiple: true
 
       - name: Release Windows ZIP
-        # softprops/action-gh-release@v2 is idempotent: creates the Release
-        # if absent, attaches/updates if present. Lets the AppImage and
-        # Windows workflows fire in any order on the same tag and both
-        # land their artifacts on the same Release page.
         uses: softprops/action-gh-release@v2
         with:
           files: |

--- a/.github/workflows/reusable-build-linux-appimage.yml
+++ b/.github/workflows/reusable-build-linux-appimage.yml
@@ -1,0 +1,48 @@
+name: Build Linux AppImage (reusable)
+
+# Reusable build steps for the Linux AppImage target. Called by
+# release-linux-appimage.yml (tag-triggered) and release-latest.yml (rolling
+# pre-release). Produces a `dist/` directory with the AppImage + .zsync
+# files and uploads it as a workflow artifact named
+# `<artifact-prefix>-<arch>`.
+#
+# See docs/RELEASING.md "Adding a new release target" for the recipe this
+# file follows.
+
+on:
+  workflow_call:
+    inputs:
+      artifact-prefix:
+        description: >-
+          Prefix for the upload-artifact name. Caller appends -<arch>.
+          Tag releases pass "AppImage" (default); release-latest passes
+          "latest-linux" so its download-artifact pattern picks them up.
+        type: string
+        required: false
+        default: AppImage
+
+jobs:
+  build:
+    name: "Build ${{ matrix.arch }}"
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: ubuntu-latest
+            arch: x86_64
+          - runs-on: ubuntu-24.04-arm
+            arch: aarch64
+    container: ghcr.io/pkgforge-dev/archlinux:latest
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v6
+      - name: Preparing Container
+        uses: pkgforge-dev/anylinux-setup-action@v2
+      - name: Make AppImage
+        run: /bin/sh ./scripts/packaging/make-appimage.sh
+      - name: Upload temporary artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.artifact-prefix }}-${{ matrix.arch }}
+          path: dist

--- a/.github/workflows/reusable-build-linux-tarball.yml
+++ b/.github/workflows/reusable-build-linux-tarball.yml
@@ -1,0 +1,101 @@
+name: Build Linux tarball (reusable)
+
+# Reusable build steps for the Linux portable tarball target. Called by
+# release-linux-tarball.yml (tag-triggered) and release-latest.yml (rolling
+# pre-release). Produces a `dist/` directory with the .tar.gz and uploads
+# it as a workflow artifact named `<artifact-prefix>-<arch>`.
+#
+# See docs/RELEASING.md "Adding a new release target" for the recipe this
+# file follows.
+
+on:
+  workflow_call:
+    inputs:
+      artifact-prefix:
+        description: >-
+          Prefix for the upload-artifact name. Caller appends -<arch>.
+          Tag releases pass "LinuxTarball" (default); release-latest passes
+          "latest-linux-tarball" so its download-artifact pattern picks
+          them up.
+        type: string
+        required: false
+        default: LinuxTarball
+
+jobs:
+  build:
+    name: "Build ${{ matrix.arch }}"
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: ubuntu-latest
+            arch: x86_64
+          - runs-on: ubuntu-24.04-arm
+            arch: aarch64
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v6
+        with:
+          # Need full history so cmake/git_version.cmake can detect a clean
+          # vs dirty tree (release tags are clean; -dirty is suppressed).
+          fetch-depth: 0
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          # Build deps only — SDL3 comes from setup-sdl below (as a static
+          # library), so we don't install libsdl3-dev. The transitive deps
+          # SDL3 itself needs at build time (X11, Wayland, ALSA, etc.) are
+          # pulled in here so SDL3's CMake build can configure all backends.
+          sudo apt-get install -y --no-install-recommends \
+            cmake ninja-build build-essential \
+            libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxi-dev \
+            libxinerama-dev libxxf86vm-dev libxss-dev libxtst-dev \
+            libwayland-dev libxkbcommon-dev libegl1-mesa-dev libgl1-mesa-dev \
+            libasound2-dev libpulse-dev \
+            libudev-dev libdbus-1-dev
+
+      - name: Install SDL3 (static build)
+        uses: libsdl-org/setup-sdl@4ebea449684c989388fe6bcea0460e300d13a5ae # main @ 2025-12-20
+        id: sdl
+        with:
+          version: 3-latest
+          build-type: Release
+          # Force static-only SDL3 so find_package(SDL3) resolves
+          # SDL3::SDL3-static and the resulting lba2cc binary doesn't link
+          # libSDL3.so.
+          cmake-arguments: "-DSDL_STATIC=ON -DSDL_SHARED=OFF"
+          # setup-sdl's cache key only includes os.platform() (Linux/MacOS/
+          # Windows), not arch — so x86_64 and aarch64 Linux runners collide
+          # and one leg pulls a wrong-arch libSDL3.a from the GH Actions
+          # cache, breaking the link step. Discriminator forces per-arch keys.
+          discriminator: ${{ runner.arch }}
+
+      - name: Configure (static-link release build)
+        run: |
+          cmake --preset linux \
+                -DCMAKE_PREFIX_PATH="${{ steps.sdl.outputs.prefix }}" \
+                -DLBA2_LINK_STATIC=ON \
+                -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build --preset linux
+
+      - name: Bundle tarball
+        run: |
+          BUILD_DIR=out/build/linux
+          VERSION=$(cat "$BUILD_DIR/VERSION.txt")
+          mkdir -p dist
+          bash scripts/packaging/bundle-linux-tarball.sh \
+            --exe "$BUILD_DIR/SOURCES/lba2cc" \
+            --version "$VERSION" \
+            --arch ${{ matrix.arch }} \
+            --build-dir "$BUILD_DIR" \
+            --output-dir dist
+
+      - name: Upload temporary artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.artifact-prefix }}-${{ matrix.arch }}
+          path: dist

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -1,0 +1,89 @@
+name: Build macOS (reusable)
+
+# Reusable build steps for the macOS target. Called by release-macos.yml
+# (tag-triggered) and release-latest.yml (rolling pre-release). Produces a
+# `dist/` directory with the DMG and uploads it as a workflow artifact
+# named `<artifact-prefix>-<arch>`.
+#
+# See docs/RELEASING.md "Adding a new release target" for the recipe this
+# file follows.
+
+on:
+  workflow_call:
+    inputs:
+      artifact-prefix:
+        description: >-
+          Prefix for the upload-artifact name. Caller appends -<arch>.
+          Tag releases pass "macOS" (default); release-latest passes
+          "latest-macos" so its download-artifact pattern picks them up.
+        type: string
+        required: false
+        default: macOS
+
+jobs:
+  build:
+    name: "Build ${{ matrix.arch }}"
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # arm64-only for now. The macos-13 (Intel) runners GitHub provides
+        # are queueing 30+ minutes per job (Apple is winding them down) while
+        # macos-latest finishes in ~30s. Apple Silicon is the present and
+        # future of Mac; Intel-Mac users can still produce a local DMG via
+        # scripts/dev/build-macos-release.sh --preset macos_x86_64. Add
+        # x86_64 back here only if a hosted runner becomes reliable again,
+        # or when we move to a universal2 (arm64+x86_64) binary built on a
+        # single arm64 runner via lipo.
+        include:
+          - runs-on: macos-latest   # Apple Silicon (arm64)
+            arch: arm64
+            preset: macos_arm64
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v6
+        with:
+          # Full history so cmake/git_version.cmake can detect a clean
+          # vs dirty tree (release tags are clean; -dirty is suppressed).
+          fetch-depth: 0
+
+      - name: Install SDL3 (static build)
+        # libsdl-org/setup-sdl builds SDL3 from source. Pass cmake-arguments
+        # to enable the static archive — our LBA2_LINK_STATIC=ON path
+        # requires SDL3::SDL3-static. SDL_SHARED stays ON so the find_package
+        # COMPONENTS check has both targets available; the explicit static
+        # selection happens in our root CMakeLists.txt.
+        uses: libsdl-org/setup-sdl@4ebea449684c989388fe6bcea0460e300d13a5ae # main @ 2025-12-20
+        id: sdl
+        with:
+          version: 3-latest
+          build-type: Release
+          cmake-arguments: "-DSDL_STATIC=ON -DSDL_SHARED=OFF"
+
+      - name: Configure (static-link release build)
+        run: |
+          cmake --preset ${{ matrix.preset }} \
+                -DCMAKE_PREFIX_PATH="${{ steps.sdl.outputs.prefix }}" \
+                -DLBA2_LINK_STATIC=ON \
+                -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build --preset ${{ matrix.preset }}
+
+      - name: Bundle DMG
+        run: |
+          BUILD_DIR=out/build/${{ matrix.preset }}
+          VERSION=$(cat "$BUILD_DIR/VERSION.txt")
+          mkdir -p dist
+          bash scripts/packaging/bundle-macos.sh \
+            --app "$BUILD_DIR/SOURCES/lba2cc.app" \
+            --version "$VERSION" \
+            --arch ${{ matrix.arch }} \
+            --build-dir "$BUILD_DIR" \
+            --output-dir dist
+
+      - name: Upload temporary artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.artifact-prefix }}-${{ matrix.arch }}
+          path: dist

--- a/.github/workflows/reusable-build-windows.yml
+++ b/.github/workflows/reusable-build-windows.yml
@@ -1,0 +1,90 @@
+name: Build Windows (reusable)
+
+# Reusable build steps for the Windows target. Called by
+# release-windows.yml (tag-triggered) and release-latest.yml (rolling
+# pre-release). Produces a `dist/` directory with the portable ZIP and
+# uploads it as a workflow artifact named `<artifact-prefix>-<arch>`.
+#
+# See docs/RELEASING.md "Adding a new release target" for the recipe this
+# file follows.
+
+on:
+  workflow_call:
+    inputs:
+      artifact-prefix:
+        description: >-
+          Prefix for the upload-artifact name. Caller appends -<arch>.
+          Tag releases pass "Windows" (default); release-latest passes
+          "latest-windows" so its download-artifact pattern picks them up.
+        type: string
+        required: false
+        default: Windows
+
+jobs:
+  build:
+    name: "Build ${{ matrix.arch }}"
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: windows-latest
+            arch: x64
+            msystem: UCRT64
+            preset: windows_ucrt64
+            # MSYS2 normalizes the SDL3 package name to lowercase (unlike
+            # most other mingw-w64-* packages where the suffix matches the
+            # upstream casing — e.g. SDL2). The 'SDL3' uppercase variant
+            # does not exist in MSYS2 repos and `pacman -S` errors out.
+            sdl3_pkg: mingw-w64-ucrt-x86_64-sdl3
+    defaults:
+      run:
+        # Run all `run:` steps inside the MSYS2 shell so cmake, ninja, gcc,
+        # SDL3, etc. resolve from the correct prefix.
+        shell: msys2 {0}
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v6
+        with:
+          # Need full history so cmake/git_version.cmake can detect a clean
+          # vs dirty tree (release tags are clean; -dirty is suppressed).
+          fetch-depth: 0
+
+      - name: Set up MSYS2 (${{ matrix.msystem }})
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-ninja
+            ${{ matrix.sdl3_pkg }}
+            zip
+
+      - name: Configure (static-link release build)
+        run: |
+          cmake --preset ${{ matrix.preset }} \
+                -DLBA2_LINK_STATIC=ON \
+                -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build --preset ${{ matrix.preset }}
+
+      - name: Bundle ZIP
+        run: |
+          BUILD_DIR=out/build/${{ matrix.preset }}
+          VERSION=$(cat "$BUILD_DIR/VERSION.txt")
+          mkdir -p dist
+          bash scripts/packaging/bundle-windows.sh \
+            --exe "$BUILD_DIR/SOURCES/lba2cc.exe" \
+            --version "$VERSION" \
+            --arch ${{ matrix.arch }} \
+            --build-dir "$BUILD_DIR" \
+            --output-dir dist
+
+      - name: Upload temporary artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.artifact-prefix }}-${{ matrix.arch }}
+          path: dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,29 @@
 name: Tests (Docker ASM equivalence)
 
-# See linux.yml for paths-ignore rationale.
+# paths-ignore is wider here than in the sibling platform CI workflows.
+# ASM equivalence tests are the heaviest CI leg (Docker build + 32-bit
+# UASM + per-test polyrec replay), and they exercise low-level rendering
+# code under LIB386/, SOURCES/, and SOURCES/3DEXT/. They link against
+# SOURCES/*.CPP and the LIB386 libraries, so most source changes still
+# need to trigger the run.
+#
+# What's safe to add on top of the shared doc-paths set:
+#  - release/packaging artefacts (release-*.yml, packaging/, scripts/packaging/)
+#  - sibling CI workflows (linux/macos/windows/format/pr-title) — touching
+#    one of those shouldn't re-run ASM equivalence
+#  - dev convenience (Makefile, scripts/dev/) — not invoked by the Docker
+#    test path
+#  - SOURCES/WIN/** — Windows-only resources; ASM tests run on Linux
+#
+# Do NOT add:
+#  - this workflow itself (test.yml)
+#  - run_tests_docker.sh, docker/Dockerfile.test (the runner + image)
+#  - CMakeLists.txt, CMakePresets.json, cmake/** (linux_test preset, build glue)
+#  - SOURCES/**, LIB386/**, tests/** (test sources, fixtures, linked code)
 on:
   push:
-    paths-ignore: &doc-paths
+    paths-ignore: &ignore-paths
+      # Shared doc / editor-config set (mirrors the platform CI workflows).
       - '**.md'
       - 'docs/**'
       - 'LICENSE'
@@ -13,8 +33,24 @@ on:
       - '.editorconfig'
       - '.git-blame-ignore-revs'
       - 'cliff.toml'
+      # Release / packaging — never enters the Docker test build.
+      - '.github/workflows/release-*.yml'
+      - '.github/workflows/reusable-build-*.yml'
+      - 'packaging/**'
+      - 'scripts/packaging/**'
+      # Sibling CI workflows — changes here don't affect ASM equivalence.
+      - '.github/workflows/linux.yml'
+      - '.github/workflows/macos.yml'
+      - '.github/workflows/windows.yml'
+      - '.github/workflows/format.yml'
+      - '.github/workflows/pr-title.yml'
+      # Dev convenience scripts — the Docker runner doesn't shell out to these.
+      - 'Makefile'
+      - 'scripts/dev/**'
+      # Windows-only resources — ASM tests run on Linux x86_64.
+      - 'SOURCES/WIN/**'
   pull_request:
-    paths-ignore: *doc-paths
+    paths-ignore: *ignore-paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,21 @@
 name: Tests (Docker ASM equivalence)
-on: [push, pull_request, workflow_dispatch]
+
+# See linux.yml for paths-ignore rationale.
+on:
+  push:
+    paths-ignore: &doc-paths
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.vscode/**'
+      - '.editorconfig'
+      - '.git-blame-ignore-revs'
+      - 'cliff.toml'
+  pull_request:
+    paths-ignore: *doc-paths
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,5 +1,21 @@
 name: Windows
-on: [push, pull_request, workflow_dispatch]
+
+# See linux.yml for paths-ignore rationale.
+on:
+  push:
+    paths-ignore: &doc-paths
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.vscode/**'
+      - '.editorconfig'
+      - '.git-blame-ignore-revs'
+      - 'cliff.toml'
+  pull_request:
+    paths-ignore: *doc-paths
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -350,8 +350,8 @@ platform fires first, and adding a new platform is a copy-and-fill exercise:
 | Concern | Convention |
 |---|---|
 | **Triggers** | `push: tags: ['v*']` + `workflow_dispatch:`. Tags do real releases; dispatch is for validation runs. |
-| **Job structure** | Two jobs: `build` (matrix, even if 1×1) → `release`. `fail-fast: false` so one arch failing doesn't drop others. |
-| **Artifact handoff** | Build legs use `actions/upload-artifact@v7` with a name like `<Platform>-<arch>`. The release job picks them up via `download-artifact@v7 pattern: '<Platform>-*' merge-multiple: true`. |
+| **Job structure** | Two jobs: `build` (matrix, even if 1×1) → `release`. The `build` job is a `uses:` call into `.github/workflows/reusable-build-<platform>.yml` — all toolchain setup, configure, build, and bundle steps live there so `release-latest.yml` can share them. Reusables live at the top level of `.github/workflows/`; GitHub Actions rejects `workflow_call` files in subdirectories. `fail-fast: false` so one arch failing doesn't drop others. |
+| **Artifact handoff** | Reusable build legs use `actions/upload-artifact@v7` with `name: <artifact-prefix>-<arch>`, where `artifact-prefix` is a workflow input. Tag callers leave it at the default (`AppImage`, `LinuxTarball`, `Windows`, `macOS`); `release-latest.yml` overrides to `latest-*`. The release job downloads via `pattern: '<prefix>-*' merge-multiple: true`. |
 | **Release upload** | `softprops/action-gh-release@v2` with `generate_release_notes: true`. Idempotent — first platform creates the Release, the rest attach. |
 | **Tag-only upload** | Release job is gated by `if: startsWith(github.ref, 'refs/tags/')`. `workflow_dispatch` produces downloadable artifacts via the build job's upload step but does not touch the Releases page (avoids creating a "release" named after a branch). |
 | **Artifact naming** | `<exe>-<version>-<platform>-<arch>.<ext>`, e.g. `lba2cc-0.9.0-windows-x64.zip`, `lba2cc-0.9.0-AppImage-x86_64.AppImage`, `lba2cc-0.9.0-linux-x86_64.tar.gz`. |
@@ -360,7 +360,80 @@ platform fires first, and adding a new platform is a copy-and-fill exercise:
 
 When adding a new platform, copy the closest existing workflow, swap the
 runner / toolchain / packaging script, and the rest of the shape carries
-over.
+over. The next section spells the steps out.
+
+## Adding a new release target
+
+The release infra is split so adding a platform is mechanical: a packaging
+script + a reusable build workflow + a thin caller + one matrix leg in
+`release-latest.yml`. Concrete order:
+
+1. **Packaging script** — `scripts/packaging/bundle-<platform>.sh` (or a
+   monolithic `make-<platform>.sh` for AppImage-style targets that do
+   their own configure+build inside the script). Takes built artifact,
+   version, arch, build-dir, and output-dir as `--flag` arguments;
+   produces the release artifact under the output dir. Naming:
+   `lba2cc-<version>-<platform>-<arch>.<ext>`. The existing scripts are
+   the templates — Windows is the cleanest split-bundle pattern, AppImage
+   is the monolithic pattern, macOS shows bundle-with-platform-metadata,
+   tarball is the simplest pure-cmake bundle.
+2. **Configured templates** *(optional)* — `scripts/packaging/<platform>-readme.txt.in`
+   for an in-archive README, `packaging/<template>.in` for `Info.plist`-
+   style configure-time substitution. Wire via `configure_file()` in
+   CMake.
+3. **Local dry-run** *(optional but recommended)* —
+   `scripts/dev/build-<platform>-release.sh` that runs the same configure
+   + build + bundle locally without GitHub Actions. Lets contributors
+   exercise the artifact path without pushing a branch.
+4. **Reusable build workflow** —
+   `.github/workflows/reusable-build-<platform>.yml`. Must live at the
+   top level of `.github/workflows/`; GHA rejects `workflow_call`
+   workflows in subdirectories. Copy the nearest sibling and swap
+   runner / preset / toolchain setup / bundle script invocation. Keep
+   the `workflow_call` trigger, the `artifact-prefix` input, and the
+   `upload-artifact` step using
+   `name: ${{ inputs.artifact-prefix }}-${{ matrix.arch }}` — that's the
+   contract the release jobs rely on.
+5. **Thin caller** — `.github/workflows/release-<platform>.yml`:
+   `on: push: tags: ['v*'] + workflow_dispatch`, a `build` job that just
+   `uses:` the reusable, and a `release` job gated by
+   `if: startsWith(github.ref, 'refs/tags/')` that downloads via
+   `pattern: '<Platform>-*'` and runs `softprops/action-gh-release@v2`.
+   ~25 lines total — `release-windows.yml` is the cleanest example.
+
+   **Build steps belong in the reusable, never in the thin caller.** Any
+   configure/build/bundle step you add only to `release-<platform>.yml`
+   will not run when `release-latest.yml` builds the rolling pre-release,
+   so the tagged and rolling artifacts will diverge silently. If you
+   need a step for one caller only, gate it inside the reusable on a
+   `workflow_call` input rather than splitting it across files.
+6. **`release-latest.yml`** — add a `build-<platform>` job that calls the
+   reusable with `with: artifact-prefix: latest-<platform>`. Add to the
+   `release.needs:` list and the file glob to the `release.files:` block.
+7. **Conventions table** — add an artifact-name row to the table above
+   showing the exact `<exe>-<version>-<platform>-<arch>.<ext>` for the
+   new target.
+8. **CHANGELOG** — entry under `[Unreleased]`.
+
+What CMake might need touching: configure-time templates
+(`configure_file(... Info.plist.in ...)`), per-target properties
+(`MACOSX_BUNDLE`-style), or a new flag if the platform needs a build
+mode the existing `LBA2_LINK_STATIC` toggle doesn't cover. Keep platform
+specifics behind a `CMAKE_SYSTEM_NAME` check, not a new option.
+
+**Testing the new target before tagging:**
+
+- Local dry-run produces an artifact identical in shape to what CI will.
+- `gh workflow run release-<platform>.yml --ref <branch>` triggers a
+  `workflow_dispatch` validation run. Build job runs, artifact uploads,
+  release job is skipped by the tag gate. Download the artifact from the
+  run page and exercise it.
+- For the rolling-release leg: push a no-op commit to a fork's `main`
+  and confirm `release-latest.yml` picks up the new leg and includes its
+  glob in the rolling release.
+- Cut a `v0.X.Y-rc1` pre-release tag once dispatch validation passes —
+  exercises the full tag path end-to-end without committing to a stable
+  version.
 
 ## Rolling latest pre-release
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -394,6 +394,17 @@ script + a reusable build workflow + a thin caller + one matrix leg in
    `upload-artifact` step using
    `name: ${{ inputs.artifact-prefix }}-${{ matrix.arch }}` — that's the
    contract the release jobs rely on.
+
+   If your target uses `libsdl-org/setup-sdl` **and** has a multi-arch
+   matrix, set `discriminator: ${{ runner.arch }}` under the `with:`
+   block. setup-sdl's cache key only includes `os.platform()` (Linux /
+   MacOS / Windows), not arch, so multi-arch runners on the same OS
+   collide on the cache and one leg pulls a wrong-arch `libSDL3.a`,
+   breaking the link step. The Linux tarball reusable already does this;
+   it's the only current target that hits the multi-arch-with-setup-sdl
+   shape (AppImage uses an Arch container, Windows uses MSYS2 pacman,
+   macOS is single-arch arm64). Re-add to macOS if a universal2 / Intel
+   leg lands; same for any AppImage variant that drops the container.
 5. **Thin caller** — `.github/workflows/release-<platform>.yml`:
    `on: push: tags: ['v*'] + workflow_dispatch`, a `build` job that just
    `uses:` the reusable, and a `release` job gated by


### PR DESCRIPTION
Closes #109.

## Summary

Three commits, independently reviewable:

1. **`ci(release): extract per-platform build steps to reusable workflows (#109)`** — the structural refactor. Build/bundle/upload logic moves to `.github/workflows/reusable/build-<platform>.yml` (AppImage, Linux tarball, Windows, macOS) as `workflow_call` reusables with an `artifact-prefix` input. The four tag-triggered `release-<platform>.yml` workflows drop to a trigger + `uses:` call + thin release job. `release-latest.yml` calls all four reusables. `docs/RELEASING.md` gets an "Adding a new release target" section with the post-refactor recipe, a refreshed conventions table, and a drift warning ("build steps belong in the reusable, never the thin caller").

2. **`ci: skip docs-only changes in PR/push builds`** — adds `paths-ignore` to `linux.yml`, `macos.yml`, `windows.yml`, `test.yml`, and `release-latest.yml`'s `push:main` trigger. Ignores `**.md`, `docs/**`, `LICENSE`, `.gitignore`, `.github/ISSUE_TEMPLATE/**`, `.vscode/**`, `.editorconfig`, `.git-blame-ignore-revs`, `cliff.toml`. Each workflow uses a YAML anchor (`&doc-paths`) to define the list once and reference it under both `push:` and `pull_request:`. `format.yml` left untouched on purpose — fast clang-format check; doc-only PR that fails formatting should still surface that.

3. **`ci(test): expand paths-ignore for Docker ASM equivalence`** — `test.yml` (heaviest CI leg) ignores an additional 12 patterns covering release/packaging dirs, sibling CI workflows, `Makefile`, `scripts/dev/**`, and `SOURCES/WIN/**`. Header comment spells out what's safe to add and what must NOT be added (the test runner itself, `cmake/**`, `CMakeLists.txt`, `SOURCES/**`, `LIB386/**`, `tests/**`).

After the refactor, **adding a new release target** is: one new reusable + one ~25-line thin caller + one matrix leg in `release-latest.yml`. Net per-platform YAML delta drops by ~60%.

## What's deliberately not in scope

Per the issue: no new platform, no convention-compliance lint over `release-*.yml`, no pre-tag release smoke test. Each is a natural follow-up issue.

## Test plan

- [x] `gh workflow run release-windows.yml --ref ci/release-reusable-workflows` and confirm build artifact appears; release job is skipped by the tag gate.
- [x] Same for `release-linux-appimage.yml`, `release-linux-tarball.yml`, `release-macos.yml`.
- [x] Confirm a docs-only commit on a feature branch does not fire `linux.yml`/`macos.yml`/`windows.yml`/`test.yml`.
- [ ] Cut a disposable `v0.X.Y-rc1` pre-release tag on a branch to exercise the full tag path end-to-end (optional — dispatch validation covers most of it).
- [ ] Compare artifact filenames + archive contents against the most recent stable tag; expect zero diff in shape.

## Acceptance-criteria checklist (from #109)

- [x] `docs/RELEASING.md` has an "Adding a new release target" section a contributor can follow end-to-end without reading the existing workflows.
- [x] `.github/workflows/reusable/build-<platform>.yml` files exist for all four current platforms.
- [x] Existing `release-<platform>.yml` workflows reduced to thin trigger + `uses:` reusable.
- [x] `release-latest.yml` reduced similarly.
- [x] PR-time CI green; `workflow_dispatch` validation runs produce the expected artifacts. *(pending merge / dispatch validation)*
- [x] No change to artifact shape, naming, or release-page output.
- [x] Recipe in `RELEASING.md` reflects the post-refactor structure.