### PR TITLE
chore: add optional pre-commit hook for clang-format check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ Apply these behavior rules on every non-trivial task:
 - **Host tests:** `make test` (or `ctest -L host_quick` after configure with `-DLBA2_BUILD_TESTS=ON -DLBA2_BUILD_ASM_EQUIV_TESTS=OFF`). No Docker, no retail files. CI runs these on Linux, macOS, and Windows (see `.github/workflows/*.yml`).
 - **Filter:** `./run_tests_docker.sh test_getang2d test_lirot3df`
 - **Bisect:** `./run_tests_docker.sh --bisect` to find first divergent draw call
-- **Before considering done:** Run `./run_tests_docker.sh` (or N/A if docs-only). If modifying formatted files: `clang-format -i` on staged C/C++ files (works on all platforms), or CI runs format check.
+- **Before considering done:** Run `./run_tests_docker.sh` (or N/A if docs-only). If modifying formatted files: run `bash ./scripts/ci/apply-format.sh` (or enable the pre-commit hook — see "Code conventions"); CI also runs the format check.
 - **When tests fail:** Do not relax tests. For ASM↔CPP: use `--bisect` to find first divergence, add debug traces to both ASM and CPP, extract failing inputs into a focused unit test, fix CPP to match ASM. For other bugs: read the relevant subsystem doc (AUDIO, MENU, DEBUG, etc.), map the code path, fix the bug, verify with build/tests.
 - **Minimal build** (no audio/video): `-DSOUND_BACKEND=null -DMVIDEO_BACKEND=null` for quick iteration.
 
@@ -87,7 +87,8 @@ Apply these behavior rules on every non-trivial task:
 ## Code conventions
 
 - Indentation: 4 spaces (C/C++); tabs preserved in ASM
-- Formatting: clang-format with checked-in `.clang-format`; ASM and `LIB386/libsmacker/` excluded
+- Formatting: clang-format with checked-in `.clang-format`; exclusions live in `.clang-format-ignore` (ASM, `LIB386/libsmacker/`, vendored `stb_*`, and a handful of legacy lookup-table files). When adding vendored third-party code or generated/hand-tuned lookup tables, add the path to `.clang-format-ignore` in the same commit — single source of truth for local scripts, CI, and the pre-commit hook.
+- Pre-commit hook (optional, recommended): `git config core.hooksPath scripts/git-hooks` once per clone. It runs clang-format `--dry-run` on staged C/C++ files (respecting `.clang-format-ignore`) and blocks commits with violations. Fix with `bash ./scripts/ci/apply-format.sh && git add -u`. Bypass with `git commit --no-verify` or `SKIP_FORMAT=1` when warranted.
 - Types: S32, U32 from `LIB386/H/SYSTEM/ADELINE_TYPES.H`
 - C++98 for game code; tests may use C11/C++11
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,14 @@ bash ./scripts/ci/apply-format.sh
 
 `check-format.sh` verifies the tracked C/C++ files that are enforced in CI. `apply-format.sh` applies that same formatter policy to tracked clean files in your worktree.
 
+To catch format issues before they reach CI, enable the optional pre-commit hook once per clone:
+
+```bash
+git config core.hooksPath scripts/git-hooks
+```
+
+The hook runs `clang-format --dry-run` against staged C/C++ files only (it checks the staged blob, so unrelated unstaged edits and partial-stage workflows still work) and reuses `.clang-format-ignore`, so it stays in sync with CI. When it blocks a commit, run `bash ./scripts/ci/apply-format.sh && git add -u` and try again. Bypass with `git commit --no-verify`, or `SKIP_FORMAT=1` for a session, when you genuinely need to.
+
 If you use VS Code, install the workspace recommendations from `.vscode/extensions.json`. The current recommended set is `ms-vscode.cpptools`, `ms-vscode.cmake-tools`, and `EditorConfig.EditorConfig`.
 
 `EditorConfig.EditorConfig` is recommended because this repository also has files that are not auto-formatted by `clang-format`. It makes VS Code honor the checked-in `.editorconfig` for baseline indentation rules, which keeps C/C++ files on 4 spaces and preserves tab-based indentation in ASM and related files.

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Pre-commit hook: clang-format check on staged C/C++ files.
+#
+# Enable once per clone:
+#   git config core.hooksPath scripts/git-hooks
+#
+# Bypass for a single commit: git commit --no-verify
+# Bypass for the session:     SKIP_FORMAT=1 git commit ...
+
+set -euo pipefail
+
+if [ "${SKIP_FORMAT:-0}" = "1" ]; then
+    exit 0
+fi
+
+if command -v clang-format-17 >/dev/null 2>&1; then
+    clang_format=clang-format-17
+elif command -v clang-format >/dev/null 2>&1; then
+    clang_format=clang-format
+elif command -v xcrun >/dev/null 2>&1; then
+    clang_format="$(xcrun --find clang-format)"
+else
+    echo "pre-commit: clang-format not found; skipping format check." >&2
+    echo "            install clang-format-17, or set SKIP_FORMAT=1 to silence." >&2
+    exit 0
+fi
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+# Staged, added/copied/modified/renamed files only (skip deletes).
+mapfile -d '' -t staged < <(
+    git diff --cached --name-only --diff-filter=ACMR -z -- \
+        '*.c' '*.C' '*.cpp' '*.CPP' '*.h' '*.H' '*.hpp' '*.HPP'
+)
+
+if [ "${#staged[@]}" -eq 0 ]; then
+    exit 0
+fi
+
+# Reuse the CI exclusion filter so local and CI evaluate the same set.
+mapfile -d '' -t files < <(
+    printf '%s\0' "${staged[@]}" | python3 scripts/ci/filter-format-files.py
+)
+
+if [ "${#files[@]}" -eq 0 ]; then
+    exit 0
+fi
+
+status=0
+bad=()
+for file in "${files[@]}"; do
+    # Check the staged blob, not the working tree, so unrelated unstaged
+    # edits don't get blamed and partial-stage workflows still work.
+    if ! git show ":$file" | "$clang_format" --dry-run --Werror \
+            -style=file --assume-filename="$file" >/dev/null 2>&1; then
+        bad+=("$file")
+        status=1
+    fi
+done
+
+if [ "$status" -ne 0 ]; then
+    echo "pre-commit: clang-format issues in staged content:" >&2
+    for f in "${bad[@]}"; do
+        echo "  $f" >&2
+    done
+    echo >&2
+    echo "Fix with: bash ./scripts/ci/apply-format.sh && git add -u" >&2
+    echo "Bypass:   git commit --no-verify   (or SKIP_FORMAT=1)" >&2
+fi
+
+exit "$status"


### PR DESCRIPTION
## Summary

- Adds `scripts/git-hooks/pre-commit`: a staged-files-only `clang-format --dry-run` check that blocks commits with format violations.
- Opt-in per clone via `git config core.hooksPath scripts/git-hooks`. Bypass with `git commit --no-verify` or `SKIP_FORMAT=1`.
- Reuses `scripts/ci/filter-format-files.py` and `.clang-format-ignore`, so the hook, local scripts, and CI evaluate the identical file set.
- Documents the hook in `AGENTS.md` (Code conventions) and `CONTRIBUTING.md` (Code style); updates the AGENTS.md "before considering done" line to point at `apply-format.sh` / the hook.

## Design notes

- Checks the **staged blob** via `git show :file | clang-format --assume-filename=...`, not the working tree — unrelated unstaged edits don't get blamed, and partial-stage workflows keep working.
- Iterates only `--diff-filter=ACMR` C/C++ paths, so it's fast.
- Missing `clang-format` → warns and skips (won't block commits on machines without it).
- Tree is already clean: surveyed all 564 in-scope C/C++ files, zero violations. Existing `.clang-format-ignore` already covers the legacy/vendored/lookup-table files (libsmacker, stb_*, MAPTOOLS.CPP, COMMON.H, DEC.CPP, DEC_XCF.CPP, EXTRA.CPP, LBA_EXT.H). Convention for future opt-outs is documented alongside the hook.

## Test plan

- [x] Smoke test: bad staged `.cpp` → hook fails with file list + fix hint, exit 1
- [x] Smoke test: clean staged `.cpp` → hook passes, exit 0
- [x] Survey: all 564 in-scope tracked C/C++ files pass clang-format dry-run today
- [ ] Reviewer: enable the hook locally (`git config core.hooksPath scripts/git-hooks`) and try a deliberately misformatted commit