### PR TITLE
ci: add clang-tidy static-analysis setup

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,38 @@
+# clang-tidy configuration — LBA2 community fork.
+#
+# Scope: memory-safety and undefined-behaviour hunting (issue #47), NOT style.
+# The Clang Static Analyzer (clang-analyzer-*) plus bugprone-* / cert-* give
+# type-accurate, path-sensitive analysis that complements the cppcheck pass.
+#
+# modernize-* and readability-* are intentionally disabled: this is a faithful
+# C++98 + x86 ASM port, not a modernization target.
+#
+# A few bugprone-/cert-* checks are disabled because they fire constantly on
+# this codebase's deliberate 1997-era patterns (S16/S32/U32 truncations,
+# unparenthesised macros, reserved-looking identifiers) and would drown the
+# real findings. They can be re-enabled later behind a baseline.
+#
+# Run with: scripts/ci/run-clang-tidy.sh <build-dir>
+# (needs compile_commands.json — CMAKE_EXPORT_COMPILE_COMMANDS is ON by default).
+
+Checks: >
+  -*,
+  clang-analyzer-*,
+  bugprone-*,
+  cert-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-narrowing-conversions,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-macro-parentheses,
+  -bugprone-reserved-identifier,
+  -cert-dcl37-c,
+  -cert-dcl51-cpp,
+  -cert-err58-cpp
+
+WarningsAsErrors: ''
+
+# Only diagnose the project's own headers. Vendored headers (stb_*, libsmacker)
+# live outside SOURCES/ and LIB386/H/ and stay excluded.
+HeaderFilterRegex: '(SOURCES/|LIB386/H/).*'
+
+FormatStyle: file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.23)
 
 project(LBA2)
 
+# Emit compile_commands.json so clang-tidy and other tooling can analyze the
+# real build configuration. See .clang-tidy and scripts/ci/run-clang-tidy.sh.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Option to enable x86 assembly (requires UASM). Default OFF since all ASM is ported to C++.
 option(ENABLE_ASM "Enable x86 assembly (requires UASM assembler)" OFF)
 

--- a/scripts/ci/run-clang-tidy.sh
+++ b/scripts/ci/run-clang-tidy.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Run clang-tidy across the project's own C/C++ sources for memory-safety and
+# undefined-behaviour checks. Scope and rationale live in .clang-tidy.
+#
+# Requires a configured build directory with compile_commands.json
+# (CMAKE_EXPORT_COMPILE_COMMANDS is ON by default in CMakeLists.txt).
+#
+# Usage: scripts/ci/run-clang-tidy.sh [build-dir]   (default: build)
+
+build_dir="${1:-build}"
+
+if [ ! -f "$build_dir/compile_commands.json" ]; then
+    echo "No compile_commands.json in '$build_dir'." >&2
+    echo "Configure a build first, e.g.: cmake -B build" >&2
+    exit 1
+fi
+
+if command -v run-clang-tidy >/dev/null 2>&1; then
+    runner=run-clang-tidy
+elif command -v run-clang-tidy-18 >/dev/null 2>&1; then
+    runner=run-clang-tidy-18
+else
+    echo "run-clang-tidy is required (part of the clang-tools-extra package)." >&2
+    exit 1
+fi
+
+# Tracked project sources, minus vendored third-party trees (libsmacker and the
+# stb single-file libraries). Vendored headers are excluded via .clang-tidy's
+# HeaderFilterRegex.
+mapfile -d '' files < <(
+    git ls-files -z -- '*.c' '*.C' '*.cpp' '*.CPP' \
+        | grep -zv -e '^LIB386/libsmacker/' -e '^LIB386/AIL/SDL/stb_vorbis\.c$'
+)
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "No files to analyze." >&2
+    exit 0
+fi
+
+"$runner" -p "$build_dir" -quiet "${files[@]}"


### PR DESCRIPTION
## Summary
- Adds a clang-tidy pass scoped to memory-safety / UB checks, complementing the existing static-analysis review with type-accurate, path-sensitive analysis.
- `CMAKE_EXPORT_COMPILE_COMMANDS=ON`, a `.clang-tidy` tuned for this codebase, and `scripts/ci/run-clang-tidy.sh` mirroring the existing `scripts/ci/` pattern.

## Why
cppcheck-style checks catch UB they can reason about statically; `clang-analyzer-*` adds symbolic, path-sensitive coverage, and `bugprone-*` / `cert-*` add integer and lifetime checks. Part of the static-analysis slice of #47.

## Notes
- No behaviour change — pure tooling.
- `modernize-*` / `readability-*` are off: this is a faithful C++98 + x86 ASM port, not a modernization target.
- A few noisy `bugprone-*` / `cert-*` checks are disabled with rationale in `.clang-tidy`; they can be re-enabled behind a baseline later.
- Vendored trees (libsmacker, stb_vorbis) are excluded.

## Test plan
- [x] `cmake -B build` emits `build/compile_commands.json`
- [x] `scripts/ci/run-clang-tidy.sh build` runs end-to-end over project sources