### PR TITLE
feat(control): arg --fixed-dt deterministic mode for the control harness

### DIFF
--- a/LIB386/H/SYSTEM/TIMER.H
+++ b/LIB386/H/SYSTEM/TIMER.H
@@ -34,6 +34,7 @@ void SetTimerHR(U32 time);
 // does not call Timer_EnableFixedDt() are byte-for-byte unaffected. See docs/CONTROL.md.
 void Timer_EnableFixedDt(U32 dt_ms); // arm fixed-dt; seeds the virtual clock to now
 void Timer_FixedDtAdvance();         // advance the virtual clock by dt_ms (once per tick)
+S32 Timer_FixedDtActive();           // non-zero while fixed-dt is armed (guards wall-clock paths)
 
 void ManageTime();
 void HandleEventsTimer(const void *event);

--- a/LIB386/H/SYSTEM/TIMER.H
+++ b/LIB386/H/SYSTEM/TIMER.H
@@ -26,6 +26,15 @@ void SaveTimer();
 void RestoreTimer();
 void SetTimerHR(U32 time);
 
+// --- Fixed-dt deterministic clock (harness-only) -----------------------------
+// When enabled, ManageTime() advances from an internal virtual clock stepped by
+// Timer_FixedDtAdvance() instead of SDL_GetTicks(), so the per-tick dt is constant
+// and the simulation is independent of wall-clock. Off by default; the engine
+// carries no default step (the caller supplies it). Default builds and any run that
+// does not call Timer_EnableFixedDt() are byte-for-byte unaffected. See docs/CONTROL.md.
+void Timer_EnableFixedDt(U32 dt_ms); // arm fixed-dt; seeds the virtual clock to now
+void Timer_FixedDtAdvance();         // advance the virtual clock by dt_ms (once per tick)
+
 void ManageTime();
 void HandleEventsTimer(const void *event);
 

--- a/LIB386/SYSTEM/TIMER.CPP
+++ b/LIB386/SYSTEM/TIMER.CPP
@@ -76,11 +76,13 @@ void SetTimerHR(U32 time) {
 }
 
 void Timer_EnableFixedDt(U32 dt_ms) {
-    // Seed the virtual clock to the current system time so the first ManageTime()
-    // delta (FixedDtNow - LastTime) is ~0 and the FPS accumulator stays sane across
-    // the switch. From here the clock only moves via Timer_FixedDtAdvance().
+    // Seed the virtual clock and force LastTime to agree with it, so the first
+    // ManageTime() delta (FixedDtNow - LastTime) is exactly 0 and no residual
+    // wall-clock interval banked during boot/load leaks into the first tick. From here
+    // the clock only moves via Timer_FixedDtAdvance(). Keeps the FPS accumulator sane.
     FixedDt = dt_ms;
     FixedDtNow = TimerSystemHR;
+    LastTime = TimerSystemHR;
     FixedDtActive = 1;
 }
 
@@ -90,6 +92,10 @@ void Timer_FixedDtAdvance() {
     if (FixedDtActive) {
         FixedDtNow += FixedDt;
     }
+}
+
+S32 Timer_FixedDtActive() {
+    return FixedDtActive;
 }
 
 void ManageTime() {

--- a/LIB386/SYSTEM/TIMER.CPP
+++ b/LIB386/SYSTEM/TIMER.CPP
@@ -24,6 +24,12 @@ static U32 MemoTimerRefHR;
 U32 LastTime;
 U32 LastEvaluate;
 
+// Fixed-dt deterministic clock (harness-only). Inert unless Timer_EnableFixedDt() is
+// called: while active, ManageTime() reads FixedDtNow instead of SDL_GetTicks().
+static S32 FixedDtActive = 0;
+static U32 FixedDt = 0;
+static U32 FixedDtNow = 0;
+
 // --- Initialization ----------------------------------------------------------
 void InitTimer() {
     LastTime = LastEvaluate = SDL_GetTicks();
@@ -69,8 +75,25 @@ void SetTimerHR(U32 time) {
     UnlockTimer();
 }
 
+void Timer_EnableFixedDt(U32 dt_ms) {
+    // Seed the virtual clock to the current system time so the first ManageTime()
+    // delta (FixedDtNow - LastTime) is ~0 and the FPS accumulator stays sane across
+    // the switch. From here the clock only moves via Timer_FixedDtAdvance().
+    FixedDt = dt_ms;
+    FixedDtNow = TimerSystemHR;
+    FixedDtActive = 1;
+}
+
+void Timer_FixedDtAdvance() {
+    // One fixed step per tick. The next unlocked ManageTime() banks it into TimerRefHR;
+    // every other ManageTime() in the tick sees an unchanged FixedDtNow and adds nothing.
+    if (FixedDtActive) {
+        FixedDtNow += FixedDt;
+    }
+}
+
 void ManageTime() {
-    TimerSystemHR = SDL_GetTicks();
+    TimerSystemHR = FixedDtActive ? FixedDtNow : SDL_GetTicks();
 
     if (!TimerLock) {
         TimerRefHR += TimerSystemHR - LastTime;

--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -32,6 +32,8 @@ static int s_have_exec = 0;
 static char s_exec[CONTROL_EXEC_MAX];
 static int s_have_tick = 0;
 static long s_tick = 0;
+static int s_have_fixed_dt = 0;
+static long s_fixed_dt = 0;
 static int s_have_dump = 0;
 static char s_dump_path[ADELINE_MAX_PATH];
 static int s_have_shot = 0;
@@ -83,6 +85,20 @@ void Control_ParseArgs(int *argc, char *argv[]) {
             }
             s_tick = v;
             s_have_tick = 1;
+            s_active = 1;
+            read += 2;
+            continue;
+        }
+        if (!strcmp(a, "--fixed-dt") && has_val) {
+            char *end = NULL;
+            long v = strtol(argv[read + 1], &end, 0);
+            if (end == argv[read + 1] || *end != '\0' || v <= 0) {
+                fprintf(stderr, "[control] --fixed-dt: invalid step '%s' (ignoring)\n",
+                        argv[read + 1]);
+            } else {
+                s_fixed_dt = v;
+                s_have_fixed_dt = 1;
+            }
             s_active = 1;
             read += 2;
             continue;
@@ -148,6 +164,13 @@ static int control_resolve_save(const char *name) {
 }
 
 int Control_Begin(void) {
+    /* Pin the deterministic clock before the boot/load path runs. With the virtual clock
+       frozen (the hook only advances it once MainLoop starts), every ManageTime() during
+       InitGame/ChangeCube banks a zero delta, so the base clock stays exactly the restored
+       save value -- no boot wall-clock leaks into it. Harness-only; off by default. */
+    if (s_have_fixed_dt)
+        Timer_EnableFixedDt((U32)s_fixed_dt);
+
     if (s_load_name) {
         if (!control_resolve_save(s_load_name)) {
             /* Report and bail without arming. The caller skips MainLoop and exits, so
@@ -360,6 +383,10 @@ void Control_TickHook(void) {
     if (!s_armed)
         return;
     s_hook_calls++;
+    /* Advance the deterministic clock one fixed step per tick. The hook runs exactly once
+       per loop-body iteration, before this tick's ManageTime() banks the step. */
+    if (s_have_fixed_dt)
+        Timer_FixedDtAdvance();
     if (s_hook_calls == 1)
         control_run_exec();
 #ifdef ENABLE_POLY_RECORDING

--- a/SOURCES/CONTROL.H
+++ b/SOURCES/CONTROL.H
@@ -4,7 +4,7 @@
 /*
  * CLI control harness: drive the engine from outside for automation / regression.
  *
- *   lba2 --load <slot> --exec "<cmd>;<cmd>" --tick <N> \
+ *   lba2 --load <slot> --exec "<cmd>;<cmd>" --tick <N> --fixed-dt <ms> \
  *        --dump-state <path> --screenshot <path> --exit
  *
  * The harness reuses existing engine seams rather than adding new ones: the console

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -1884,7 +1884,13 @@ restartloop:
 
         if (FollowCamTerrainFrame) {
             RestoreTimer();
-            TimerRefHR += TimerSystemHR - FollowCamTimerBefore;
+            // The re-add compensates real render+vsync wall-clock so the follow-cam frame
+            // doesn't stall the game clock. Under fixed-dt that wall-clock term is exactly
+            // the nondeterminism we are pinning out, so skip it: the clock advances by the
+            // fixed step alone. Default (non-fixed-dt) behaviour is unchanged.
+            if (!Timer_FixedDtActive()) {
+                TimerRefHR += TimerSystemHR - FollowCamTimerBefore;
+            }
             FollowCamTerrainFrame = FALSE;
         }
 

--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -25,6 +25,7 @@ make build      # -> build/SOURCES/lba2cc
 lba2cc --load <slot>          restore a save before the loop starts
        --exec "<cmd>;<cmd>"   run console commands (';'-separated) on the first tick
        --tick <N>             advance N simulation ticks
+       --fixed-dt <ms>        advance the clock by a constant <ms> per tick (deterministic)
        --dump-state <path>    write a JSON snapshot of engine state
        --screenshot <path>    write a PNG of the rendered frame
        --polyrec <path>       record polygon draw calls of the frame (ENABLE_POLY_RECORDING builds)
@@ -82,6 +83,13 @@ save directory, then with a `.lba` suffix — so both `--load "021 Palace"` and
   draw-call recorder (`tests/SNAPSHOT/`) at the final tick, writing a `.lba2polyrec` file at
   the chosen path — the scripted equivalent of the manual Alt+F9 capture. On a build without
   the option it prints a warning and is a no-op.
+- **`--fixed-dt <ms>` makes the run deterministic.** It pins the per-tick clock step to a
+  constant instead of wall-clock, so `--dump-state` is reproducible run-to-run (see
+  Determinism). The step is a fixed *choice*, not a recovered constant — the canonical value
+  for golden baselines is **16 ms** (≈ the 60 fps the dump reports). A different step yields a
+  different but still-reproducible trajectory, so pick one and keep it. The flag is harness-only
+  and has no effect on default gameplay timing. An invalid or non-positive value is ignored with
+  a diagnostic.
 - A bad `--load` path exits cleanly with a `save not found` diagnostic.
 
 ## `--dump-state` JSON
@@ -137,16 +145,34 @@ The same `--load X --tick N` is **more reproducible than expected**. Measured by
   per-tick wall-clock variance feeding movement integration. The `srand(TimerRefHR)` reseed
   produced no observable divergence.
 
-So the dominant nondeterminism is **variable per-tick dt**, not RNG. Practical guidance:
+So the dominant nondeterminism is **variable per-tick dt**, not RNG. Two ways to run:
 
-- Build/run with `-DSOUND_BACKEND=null` (or `SDL_AUDIODRIVER=dummy`).
-- Assert **exact** on discrete and static fields (scene, vars, hero behaviour/body/anim,
-  non-moving actors); allow a small **tolerance** on moving-actor positions; ignore `fps`
-  and `timer_ref_hr`.
+- **Without `--fixed-dt` (variable dt):** build/run with `-DSOUND_BACKEND=null` (or
+  `SDL_AUDIODRIVER=dummy`). Assert **exact** on discrete and static fields (scene, vars, hero
+  behaviour/body/anim, non-moving actors); allow a small **tolerance** on moving-actor
+  positions; ignore `fps` and `timer_ref_hr`.
+- **With `--fixed-dt <ms>` (constant dt):** the clock advances by exactly `<ms>` per tick, so
+  `timer_ref_hr` becomes `base + N*ms` and moving-actor positions stop jittering. Measured: a
+  busy exterior save dumped 10× was byte-identical including `timer_ref_hr` and
+  `x/y/z/beta/anim/last_frame`; only `fps` and `log` stay run-specific. So under fixed-dt those
+  kinematic fields can be asserted exact, not just within tolerance. This is the prerequisite
+  for faithful input replay.
 
-A future `--fixed-dt` mode (pin the timer to a constant per-tick step; reseed RNG) would
-make dumps fully reproducible and is the prerequisite for faithful input replay — see
-Roadmap. It builds on the existing `LockTimer`/`SetTimerHR` hooks.
+  **Full exterior determinism requires the null sound backend** (`-DSOUND_BACKEND=null`), not
+  just `SDL_AUDIODRIVER=dummy`. With the SDL audio backend, voices are serviced on a wall-clock
+  callback thread and exterior ambient-sample logic (`GereAmbiance`, `IsSamplePlaying`) branches
+  the simulation nondeterministically even under the dummy *driver* — a residual ±1-unit
+  actor-position wobble remains. The null *backend* removes that path. Interior scenes are
+  deterministic either way. fixed-dt pins the clock; it does not determinise audio-thread timing.
+
+The single RNG seed (`srand(TimerRefHR)` in `ChangeCube`) is already pinned by the restored
+save clock — confirmed: under fixed-dt the dumps are identical with no explicit reseed.
+
+Caveat — exactness is **per platform/build**. `--fixed-dt` removes *temporal* nondeterminism,
+not the cross-platform coordinate differences from `long double` precision (80-bit on Linux
+x86_64, 64-bit on Windows/macOS-ARM; see [PLATFORM.md](PLATFORM.md)). Two platforms running the
+identical fixed-dt sequence can still land on slightly different positions. Keep golden
+baselines per-platform, or compare across platforms with a tolerance.
 
 ## Tests
 
@@ -174,10 +200,12 @@ non-deterministic base.
    regression net for the widescreen / projection work: the world-space dump is the
    guardrail that rendering changes don't perturb the simulation; screenshots are the
    human-reviewed visual. See `docs/AUTOMATION_PLAN.md`.
-2. **`--fixed-dt` deterministic mode.** Pin the per-tick timer step (and reseed RNG) so the
-   simulation is independent of wall-clock. The determinism measurements point at variable
-   dt as the lever. This upgrades the baseline tolerance to exact, and is the prerequisite
-   for replay.
+2. **`--fixed-dt` deterministic mode** *(done)*. Pin the per-tick timer step so the simulation
+   is independent of wall-clock — the determinism measurements pointed at variable dt as the
+   lever. No RNG reseed was needed: the only seed (`srand(TimerRefHR)`) is already pinned by the
+   restored save clock. This upgrades the baseline tolerance to exact (same-platform) and is the
+   prerequisite for replay. See `docs/FIXED_DT_PLAN.md`. Promoting the baseline harness's
+   kinematic tier to exact is the remaining follow-up.
 3. **Input record/replay.** Capture input per tick and replay a whole session — the
    gameplay-regression counterpart to the existing draw-call polyrec. Attaches at the same
    top-of-loop seam as `Control_TickHook`; depends on (2) to reproduce faithfully.

--- a/docs/FIXED_DT_PLAN.md
+++ b/docs/FIXED_DT_PLAN.md
@@ -70,6 +70,17 @@ void ManageTime() {
 
 ---
 
+> **Implementation correction (post-build).** The "neutralised for free" reasoning below was
+> wrong in practice: an exterior follow-cam save still leaked wall-clock under the virtual
+> clock, so the re-add was explicitly guarded off in fixed-dt mode (research option (ii)) via a
+> `Timer_FixedDtActive()` accessor — a one-line `PERSO.CPP` edit, opt-in. Two further leaks
+> surfaced and were fixed: the first-tick step (force `LastTime = FixedDtNow` in
+> `Timer_EnableFixedDt`) and boot-residual contamination of the base clock (enable fixed-dt at
+> the *top* of `Control_Begin`, before the load, so boot `ManageTime` calls freeze). With all
+> three closed, a busy exterior save is byte-identical across 10 runs **on the null sound
+> backend**; the SDL backend retains a residual audio-thread wobble (see CONTROL.md). The
+> theory below is kept for the record.
+
 ## 2. FollowCam timer re-add — neutralised for free
 
 The research's top hazard ([`PERSO.CPP:1877-1889`](../SOURCES/PERSO.CPP)):
@@ -199,9 +210,11 @@ call sites):
 
 **`SOURCES/CONTROL.H`** — extend the usage comment block (`:6-15`) with `--fixed-dt`.
 
-No edits to `PERSO.CPP` game logic: the FollowCam re-add (§2) needs none, and the hook/parse/
-boot seams already exist. This keeps the LIB386 footprint to one source line plus two small
-functions, all dead unless the harness arms them.
+One `PERSO.CPP` edit was needed after all (see §2 correction): the FollowCam re-add at
+`:1892` is guarded behind `Timer_FixedDtActive()` so it is skipped only in fixed-dt mode —
+default behaviour unchanged. The LIB386 footprint is the one `ManageTime` source line plus
+three small functions (`Timer_EnableFixedDt`, `Timer_FixedDtAdvance`, `Timer_FixedDtActive`),
+all dead unless the harness arms them.
 
 ---
 

--- a/docs/FIXED_DT_PLAN.md
+++ b/docs/FIXED_DT_PLAN.md
@@ -1,0 +1,321 @@
+# Fixed-dt deterministic mode — plan
+
+Phase 2 design for a harness-only `--fixed-dt <ms>` flag that advances the simulation by a
+constant time step per tick instead of by wall-clock, making `--dump-state` fully
+reproducible and unblocking faithful input record/replay. Builds on
+[FIXED_DT_RESEARCH.md](FIXED_DT_RESEARCH.md) (Phase 1) and the existing CLI control harness
+([CONTROL.md](CONTROL.md), [../SOURCES/CONTROL.CPP](../SOURCES/CONTROL.CPP)).
+
+Hard constraint carried throughout: the mode is opt-in and must not change default-build or
+normal gameplay timing. It is only ever active when the harness drives it. Line numbers were
+re-verified against the working tree; treat them as "look here" and re-grep before relying on
+an exact number.
+
+---
+
+## 1. Decision: virtual time source in `ManageTime()`, advanced once per tick from the hook
+
+Research §3 framed two candidates: (a) a guarded fixed increment inside `ManageTime()`, and
+(b) a hook-driven `LockTimer` + `SetTimerHR(TimerRefHR + DT)`. Both have the problems the
+research flagged — (a) must gate the increment so it fires once per *tick* and not once per
+*`ManageTime` call* (the loop calls `ManageTime` many times via `Lock`/`Save`/`Restore`), and
+(b) must reason about the hook running *before* this tick's `ManageTime` (`:551` vs `:578`)
+and still neutralise the FollowCam re-add.
+
+The chosen design is a refinement of (a) that dissolves both problems: **replace the time
+*source* `ManageTime()` reads, rather than special-casing the increment.**
+
+In fixed-dt mode, `ManageTime()` reads a virtual clock `FixedDtNow` instead of
+`SDL_GetTicks()`. The harness advances `FixedDtNow` by exactly `DT` once per tick from
+`Control_TickHook()`. Everything else in `TIMER.CPP` — `LockTimer`/`UnlockTimer`,
+`SaveTimer`/`RestoreTimer`, `SetTimerHR`, the `!TimerLock` accumulate branch — runs
+unchanged, because they all derive from the same "now."
+
+Why this dominates raw (a) and (b):
+
+- **Over-counting solves itself.** `FixedDtNow` only changes at the hook, so within a single
+  tick every `ManageTime()` call (including the dozens inside `Save`/`Restore`/`Lock` pairs)
+  sees the *same* value. Each such call computes `delta = FixedDtNow - LastTime`, which is `0`
+  after the first — so the internal calls contribute nothing to `TimerRefHR`. The single `DT`
+  step advanced at the hook is banked exactly once, by the first unlocked `ManageTime()` after
+  the hook (the steady-state call at [`PERSO.CPP:578`](../SOURCES/PERSO.CPP)). No per-call
+  gating, no "which `ManageTime` is the real one" bookkeeping.
+- **The hook-ordering question disappears.** Advancing `FixedDtNow` at the hook (`:551`,
+  *before* `ManageTime()` at `:578`) is exactly right: the hook arms the step and the very next
+  unlocked `ManageTime()` banks it into `TimerRefHR`. The movers at
+  [`PERSO.CPP:1471-1476`](../SOURCES/PERSO.CPP) (`GetDeltaMove`) and the animation interpolator
+  `ObjectSetInterDep` both read `TimerRefHR` *after* `:578`, so they observe exactly `+DT`
+  versus the previous tick. (Confirmed: `MyGetInput()` at `:577` does not call `ManageTime` —
+  grep of `SOURCES/INPUT.CPP`/`CONFIG/INPUT.CPP` shows no timer touch — so `:578` is the first
+  and only steady-state bank site.)
+- **The FollowCam re-add neutralises itself** — see §2.
+
+Cost: a small, well-contained edit to one `LIB386` file (`TIMER.CPP`), behind a flag that is
+only set by `SOURCES/CONTROL.CPP`. The flag state lives in `TIMER.CPP` with C-linkage setters,
+matching how `SetTimerHR`/`LockTimer` are already reused by the harness and the console `timer`
+command. When the flag is off, `ManageTime()` takes the identical `SDL_GetTicks()` path it does
+today — byte-for-byte unchanged behaviour for default builds and non-fixed-dt harness runs.
+
+Sketch of the `ManageTime()` change (final form decided in implementation):
+
+```c
+void ManageTime() {
+    TimerSystemHR = FixedDtActive ? FixedDtNow : SDL_GetTicks();
+    if (!TimerLock)
+        TimerRefHR += TimerSystemHR - LastTime;
+    LastTime = TimerSystemHR;
+    // ...FPS accounting unchanged (wall-clock-ish; dropped from the dump)...
+}
+```
+
+---
+
+## 2. FollowCam timer re-add — neutralised for free
+
+The research's top hazard ([`PERSO.CPP:1877-1889`](../SOURCES/PERSO.CPP)):
+
+```c
+U32 FollowCamTimerBefore = 0;
+if (FollowCamTerrainFrame) { SaveTimer(); FollowCamTimerBefore = TimerSystemHR; }
+AffScene(FirstTime);
+if (FollowCamTerrainFrame) {
+    RestoreTimer();
+    TimerRefHR += TimerSystemHR - FollowCamTimerBefore;   // re-adds real render+vsync ms
+    FollowCamTerrainFrame = FALSE;
+}
+```
+
+Under the virtual clock this requires **no edit**. `FollowCamTimerBefore` is captured from
+`TimerSystemHR` at `:1880`; the re-add at `:1887` uses `TimerSystemHR` as refreshed by
+`RestoreTimer()`'s internal `ManageTime()` at `:1886`. Both reads happen *within the same
+tick*, during which `FixedDtNow` does not change (it only advances at the hook, `:551`).
+Therefore `TimerSystemHR` at `:1886` equals `FixedDtTimerBefore` captured at `:1880`, and the
+re-add evaluates to `TimerRefHR += 0`. The wall-clock term it injects in normal mode is
+identically zero in fixed-dt mode.
+
+This is the decisive advantage of replacing the time *source* rather than gating the
+increment: the same property that freezes the clock within a tick makes every "add back a
+`TimerSystemHR` delta" site (the FollowCam block, and the `DEBUG_TOOLS` benchmark at
+`:645-703`, which is off the harness path anyway) collapse to a no-op automatically. We will
+still assert this empirically on an exterior follow-cam save in validation (§ Validation),
+since it is the research's flagged correctness hazard.
+
+---
+
+## 3. DT semantics, canonical value, Save/Restore interaction
+
+- **Units.** `--fixed-dt <ms>` takes an integer count of milliseconds — the same unit as
+  `TimerRefHR` and the `delta` in `GetDeltaMove` ([`MOVE.CPP:64-78`](../LIB386/3D/MOVE.CPP)).
+  One tick advances `TimerRefHR` by exactly that many ms.
+- **Canonical value: 16 ms — and no engine default.** No hardcoded target-frame-ms constant
+  exists in the engine (re-confirmed by grep of `TIMER.CPP`/`PERSO.CPP`), so the canonical value
+  is a fixed *choice*, not a recovered constant. 16 ms (≈ the 60 fps the dump reports, and SDL's
+  vsync cadence) is what the baseline harness passes and what goldens are generated against. The
+  precise number is arbitrary so long as it is fixed: §5 of the research notes `GetDeltaAccMove`
+  truncates the accumulator by 1000, so a *different* `DT` yields a different (each internally
+  reproducible) trajectory.
+- **Where the 16 lives — exactly one named place, never the engine.** `Timer_EnableFixedDt`
+  takes `dt_ms` as a parameter, so the engine carries no default and no policy. `--fixed-dt`
+  *requires* an explicit value (like `--tick`), so there is no bare literal in `CONTROL.CPP`
+  either. The canonical 16 appears once, as a named constant in the baseline harness
+  (`CANONICAL_DT_MS = 16`, with a rationale comment), and is documented once in `CONTROL.md` as
+  the source of truth — so nobody regenerates goldens with a different step, and there is no
+  magic number scattered across C, the flag, and the test.
+- **Interaction with `SaveTimer`/`RestoreTimer`.** A `Save`/`Restore` pair rewinds `TimerRefHR`
+  to its pre-`Save` value, making the bracketed region transparent to the game clock. Under the
+  virtual clock that value did not move during the region (no hook fired inside it), so the pair
+  is transparent in exactly the way it is designed to be — it rewinds to a value that never
+  changed. The harness advances `FixedDtNow` at the hook (`:551`), which is outside every
+  `Save`/`Restore`/`Lock` region in the loop body (the FollowCam `Save`/`Restore` is at
+  `:1879-1886`, well after the hook), so the `DT` step is never swallowed by a rewind.
+- **Lock edge case.** If `TimerLock > 0` at the moment the hook advances `FixedDtNow` (e.g. a
+  focus-lost `LockTimer` via `HandleEventsTimer`), the step is not lost — it is banked by the
+  next unlocked `ManageTime()`, identical to how wall-clock time is handled today. A `--exit`
+  harness run is normally focused, so this is a robustness note, not an expected path.
+
+---
+
+## 4. RNG — clock pin is sufficient, verify don't reseed
+
+The only seed in the game is `srand(TimerRefHR)` in `ChangeCube()`
+([`OBJECT.CPP:1171`](../SOURCES/OBJECT.CPP)) — confirmed single hit in research §4. For the
+`--load X --tick N` workflow, `TimerRefHR` on the load path is the restored save value (a fixed
+number for a given save), so the seed is already deterministic across runs — consistent with the
+measured "the `srand(TimerRefHR)` reseed produced no observable divergence" (CONTROL.md
+determinism section).
+
+`ChangeCube()` at [`PERSO.CPP:540`](../SOURCES/PERSO.CPP) runs *before* the hook (`:551`). For a
+mid-run cube change on tick N, the seed is `TimerRefHR` as banked by tick N-1, i.e.
+`base + (N-1)*DT` — deterministic under a working clock pin. **Decision: no explicit reseed.**
+The clock pin determinises the seed for both the load path and mid-run transitions. This is a
+claim to *verify* in validation (a 3× repeat that crosses a cube boundary), not to assert — if a
+counterexample surfaces, the fallback is a fixed reseed in `Control_Begin`, but the research and
+the existing measurement both indicate it is unnecessary.
+
+---
+
+## 5. Files, signatures, pin sites
+
+**`LIB386/H/SYSTEM/TIMER.H`** — declare the two C-linkage entry points (in the existing
+`extern "C"` block, near `SetTimerHR`):
+
+```c
+/* Harness-only deterministic clock. When enabled, ManageTime() advances from an
+   internal virtual clock stepped by Timer_FixedDtAdvance() instead of SDL_GetTicks(),
+   making the per-tick dt constant. Off by default; default builds are unaffected. */
+void Timer_EnableFixedDt(U32 dt_ms);   /* arm fixed-dt; seeds the virtual clock to now */
+void Timer_FixedDtAdvance(void);       /* advance the virtual clock by dt_ms (once per tick) */
+```
+
+**`LIB386/SYSTEM/TIMER.CPP`** — add file-scope state and the two functions, modify
+`ManageTime()`:
+
+- New state (alongside the existing private state, `:20-25`):
+  `static S32 FixedDtActive = 0; static U32 FixedDt = 0; static U32 FixedDtNow = 0;`
+- `Timer_EnableFixedDt(U32 dt_ms)`: `FixedDt = dt_ms; FixedDtNow = TimerSystemHR;
+  FixedDtActive = 1;` — seeding `FixedDtNow` to the current `TimerSystemHR` keeps the first
+  `delta` (`FixedDtNow - LastTime`) at ~0 and keeps the FPS accumulator sane across the switch.
+- `Timer_FixedDtAdvance()`: `if (FixedDtActive) FixedDtNow += FixedDt;`
+- `ManageTime()`: change only the source line to
+  `TimerSystemHR = FixedDtActive ? FixedDtNow : SDL_GetTicks();` (`:73`). Everything else
+  unchanged. No other `LIB386` file is touched.
+
+**`SOURCES/CONTROL.CPP`** — flag parse + wiring (no new engine seam; reuses the existing three
+call sites):
+
+- Parse `--fixed-dt <ms>` in `Control_ParseArgs` (`:57-122`), alongside `--tick`: store into
+  `static int s_have_fixed_dt; static long s_fixed_dt;` with the same `strtol` validation and
+  `s_active = 1`. The value is **required** (mirroring `--tick`); an absent/invalid value is a
+  parse error, not a silent default — so no canonical literal is baked into `CONTROL.CPP`. The
+  canonical 16 lives only in the baseline harness (§3, §6).
+- In `Control_Begin` (`:150-180`), after the load/fresh-start branch and before arming:
+  `if (s_have_fixed_dt) Timer_EnableFixedDt((U32)s_fixed_dt);`
+- In `Control_TickHook` (`:359-375`), advance once per tick *before* the finalize check:
+  `if (s_have_fixed_dt) Timer_FixedDtAdvance();` placed right after `s_hook_calls++` (`:362`).
+  The hook runs exactly once per loop-body iteration, which is the per-tick guarantee — cube-
+  change "ticks" (the documented `--tick` over-count) also advance one `DT`, keeping
+  `timer_ref_hr` a pure function of loop iterations.
+- Add `#include <SYSTEM/TIMER.H>` — already present (`:13`).
+
+**`SOURCES/CONTROL.H`** — extend the usage comment block (`:6-15`) with `--fixed-dt`.
+
+No edits to `PERSO.CPP` game logic: the FollowCam re-add (§2) needs none, and the hook/parse/
+boot seams already exist. This keeps the LIB386 footprint to one source line plus two small
+functions, all dead unless the harness arms them.
+
+---
+
+## 6. Baseline promotion + cross-platform
+
+Per research §5/§6, the promotion is **same-platform exact**, not cross-platform exact — `long
+double` + `lrintl()` projection rounds differently on Linux x86_64 (80-bit) vs Windows/macOS-ARM
+(64-bit), and fixed-dt removes *temporal* nondeterminism only, not that *spatial* difference.
+
+Plan for [`tests/savegame/corpus/baseline_harness.py`](../tests/savegame/corpus/baseline_harness.py):
+
+1. **Pass the flag.** Add `--fixed-dt $CANONICAL_DT_MS` to the `cmd` list in `run_save`
+   (`:59-60`), where `CANONICAL_DT_MS = 16` is a module constant (the single named definition,
+   §3), exposed as an overridable `--fixed-dt` CLI arg for experiments.
+2. **Verify soft notes drop to zero first.** Re-run without `--update`; expect every
+   `(+N kinematic)` annotation (`:156,163`) to vanish across the corpus. This is the gate — do
+   not promote until it holds.
+3. **Promote kinematics to structural.** Delete the `SOFT_POS`/`SOFT_OTHER` special-cases in
+   `diff()` (`:105-110`) and the constants (`:39-41`) so `x/y/z/beta/anim/last_frame` mismatches
+   become hard failures, then regenerate goldens with `--update`. Update the module docstring
+   (`:14-17`) and the final-line note (`:171`).
+4. **Cross-platform: single canonical platform, not per-platform subdirectories.** Because
+   exactness is per-platform, goldens generated on one OS will *structurally* fail on another for
+   the kinematic fields. Rather than build a `baselines/<platform>/` matrix now, define the
+   goldens on **one canonical platform** — the Linux x86_64 build the maintainer/CI already uses
+   — and document that validating elsewhere means matching that platform. This keeps the
+   guardrail strict and the layout flat; per-platform subdirectories can be added later only if a
+   second platform actually needs committed goldens.
+
+   - **Why Linux-only goldens, even though Windows/macOS hardware is available.** As a regression
+     net, extra platforms add little: a simulation-*logic* regression breaks all three and is
+     already caught on Linux; the only Win/macOS-specific delta is the known, constant
+     `long double` precision drift, not a regression. And committed per-platform goldens are a
+     maintenance trap — CI cannot regenerate them (no retail data in CI), so every
+     simulation-touching PR would owe three hand-regenerated sets.
+   - **Do run all three once, as a measurement, not as committed goldens.** Research §5 flags
+     cross-platform drift but never *quantified* it. A one-time fixed-dt corpus run on
+     Linux/Windows/macOS, diffed, answers the open question: is the drift a few units and bounded,
+     or does 80-bit-vs-64-bit rounding amplify over N ticks? Record the magnitude in
+     `FIXED_DT_RESEARCH.md`. This also surfaces any genuinely structural per-platform difference
+     (struct packing, the `T_PTR_NUM` 32/64 union) without standing up continuous goldens. The
+     trigger to add per-platform committed goldens is "this measurement showed drift we must
+     guard," not "the machines exist."
+   - **Docker as the canonical-platform mechanism (follow-up, not this PR).** A non-Linux
+     contributor can reproduce the canonical platform in a Linux x86_64 container (SDL dummy
+     video, null audio, their own retail data mounted) instead of trusting a native run. Note
+     this is *not* the existing equiv-test container — that is 32-bit x86 + UASM, runs
+     pure-function byte-equality in CI, and needs no assets or display; the baseline harness
+     drives the full game binary and needs retail data + a display, so it stays local-only and
+     gets its own image. The container makes the *golden* portable; it does not make a native
+     macOS/Windows run match (80-bit vs 64-bit `long double` still differs there).
+
+   This is the one place the plan pushes back on "promote to fully exact": exact within a
+   platform/build, yes; exact across platforms, not guaranteed by fixed-dt alone.
+
+`timer_ref_hr` also becomes deterministic under the pin (`base + N*DT`), so it can move out of
+`VOLATILE` (`:34`) and be asserted — a useful secondary check that the pin is intact. `fps` and
+`log` stay volatile.
+
+---
+
+## Validation
+
+Stated as concrete, runnable checks (research §6):
+
+1. **Reproducibility across runs.** Run `--load X --tick N --fixed-dt 16 --dump-state` 3× on
+   the same build/platform with the null audio backend; diff the dumps. Success = byte-identical
+   *including* `x/y/z/beta/anim/last_frame` and `timer_ref_hr`. Today those drift ~0.1% on busy
+   exterior scenes; fixed-dt should drop that to zero.
+2. **FollowCam hazard specifically.** Item (1) on an exterior follow-cam save (a terrain frame
+   where `FollowCamTerrainFrame` fires) — proves the re-add (§2) is genuinely a no-op under the
+   pin, not just in theory.
+3. **RNG / cube-boundary.** Item (1) on a `--tick N` that crosses a cube change; byte-identical
+   dumps confirm `srand(TimerRefHR)` is pinned without an explicit reseed (§4).
+4. **Baseline kinematic tier → zero soft notes**, then promote (§6).
+5. **Opt-in regression guard.** A default run and a harness run *without* `--fixed-dt` must be
+   byte-for-byte unchanged vs the current binary (A/B dump on a non-fixed-dt run). Proves the
+   `FixedDtActive ? … : SDL_GetTicks()` branch is inert when off.
+6. **Simulation still advances.** Extend the spirit of
+   [`tests/automation/test_tick.sh`](../tests/automation/test_tick.sh): under fixed-dt the clock
+   advances by exactly `N*DT` and the hero idle-anim frame advances deterministically — a
+   stronger assertion than today's "advanced at all."
+7. **Residual time-read audit.** Grep `GERELIFE.CPP`/`GERETRAK.CPP` for branch-on-`TimerRefHR`
+   script logic (research §2 left this not-exhaustively-audited); confirm all reads are pure
+   functions of the now-deterministic `TimerRefHR`.
+
+---
+
+## Commit / PR breakdown
+
+Focused, reviewable, dependency-ordered:
+
+1. **`feat(timer): virtual fixed-dt clock source behind a harness flag`** — `TIMER.H` +
+   `TIMER.CPP` (state, two functions, the one `ManageTime` source line). Inert until armed; the
+   diff is self-contained and reviewable against the "default builds unchanged" constraint.
+2. **`feat(control): --fixed-dt deterministic mode`** — `CONTROL.CPP` parse + wiring,
+   `CONTROL.H` + `CONTROL.md` docs (flag, canonical 16 ms, determinism section update,
+   roadmap item 2 → done). Validation items 1-3, 5, 6.
+3. **`test(savegame): promote kinematic baseline tier to structural under fixed-dt`** —
+   `baseline_harness.py` flag wiring + soft-tier removal + goldens regenerated on the canonical
+   platform. Validation item 4. Separated because it regenerates committed golden data and is the
+   step most likely to need maintainer input on the canonical-platform choice.
+
+Could be one PR if the maintainer prefers, but the timer-core change is worth isolating so the
+"does this touch default gameplay timing?" review is trivial.
+
+## What I'd push back on in this scope
+
+- **"Fully reproducible" is same-platform.** fixed-dt does not erase the `long double`
+  cross-platform coordinate difference (§6). Promising cross-platform byte-identical dumps would
+  overstate it; the plan defines goldens on one canonical platform (Docker as the later
+  portability mechanism) rather than claiming native cross-platform identity.
+- **fixed-dt is not a real-audio determiniser.** Audio-timed script branches
+  (`IsSamplePlaying`, research §5) stay nondeterministic under real audio; the harness relies on
+  the null backend, same as today. Worth stating so nobody expects fixed-dt to cover it.
+- **No explicit RNG reseed unless validation demands it.** Adding a reseed "to be safe" is
+  speculative complexity the measurement does not justify (§4); gate it on item 3 failing.

--- a/docs/FIXED_DT_RESEARCH.md
+++ b/docs/FIXED_DT_RESEARCH.md
@@ -1,0 +1,365 @@
+# Fixed-dt deterministic mode — research
+
+Phase 1 research for a harness-only `--fixed-dt <ms>` flag that advances the simulation by
+a constant time step per tick instead of by wall-clock, so `--dump-state` becomes fully
+reproducible and the baseline harness's kinematic tier can be promoted from
+reported-but-non-fatal to exact. This is findings only — no design decision, no
+implementation. It builds on the CLI control harness (`SOURCES/CONTROL.{H,CPP}`,
+`docs/CONTROL.md`) and on the determinism measurement recorded there.
+
+Hard constraint carried through every section: the mode must be opt-in and must not change
+default gameplay timing. It is only ever active when the harness drives it.
+
+Line numbers were verified against the working tree at the time of writing. Treat them as
+"look here," re-grep before relying on an exact number. Where I am unsure I say so rather
+than guessing.
+
+---
+
+## 1. Timer mechanics
+
+The game clock lives in `LIB386/SYSTEM/TIMER.CPP`. The relevant globals
+(`TIMER.CPP:15-23`):
+
+- `TimerSystemHR` — the raw `SDL_GetTicks()` reading from the last `ManageTime()` call.
+- `TimerRefHR` — the master game clock in ms. This is what the whole simulation reads. It
+  is persisted in saves and restored by `--load` (see `docs/CONTROL.md`), so it starts at
+  the save's accumulated play-time, not zero.
+- `TimerLock` — when non-zero, `ManageTime()` stops advancing `TimerRefHR` (the clock is
+  frozen).
+- `CmptMemoTimerRef` / `MemoTimerRefHR` — the save/restore nesting counter and the saved
+  clock value.
+- `LastTime` — the previous `TimerSystemHR`, used to compute the per-call wall-clock delta.
+
+How the clock advances (`ManageTime()`, `TIMER.CPP:72-88`):
+
+```c
+TimerSystemHR = SDL_GetTicks();
+if (!TimerLock)
+    TimerRefHR += TimerSystemHR - LastTime;   // wall-clock delta since last call
+LastTime = TimerSystemHR;
+// ...FPS accounting...
+```
+
+So each `ManageTime()` call adds the real wall-clock milliseconds elapsed since the
+previous call — unless `TimerLock > 0`, in which case the delta is dropped entirely (it is
+not deferred or accumulated; the wall time spent locked simply vanishes from the game
+clock). This is the variable-dt mechanism the determinism finding identified.
+
+Helper roles (`TIMER.CPP:38-70`):
+
+- `LockTimer()` — calls `ManageTime()` (banking the elapsed time up to now), then `++TimerLock`.
+- `UnlockTimer()` — if `TimerLock > 0`, calls `ManageTime()` then `--TimerLock`. The
+  `ManageTime()` while still locked refreshes `LastTime` to "now," so the locked interval
+  does not leak into `TimerRefHR` when the lock drops to zero.
+- `SetTimerHR(time)` — `LockTimer(); TimerRefHR = time; UnlockTimer();`. Sets the clock to
+  an absolute value with the lock held so the surrounding `ManageTime()` calls don't perturb
+  it. This is exactly the seam the console `timer` command uses (`SetTimerHR(TimerRefHR + ms)`).
+- `SaveTimer()` — on the *first* nesting level (`!CmptMemoTimerRef++`), calls `ManageTime()`
+  and stashes `MemoTimerRefHR = TimerRefHR`. Re-entrant via the counter.
+- `RestoreTimer()` — on the *last* unwind (`!--CmptMemoTimerRef`), calls `ManageTime()` then
+  `TimerRefHR = MemoTimerRefHR`. So a `SaveTimer()`/`RestoreTimer()` pair makes everything in
+  between transparent to the game clock: real time passes but `TimerRefHR` is rewound to its
+  pre-`SaveTimer` value. `DEBUG_TOOLS` builds even print a warning if the pairing is
+  unbalanced (`PERSO.CPP:557-561`).
+
+Per `MainLoop` iteration the clock advances at exactly one place in the steady state:
+`ManageTime()` at `PERSO.CPP:578`, right after `MyGetInput()` at `:577`. That single call
+adds the frame's wall-clock duration. Everything downstream in the same iteration
+(movement, animation, timed script logic) reads the resulting `TimerRefHR`. The other
+`ManageTime()` calls in the loop are inside `Lock`/`Save`/`Restore` helpers and busy-wait
+spots (e.g. the `DEBUG_TOOLS` 20-loop benchmark at `PERSO.CPP:645-703`) and do not add a
+second steady-state increment.
+
+One subtlety: `Control_TickHook()` is at `PERSO.CPP:551`, which is *before*
+`MyGetInput()`/`ManageTime()` in the loop body (`:577-578`) and *after* the `ChangeCube`
+block (`:495-547`). So at the moment the hook runs on iteration N, `TimerRefHR` still holds
+the value from iteration N-1's `ManageTime()` (or the loaded save's value on the first
+iteration). This ordering matters for any "pin the clock from the hook" approach (§3).
+
+---
+
+## 2. dt consumers — the surface that must observe a constant dt
+
+Everything that turns elapsed `TimerRefHR` into simulation state. If the clock advances by a
+constant step each tick, all of these become reproducible.
+
+**Movement / speed integration — `LIB386/3D/MOVE.CPP`.** The core is `GetDeltaMove(MOVE *)`
+(`MOVE.CPP:64-78`): `delta = TimerRefHR - pmove->LastTimer`, accumulate `Acc += delta * Speed`,
+advance `pmove->LastTimer = TimerRefHR`, and return integer steps via `GetDeltaAccMove`
+(`:167-175`, divides accumulator by 1000). Each `MOVE` carries its own `LastTimer`
+(`LIB386/H/3D/MOVE.H:13-15`), so the dt a mover sees is the gap between successive reads of
+the clock, not an absolute. `ChangeSpeedMove` (`:12-25`) does the same banking when speed
+changes. Consumers in the loop:
+
+- `StepFalling = GetDeltaMove(&RealFalling)` and `StepShifting = GetDeltaMove(&RealShifting)`
+  at `PERSO.CPP:1471-1473` — global per-frame fall/conveyor deltas applied to all objects.
+- `pansample = GetDeltaMove(&SampleAlwaysMove)` at `PERSO.CPP:1476` — sample panning rate.
+- `RealFalling`/`RealShifting`/`SampleAlwaysMove` are (re)initialised at `PERSO.CPP:459-464`
+  with `InitMove`, which resets `Acc` and stamps `LastTimer = TimerRefHR`
+  (`MOVE.H:44-48`). The grep surface for other movers is `GetDeltaMove` / `GetBoundMove` /
+  `GetBoundAngleMove` callers across `SOURCES/` (script-driven actor motion in
+  `GERETRAK.CPP`, door/lift bounds, etc.) — all route through the same `TimerRefHR - LastTimer`
+  read, so pinning the clock pins them uniformly.
+
+**Animation interpolation — `LIB386/ANIM/FRAME.CPP`, `INTERDEP.CPP`.** `SetInterAnim`
+(`FRAME.CPP:42-43`) stamps `obj->LastTimer = obj->Time = TimerRefHR` at anim start.
+`ObjectSetInterDep` (`INTERDEP.CPP:14-153`) is the per-frame interpolator: it compares
+`TimerRefHR` to `obj->Time`/`obj->NextTimer`, computes an `interpolator` fraction
+(`:51-53`) from `(Time - LastTimer)` over `(NextTimer - LastTimer)`, and advances the frame
+when `Time >= NextTimer`. The interpolation fraction — and therefore the per-tick pose,
+which feeds `hero.last_frame`/`anim` and the actors' positions — is a direct function of how
+much `TimerRefHR` advanced this tick. This is precisely the kinematic tier
+(`x/y/z/beta/anim/last_frame`) the baseline harness currently treats as soft.
+
+**Timed script / object logic — `SOURCES/OBJECT.CPP` and others.** Many sites read
+`TimerRefHR` as an absolute timestamp for timeouts and animation phases, e.g. rotating
+platforms (`OBJECT.CPP:4598-4626`, `angle = ((TimerRefHR - Info2) * 320) / SRot + Info1`),
+extras lifetimes (`:5564-5613`), cinema cycles (`:4684-4722`), proto timers
+(`:4120-4158`), flash effects (`:5476`, `(TimerRefHR & 0xFF)`). These are deterministic
+under a pinned clock because `TimerRefHR` itself becomes a deterministic sequence — they read
+the same global. (`TimerProto`, `TimerCinema`, `PersoFlashTimer`, the per-object `Info`/
+`Info2` stamps are all derived from `TimerRefHR`.)
+
+**FPS counter — `TIMER.CPP:82-87`.** `NbFramePerSecond` is wall-clock derived and will stay
+nondeterministic; the dump already drops it (`baseline_harness.py:34`). Not a simulation
+consumer.
+
+Net: the entire moving-actor surface flows from one global, `TimerRefHR`, read at three
+kinds of sites (per-mover `GetDeltaMove`, per-anim `ObjectSetInterDep`, and direct absolute
+reads). Make `TimerRefHR` advance by a constant per tick and all three become reproducible.
+I am confident about the movement and animation paths; I have *not* exhaustively audited
+every absolute-`TimerRefHR` read in `GERELIFE.CPP`/`GERETRAK.CPP` for branch-on-time logic,
+so a residual "is there any time read that isn't a pure function of `TimerRefHR`" check
+belongs in Phase 2 validation (§6).
+
+---
+
+## 3. Injection point — two candidate approaches
+
+The goal is: on a fixed-dt tick, `TimerRefHR` advances by a constant `DT` rather than by the
+wall-clock delta. Two ways to achieve that.
+
+### (a) Teach `ManageTime()` to add a fixed increment under a mode flag
+
+Add a flag (set only by the harness) that makes the `!TimerLock` branch of `ManageTime()`
+(`TIMER.CPP:75-77`) add a constant `DT` instead of `TimerSystemHR - LastTime`.
+
+- **Pro:** there is exactly one steady-state increment site (§1), so one guarded branch
+  covers the whole simulation. Every `GetDeltaMove`/`ObjectSetInterDep`/absolute read sees a
+  clean constant step with no special-casing. It naturally composes with `Lock`/`Save`/
+  `Restore` — those still freeze/rewind around their regions; the only change is the *size*
+  of the increment when the clock is allowed to move.
+- **Con:** it edits a `LIB386` file (`TIMER.CPP`) that is otherwise pure C-linkage engine
+  code, to add behaviour driven by a `SOURCES`-level harness. The flag would need to live
+  somewhere both can reach (a `TIMER.CPP` global with a setter, set from `CONTROL.CPP`),
+  which is a small but real coupling. It also still calls `SDL_GetTicks()` and updates
+  `LastTime`/the FPS counter, so FPS stays wall-clock (fine — it's dropped).
+- **Subtlety:** `ManageTime()` is called many times per loop (inside every `Lock`/`Save`/
+  `Restore`), but only the ones with `TimerLock == 0` advance the clock. A naive "add DT on
+  every `ManageTime`" would over-count badly. The increment must be gated so it fires once
+  per *tick*, not once per `ManageTime`. The cleanest framing is: the harness arms a
+  "pending DT" before the tick's main `ManageTime` and the function consumes it once. This
+  needs care precisely because of the many `Save`/`Restore` `ManageTime` calls.
+
+### (b) `LockTimer()` for the tick, then one `SetTimerHR(TimerRefHR + DT)` from the hook
+
+Drive it entirely from `Control_TickHook()` (`CONTROL.CPP:359`): hold the clock locked for
+the whole tick so wall-clock never leaks in, and bump it by `DT` exactly once per tick.
+
+- **Pro:** zero `LIB386` changes — it reuses the existing public `SetTimerHR`/`LockTimer`
+  seams (the same ones the console `timer` command and `docs/CONTROL.md` already cite). The
+  whole feature stays inside the harness TU, matching the harness's stated design ("reuses
+  existing engine seams rather than changing game logic," `CONTROL.H:11-13`). Strongly
+  preferred on the surgical-changes / opt-in principles.
+- **Con — this is the load-bearing risk:** the loop is *saturated* with `SaveTimer`/
+  `RestoreTimer` and `LockTimer`/`UnlockTimer` pairs (dozens of sites; grep `PERSO.CPP` for
+  `SaveTimer`/`RestoreTimer` returns ~50 hits across menus, the load path, benchmarks, and
+  notably the FollowCam compensation). If the harness leaves `TimerLock` raised across the
+  tick, it nests with all of those. `SaveTimer`/`RestoreTimer` are counter-based and
+  re-entrant so they tolerate nesting, but the *semantics* interact: while the harness lock
+  is held, every internal `ManageTime()` drops its delta, so the internal `Save`/`Restore`
+  pairs become no-ops on the clock value (they rewind to a value that never moved) — which is
+  arguably what we want, but needs verifying tick by tick. The cleaner variant is *not* to
+  hold a lock across the tick at all, but to let the normal `ManageTime()` run and then, once
+  per tick from the hook, overwrite the clock to a deterministic value: `SetTimerHR(base + n*DT)`
+  where `base` is the loaded clock and `n` the tick index. That makes the per-tick clock a
+  pure function of the tick count regardless of how much real time `ManageTime` added, and
+  `SetTimerHR` already brackets itself in `LockTimer`/`UnlockTimer`.
+- **Subtlety — hook timing (§1):** the hook runs *before* this tick's `ManageTime()`
+  (`:551` vs `:578`). So a "set the clock from the hook" approach sets the value that the
+  *upcoming* tick will read after `MyGetInput`. If instead we want the increment applied
+  after `ManageTime` has run, the hook is the wrong seam and a post-`ManageTime` call site
+  (or approach (a)) is needed. This ordering is the single most important thing to pin down
+  in Phase 2; I am not certain which side of `ManageTime` the pin must sit on to get the
+  movers to see exactly `DT`, because `GetDeltaMove` reads `TimerRefHR` at `:1471` (after
+  `ManageTime`) while `ObjectSetInterDep` reads it later still. A `SetTimerHR` from the hook
+  (pre-`ManageTime`) followed by the normal `ManageTime` would add the *real* delta on top of
+  the pinned value, defeating the purpose — so a from-the-hook overwrite likely has to also
+  neutralise the subsequent `ManageTime` (e.g. by holding the lock through `:578`, i.e.
+  variant (b)-with-lock). This tension is the reason approach (a) is structurally cleaner
+  even though it touches `LIB386`.
+
+### FollowCam timer compensation interaction (both approaches)
+
+`PERSO.CPP:1877-1889` saves the timer before `AffScene` and, after it, does
+`RestoreTimer(); TimerRefHR += TimerSystemHR - FollowCamTimerBefore;` — it deliberately adds
+back the *real* wall-clock render+vsync duration so the follow-camera frames don't stall the
+game clock. Under fixed-dt this hand-rolled re-add reintroduces a wall-clock term
+(`TimerSystemHR - FollowCamTimerBefore`) *after* our pin, so it would corrupt determinism on
+exterior follow-cam frames. Same shape, smaller, at `PERSO.CPP:645-703` (the `DEBUG_TOOLS`
+benchmark) and any other site that manually adds a `TimerSystemHR` delta. A fixed-dt mode has
+to either (i) pin the clock *after* this block, or (ii) make this re-add a no-op when the
+mode is active. This is a concrete correctness hazard, not a theoretical one — flag it
+prominently for Phase 2. Note `WaitVideoSync()` is a no-op (`LIB386/SVGA/SDL.CPP:113-114`)
+and vsync is delegated to `SDL_SetRenderVSync` (`WINDOW.CPP:159`), so the render stall the
+FollowCam block compensates for is real present latency, not an explicit busy-wait.
+
+**Tentative lean (not a decision):** approach (a) is structurally cleaner — one increment
+site, no nesting against the `Save`/`Restore` thicket, naturally once-per-tick if gated
+right — at the cost of a small, well-contained `LIB386` edit behind a harness-set flag.
+Approach (b) keeps everything in the harness TU but has to reason about the
+`Lock`/`Save`/`Restore` nesting and the hook-vs-`ManageTime` ordering, and still needs the
+FollowCam re-add neutralised. Either way the FollowCam re-add must be handled. The decision
+belongs in Phase 2.
+
+---
+
+## 4. RNG
+
+There is exactly one RNG seed in the game: `srand(TimerRefHR)` in `ChangeCube()`
+(`OBJECT.CPP:1171`) — confirmed by grepping `srand` across `SOURCES/` and `LIB386/`
+(only that one hit). `Rnd(n)` is `rand() % n` and `MyRnd` wraps it (per the prior automation
+research; not re-verified here).
+
+Does pinning the clock *before* `ChangeCube` already determinise the seed? **Partly, and the
+detail matters.** `ChangeCube()` runs inside the `if (NewCube != -1)` block at
+`PERSO.CPP:540`, which is *above* `Control_TickHook()` at `:551`. So on the load path
+(`Control_Begin` calls `ChangeCube()` directly at `CONTROL.CPP:163`, and the first loop
+iteration may call it again), the seed is taken from whatever `TimerRefHR` holds at that
+moment. On `--load`, `TimerRefHR` is the *restored save value* (a fixed number for a given
+save), so `srand(TimerRefHR)` is in fact already deterministic across runs for a loaded
+save — which is consistent with the measured finding that "the `srand(TimerRefHR)` reseed
+produced no observable divergence." The seed isn't the drift source; the per-tick dt is.
+
+So the spec's measured conclusion holds up under inspection: for the `--load X --tick N`
+workflow, the seed is already pinned by the restored clock, and no explicit reseed is needed
+for the *currently observed* determinism. **Caveat I cannot rule out without testing:** if a
+fixed-dt run ever triggers a *mid-run* `ChangeCube` (a scene transition during the ticks,
+which the harness over-counts per `docs/CONTROL.md`), the seed at that transition is
+`TimerRefHR` at that tick — which is deterministic only if the clock was already pinned by
+then. With a working fixed-dt that is true. So: an explicit fixed reseed is likely
+*unnecessary* given a working clock pin, but a fixed-dt mode that also wants to be robust to
+mid-run cube changes should confirm the clock is pinned before the `:540` `ChangeCube` (it
+is, if the pin is applied each tick before that block — note the hook is *after* it, so a
+hook-only pin does not cover the first `ChangeCube`; `Control_Begin`'s direct `ChangeCube`
+already runs with the restored clock, which is fine). I would verify this empirically rather
+than assert it.
+
+---
+
+## 5. Hazards — what still varies under a pinned clock
+
+- **The FollowCam wall-clock re-add (§3).** `PERSO.CPP:1887` adds real elapsed ms back into
+  `TimerRefHR` on exterior follow-cam frames. This is the highest-priority hazard: it
+  silently reintroduces nondeterminism after any clock pin. Must be neutralised in fixed-dt
+  mode.
+- **Other `SDL_GetTicks()` readers.** Grep across `LIB386/`+`SOURCES/` (excluding ASM):
+  `TIMER.CPP:29,73` (the clock itself), `MOUSE.CPP:41,74` (pointer-idle hide timer — cosmetic,
+  not simulation), `AIL/SDL/SAMPLE.CPP:432,461` (audio voice timing — audio thread, see
+  below), `PLAYACF.CPP:509-539` and `RES_PICKER.CPP:191` (video/resource-picker pacing —
+  modal paths the harness already avoids per `docs/CONTROL.md`). None of these feed the
+  world-state dump under the null audio backend, but they are the exhaustive set of raw
+  wall-clock reads to be aware of.
+- **Audio thread.** The SDL audio backend services voices on a callback thread
+  (`AIL/SDL/SAMPLE.CPP`, `LockVoices`/`SDL_LockAudioStream` around `:248-510`), and some
+  script logic gates on `IsSamplePlaying(...)` (`PERSO.CPP:1566`). With real audio, sample
+  completion timing is wall-clock and threaded, so it can branch script logic
+  nondeterministically. The baseline harness already runs with `SDL_AUDIODRIVER=dummy`
+  (`baseline_harness.py:56`) / null backend, which sidesteps both. Fixed-dt does *not* fix
+  audio-timed branches; it relies on the null backend, same as today. Worth stating
+  explicitly so nobody expects fixed-dt alone to determinise a real-audio run.
+- **`FirstLoop` asymmetry.** The first post-load tick differs from later ticks
+  (`PERSO.CPP:543`, gating at `:1549`-ish per the automation research). Not nondeterministic,
+  but means tick 1 ≠ tick 2 for the same state — the dump must keep recording the tick count
+  (it does: `CONTROL.CPP:257-261`).
+- **Platform precision (long double).** Projection/rotation use `long double` + `lrintl()`,
+  which is 80-bit on Linux x86_64 but 64-bit on Windows/macOS-ARM (see `CLAUDE.md`,
+  `docs/PLATFORM.md`). Fixed-dt removes *temporal* nondeterminism but **does not** remove
+  *cross-platform* coordinate differences: two platforms running the identical fixed-dt
+  sequence can still land on slightly different `x/y/z` because the math rounds differently.
+  Implication for §6: a fixed-dt golden is reproducible *on the same platform/build*; the
+  baseline harness should keep goldens per-platform or keep a position tolerance for
+  cross-platform comparisons even after the kinematic tier goes exact same-platform. This is
+  the one place I'd push back on "promote kinematics to fully exact" — exact within a
+  platform, yes; exact across platforms, not guaranteed by fixed-dt alone.
+- **Integer vs sub-step truncation.** `GetDeltaAccMove` divides the accumulator by 1000 and
+  keeps the remainder in `Acc` (`MOVE.CPP:167-175`). A constant `DT` makes the accumulator
+  sequence deterministic, but the *choice* of `DT` changes the truncation pattern, so two
+  different `--fixed-dt` values produce different (each internally reproducible) trajectories.
+  The harness should pick and document one canonical `DT` for goldens (a value matching the
+  game's nominal frame time — verify what the engine targets; I did not find a hardcoded
+  target-frame-ms constant in this pass).
+
+---
+
+## 6. Validation plan
+
+How to *prove* fixed-dt works, using tooling that already exists:
+
+1. **Reproducibility across runs (the core claim).** Run a fixed-dt `--load X --tick N
+   --dump-state` 3× on the same build/platform with the null audio backend and diff the
+   dumps. Success = byte-identical including the kinematic fields (`x/y/z/beta/anim/
+   last_frame`). Today those fields drift ~0.1% on busy exterior scenes (`docs/CONTROL.md`
+   determinism section); fixed-dt should drop that to zero. `fps`/`timer_ref_hr` are expected
+   to differ run-to-run only if the clock pin is imperfect — under a correct pin
+   `timer_ref_hr` becomes a deterministic function of the tick count, so it can move from the
+   `VOLATILE` set to checked.
+2. **Baseline harness kinematic tier → zero soft notes.** Re-run
+   `tests/savegame/corpus/baseline_harness.py` with the binary built/run in fixed-dt mode.
+   Expected outcome: the `(+N kinematic)` annotations (`baseline_harness.py:156,163`) drop to
+   zero across the corpus. Concretely that means `SOFT_POS`/`SOFT_OTHER`
+   (`baseline_harness.py:39-40`) no longer fire.
+3. **Promote kinematics to structural.** Once (2) holds, move `x/y/z/beta` and
+   `anim/last_frame` out of the soft tiers so a mismatch becomes a hard failure — i.e. delete
+   the `SOFT_POS`/`SOFT_OTHER` special-cases in `diff()` (`baseline_harness.py:105-110`) and
+   regenerate goldens with `--update`. Caveat from §5: this exactness is *per platform/build*;
+   if goldens are shared across platforms, keep a tolerance or store per-platform goldens,
+   because long-double precision still differs.
+4. **Regression guard for the constraint.** Prove the mode is opt-in: a default (non-harness)
+   run, and a harness run *without* `--fixed-dt`, must behave exactly as today (variable dt).
+   The cleanest check is that `ManageTime()`/the loop is byte-for-byte unchanged in behaviour
+   when the flag is off — e.g. a host test or an A/B dump showing no difference vs the current
+   binary on a non-fixed-dt run.
+5. **Sanity that simulation still advances.** Keep the spirit of `tests/automation/test_tick.sh`
+   (1 vs 60 ticks must advance the clock and the hero's idle-anim frame): under fixed-dt the
+   clock advances by exactly `N*DT` and the anim frame advances deterministically, which is a
+   stronger assertion than the current "advanced at all."
+
+---
+
+## Summary
+
+- The whole moving-actor surface is driven by one global, `TimerRefHR`, advanced once per
+  steady-state tick in `ManageTime()` (`TIMER.CPP:72-88`, called at `PERSO.CPP:578`). dt
+  consumers are `GetDeltaMove` (`MOVE.CPP:64-78`; movement/fall/shift at
+  `PERSO.CPP:1471-1476`), the animation interpolator `ObjectSetInterDep`
+  (`INTERDEP.CPP:14-153`), and many absolute-`TimerRefHR` reads in `OBJECT.CPP`. Pin the
+  clock and they all reproduce.
+- Two injection approaches: (a) a guarded fixed increment inside `ManageTime()` — structurally
+  cleaner, one site, small `LIB386` edit; (b) drive `SetTimerHR`/`LockTimer` from
+  `Control_TickHook` — no `LIB386` change but must reason about the dense `Save`/`Restore`
+  nesting and the hook-runs-before-`ManageTime` ordering (`:551` vs `:578`). No decision made.
+- RNG is already effectively pinned for the `--load --tick` workflow: the only seed is
+  `srand(TimerRefHR)` at `OBJECT.CPP:1171`, and on `--load` `TimerRefHR` is the restored save
+  value, so the seed is already deterministic — matching the measured "reseed produced no
+  divergence." No explicit reseed appears necessary given a working clock pin; verify rather
+  than assume for mid-run cube changes.
+- Main open questions / hazards: (1) the FollowCam wall-clock re-add at `PERSO.CPP:1887`
+  reintroduces real time after any pin and must be neutralised; (2) which side of
+  `ManageTime` the pin must sit on for movers to see exactly `DT` (hook ordering); (3)
+  cross-platform long-double precision means fixed-dt gives same-platform exactness, not
+  cross-platform — the baseline promotion in §6 should account for that; (4) the canonical
+  `DT` value to standardise goldens on (no hardcoded target-frame-ms constant found this
+  pass); (5) a residual audit of branch-on-`TimerRefHR` script logic in
+  `GERELIFE.CPP`/`GERETRAK.CPP`.


### PR DESCRIPTION
## What

Adds an opt-in `--fixed-dt <ms>` flag to the CLI control harness. It advances the simulation by a constant time step per tick instead of by wall-clock, so `--dump-state` becomes reproducible run-to-run. This is the prerequisite for faithful input record/replay (harness roadmap step 2).

Hard constraint held throughout: the mode is **opt-in and does not change default-build or normal gameplay timing**. The new code is inert unless the harness arms it.

## How

A virtual time source in the timer: when `Timer_EnableFixedDt()` is called, `ManageTime()` reads an internal virtual clock (`FixedDtNow`) stepped once per tick from `Control_TickHook()`, instead of `SDL_GetTicks()`. Because the clock is frozen within a tick, every internal `ManageTime()` (the dense `Lock`/`Save`/`Restore` calls) computes a zero delta and the single per-tick step is banked exactly once — no per-call gating needed. When the flag is off, `ManageTime()` takes the identical `SDL_GetTicks()` path it does today.

Getting to *exact* same-platform determinism took three fixes, each found by running a save repeatedly and diffing dumps:

- **Enable before the load** (top of `Control_Begin`) so boot `ManageTime()` calls freeze and the base clock stays exactly the restored save value — no boot wall-clock contamination.
- **Force `LastTime = FixedDtNow` when arming** so the first tick's step is exactly `DT`.
- **Guard the FollowCam wall-clock re-add** (`PERSO.CPP`) behind `Timer_FixedDtActive()` so it is skipped only in fixed-dt mode. This re-add was the largest exterior leak; it is skipped, never altered, for default builds.

The only RNG seed (`srand(TimerRefHR)` in `ChangeCube`) is already pinned by the restored clock, so no reseed is needed.

## Result

A busy exterior save dumped 10× is byte-identical including `timer_ref_hr` and all kinematic fields — **on the null sound backend** (`-DSOUND_BACKEND=null`). With the SDL audio backend, exterior ambient-sample timing is serviced on a wall-clock thread that branches the simulation, so `SDL_AUDIODRIVER=dummy` alone leaves a small wobble; fixed-dt pins the clock, not audio-thread timing. Interior scenes are deterministic on either backend. Exactness is per platform/build (`long double` precision differs across platforms).

## Scope / footprint

- LIB386: one `ManageTime()` source line plus three small functions (`Timer_EnableFixedDt`, `Timer_FixedDtAdvance`, `Timer_FixedDtActive`), all dead unless armed.
- SOURCES: flag parse + wiring in `CONTROL.CPP`, one guarded line in `PERSO.CPP`.
- Docs: `docs/FIXED_DT_RESEARCH.md` (Phase 1), `docs/FIXED_DT_PLAN.md` (Phase 2), `docs/CONTROL.md` updated.

Promoting the baseline harness's kinematic tier to exact is a **follow-up PR** that depends on this one.

## Testing

- `make build` clean; `make test` (host suite) passes; clang-format clean.
- Determinism verified as above (interior + exterior, null backend, repeated dumps).
- Default path (no `--fixed-dt`) confirmed unchanged.