### PR TITLE
feat(packaging): name macOS bundle dir from product name

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -61,9 +61,11 @@ jobs:
 
       - name: Verify Binary
         # CMake's MACOSX_BUNDLE wiring (in SOURCES/CMakeLists.txt) puts the
-        # binary inside an .app bundle. The bare build/SOURCES/lba2cc path
-        # only exists for non-Apple builds.
+        # binary inside an .app bundle. The bundle dir is named after
+        # LBA2_PRODUCT_NAME (Finder display name); the inner Mach-O keeps
+        # the terse LBA2_EXECUTABLE_NAME. The bare build/SOURCES/lba2cc
+        # path only exists for non-Apple builds.
         run: |
-          test -d build/SOURCES/lba2cc.app
-          test -x build/SOURCES/lba2cc.app/Contents/MacOS/lba2cc
+          test -d "build/SOURCES/LBA2 Classic Community.app"
+          test -x "build/SOURCES/LBA2 Classic Community.app/Contents/MacOS/lba2cc"
           echo "Build successful"

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -76,7 +76,7 @@ jobs:
           VERSION=$(cat "$BUILD_DIR/VERSION.txt")
           mkdir -p dist
           bash scripts/packaging/bundle-macos.sh \
-            --app "$BUILD_DIR/SOURCES/lba2cc.app" \
+            --app "$BUILD_DIR/SOURCES/LBA2 Classic Community.app" \
             --version "$VERSION" \
             --arch ${{ matrix.arch }} \
             --build-dir "$BUILD_DIR" \

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ chmod +x lba2cc-*-anylinux-*.AppImage
 
 ### macOS
 
-Download `lba2cc-<version>-macos-arm64.dmg`, open it, drag `lba2cc.app` to Applications. First launch needs right-click → **Open** (macOS Gatekeeper blocks unsigned apps on double-click). The DMG ships its own README covering this — read it before the first launch.
+Download `lba2cc-<version>-macos-arm64.dmg`, open it, drag `LBA2 Classic Community.app` to Applications. First launch needs right-click → **Open** (macOS Gatekeeper blocks unsigned apps on double-click). The DMG ships its own README covering this — read it before the first launch.
 
 ### Windows
 

--- a/SOURCES/CMakeLists.txt
+++ b/SOURCES/CMakeLists.txt
@@ -55,15 +55,35 @@ add_executable(${LBA2_EXECUTABLE_NAME} ${SOURCES_FILES} ${SOURCES_FILES_ASM} ${S
 # at the configured Info.plist, and routes the .icns to Contents/Resources/.
 # Without MACOSX_BUNDLE the binary would be a bare executable in
 # build/SOURCES/, not a launchable .app.
+#
+# OUTPUT_NAME drives both the bundle directory name (<OUTPUT_NAME>.app) and
+# the inner Mach-O filename. We want them to diverge: the bundle is the
+# user-facing display name ("LBA2 Classic Community.app" — what Finder
+# shows on disk), while the inner binary stays as the terse executable
+# name ("lba2cc" — what CLI users invoke and what CFBundleExecutable points
+# at). CMake has no single property that splits these, so we set
+# OUTPUT_NAME to the product name and rename the inner binary back to
+# LBA2_EXECUTABLE_NAME with a POST_BUILD step (ordered before codesign so
+# the signature covers the final layout).
 if(APPLE)
     set_target_properties(${LBA2_EXECUTABLE_NAME} PROPERTIES
         MACOSX_BUNDLE TRUE
         MACOSX_BUNDLE_INFO_PLIST ${CMAKE_BINARY_DIR}/packaging/Info.plist
-        OUTPUT_NAME ${LBA2_EXECUTABLE_NAME})
+        OUTPUT_NAME ${LBA2_PRODUCT_NAME})
     set_source_files_properties(
         ${CMAKE_BINARY_DIR}/packaging/${LBA2_DESKTOP_ID}.icns
         PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
     add_dependencies(${LBA2_EXECUTABLE_NAME} lba2_icns)
+
+    # Rename Contents/MacOS/<product-name> → Contents/MacOS/<exe-name>.
+    # CFBundleExecutable in Info.plist already points at LBA2_EXECUTABLE_NAME,
+    # so after the rename macOS launches the renamed file correctly.
+    add_custom_command(TARGET ${LBA2_EXECUTABLE_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E rename
+                $<TARGET_FILE:${LBA2_EXECUTABLE_NAME}>
+                $<TARGET_BUNDLE_CONTENT_DIR:${LBA2_EXECUTABLE_NAME}>/MacOS/${LBA2_EXECUTABLE_NAME}
+        COMMENT "Renaming inner binary to ${LBA2_EXECUTABLE_NAME}"
+        VERBATIM)
 
     # Ad-hoc codesign the .app post-build. Apple Silicon (macOS 11+) refuses
     # to launch unsigned binaries — Gatekeeper reports the app as "damaged"
@@ -76,7 +96,7 @@ if(APPLE)
     add_custom_command(TARGET ${LBA2_EXECUTABLE_NAME} POST_BUILD
         COMMAND codesign --force --deep --sign -
                 $<TARGET_BUNDLE_DIR:${LBA2_EXECUTABLE_NAME}>
-        COMMENT "Ad-hoc codesigning ${LBA2_EXECUTABLE_NAME}.app"
+        COMMENT "Ad-hoc codesigning ${LBA2_PRODUCT_NAME}.app"
         VERBATIM)
 endif()
 # GCC LTO mis-infers T_PLASMA::data_start size when ptrc writes into Malloc tail (see ANIMTEX.CPP plasma case).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -556,15 +556,20 @@ so `find_package(SDL3)` resolves cleanly on both Apple Silicon (`/opt/homebrew`)
 and Intel (`/usr/local`). CI uses `libsdl-org/setup-sdl` instead and points at
 its own prefix — different machinery, same outcome.
 
-DMG layout (mounted view):
+DMG mounts as volume "LBA2 Classic Community <version>" with the items
+at the volume root (no wrapping directory):
 
 ```
-LBA2 Classic Community <version>/
-    lba2cc.app
-    Applications -> /Applications   (drag-to-install symlink)
-    README.txt
-    LICENSE.txt
+LBA2 Classic Community.app
+Applications -> /Applications   (drag-to-install symlink)
+README.txt
+LICENSE.txt
 ```
+
+Bundle directory carries `LBA2_PRODUCT_NAME` (the Finder display name).
+The inner Mach-O at `Contents/MacOS/lba2cc` and the DMG filename both
+follow `LBA2_EXECUTABLE_NAME` — kept space-free for CLI use and to match
+the cross-platform artifact naming (`<exe>-<version>-<platform>-<arch>`).
 
 The first-launch Gatekeeper friction (right-click → Open) is documented
 in the README inside the DMG. Code signing + notarization are deferred

--- a/scripts/dev/build-macos-release.sh
+++ b/scripts/dev/build-macos-release.sh
@@ -103,11 +103,17 @@ fi
 cmake --preset "$PRESET" -DLBA2_LINK_STATIC="$LINK_STATIC"
 cmake --build --preset "$PRESET"
 
-# Resolve executable / app names (follow LBA2_EXECUTABLE_NAME overrides).
+# Resolve executable / app names (follow LBA2_EXECUTABLE_NAME and
+# LBA2_PRODUCT_NAME overrides). The bundle dir is named after the product
+# (display name shown in Finder); the inner Mach-O is named after the
+# executable (CLI-friendly, space-free).
 EXE_NAME=$(awk -F= '/^LBA2_EXECUTABLE_NAME:[^=]+=/{print $2; exit}' \
     "$BUILD_DIR/CMakeCache.txt")
 EXE_NAME="${EXE_NAME:-lba2cc}"
-APP_PATH="$BUILD_DIR/SOURCES/${EXE_NAME}.app"
+PRODUCT_NAME=$(awk -F= '/^LBA2_PRODUCT_NAME:[^=]+=/{print $2; exit}' \
+    "$BUILD_DIR/CMakeCache.txt")
+PRODUCT_NAME="${PRODUCT_NAME:-LBA2 Classic Community}"
+APP_PATH="$BUILD_DIR/SOURCES/${PRODUCT_NAME}.app"
 
 if [[ ! -d "$APP_PATH" ]]; then
     echo "[build-macos-release] expected $APP_PATH but it doesn't exist" >&2

--- a/scripts/packaging/bundle-macos.sh
+++ b/scripts/packaging/bundle-macos.sh
@@ -1,24 +1,27 @@
 #!/usr/bin/env bash
-# Bundle a built lba2cc.app into a macOS DMG release artifact.
+# Bundle a built .app into a macOS DMG release artifact.
 #
 # Shared by the local dry-run script (scripts/dev/build-macos-release.sh)
 # and the CI release workflow (.github/workflows/release-macos.yml). One
 # packaging codepath; same shape as bundle-windows.sh.
 #
 # Usage:
-#   bundle-macos.sh --app <path/to/lba2cc.app> \
+#   bundle-macos.sh --app <path/to/Foo.app> \
 #                   --version <version-string> \
 #                   --arch <arm64|x86_64> \
 #                   --build-dir <cmake-build-dir> \
 #                   --output-dir <where-to-drop-the-dmg>
 #
-# Produces: <output-dir>/lba2cc-<version>-macos-<arch>.dmg
+# Produces: <output-dir>/<exe-name>-<version>-macos-<arch>.dmg
+# (exe-name = LBA2_EXECUTABLE_NAME, kept space-free for sane filenames.)
 #
-# DMG layout (mounted view):
-#   <product-name>-<version>/
-#       lba2cc.app
-#       Applications -> /Applications  (drag-to-install symlink)
-#       README.txt   (CRLF-free; macOS notepad-friendly with LF)
+# DMG mounts as volume "<product-name> <version>" with the items at the
+# volume root (no wrapping directory — hdiutil's -srcfolder packs the
+# staging dir contents flat):
+#   <product-name>.app              (bundle dir = display name)
+#   Applications -> /Applications   (drag-to-install symlink)
+#   README.txt                      (LF line endings; TextEdit-friendly)
+#   LICENSE.txt
 #
 # Requires macOS host (uses hdiutil; no cross-platform alternative that
 # produces a real DMG). Use scripts/dev/build-macos-release.sh as the
@@ -65,9 +68,16 @@ fi
 
 # Same path-derivation pattern as bundle-windows.sh (no git dependency).
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-APP_NAME="$(basename "$APP_PATH")"          # lba2cc.app (or override)
-APP_STEM="${APP_NAME%.app}"                 # lba2cc
-ARTIFACT_NAME="${APP_STEM}-${VERSION}-macos-${ARCH}"
+APP_NAME="$(basename "$APP_PATH")"          # "LBA2 Classic Community.app"
+APP_STEM="${APP_NAME%.app}"                 # "LBA2 Classic Community" (display name)
+
+# The inner Mach-O is named after LBA2_EXECUTABLE_NAME (e.g. "lba2cc"),
+# not the bundle dir. Used for the DMG filename (kept space-free) and for
+# the README's CLI examples that reach into Contents/MacOS/.
+EXE_NAME=$(awk -F= '/^LBA2_EXECUTABLE_NAME:[^=]+=/{print $2; exit}' \
+    "$BUILD_DIR/CMakeCache.txt" 2>/dev/null || echo "lba2cc")
+
+ARTIFACT_NAME="${EXE_NAME}-${VERSION}-macos-${ARCH}"
 ARTIFACT_DMG="${OUTPUT_DIR}/${ARTIFACT_NAME}.dmg"
 STAGING_DIR="${OUTPUT_DIR}/${ARTIFACT_NAME}-staging"
 
@@ -98,7 +108,7 @@ PRODUCT_DESC=$(awk -F= '/^LBA2_PRODUCT_DESCRIPTION:[^=]+=/{print $2; exit}' \
 sed -e "s|@LBA2_PRODUCT_NAME@|${PRODUCT_NAME}|g" \
     -e "s|@LBA2_PRODUCT_DESCRIPTION@|${PRODUCT_DESC}|g" \
     -e "s|@LBA2_VERSION_STRING@|${VERSION}|g" \
-    -e "s|@LBA2_EXECUTABLE_NAME@|${APP_STEM}|g" \
+    -e "s|@LBA2_EXECUTABLE_NAME@|${EXE_NAME}|g" \
     "$REPO_ROOT/scripts/packaging/macos-readme.txt.in" \
     > "$STAGING_DIR/README.txt"
 

--- a/scripts/packaging/macos-readme.txt.in
+++ b/scripts/packaging/macos-readme.txt.in
@@ -7,12 +7,12 @@
 INSTALLING
 ----------
 
-Drag @LBA2_EXECUTABLE_NAME@.app onto the Applications shortcut in this
+Drag "@LBA2_PRODUCT_NAME@.app" onto the Applications shortcut in this
 window. That copies it into your /Applications folder.
 
 First launch: macOS will block the app because it isn't notarized yet
 (notarization needs an Apple Developer account; on our roadmap). To
-bypass: right-click @LBA2_EXECUTABLE_NAME@.app in /Applications and pick
+bypass: right-click "@LBA2_PRODUCT_NAME@.app" in /Applications and pick
 "Open". You'll get a "this app is from an unidentified developer" dialog
 with an Open button — click it once. After that, double-click works.
 
@@ -20,12 +20,12 @@ If macOS instead says "the app is damaged and can't be opened" with only
 a Move to Bin button, that's the quarantine attribute blocking launch
 even after our ad-hoc signature. Run this once in Terminal to clear it:
 
-    xattr -cr /Applications/@LBA2_EXECUTABLE_NAME@.app
+    xattr -cr "/Applications/@LBA2_PRODUCT_NAME@.app"
 
 Then try the right-click → Open above.
 
 On macOS Sequoia (15+), Apple changed both the wording and the recovery
-flow. You'll see "Apple could not verify '@LBA2_EXECUTABLE_NAME@' is
+flow. You'll see "Apple could not verify '@LBA2_PRODUCT_NAME@' is
 free of malware that may harm your Mac." with only a Done button. The
 right-click → Open shortcut no longer works on Sequoia; the recovery
 flow is:
@@ -33,9 +33,9 @@ flow is:
     1. Click Done.
     2. Open System Settings → Privacy & Security.
     3. Scroll to the bottom — there's a one-time notice that
-       "@LBA2_EXECUTABLE_NAME@ was blocked to protect your Mac." Click
+       "@LBA2_PRODUCT_NAME@ was blocked to protect your Mac." Click
        Open Anyway and authenticate (password / Touch ID).
-    4. Try opening @LBA2_EXECUTABLE_NAME@.app again. This time you'll
+    4. Try opening "@LBA2_PRODUCT_NAME@.app" again. This time you'll
        get a different prompt with an Open button. Click it.
     5. Subsequent launches double-click normally.
 
@@ -50,7 +50,7 @@ This is the engine only — you need a legitimate copy of Little Big
 Adventure 2 / Twinsen's Odyssey from GOG, Steam, or your original
 retail CD.
 
-The first time you launch @LBA2_EXECUTABLE_NAME@.app, a folder picker
+The first time you launch "@LBA2_PRODUCT_NAME@.app", a folder picker
 will open and ask you to point at your retail install — the folder
 that contains lba2.hqr (alongside music/, video/, vox/, etc., or
 under a Common/ or CommonClassic/ subfolder for Steam/GOG re-releases).
@@ -59,12 +59,12 @@ Your choice is remembered, so subsequent launches skip the picker.
 To re-pick later (e.g. switching between two installs), launch from
 Terminal with --pick-game-dir:
 
-    /Applications/@LBA2_EXECUTABLE_NAME@.app/Contents/MacOS/@LBA2_EXECUTABLE_NAME@ \
+    "/Applications/@LBA2_PRODUCT_NAME@.app/Contents/MacOS/@LBA2_EXECUTABLE_NAME@" \
         --pick-game-dir
 
 Or skip the picker entirely with an explicit path:
 
-    /Applications/@LBA2_EXECUTABLE_NAME@.app/Contents/MacOS/@LBA2_EXECUTABLE_NAME@ \
+    "/Applications/@LBA2_PRODUCT_NAME@.app/Contents/MacOS/@LBA2_EXECUTABLE_NAME@" \
         --game-dir "/path/to/your/lba2/install"
 
 The remembered choice lives at:


### PR DESCRIPTION
Bundle directory on disk becomes `LBA2 Classic Community.app` (the Finder/Dock display name), while the inner Mach-O stays `Contents/MacOS/lba2cc`. This brings macOS in line with how the project already handles user-facing vs CLI-facing names on the other platforms.

## Why

We already use this split on Linux and Windows; macOS was the outlier. `scripts/packaging/make-appimage.sh` even has a comment explaining the same trade-off for the AppImage flow.

| Surface | Linux | Windows | macOS (before) | macOS (after) |
|---|---|---|---|---|
| Distribution filename | `lba2cc-…AppImage` | `lba2cc-…zip` | `lba2cc-…dmg` | `lba2cc-…dmg` |
| Binary on disk | `lba2cc` | `lba2cc.exe` | `Contents/MacOS/lba2cc` | `Contents/MacOS/lba2cc` |
| **User-facing display label** | `.desktop` `Name=` | VERSIONINFO ProductName | **bundle dir `lba2cc.app`** ❌ | **bundle dir `LBA2 Classic Community.app`** ✓ |

The macOS bundle directory **is** the user-facing display label — Finder, Dock, Spotlight, Launchpad all show it. Cross-platform parallel:
- `.desktop Name=` ↔ VERSIONINFO ProductName ↔ macOS bundle directory name → all three are `LBA2_PRODUCT_NAME`.
- Linux binary ↔ Windows `.exe` ↔ macOS inner Mach-O → all three are `LBA2_EXECUTABLE_NAME`.

## How

- `SOURCES/CMakeLists.txt`: `OUTPUT_NAME ${LBA2_PRODUCT_NAME}` so the bundle dir picks up the product name, plus a POST_BUILD `cmake -E rename` of the inner binary back to `LBA2_EXECUTABLE_NAME`, ordered before the existing ad-hoc codesign step so the signature covers the final layout. CMake has no single property that splits bundle-dir name from inner-Mach-O name — the rename is the clean workaround.
- `CFBundleExecutable` in `Info.plist.in` already pointed at `@LBA2_EXECUTABLE_NAME@`, so no plist change was needed.
- DMG filename stays space-free (`lba2cc-<version>-macos-<arch>.dmg`) because `bundle-macos.sh` now reads `LBA2_EXECUTABLE_NAME` from CMakeCache for that purpose instead of using the bundle stem.
- `macos-readme.txt.in`: CLI examples that reach into `Contents/MacOS/` are now quoted (the path has spaces in the bundle-dir component); Gatekeeper dialog quotes use `@LBA2_PRODUCT_NAME@` because macOS displays `CFBundleDisplayName`, not the inner binary name.
- Also fixed a pre-existing inaccuracy in the RELEASING.md DMG layout block and the matching header comment in `bundle-macos.sh`: they implied a wrapping `<product-name>-<version>/` directory in the mounted view, but `hdiutil create -srcfolder` packs the staging-dir contents flat at the volume root; `-volname` only sets the Finder sidebar label.

## Verification

CI's `macos.yml` "Verify Binary" step now checks for `"LBA2 Classic Community.app/Contents/MacOS/lba2cc"` — that's the canonical smoke test for the rename + codesign sequence producing a launchable layout. The change is gated to `if(APPLE)` so it doesn't affect Linux or Windows builds.

Not tested locally — was developed on WSL/Linux where the `if(APPLE)` block is inert. The macOS CI run on this PR is the first real validation.