### PR TITLE
refactor: extract render-space dimensions to RESOLUTION_X/Y constants

### DIFF
--- a/LIB386/H/SYSTEM/RESOLUTION.H
+++ b/LIB386/H/SYSTEM/RESOLUTION.H
@@ -1,0 +1,26 @@
+#pragma once
+
+// Render-space framebuffer dimensions.
+//
+// These are the dimensions of the engine's internal framebuffer (the Log/Screen
+// buffers allocated in MEM.CPP, the surface CreateScreenMemory configures, and
+// the area the 3D pipeline and cinema bars cover). They are NOT the authored
+// UI layout dimensions (which remain 640x480 by convention and are encoded as
+// literals in UI code).
+//
+// Default 640x480 matches the original game. Overridable by the build system
+// (e.g. -DRESOLUTION_X=...) to enable wider canvases. Anything other than the
+// default is currently untested and requires additional work in the UI layer
+// and pre-rendered art handling.
+
+#ifndef RESOLUTION_X
+#define RESOLUTION_X 640
+#endif
+
+#ifndef RESOLUTION_Y
+#define RESOLUTION_Y 480
+#endif
+
+#if (RESOLUTION_X & 7)
+#error Horizontal resolution must be a multiple of 8
+#endif

--- a/SOURCES/DEFINES.H
+++ b/SOURCES/DEFINES.H
@@ -205,6 +205,9 @@
 // SaveGame
 #define SAVE_VERSION 4
 // on stocke les sauvegardes dans BufSpeak
+// NB: literal 640*480 is intentional — partitions BufSpeak (sized to
+// RESOLUTION_X*RESOLUTION_Y in MEM.CPP). Keeping the slot count fixed avoids
+// silently growing the save list when the framebuffer is widened.
 #define MAX_PLAYER ((640 * 480) / (MAX_SIZE_PLAYER_NAME + 1 + sizeof(char *)))
 #define MAX_SIZE_PLAYER_NAME 100 // Calculé avec des ',' par Isabelle
 

--- a/SOURCES/INITADEL.C
+++ b/SOURCES/INITADEL.C
@@ -18,6 +18,7 @@
 #include "SYSTEM/LOGPRINT.H"
 #include "SYSTEM/LZ.H"
 #include "SYSTEM/MOUSE.H"
+#include "SYSTEM/RESOLUTION.H"
 #include "SYSTEM/TIMER.H"
 #include "SYSTEM/WINDOW.H"
 
@@ -42,23 +43,11 @@ int WriteEmbeddedDefaultLba2Cfg(const char *destPath);
 #endif // DEMO
 
 #define ibuffer ScreenAux
-#define ibuffersize (640 * 480 + RECOVER_AREA)
+#define ibuffersize (RESOLUTION_X * RESOLUTION_Y + RECOVER_AREA)
 
 // -----------------------------------------------------------------------------
-#ifndef RESOLUTION_X
-#define RESOLUTION_X 640
-#endif
-
-#ifndef RESOLUTION_Y
-#define RESOLUTION_Y 480
-#endif
-
 #ifndef RESOLUTION_DEPTH
 #define RESOLUTION_DEPTH 8
-#endif
-
-#if (RESOLUTION_X & 7)
-#error Horizontal resolution must be a multiple of 8
 #endif
 
 // ··········································································

--- a/SOURCES/MEM.CPP
+++ b/SOURCES/MEM.CPP
@@ -8,6 +8,7 @@
 #include "C_EXTERN.H" // include LBA2
 
 #include <SVGA/SCREEN.H>
+#include <SYSTEM/RESOLUTION.H>
 #include "DIRECTORIES.H"
 
 extern U8 *BufferSmack; // tempo ?
@@ -29,9 +30,9 @@ struct SizeInfo {
 
 T_MEM ListMem[] = {
     {(void **)&PtrZBuffer, SIZE_Z_BUFFER}, // Calculé dynamiquement (GRILLE.CPP) -> InitBufferCube())
-    {(void **)&ScreenAux, 640 * 480 + RECOVER_AREA},
-    {(void **)&BufSpeak, 640 * 480 + RECOVER_AREA},
-    {(void **)&Screen, 640 * 480 + RECOVER_AREA},
+    {(void **)&ScreenAux, RESOLUTION_X *RESOLUTION_Y + RECOVER_AREA},
+    {(void **)&BufSpeak, RESOLUTION_X *RESOLUTION_Y + RECOVER_AREA},
+    {(void **)&Screen, RESOLUTION_X *RESOLUTION_Y + RECOVER_AREA},
     {(void **)&BufferMaskBrick, 0}, // Calculé dynamiquement (GRILLE.CPP -> InitBufferCube())
     {(void **)&BufMap, 0},          // Calculé dynamiquement (GRILLE.CPP -> InitBufferCube())
     {(void **)&TabBlock, 0},        // Calculé dynamiquement (GRILLE.CPP -> InitBufferCube())

--- a/SOURCES/OBJECT.CPP
+++ b/SOURCES/OBJECT.CPP
@@ -4686,19 +4686,19 @@ void FixeCinemaMode(S32 flagflip) {
                 SetClipWindow(ClipWindowXMin,
                               ymin,
                               ClipWindowXMax,
-                              479 - ymin);
+                              (S32)ModeDesiredY - 1 - ymin);
             }
 
             if (ClipWindowYMin > 0) {
                 MemoClipWindow();
                 UnsetClipWindow();
 
-                Box(0, 0, 639, MemoClipWindowYMin - 1, COUL_CINEMA);
-                Box(0, MemoClipWindowYMax + 1, 639, 479, COUL_CINEMA);
+                Box(0, 0, (S32)ModeDesiredX - 1, MemoClipWindowYMin - 1, COUL_CINEMA);
+                Box(0, MemoClipWindowYMax + 1, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, COUL_CINEMA);
 
                 if (flagflip) {
-                    BoxStaticAdd(0, 0, 639, MemoClipWindowYMin - 1);
-                    BoxStaticAdd(0, MemoClipWindowYMax + 1, 639, 479);
+                    BoxStaticAdd(0, 0, (S32)ModeDesiredX - 1, MemoClipWindowYMin - 1);
+                    BoxStaticAdd(0, MemoClipWindowYMax + 1, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1);
                 }
 
                 RestoreClipWindow();
@@ -4708,8 +4708,8 @@ void FixeCinemaMode(S32 flagflip) {
             MemoClipWindow();
             UnsetClipWindow();
 
-            Box(0, 0, 639, MemoClipWindowYMin - 1, COUL_CINEMA);
-            Box(0, MemoClipWindowYMax + 1, 639, 479, COUL_CINEMA);
+            Box(0, 0, (S32)ModeDesiredX - 1, MemoClipWindowYMin - 1, COUL_CINEMA);
+            Box(0, MemoClipWindowYMax + 1, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, COUL_CINEMA);
 
             RestoreClipWindow();
         }
@@ -4724,20 +4724,20 @@ void FixeCinemaMode(S32 flagflip) {
                 SetClipWindow(ClipWindowXMin,
                               ymin,
                               ClipWindowXMax,
-                              479 - ymin);
+                              (S32)ModeDesiredY - 1 - ymin);
             }
 
             MemoClipWindow();
             UnsetClipWindow();
 
             if (MemoClipWindowYMin > 0) {
-                Box(0, 0, 639, MemoClipWindowYMin - 1, COUL_CINEMA);
-                Box(0, MemoClipWindowYMax + 1, 639, 479, COUL_CINEMA);
+                Box(0, 0, (S32)ModeDesiredX - 1, MemoClipWindowYMin - 1, COUL_CINEMA);
+                Box(0, MemoClipWindowYMax + 1, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, COUL_CINEMA);
             }
 
             if (flagflip) {
-                BoxStaticAdd(0, 0, 639, 39);
-                BoxStaticAdd(0, 439, 639, 479);
+                BoxStaticAdd(0, 0, (S32)ModeDesiredX - 1, 39);
+                BoxStaticAdd(0, (S32)ModeDesiredY - 41, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1);
             }
 
             RestoreClipWindow();
@@ -4747,8 +4747,8 @@ void FixeCinemaMode(S32 flagflip) {
                 MemoClipWindow();
                 UnsetClipWindow();
 
-                BoxStaticAdd(0, 0, 639, 39);
-                BoxStaticAdd(0, 439, 639, 479);
+                BoxStaticAdd(0, 0, (S32)ModeDesiredX - 1, 39);
+                BoxStaticAdd(0, (S32)ModeDesiredY - 41, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1);
 
                 RestoreClipWindow();
             }
@@ -4763,8 +4763,8 @@ void RestoreCinemaMode(void) {
     if (!CinemaMode
             AND(ClipWindowYMin > 0 OR ClipWindowYMin != LastYCinema)) {
         // restore Log
-        CopyBlock(0, ClipWindowYMin, 639, 39, Screen, 0, ClipWindowYMin, Log);
-        CopyBlock(0, 439, 639, ClipWindowYMax, Screen, 0, 439, Log);
+        CopyBlock(0, ClipWindowYMin, (S32)ModeDesiredX - 1, 39, Screen, 0, ClipWindowYMin, Log);
+        CopyBlock(0, (S32)ModeDesiredY - 41, (S32)ModeDesiredX - 1, ClipWindowYMax, Screen, 0, (S32)ModeDesiredY - 41, Log);
     }
 }
 
@@ -6055,7 +6055,7 @@ startaffscene:
 #endif
     {
         S32 num = 11;
-        S32 x = 639 - 103;
+        S32 x = (S32)ModeDesiredX - 1 - 103;
 
 #ifndef DEMO
         switch (DistribVersion) {
@@ -6064,7 +6064,7 @@ startaffscene:
         case VIRGIN_VERSION:
         case VIRGIN_ASIA_VERSION:
             num = 16; // Logo Americain
-            x = 639 - 110;
+            x = (S32)ModeDesiredX - 1 - 110;
             break;
         }
 #endif
@@ -6082,7 +6082,7 @@ startaffscene:
         if (CubeMode == CUBE_EXTERIEUR AND TEMPETE_ACTIVE)
             num++;
 
-        AffGraph(0, 639 - 110, 75, HQR_Get(HQRPtrSprite, num));
+        AffGraph(0, (S32)ModeDesiredX - 1 - 110, 75, HQR_Get(HQRPtrSprite, num));
 #else
         // a cause du CinemaMode
         BoxStaticAdd(ScreenXMin, ScreenYMin, ScreenXMax, ScreenYMax);

--- a/SOURCES/SORT.CPP
+++ b/SOURCES/SORT.CPP
@@ -1,5 +1,7 @@
 #include "C_EXTERN.H"
 
+#include <SVGA/SCREEN.H>
+
 S32 NbTriObj = 0;
 
 /*══════════════════════════════════════════════════════════════════════════*
@@ -206,8 +208,8 @@ S32 TreeInsert(S16 numtype, S32 posx, S32 posy, S32 posz,
     }
 
     // PreClipping
-    if ((x1 < 0) OR(x0 >= 640)
-            OR(y1 < 0) OR(y0 >= 480)) {
+    if ((x1 < 0) OR(x0 >= (S32)ModeDesiredX)
+            OR(y1 < 0) OR(y0 >= (S32)ModeDesiredY)) {
         if (!(numtype & SORT_NO_PRECLIP)) {
             return FALSE;
         }


### PR DESCRIPTION
## Summary

No-op refactor that names the engine's render-space dimensions and routes the hardcoded `640`/`480`/`639`/`479`/`439` literals in render-space code through them. Prerequisite for any future widescreen / higher-resolution work; intentionally changes no behavior on its own.

- New `LIB386/H/SYSTEM/RESOLUTION.H` with `#ifndef`-guarded `RESOLUTION_X` / `RESOLUTION_Y` so the build system can override them (`-DRESOLUTION_X=...`).
- Compile-time allocations in `SOURCES/MEM.CPP` and `SOURCES/INITADEL.C`'s `ibuffersize` use the new constants.
- Runtime render-edge literals in `SOURCES/SORT.CPP::TreeInsert` (preclip) and `SOURCES/OBJECT.CPP::FixeCinemaMode` / `RestoreCinemaMode` / top-right logo anchor use `ModeDesiredX` / `ModeDesiredY`-derived expressions.
- `MAX_PLAYER` in `SOURCES/DEFINES.H` deliberately stays keyed to literal `640*480` (it partitions `BufSpeak`, and a silent slot-count change would walk off the buffer). Comment added.

## Scope notes

- **Not touched on purpose:** the ~150 UI-space literals (`320` centering, `639-16` dialogue right edge, menu coords, holomap layout, etc.). They encode the 640×480 authored UI layout, not the framebuffer size. The widescreen UI strategy (centered vs scaled) is a separate decision.
- `LIB386/H/FILLER.H::SIZE_VIDEOLINE EQU 640` is ASM-only and dead in the shipping binary (every `.ASM` source is commented out in the active `CMakeLists.txt`; ASM only compiles under the `tests/` UASM Docker harness).
- The 40-pixel cinema bar height stays literal — authored layout, not a screen dimension.
- The top-right in-game logo is anchored to **render-right** (`ModeDesiredX-1-103`). If a future widescreen build adopts a centered-UI strategy, this site is one of a handful that would re-anchor; flagged for that future review.

## Two commits

1. `refactor(resolution): extract framebuffer dimensions to RESOLUTION.H` — header + compile-time allocations.
2. `refactor(render): route cinema bars and sort preclip through ModeDesiredX/Y` — runtime edges.

## Test plan

- [x] `make build` clean on Linux.
- [x] `make test` — 8/8 host tests pass.
- [x] `./run_tests_docker.sh` — 102/102 pass, including the 16 polyrec ASM↔CPP equivalence replays. Bit-exact equivalence is the load-bearing signal that this is a true no-op.
- [x] `bash ./scripts/ci/check-format.sh` clean (pre-commit hook caught one nit in `MEM.CPP` — clang-format strips the space between adjacent macro identifiers next to a pointer cast, matching the pattern of the existing line 39).
- [x] Manual smoke against retail data: open inventory, enter a cinematic, save/load, holomap. Visual identity expected.
- [x] CI matrix (macOS, Windows UCRT64, cross_linux2win) — verifying the new header is portable.

## What this unlocks

A subsequent change can flip `-DRESOLUTION_X=768` (or any width) and produce a wider framebuffer where the 3D world and cinema bars cover the full canvas, with UI staying at its existing 640-authored coordinates. That's a separate PR with its own design call (see issue #45 for the phase structure).