### PR TITLE
fix: uninitialised read of old position in GereExtras

### DIFF
--- a/SOURCES/EXTRA.CPP
+++ b/SOURCES/EXTRA.CPP
@@ -1685,6 +1685,14 @@ void	GereExtras()
 
 		type = ptrextra->Flags & EXTRA_MASK_WEAPON ;
 
+		// EXTRA_END_OBJ / EXTRA_END_COL read oldx/y/z, but only the movement
+		// flags (EXTRA_FLY / EXTRA_SEARCH_*) assign them. Default to the
+		// current position so an extra without a movement flag gets a
+		// zero-length collision check instead of a stale or uninitialised one.
+		oldx = ptrextra->PosX ;
+		oldy = ptrextra->PosY ;
+		oldz = ptrextra->PosZ ;
+
 		if( ptrextra->Flags & EXTRA_TIME_OUT )
 		{
 			if( TimerRefHR >= ptrextra->Timer + ptrextra->TimeOut )


### PR DESCRIPTION
## Summary
Fixes an uninitialised read in `GereExtras()` flagged by the clang-tidy pass. Part of #47.

## The bug
`oldx/oldy/oldz` are function-scope, but assigned only inside the movement-flag blocks (`EXTRA_FLY`, `EXTRA_SEARCH_OBJ`, `EXTRA_SEARCH_KEY`). The `EXTRA_END_OBJ` / `EXTRA_END_COL` blocks read them unconditionally — and these are independent flag bits, so an extra carrying an END flag but no movement flag reads a stale value carried over from a previous loop iteration, or an uninitialised one on the first such extra. clang-analyzer flagged three read sites (`core.CallAndMessage`).

## The fix
Default `oldx/oldy/oldz` to the current position at the top of the per-extra loop. Extras with a movement flag overwrite it exactly as before (no behaviour change); extras without one now get a zero-length collision check instead of garbage.

## Notes
- `GereExtras()` isn't unit-testable in isolation and has no ASM-equivalence harness, so the regression pin is the clang-tidy gate itself: reverting the init brings the three `core.*` findings straight back. Verified — the three findings are gone and the build links.
- A second, separate uninitialised read in the same function (`numobj` on the conch-attract pickup path) is held for a follow-up — it needs a game-behaviour decision.

## Test plan
- [x] `make build` links
- [x] `scripts/ci/run-clang-tidy.sh build` — no `clang-analyzer-core.*` findings at the three EXTRA.CPP read sites