### PR TITLE
perf(control): disable vsync under the harness for fast fast-forward

### DIFF
--- a/LIB386/H/SYSTEM/WINDOW.H
+++ b/LIB386/H/SYSTEM/WINDOW.H
@@ -25,6 +25,12 @@ void WindowToSurfaceCoords(S32 windowX, S32 windowY, S32 *surfaceX, S32 *surface
 void SetWindowFullscreen(bool fullscreen);
 bool GetWindowFullscreen();
 
+// Toggle renderer vsync at runtime. On (the default) paces presents to the display
+// refresh; off lets the loop run flat-out. The control harness turns it off so a
+// scripted run is not capped at ~60 fps -- presentation only, no effect on rendered
+// pixels or simulation state.
+void Window_SetVSync(int enabled);
+
 void ManageWindow();
 void HandleEventsWindow(const void *event);
 

--- a/LIB386/SYSTEM/WINDOW.CPP
+++ b/LIB386/SYSTEM/WINDOW.CPP
@@ -300,6 +300,12 @@ bool GetWindowFullscreen() {
     return windowFullscreenEnabled;
 }
 
+void Window_SetVSync(int enabled) {
+    if (sdlRenderer != NULL) {
+        SDL_SetRenderVSync(sdlRenderer, enabled ? 1 : 0);
+    }
+}
+
 void ManageWindow() {
     // Empty
 }

--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -9,9 +9,10 @@
 #include "CONSOLE/CONSOLE.H"
 
 #include <FILEIO/SAVEPNG.H>
-#include <SVGA/SCREEN.H>  /* Screen, ModeDesiredX/Y */
-#include <SYSTEM/TIMER.H> /* TimerRefHR, NbFramePerSecond */
-#include <SYSTEM/FILES.H> /* ExistsFileOrDir */
+#include <SVGA/SCREEN.H>   /* Screen, ModeDesiredX/Y */
+#include <SYSTEM/TIMER.H>  /* TimerRefHR, NbFramePerSecond */
+#include <SYSTEM/WINDOW.H> /* Window_SetVSync */
+#include <SYSTEM/FILES.H>  /* ExistsFileOrDir */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -170,6 +171,11 @@ int Control_Begin(void) {
        save value -- no boot wall-clock leaks into it. Harness-only; off by default. */
     if (s_have_fixed_dt)
         Timer_EnableFixedDt((U32)s_fixed_dt);
+
+    /* No human is watching a --exit run, so drop the ~60 fps vsync cap and let the loop
+       run flat-out. Presentation only -- the rendered pixels and simulation state are
+       unchanged (verified: dumps and screenshots are identical with vsync off). */
+    Window_SetVSync(0);
 
     if (s_load_name) {
         if (!control_resolve_save(s_load_name)) {

--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -62,6 +62,10 @@ save directory, then with a `.lba` suffix — so both `--load "021 Palace"` and
 - **A rendered artifact needs a tick.** `--screenshot` forces a minimum of one tick (you
   can't screenshot a frame that was never drawn). A `--dump-state` with `--tick 0` reflects
   the loaded state before any simulation step.
+- **Vsync is off under the harness.** A `--exit` run disables the renderer's vsync cap so
+  the loop runs flat-out instead of at ~60 fps — a long `--tick N` run is ~10-14x faster
+  (e.g. 2000 ticks: ~34 s to ~2.5 s here). Presentation only: the dumped state and rendered
+  pixels are identical (verified 0 drift over the save corpus).
 - **A tick is one main-loop iteration, normally one rendered frame.** In a settled scene
   the two are identical. The exception is a cube transition: when a script (or a `cube`
   command) changes the scene, the loop restarts its body to load the new cube, which counts


### PR DESCRIPTION
## What

A headless `--exit` run cost ~16 ms/tick — and profiling showed that's entirely the renderer's vsync cap (`SDL_SetRenderVSync(.,1)` + `RenderPresent`, `WINDOW.CPP`), not the simulation (the sim is ~1.3 ms/tick). No human watches a `--exit` run, so `Control_Begin` now turns vsync off via a new `Window_SetVSync()` seam and lets the loop run flat-out.

## Measured (null backend, `--tick 2000`)

| save | vsync on | vsync off |
|---|---|---|
| Desert Island | 34.7 s | 2.75 s |
| Emperor Palace | 34.1 s | 2.43 s |
| Hacienda | 34.2 s | 3.15 s |

~10–14x for long scripted runs. This is the prerequisite for soak-testing scene scripts (or a future input replay) on a fast timer — `--fixed-dt` already pinned sim-time; this removes the wall-clock pacing.

## Safety

- **State-neutral:** vsync controls present *timing*, not the rendered framebuffer or the simulation. Verified by a full save-corpus compare with vsync off against goldens captured with vsync on — **0 drift**.
- **Opt-in:** only `Control_Begin` (the `--exit` automation path) disables it; default gameplay keeps vsync. The new `Window_SetVSync()` is a thin runtime toggle on the live renderer.
- Builds clean (SDL + null); clang-format clean.

## Notes

Completes the harness speedup series alongside #166 (skip CD splash) and #167 (`--jobs`). Together: a corpus check drops from minutes to seconds, and long scripted/soak runs go from real-time to a few seconds. `docs/CONTROL.md` updated.