### PR TITLE
fix(menu): make save/load slot nav edge-only

### DIFF
--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -1296,6 +1296,16 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
 */
             timeranotherkey = TimerRefHR + TEMPO_REPEAT_KEY;
             Input = MyKey = 0;
+
+            // Wait for key release so a single press advances exactly one
+            // slot, matching DoGameMenu's edge-only feel.  Without this,
+            // the mouse-active MyGetInput() poll below re-samples the
+            // still-held arrow every frame and races through the list.
+            do {
+                BoxUpdate();
+                MyGetInput();
+            } while (MyKey OR Input);
+
             flag = 0;
         }
 


### PR DESCRIPTION
## What & why

`ChoosePlayerName()` (the save / load slot list) races through the entire list when an arrow key is held — or even on a quick tap whose key-down phase spans more than one frame. When the menu mouse is active (the default), the input poll at `SOURCES/GAMEMENU.CPP:1326-1329` calls `MyGetInput()` every frame, so the still-held `K_GRAY_UP` / `K_GRAY_DOWN` gets re-sampled and bumps `select` each iteration. The non-mouse path is throttled via `timeranotherkey` (auto-repeat), but the mouse path bypasses it.

`DoGameMenu()` (top menu / options / controller submenus) does not have this — it ends its `flag == 1` redraw block with a release-flush at `SOURCES/GAMEMENU.CPP:2486-2489`:

```cpp
do {
    DrawGameMenu(ptrmenu, TRUE);
    MyGetInput();
} while (MyKey OR Input);
```

…which blocks until both `MyKey` and `Input` clear. Hold the key, nothing extra happens. One press = one step.

This PR mirrors that flush inside `ChoosePlayerName`'s `flag == 1` block:

```cpp
do {
    BoxUpdate();
    MyGetInput();
} while (MyKey OR Input);
```

`BoxUpdate()` matches what the surrounding loop already calls at `:1427` to push dirty rects, so the screen stays live during the wait. The flush sits inside `flag == 1` so it covers every path that changes selection: up/down (`:1429`, `:1449`), page-up/down/home/end (`:1470-1559`), delete (`:1597`), and mouse-driven (`:1349`, `:1362`, `:1396`, `:1415`).

## Notes for reviewers

- **Overlap with #79.** Bruno's PR fixes the same held-arrow race via a different mechanism (rate-limit nav keys to the `timeranotherkey` window, preserving auto-repeat). His PR also adds gamepad D-pad / stick → `K_GRAY_*` translation that's missing here. See https://github.com/LBALab/lba2-classic-community/pull/79#issuecomment-4460454824 for the coordination discussion — either this lands and #79 rebases to the gamepad-only portion, or #79 picks up the release-flush and this gets closed.
- **Initial menu entry**: `InitWaitNoKey()` at `:1251` already zeros input, so the first pass through `flag == 1` sees the flush as a no-op.
- **Held gamepad direction**: `Input` keeps its `I_UP` / `I_DOWN` bit set, so the flush blocks until release — same contract as keyboard. `DoGameMenu` has the same semantics today.
- **Delete path** (`:1562`): flushing after delete waits for `K_D` / `K_BACKSPACE` release, which is what you'd want (no second confirmation firing instantly).

## Checklist

- [x] Build passes on my platform (Linux)
- [ ] If LIB386 / 3DEXT touched: ASM equivalence tests pass (`./run_tests_docker.sh`)
- [ ] If behavior changes: opt-in via flag/cvar/config (preserves default game feel)
- [ ] Docs updated in the same PR if behavior or workflow changed
- [x] French comments and ASCII art preserved in any modified files
