### PR TITLE
fix: undefined-behaviour hardening from the static-analysis pass

### DIFF
--- a/LIB386/H/SYSTEM/ADELINE_TYPES.H
+++ b/LIB386/H/SYSTEM/ADELINE_TYPES.H
@@ -52,6 +52,17 @@ typedef void(BOX_FUNC)(T_BOX *pbox);
 #define TRUE 1
 #define FALSE 0
 
+//------------------------------------------------------------------------------
+// Marks a function that never returns (exit/abort wrappers). Lets the compiler
+// and static analyzers know control does not fall through past the call.
+#if defined(__GNUC__) || defined(__clang__)
+#define LBA_NORETURN __attribute__((noreturn))
+#elif defined(_MSC_VER)
+#define LBA_NORETURN __declspec(noreturn)
+#else
+#define LBA_NORETURN
+#endif
+
 // =============================================================================
 #ifdef __cplusplus
 }

--- a/LIB386/pol_work/POLYGOUR.CPP
+++ b/LIB386/pol_work/POLYGOUR.CPP
@@ -379,7 +379,7 @@ S32 Filler_DitherTable(U32 nbLines, U32 fillCurXMin, U32 fillCurXMax) {
             U32 i = 0;
             if (ditherCount > 1) {
                 // Rotate dither pattern based on pixel position
-                ditherValue = ((ditherValue << (ditherCount & 31)) | (ditherValue >> (32 - (ditherCount & 31)))) & 0xFF;
+                ditherValue = ((ditherValue << (ditherCount & 31)) | (ditherValue >> ((32 - (ditherCount & 31)) & 31))) & 0xFF;
 
                 // Process pairs of pixels
                 U32 pairCount = ditherCount >> 1;
@@ -401,7 +401,7 @@ S32 Filler_DitherTable(U32 nbLines, U32 fillCurXMin, U32 fillCurXMax) {
                     line[i++] = color2;
 
                     ditherValue &= 0xFF;
-                    ditherValue = ((ditherValue << (ditherCount & 31)) | (ditherValue >> (32 - (ditherCount & 31)))) & 0xFF;
+                    ditherValue = ((ditherValue << (ditherCount & 31)) | (ditherValue >> ((32 - (ditherCount & 31)) & 31))) & 0xFF;
                     ditherValue += gouraudValue;
                     gouraudValue += gouraudSlope;
                 }

--- a/SOURCES/3DEXT/LOADISLE.CPP
+++ b/SOURCES/3DEXT/LOADISLE.CPP
@@ -38,7 +38,7 @@
 
 #define HQR_STEP_CUBE 6
 
-extern void TheEndCheckFile(const char *filename);
+extern LBA_NORETURN void TheEndCheckFile(const char *filename);
 extern void TheEnd(S32 num, const char *error);
 
 //extern	U32	IsleMem ;

--- a/SOURCES/COMMON.H
+++ b/SOURCES/COMMON.H
@@ -399,7 +399,7 @@ typedef	struct	{
 
 #define	CADRE_RED	(1<<16)	// Cadres rouges
 
-#define	A_FLIP		(1<<31)	// Flip les boites dessinées
+#define	A_FLIP		(1U<<31)	// Flip les boites dessinées
 
 #define	ALL_ANGLES	(DRAW_SG|DRAW_IG|DRAW_ID|DRAW_SD)
 #define	ALL_ARROWS	(ARROW_SG|ARROW_IG|ARROW_ID|ARROW_SD)

--- a/SOURCES/INPUT.H
+++ b/SOURCES/INPUT.H
@@ -34,13 +34,13 @@
 #define I_CAMERA_LEVEL_PLUS (1 << 23)  // '+'		Niveau Caméra suivant
 #define I_CAMERA_LEVEL_MOINS (1 << 24) // '-'		Niveau Caméra Precedent
 
-#define I_WEAPON_1 (1 << 25) // '1'		Arme 1 (Balle Magique)
-#define I_WEAPON_2 (1 << 26) // '2'		Arme 2 (Balle Magique)
-#define I_WEAPON_3 (1 << 27) // '3'		Arme 3 (Balle Magique)
-#define I_WEAPON_4 (1 << 28) // '4'		Arme 4 (Balle Magique)
-#define I_WEAPON_5 (1 << 29) // '5'		Arme 5 (Balle Magique)
-#define I_WEAPON_6 (1 << 30) // '6'		Arme 6 (Balle Magique)
-#define I_WEAPON_7 (1 << 31) // '7'		Arme 7 (Balle Magique)
+#define I_WEAPON_1 (1 << 25)  // '1'		Arme 1 (Balle Magique)
+#define I_WEAPON_2 (1 << 26)  // '2'		Arme 2 (Balle Magique)
+#define I_WEAPON_3 (1 << 27)  // '3'		Arme 3 (Balle Magique)
+#define I_WEAPON_4 (1 << 28)  // '4'		Arme 4 (Balle Magique)
+#define I_WEAPON_5 (1 << 29)  // '5'		Arme 5 (Balle Magique)
+#define I_WEAPON_6 (1 << 30)  // '6'		Arme 6 (Balle Magique)
+#define I_WEAPON_7 (1U << 31) // '7'		Arme 7 (Balle Magique)
 
 // Input2
 

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2070,7 +2070,7 @@ void InitProgram() {
 }
 
 /*══════════════════════════════════════════════════════════════════════════*/
-void TheEndCheckFile(const char *filename) {
+LBA_NORETURN void TheEndCheckFile(const char *filename) {
     if (FileSize(filename))
         End_Num = NOT_ENOUGH_MEM;
     else

--- a/SOURCES/PERSO.H
+++ b/SOURCES/PERSO.H
@@ -26,7 +26,7 @@ extern S32 MainLoop(void);
 /*--------------------------------------------------------------------------*/
 extern void InitProgram();
 /*--------------------------------------------------------------------------*/
-extern void TheEndCheckFile(const char *filename);
+extern LBA_NORETURN void TheEndCheckFile(const char *filename);
 /*--------------------------------------------------------------------------*/
 extern void InitTheEnd(S32 num, char *error);
 /*--------------------------------------------------------------------------*/

--- a/tests/pol_work/test_polygour.cpp
+++ b/tests/pol_work/test_polygour.cpp
@@ -462,6 +462,34 @@ static void test_asm_random_dither_table(void) {
     }
 }
 
+/* Regression (#47): a scanline width that is a nonzero multiple of 32 makes
+ * (ditherCount & 31) == 0 in Filler_DitherTable's dither-pattern rotate, so the
+ * original `>> (32 - (ditherCount & 31))` shifted a 32-bit value by 32 — UB.
+ * Zero edge slopes keep the width constant, so widths 32 and 64 hit the rotate
+ * on every scanline. x86 masks shift counts so buggy/fixed output matches here;
+ * the case earns its keep under UBSan and on targets that don't mask. */
+static void test_asm_equiv_dither_table_width_mult_32(void) {
+    static const U32 widths[2] = {32, 64};
+    for (int w = 0; w < 2; w++) {
+        U32 xmin = 16 << 16;
+        U32 xmax = (16 + widths[w]) << 16;
+
+        setup_gouraud_table_filler(30, 4, xmin, xmax, 0x020000, 0x800);
+        Filler_DitherTable(4, xmin, xmax);
+        memcpy(gour_cpp_buf, g_poly_framebuf, TEST_POLY_SIZE);
+
+        setup_gouraud_table_filler(30, 4, xmin, xmax, 0x020000, 0x800);
+        call_asm_Filler_DitherTable(4, xmin, xmax);
+        memcpy(gour_asm_buf, g_poly_framebuf, TEST_POLY_SIZE);
+
+        char msg[96];
+        snprintf(msg, sizeof(msg),
+                 "Filler_DitherTable width=%u (dither-rotate shift-by-32 UB)",
+                 widths[w]);
+        ASSERT_ASM_CPP_MEM_EQ(gour_asm_buf, gour_cpp_buf, TEST_POLY_SIZE, msg);
+    }
+}
+
 /* ── Filler_GouraudFog ─────────────────────────────────────────── */
 
 static void test_asm_equiv_gouraud_fog(void) {
@@ -1360,6 +1388,7 @@ int main(void) {
     RUN_TEST(test_asm_random_gouraud_table);
     RUN_TEST(test_asm_equiv_dither_table);
     RUN_TEST(test_asm_random_dither_table);
+    RUN_TEST(test_asm_equiv_dither_table_width_mult_32);
     /* Filler_GouraudFog / DitherFog */
     RUN_TEST(test_asm_equiv_gouraud_fog);
     RUN_TEST(test_asm_random_gouraud_fog);


### PR DESCRIPTION
## Summary
Three undefined-behaviour fixes surfaced by the static-analysis pass for #47, one commit each:

- **`(1 << 31)` → `(1U << 31)`** for the `I_WEAPON_7` and `A_FLIP` bit masks — shifting into the sign bit of a signed `int` is UB; both are pure `U32` masks so the value is unchanged.
- **shift-by-32 in `Filler_DitherTable`** — the dither rotate `(x << n) | (x >> (32 - n))` becomes a shift by 32 when the scanline width is a multiple of 32 (`n == 0`). Masking the count with `& 31` makes rotate-by-zero a no-op, which is the intended behaviour. Includes a regression test.
- **`TheEndCheckFile` marked `noreturn`** — it ends in `exit(0)`, but without the attribute the common `if (!ptr) TheEndCheckFile(...)` then-deref pattern looks like (and would be) a null dereference. A new `LBA_NORETURN` macro fixes every such call site at the root.

## Why
This is the "UB hidden in some builds/platforms" class #47 targets. Each fix is small and behaviour-preserving on x86.

## Notes
- The POLYGOUR test deterministically drives the width-multiple-of-32 boundary. On x86 the buggy and fixed code produce identical output (x86 masks shift counts), so the test becomes a live tripwire under UBSan — tracked in #138. It would also catch the bug on targets that don't mask, and the fix restores ASM equivalence at those widths.
- The `noreturn` change resolves the same pattern at ~45 call sites, not just the one the analyzer happened to flag.

## Test plan
- [x] `make build` succeeds
- [x] `make test` (host suite) passes
- [x] `./run_tests_docker.sh test_polygour` passes (ASM-equivalence suite)