### PR TITLE
fix(deffile): signed-char EOL desync + self-aliasing strcpy (#115)

### DIFF
--- a/LIB386/SYSTEM/DEFFILE.CPP
+++ b/LIB386/SYSTEM/DEFFILE.CPP
@@ -85,9 +85,9 @@ static inline S32 ReadBufferString(const char *identificateur) {
             }
         }
 
-        while (*ptrdef >= 32)
+        while ((U8)*ptrdef >= 32)
             ptrdef++; // next line
-        while (*ptrdef < 32)
+        while ((U8)*ptrdef < 32 && ptrdef < EndPtrDef)
             ptrdef++;
     }
     return FALSE;
@@ -113,7 +113,12 @@ S32 DefFileBufferInit(char *file, void *buffer, S32 maxsize) {
 
     Load(file, buffer);
 
-    strcpy(FileName, file);
+    // Re-entry from DefFileBufferWriteString passes the module-static FileName
+    // back in as `file`, which aliases the strcpy destination. Self-copy is UB
+    // (ASan: strcpy-param-overlap); skip the copy when source and dest alias.
+    if (file != FileName) {
+        strcpy(FileName, file);
+    }
 
     BufferSize = maxsize;
     OrgPtrDef = (char *)buffer;
@@ -123,7 +128,7 @@ S32 DefFileBufferInit(char *file, void *buffer, S32 maxsize) {
         if (EndPtrDef < OrgPtrDef) {
             break;
         }
-    } while (*EndPtrDef <= 32);
+    } while ((U8)*EndPtrDef <= 32);
 
     EndPtrDef++;
 
@@ -169,7 +174,7 @@ S32 DefFileBufferReadValue2(const char *ident, S32 *result) {
     }
 
     ptrdef = DefString;
-    while (*ptrdef > 32)
+    while ((U8)*ptrdef > 32)
         ptrdef++;
     *ptrdef = 0;
     LenDefString = ptrdef - DefString;
@@ -228,7 +233,7 @@ S32 DefFileBufferWriteString(const char *ident, const char *string) {
     {
         Write(handle, OrgPtrDef, PtrEndIdent - OrgPtrDef);
 
-        while (*PtrEndIdent >= 32)
+        while ((U8)*PtrEndIdent >= 32)
             PtrEndIdent++; // skip until EOL
         if (*PtrEndIdent == 13)
             PtrEndIdent++;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_subdirectory(credits)
 add_subdirectory(copymask_negx)
 add_subdirectory(version)
 add_subdirectory(savegame)
+add_subdirectory(deffile)
 
 if(LBA2_BUILD_ASM_EQUIV_TESTS)
 include(cmake/asm_test_helpers.cmake)

--- a/tests/deffile/CMakeLists.txt
+++ b/tests/deffile/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(test_deffile_latin1 test_deffile_latin1.cpp
+    ${CMAKE_SOURCE_DIR}/LIB386/SYSTEM/DEFFILE.CPP
+    ${CMAKE_SOURCE_DIR}/LIB386/SYSTEM/FILES.CPP
+    ${CMAKE_SOURCE_DIR}/LIB386/SYSTEM/LOADSAVE.CPP
+    ${CMAKE_SOURCE_DIR}/LIB386/SYSTEM/LOGPRINT.CPP
+    ${CMAKE_SOURCE_DIR}/LIB386/SYSTEM/ITOA.CPP)
+
+target_include_directories(test_deffile_latin1 PRIVATE
+    ${CMAKE_SOURCE_DIR}/LIB386/H
+)
+
+set_target_properties(test_deffile_latin1 PROPERTIES CXX_STANDARD 11)
+
+add_test(NAME test_deffile_latin1 COMMAND test_deffile_latin1)
+
+register_host_test(test_deffile_latin1)

--- a/tests/deffile/test_deffile_latin1.cpp
+++ b/tests/deffile/test_deffile_latin1.cpp
@@ -1,0 +1,174 @@
+// Host-only regression test for LIB386/SYSTEM/DEFFILE.CPP (issue #115).
+//
+// Pins two bugs in the .cfg parser/writer:
+//
+//   A) Signed-char EOL detection treated high-bit bytes (Latin-1 / UTF-8
+//      continuation bytes like 0xC3 in "Français") as control characters,
+//      which truncated lines mid-token and made successive rewrites splice
+//      garbage into the file. Repro: any cfg field containing a non-ASCII
+//      byte, then any settings-change rewrite.
+//
+//   B) DefFileBufferWriteString re-initializes after a write by passing the
+//      module-static FileName buffer back into DefFileBufferInit, where it
+//      reaches strcpy(FileName, file) with source == dest — undefined
+//      behavior, flagged by ASan as strcpy-param-overlap.
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+#include <SYSTEM/ADELINE.H>
+#include <SYSTEM/ADELINE_TYPES.H>
+#include <SYSTEM/DEFFILE.H>
+#include <SYSTEM/FILES.H>
+
+namespace {
+
+std::string MakeTempCfgPath() {
+    const char *tmp = std::getenv("TMPDIR");
+    if (!tmp || !*tmp)
+        tmp = "/tmp";
+    char buf[512];
+    std::snprintf(buf, sizeof(buf), "%s/lba2_deffile_test_%d.cfg", tmp, (int)getpid());
+    return std::string(buf);
+}
+
+void WriteFile(const char *path, const std::string &contents) {
+    FILE *f = std::fopen(path, "wb");
+    assert(f != NULL);
+    std::fwrite(contents.data(), 1, contents.size(), f);
+    std::fclose(f);
+}
+
+std::string ReadFile(const char *path) {
+    FILE *f = std::fopen(path, "rb");
+    assert(f != NULL);
+    std::fseek(f, 0, SEEK_END);
+    long n = std::ftell(f);
+    std::fseek(f, 0, SEEK_SET);
+    std::string out(n, '\0');
+    if (n > 0)
+        std::fread(&out[0], 1, n, f);
+    std::fclose(f);
+    return out;
+}
+
+size_t CountOccurrences(const std::string &hay, const std::string &needle) {
+    size_t count = 0;
+    size_t pos = 0;
+    while ((pos = hay.find(needle, pos)) != std::string::npos) {
+        ++count;
+        pos += needle.size();
+    }
+    return count;
+}
+
+} // namespace
+
+int main() {
+    const std::string path = MakeTempCfgPath();
+    char path_buf[512];
+    std::snprintf(path_buf, sizeof(path_buf), "%s", path.c_str());
+
+    // ── Test 1: rewriting a field whose old value contains Latin-1 (Bug A) ──
+    // The writer's "skip until EOL" loop at the start of the suffix copy uses
+    // signed-char comparison. With "Français" as the old value, the 0xC3
+    // continuation byte reads as negative, the skip stops mid-token, and the
+    // trailing "ais\r\n" gets spliced into the file as a stray line after
+    // the rewritten value.
+    {
+        const std::string original =
+            "Language: Français\r\n"
+            "LanguageCD: English\r\n"
+            "Input0_1: 42\r\n";
+        WriteFile(path_buf, original);
+
+        std::vector<char> buffer(8192, 0);
+        S32 ok = DefFileBufferInit(path_buf, &buffer[0], (S32)buffer.size());
+        assert(ok == TRUE);
+
+        ok = DefFileBufferWriteString("Language", "English");
+        assert(ok == TRUE);
+
+        const std::string after = ReadFile(path_buf);
+        // Old value gone, new value in place.
+        assert(after.find("Français") == std::string::npos);
+        assert(after.find("Language: English") != std::string::npos);
+        // Bug A signature: stray "ais"-shaped suffix line after the rewrite.
+        assert(after.find("\nais\r\n") == std::string::npos);
+        assert(after.find("\nçais") == std::string::npos);
+        // Subsequent lines preserved verbatim.
+        assert(after.find("LanguageCD: English") != std::string::npos);
+        assert(after.find("Input0_1: 42") != std::string::npos);
+    }
+
+    // ── Test 2: cumulative bleed across repeated rewrites (Bug A) ───────────
+    // Bug A's hallmark is that the corruption *accumulates* — each rewrite
+    // through a Latin-1-bearing field splices another partial copy in. Three
+    // cycles back to "Français" must leave exactly one occurrence.
+    {
+        const std::string original =
+            "Language: Français\r\n"
+            "Input0_1: 1\r\n";
+        WriteFile(path_buf, original);
+
+        std::vector<char> buffer(8192, 0);
+        assert(DefFileBufferInit(path_buf, &buffer[0], (S32)buffer.size()) == TRUE);
+
+        assert(DefFileBufferWriteString("Language", "English") == TRUE);
+        assert(DefFileBufferWriteString("Language", "Français") == TRUE);
+        assert(DefFileBufferWriteString("Language", "English") == TRUE);
+        assert(DefFileBufferWriteString("Language", "Français") == TRUE);
+
+        const std::string after = ReadFile(path_buf);
+        assert(CountOccurrences(after, "Français") == 1);
+        assert(after.find("\nais\r\n") == std::string::npos);
+        assert(after.find("Input0_1: 1") != std::string::npos);
+    }
+
+    // ── Test 3: DefFileBufferWriteString self-aliasing strcpy (Bug B) ───────
+    // DefFileBufferWriteString re-enters DefFileBufferInit with the static
+    // FileName buffer as the source argument; the guarded copy must not blow
+    // up under ASan (strcpy-param-overlap). Behaviorally, the post-write
+    // state must remain readable.
+    {
+        const std::string original = "Foo: bar\r\nBaz: qux\r\n";
+        WriteFile(path_buf, original);
+
+        std::vector<char> buffer(8192, 0);
+        assert(DefFileBufferInit(path_buf, &buffer[0], (S32)buffer.size()) == TRUE);
+        assert(DefFileBufferWriteString("Foo", "changed") == TRUE);
+
+        char *foo = DefFileBufferReadString("Foo");
+        assert(foo != NULL);
+        assert(std::strcmp(foo, "changed") == 0);
+        char *baz = DefFileBufferReadString("Baz");
+        assert(baz != NULL);
+        assert(std::strcmp(baz, "qux") == 0);
+    }
+
+    // ── Test 4: ReadBufferString does not desync past a Latin-1 line ────────
+    // The inter-line skip loop at the bottom of ReadBufferString also used
+    // signed comparisons. A high-bit byte in a line *preceding* the target
+    // could cause the scanner to walk into the middle of the next line.
+    {
+        const std::string original =
+            "Header: Français\r\n"
+            "Target: hello\r\n";
+        WriteFile(path_buf, original);
+
+        std::vector<char> buffer(8192, 0);
+        assert(DefFileBufferInit(path_buf, &buffer[0], (S32)buffer.size()) == TRUE);
+
+        char *target = DefFileBufferReadString("Target");
+        assert(target != NULL);
+        assert(std::strcmp(target, "hello") == 0);
+    }
+
+    std::remove(path_buf);
+    return 0;
+}

--- a/tests/deffile/test_deffile_latin1.cpp
+++ b/tests/deffile/test_deffile_latin1.cpp
@@ -27,13 +27,13 @@
 // CHECK() survives Release/NDEBUG (unlike <cassert>'s assert). The test uses real file
 // I/O and must hard-abort if a precondition fails, otherwise downstream
 // std::string(size, ...) constructions hit length_error on garbage sizes.
-#define CHECK(cond)                                                      \
-    do {                                                                 \
-        if (!(cond)) {                                                   \
-            std::fprintf(stderr, "%s:%d: CHECK failed: %s\n", __FILE__,  \
-                         __LINE__, #cond);                               \
-            std::abort();                                                \
-        }                                                                \
+#define CHECK(cond)                                                     \
+    do {                                                                \
+        if (!(cond)) {                                                  \
+            std::fprintf(stderr, "%s:%d: CHECK failed: %s\n", __FILE__, \
+                         __LINE__, #cond);                              \
+            std::abort();                                               \
+        }                                                               \
     } while (0)
 
 namespace {

--- a/tests/deffile/test_deffile_latin1.cpp
+++ b/tests/deffile/test_deffile_latin1.cpp
@@ -13,12 +13,10 @@
 //      reaches strcpy(FileName, file) with source == dest — undefined
 //      behavior, flagged by ASan as strcpy-param-overlap.
 
-#include <cassert>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <string>
-#include <unistd.h>
 #include <vector>
 
 #include <SYSTEM/ADELINE.H>
@@ -26,33 +24,41 @@
 #include <SYSTEM/DEFFILE.H>
 #include <SYSTEM/FILES.H>
 
+// CHECK() survives Release/NDEBUG (unlike <cassert>'s assert). The test uses real file
+// I/O and must hard-abort if a precondition fails, otherwise downstream
+// std::string(size, ...) constructions hit length_error on garbage sizes.
+#define CHECK(cond)                                                      \
+    do {                                                                 \
+        if (!(cond)) {                                                   \
+            std::fprintf(stderr, "%s:%d: CHECK failed: %s\n", __FILE__,  \
+                         __LINE__, #cond);                               \
+            std::abort();                                                \
+        }                                                                \
+    } while (0)
+
 namespace {
 
-std::string MakeTempCfgPath() {
-    const char *tmp = std::getenv("TMPDIR");
-    if (!tmp || !*tmp)
-        tmp = "/tmp";
-    char buf[512];
-    std::snprintf(buf, sizeof(buf), "%s/lba2_deffile_test_%d.cfg", tmp, (int)getpid());
-    return std::string(buf);
-}
+// CWD-relative path: works identically on POSIX, MSYS2, and native Windows.
+// CTest runs each test in its build directory, which is always writable.
+const char *kTempCfgPath = "test_deffile_latin1.tmp.cfg";
 
 void WriteFile(const char *path, const std::string &contents) {
     FILE *f = std::fopen(path, "wb");
-    assert(f != NULL);
+    CHECK(f != NULL);
     std::fwrite(contents.data(), 1, contents.size(), f);
     std::fclose(f);
 }
 
 std::string ReadFile(const char *path) {
     FILE *f = std::fopen(path, "rb");
-    assert(f != NULL);
+    CHECK(f != NULL);
     std::fseek(f, 0, SEEK_END);
     long n = std::ftell(f);
+    CHECK(n >= 0);
     std::fseek(f, 0, SEEK_SET);
-    std::string out(n, '\0');
+    std::string out((size_t)n, '\0');
     if (n > 0)
-        std::fread(&out[0], 1, n, f);
+        std::fread(&out[0], 1, (size_t)n, f);
     std::fclose(f);
     return out;
 }
@@ -70,9 +76,9 @@ size_t CountOccurrences(const std::string &hay, const std::string &needle) {
 } // namespace
 
 int main() {
-    const std::string path = MakeTempCfgPath();
-    char path_buf[512];
-    std::snprintf(path_buf, sizeof(path_buf), "%s", path.c_str());
+    // DefFileBufferInit takes a non-const char*; copy the path into a buffer.
+    char path[512];
+    std::snprintf(path, sizeof(path), "%s", kTempCfgPath);
 
     // ── Test 1: rewriting a field whose old value contains Latin-1 (Bug A) ──
     // The writer's "skip until EOL" loop at the start of the suffix copy uses
@@ -85,25 +91,25 @@ int main() {
             "Language: Français\r\n"
             "LanguageCD: English\r\n"
             "Input0_1: 42\r\n";
-        WriteFile(path_buf, original);
+        WriteFile(path, original);
 
         std::vector<char> buffer(8192, 0);
-        S32 ok = DefFileBufferInit(path_buf, &buffer[0], (S32)buffer.size());
-        assert(ok == TRUE);
+        S32 ok = DefFileBufferInit(path, &buffer[0], (S32)buffer.size());
+        CHECK(ok == TRUE);
 
         ok = DefFileBufferWriteString("Language", "English");
-        assert(ok == TRUE);
+        CHECK(ok == TRUE);
 
-        const std::string after = ReadFile(path_buf);
+        const std::string after = ReadFile(path);
         // Old value gone, new value in place.
-        assert(after.find("Français") == std::string::npos);
-        assert(after.find("Language: English") != std::string::npos);
+        CHECK(after.find("Français") == std::string::npos);
+        CHECK(after.find("Language: English") != std::string::npos);
         // Bug A signature: stray "ais"-shaped suffix line after the rewrite.
-        assert(after.find("\nais\r\n") == std::string::npos);
-        assert(after.find("\nçais") == std::string::npos);
+        CHECK(after.find("\nais\r\n") == std::string::npos);
+        CHECK(after.find("\nçais") == std::string::npos);
         // Subsequent lines preserved verbatim.
-        assert(after.find("LanguageCD: English") != std::string::npos);
-        assert(after.find("Input0_1: 42") != std::string::npos);
+        CHECK(after.find("LanguageCD: English") != std::string::npos);
+        CHECK(after.find("Input0_1: 42") != std::string::npos);
     }
 
     // ── Test 2: cumulative bleed across repeated rewrites (Bug A) ───────────
@@ -114,20 +120,20 @@ int main() {
         const std::string original =
             "Language: Français\r\n"
             "Input0_1: 1\r\n";
-        WriteFile(path_buf, original);
+        WriteFile(path, original);
 
         std::vector<char> buffer(8192, 0);
-        assert(DefFileBufferInit(path_buf, &buffer[0], (S32)buffer.size()) == TRUE);
+        CHECK(DefFileBufferInit(path, &buffer[0], (S32)buffer.size()) == TRUE);
 
-        assert(DefFileBufferWriteString("Language", "English") == TRUE);
-        assert(DefFileBufferWriteString("Language", "Français") == TRUE);
-        assert(DefFileBufferWriteString("Language", "English") == TRUE);
-        assert(DefFileBufferWriteString("Language", "Français") == TRUE);
+        CHECK(DefFileBufferWriteString("Language", "English") == TRUE);
+        CHECK(DefFileBufferWriteString("Language", "Français") == TRUE);
+        CHECK(DefFileBufferWriteString("Language", "English") == TRUE);
+        CHECK(DefFileBufferWriteString("Language", "Français") == TRUE);
 
-        const std::string after = ReadFile(path_buf);
-        assert(CountOccurrences(after, "Français") == 1);
-        assert(after.find("\nais\r\n") == std::string::npos);
-        assert(after.find("Input0_1: 1") != std::string::npos);
+        const std::string after = ReadFile(path);
+        CHECK(CountOccurrences(after, "Français") == 1);
+        CHECK(after.find("\nais\r\n") == std::string::npos);
+        CHECK(after.find("Input0_1: 1") != std::string::npos);
     }
 
     // ── Test 3: DefFileBufferWriteString self-aliasing strcpy (Bug B) ───────
@@ -137,18 +143,18 @@ int main() {
     // state must remain readable.
     {
         const std::string original = "Foo: bar\r\nBaz: qux\r\n";
-        WriteFile(path_buf, original);
+        WriteFile(path, original);
 
         std::vector<char> buffer(8192, 0);
-        assert(DefFileBufferInit(path_buf, &buffer[0], (S32)buffer.size()) == TRUE);
-        assert(DefFileBufferWriteString("Foo", "changed") == TRUE);
+        CHECK(DefFileBufferInit(path, &buffer[0], (S32)buffer.size()) == TRUE);
+        CHECK(DefFileBufferWriteString("Foo", "changed") == TRUE);
 
         char *foo = DefFileBufferReadString("Foo");
-        assert(foo != NULL);
-        assert(std::strcmp(foo, "changed") == 0);
+        CHECK(foo != NULL);
+        CHECK(std::strcmp(foo, "changed") == 0);
         char *baz = DefFileBufferReadString("Baz");
-        assert(baz != NULL);
-        assert(std::strcmp(baz, "qux") == 0);
+        CHECK(baz != NULL);
+        CHECK(std::strcmp(baz, "qux") == 0);
     }
 
     // ── Test 4: ReadBufferString does not desync past a Latin-1 line ────────
@@ -159,16 +165,16 @@ int main() {
         const std::string original =
             "Header: Français\r\n"
             "Target: hello\r\n";
-        WriteFile(path_buf, original);
+        WriteFile(path, original);
 
         std::vector<char> buffer(8192, 0);
-        assert(DefFileBufferInit(path_buf, &buffer[0], (S32)buffer.size()) == TRUE);
+        CHECK(DefFileBufferInit(path, &buffer[0], (S32)buffer.size()) == TRUE);
 
         char *target = DefFileBufferReadString("Target");
-        assert(target != NULL);
-        assert(std::strcmp(target, "hello") == 0);
+        CHECK(target != NULL);
+        CHECK(std::strcmp(target, "hello") == 0);
     }
 
-    std::remove(path_buf);
+    std::remove(path);
     return 0;
 }


### PR DESCRIPTION
Closes #115.

## Summary

`LIB386/SYSTEM/DEFFILE.CPP` had two latent bugs that together corrupted `lba2.cfg` and relied on undefined C behavior:

- **Bug A** — signed-`char` comparisons against ASCII control thresholds (`>= 32`, `<= 32`) treated high-bit bytes (Latin-1 / UTF-8 continuation, e.g. `0xC3` in `Français`) as control characters. EOL detection stopped mid-token, and successive rewrites spliced partial copies into the file. Surface symptom in the reported case: 21 `çais` lines and all 144 input bindings zeroed.
- **Bug B** — `DefFileBufferWriteString` re-initializes after a write by passing the module-static `FileName` back into `DefFileBufferInit`, where `strcpy(FileName, file)` aliases its own destination. UB; flagged by ASan as `strcpy-param-overlap`.

## Changes

- Cast through `(U8)` at the five byte-comparison sites in `ReadBufferString`, `DefFileBufferInit`, `DefFileBufferReadValue2`, and `DefFileBufferWriteString`.
- Guard the self-aliasing `strcpy` at `DefFileBufferInit:116`.
- Add `tests/deffile/test_deffile_latin1.cpp` — host-only regression test covering:
  - Latin-1 field rewrite without stray suffix line
  - Cumulative-bleed property across repeated rewrites
  - Post-write re-entry path that triggers ASan on Bug B
  - Read-side desync past a Latin-1-bearing line
- Registered as `host_quick` — runs in `make test` and CI on Linux/macOS/Windows. Verified to fail on the unfixed code and pass on the fixed code.

The fix is scoped to Option 1 from the issue (mechanical, backwards-compatible). The structural rewrite of the write path (Option 2) is deferred to its own PR.

## Test plan

- [x] `make test` passes locally (8/8 host tests)
- [x] Test verified to **fail** when the `(U8)` casts are reverted
- [x] `bash ./scripts/ci/apply-format.sh` clean
- [x] CI green on Linux/macOS/Windows