### PR TITLE
ci: drop install-linux-dependencies from macOS SDL3 step

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,7 +36,6 @@ jobs:
         uses: libsdl-org/setup-sdl@4ebea449684c989388fe6bcea0460e300d13a5ae # main @ 2025-12-20
         id: sdl
         with:
-          install-linux-dependencies: true
           version: 3-latest
           build-type: ${{ env.BUILD_TYPE }}
 


### PR DESCRIPTION
## Summary
- `macos.yml` passed `install-linux-dependencies: true` to the `setup-sdl` step — a copy-paste leftover from `linux.yml`.
- It's a no-op on macOS runners, so this just removes the dead input.

## Test plan
- [x] macOS CI build still passes (SDL3 installs as before)