### PR TITLE
fix: drop no-op/off-by-one +0.5 bias in terrain vertex projection

### DIFF
--- a/SOURCES/3DEXT/TERRAIN.CPP
+++ b/SOURCES/3DEXT/TERRAIN.CPP
@@ -828,9 +828,8 @@ void AffichageTerrainZBuf(void) {
 
                 ptrs->Zrot = zr;
 
-                // Add 0.5 bias before truncation to reduce edge artifacts from coordinate precision loss
-                ptrs->X2D = (S16)(Xp + 0.5);
-                ptrs->Y2D = (S16)(Yp + 0.5);
+                ptrs->X2D = (S16)Xp;
+                ptrs->Y2D = (S16)Yp;
 
             } else {
                 *ptra = 0;


### PR DESCRIPTION
## Summary

`AffichageTerrainZBuf` stored projected terrain vertices as `(S16)(Xp + 0.5)` / `(S16)(Yp + 0.5)`. But `Xp`/`Yp` from `LongProjectPoint` are already `lrintl`-rounded `S32` values — faithful to the original x87 `fistp`. So the `+ 0.5`:

- is a **no-op** for non-negative coordinates, and
- introduces an **off-by-one toward zero** for negative ones.

This restores the plain `(S16)Xp` / `(S16)Yp` truncation from before `73234aa` ("improve polygon edge bleeding - still buggy"), whose terrain change was the one piece of that commit never reverted.

## Notes

This is a correctness/faithfulness cleanup — it does not fix a known visible bug. It came out of investigating an exterior-terrain seam (filed separately as #144); the seam turned out to be original cube-boundary behaviour, unrelated to this `+0.5`. Committing the revert anyway because the math is provably one-directional: it can only make negative-coordinate vertices more correct, never less.

## Test plan

- [x] Builds clean
- [x] Exterior scenes render unchanged (no observable difference expected — `+0.5` was a no-op for the common case)