### PR TITLE
fix: drop wrong-typed extern for TempoRealAngle in savegame load

### DIFF
--- a/SOURCES/SAVEGAME.CPP
+++ b/SOURCES/SAVEGAME.CPP
@@ -1469,9 +1469,6 @@ void SaveContexte(S32 savetimerrefhr) {
 static S32 LoadContexteReadObjectsAtStride(S32 use_wire32) {
     S32 n;
     T_OBJET *ptrobj = ListObjet;
-#if defined(DEBUG_TOOLS) || defined(TEST_TOOLS) || defined(EDITLBA2)
-    extern S32 TempoRealAngle;
-#endif
     for (n = 0; n < NbObjets; n++, ptrobj++) {
         LbaReadByte(ptrobj->GenBody);
         LbaReadByte(ptrobj->Col);


### PR DESCRIPTION
## Summary

The `DEBUG_TOOLS` build is currently broken:

```
SOURCES/SAVEGAME.CPP:1473:16: error: conflicting declaration 'S32 TempoRealAngle'
SOURCES/SAVEGAME.CPP:52:17: note: previous declaration as 'T_REAL_VALUE_HR TempoRealAngle'
```

PR #62's stride-retry refactor extracted `LoadContexteReadObjectsAtStride()` and added `extern S32 TempoRealAngle;` inside it. But `TempoRealAngle` is a file-scope variable in the same translation unit, defined as `T_REAL_VALUE_HR` at `SAVEGAME.CPP:52` — so the `extern` was both wrong-typed and redundant. It only broke `DEBUG_TOOLS` builds, where `T_REAL_VALUE_HR` / `TempoRealAngle` are compiled in and the conflict surfaces.

Fix: remove the `extern`; the file-scope definition is already in scope.

## Test plan

- [x] `cmake -B build -DDEBUG_TOOLS=ON && cmake --build build` — now compiles and links cleanly
- [x] Default build unaffected (the block was already `#if`-gated out)