### PR TITLE
feat(control): add --demo attract mode + deterministic playthrough fixture

### DIFF
--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -42,6 +42,7 @@ static char s_shot_path[ADELINE_MAX_PATH];
 static int s_have_polyrec = 0;
 static char s_polyrec_path[ADELINE_MAX_PATH];
 static int s_exit = 0;
+static int s_demo = 0;
 
 /* --- Runtime ---------------------------------------------------------------- */
 static long s_hook_calls = 0;
@@ -131,6 +132,12 @@ void Control_ParseArgs(int *argc, char *argv[]) {
             read += 1;
             continue;
         }
+        if (!strcmp(a, "--demo")) {
+            s_demo = 1;
+            s_active = 1;
+            read += 1;
+            continue;
+        }
 
         argv[write++] = argv[read++];
     }
@@ -176,6 +183,13 @@ int Control_Begin(void) {
        run flat-out. Presentation only -- the rendered pixels and simulation state are
        unchanged (verified: dumps and screenshots are identical with vsync off). */
     Window_SetVSync(0);
+
+    /* Attract/demo mode: the scene's scripts drive the hero along authored tracks (a
+       "canned playthrough"), and dialogues/choices auto-advance on the game clock instead
+       of waiting for input. Combined with --fixed-dt this is a deterministic scripted run.
+       Opt-in; default gameplay is unaffected. */
+    if (s_demo)
+        DemoSlide = TRUE;
 
     if (s_load_name) {
         if (!control_resolve_save(s_load_name)) {

--- a/SOURCES/CONTROL.H
+++ b/SOURCES/CONTROL.H
@@ -4,7 +4,7 @@
 /*
  * CLI control harness: drive the engine from outside for automation / regression.
  *
- *   lba2 --load <slot> --exec "<cmd>;<cmd>" --tick <N> --fixed-dt <ms> \
+ *   lba2 --load <slot> --exec "<cmd>;<cmd>" --tick <N> --fixed-dt <ms> --demo \
  *        --dump-state <path> --screenshot <path> --exit
  *
  * The harness reuses existing engine seams rather than adding new ones: the console

--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -26,6 +26,7 @@ lba2cc --load <slot>          restore a save before the loop starts
        --exec "<cmd>;<cmd>"   run console commands (';'-separated) on the first tick
        --tick <N>             advance N simulation ticks
        --fixed-dt <ms>        advance the clock by a constant <ms> per tick (deterministic)
+       --demo                 attract/demo mode: scripts drive the scene, modals auto-advance
        --dump-state <path>    write a JSON snapshot of engine state
        --screenshot <path>    write a PNG of the rendered frame
        --polyrec <path>       record polygon draw calls of the frame (ENABLE_POLY_RECORDING builds)
@@ -94,6 +95,16 @@ save directory, then with a `.lba` suffix — so both `--load "021 Palace"` and
   different but still-reproducible trajectory, so pick one and keep it. The flag is harness-only
   and has no effect on default gameplay timing. An invalid or non-positive value is ignored with
   a diagnostic.
+- **`--demo` runs attract/demo mode** (sets `DemoSlide`). It only does something on an authored
+  *demo scene* (the copies at cubes 193-221, see [SCENES.md](SCENES.md)): such a scene drives
+  itself from its Life/Track scripts with no player input, and dialogues/choices auto-advance on
+  the game clock instead of waiting — so it plays through headless instead of hanging on a prompt.
+  (On a regular scene there is no demo script, so the hero just idles.) Combined with `--fixed-dt`
+  this is a deterministic scripted playthrough; cube 193 (the retail menu attract,
+  `GAMEMENU.CPP:2435`) is exercised this way by `tests/automation/test_demo.sh`. Opt-in; default
+  gameplay is unaffected. (Note: a demo scene ends on a cutscene/`PLAY_ACF` that `--demo` does not
+  auto-advance, so it still blocks a `--exit` run — cap the tick budget before it; see the modal
+  caveat above.)
 - A bad `--load` path exits cleanly with a `save not found` diagnostic.
 
 ## `--dump-state` JSON

--- a/tests/automation/test_demo.sh
+++ b/tests/automation/test_demo.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# --demo: deterministic scripted-playthrough fixture. Cube 193 is the retail attract scene
+# (GAMEMENU.CPP:2435 loads NewCube=193 with DemoSlide for the menu's idle demo) — an authored
+# "demo scene" (SCENES.md "Demo scenes (193-221)", a Twinsen's-House copy with demo scripts).
+# Under --demo it runs itself from its Life/Track scripts with no player input: the hero walks an
+# authored path while the scene plays. With --fixed-dt that run is deterministic, making it a
+# regression guardrail far broader than an 8-tick settled save — it exercises the Life/Track
+# interpreters, animation, and movement over time.
+#
+# 500 ticks (~8 s of game time) stays clear of the cutscene the demo ends on (which would block a
+# --exit run; the demo scenes are short clips). Asserts (1) the run is reproducible — two runs
+# byte-identical on simulation state — and (2) it is live — state at tick N differs from tick 1
+# (scripts ran, did not idle or hang). timer_ref_hr is dropped: a fresh-start cube jump (no
+# --load) does not pin the absolute clock the way a restored save does, but every simulation
+# field is deterministic (verified serial and 5-way parallel).
+TESTNAME=demo
+. "$(dirname "$0")/lib.sh"
+precheck
+
+DEMO_CUBE=193
+TICKS=500
+
+a="$(mktemp)"; b="$(mktemp)"; c="$(mktemp)"
+trap 'rm -f "$a" "$b" "$c"' EXIT
+
+ctl --exec "cube $DEMO_CUBE" --demo --tick 1     --fixed-dt 16 --dump-state "$a" --exit >/dev/null 2>&1 \
+    || fail "demo tick 1 run: non-zero exit ($?)"
+ctl --exec "cube $DEMO_CUBE" --demo --tick $TICKS --fixed-dt 16 --dump-state "$b" --exit >/dev/null 2>&1 \
+    || fail "demo tick $TICKS run: non-zero exit ($?)"
+ctl --exec "cube $DEMO_CUBE" --demo --tick $TICKS --fixed-dt 16 --dump-state "$c" --exit >/dev/null 2>&1 \
+    || fail "demo tick $TICKS rerun: non-zero exit ($?)"
+
+# Determinism: the two $TICKS runs must agree on all simulation state. Drop wall-clock-derived
+# fields (fps, timer_ref_hr) and the console log.
+python3 - "$b" "$c" <<'PY' || fail "scripted playthrough not reproducible (runs differ)"
+import json, sys
+def norm(p):
+    d = json.load(open(p))
+    for k in ("fps", "timer_ref_hr", "log"):
+        d.pop(k, None)
+    return d
+sys.exit(0 if norm(sys.argv[1]) == norm(sys.argv[2]) else 1)
+PY
+
+# Liveness: the simulation advanced between tick 1 and tick $TICKS (scripts ran, not frozen).
+python3 - "$a" "$b" <<'PY' || fail "scene did not advance (tick 1 == tick N): demo idle or hung"
+import json, sys
+def norm(p):
+    d = json.load(open(p))
+    for k in ("fps", "timer_ref_hr", "log", "tick"):
+        d.pop(k, None)
+    return d
+sys.exit(0 if norm(sys.argv[1]) != norm(sys.argv[2]) else 1)
+PY
+
+hl=$(jget "$a" "d['hero']['last_frame']"); hl2=$(jget "$b" "d['hero']['last_frame']")
+pass "cube $DEMO_CUBE demo: $TICKS ticks reproducible and advancing (hero anim frame $hl->$hl2)"


### PR DESCRIPTION
Adds an opt-in `--demo` harness flag and a deterministic scripted-playthrough regression test, building on the step-3 research (#170).

## `--demo`
Sets `DemoSlide` for the run: the loaded scene drives itself from its Life/Track scripts with no player input, and dialogues/choices auto-advance on the game clock instead of waiting for input — so a scripted scene plays through headless instead of hanging on a prompt. Opt-in; default gameplay is unaffected. (It does **not** auto-advance full cutscenes/`PLAY_ACF`, which still block a `--exit` run.)

## The fixture — `tests/automation/test_demo.sh`
Cube 5 is the `SlideDemo` attract scene. Run under `--demo --fixed-dt 16` for 800 ticks, the scene runs itself deterministically: actors move, an object is destroyed, the hero idle-animates and crosses a zone. The test asserts:
1. **Reproducible** — two runs are byte-identical on simulation state.
2. **Live** — state at tick 800 differs from tick 1 (scripts ran; not idle/hung).

This is a regression guardrail much broader than an 8-tick settled save — it exercises the Life/Track interpreters and animation *over time*. `timer_ref_hr` is dropped from the comparison (a fresh-start cube jump doesn't pin the absolute clock the way a restored save does, but every simulation field is deterministic). Verified deterministic on both the SDL+dummy and null backends.

Notably it needs no save fixture (uses `--exec "cube 5"`), so it runs in more environments than the `--load`-based automation tests. Skips cleanly without a binary/display.

## Notes
Local-only (needs retail data + a display), like the rest of `tests/automation/`. The research that found cube 5 as a clean fixture — and ruled out the bat-class scenes — is in #170 / `docs/INPUT_REPLAY_RESEARCH.md`.