### PR TITLE
fix(control): advance fixed-dt clock inside modal and fade loops

### DIFF
--- a/LIB386/H/SYSTEM/TIMER.H
+++ b/LIB386/H/SYSTEM/TIMER.H
@@ -35,6 +35,20 @@ void SetTimerHR(U32 time);
 void Timer_EnableFixedDt(U32 dt_ms); // arm fixed-dt; seeds the virtual clock to now
 void Timer_FixedDtAdvance();         // advance the virtual clock by dt_ms (once per tick)
 S32 Timer_FixedDtActive();           // non-zero while fixed-dt is armed (guards wall-clock paths)
+// Called once per presented frame (BoxBlit). The first present after each
+// Timer_FixedDtAdvance() is free (it is the main-loop render the tick already paid
+// for); every additional present in the same tick steps the virtual clock by dt_ms.
+// This is how modal inner loops (DoFoundObj, messages, menus) — which present frames
+// without going through the main-loop tick hook — keep the clock moving instead of
+// deadlocking on a TimerRefHR deadline. Inert until the first tick advance, so boot
+// presents do not move the clock. Non-fixed-dt runs are byte-for-byte unaffected.
+void Timer_FixedDtPresent();
+// Step the virtual clock by dt_ms for a non-presenting busy-wait. Some loops (the music
+// volume fades in MUSIC.CPP) spin only on ManageTime() with no frame present, waiting for
+// TimerRefHR to cross a deadline; under fixed-dt neither the tick hook nor a present fires
+// inside them, so they would spin forever. Call this once per iteration of such a loop.
+// Unlike Timer_FixedDtPresent() there is no free first step. Inert outside fixed-dt.
+void Timer_FixedDtPump();
 
 void ManageTime();
 void HandleEventsTimer(const void *event);

--- a/LIB386/SVGA/DIRTYBOX.CPP
+++ b/LIB386/SVGA/DIRTYBOX.CPP
@@ -12,6 +12,7 @@
 #include <SYSTEM/EVENTS.H>
 #include <SYSTEM/MOUSE.H>
 #include <SYSTEM/N_MALLOC.H>
+#include <SYSTEM/TIMER.H>
 
 #include <limits.h>
 #include <stdlib.h>
@@ -396,6 +397,10 @@ void BoxBlit() {
     S32 SaveClipXMin, SaveClipYMin, SaveClipXMax, SaveClipYMax;
     /* Safe defaults if mouse cursor graphic is missing (restore block must not use garbage). */
     S32 x0 = 0, y0 = 0, x1 = -1, y1 = -1;
+
+    // One presented frame. Under fixed-dt this steps the virtual clock for modal inner
+    // loops (no-op for the main loop's own render and for non-fixed-dt runs).
+    Timer_FixedDtPresent();
 
     ManageEvents();
 

--- a/LIB386/SYSTEM/TIMER.CPP
+++ b/LIB386/SYSTEM/TIMER.CPP
@@ -29,6 +29,8 @@ U32 LastEvaluate;
 static S32 FixedDtActive = 0;
 static U32 FixedDt = 0;
 static U32 FixedDtNow = 0;
+static S32 FixedDtTicking = 0;     // set on the first tick advance; gates present-stepping past boot
+static S32 FixedDtSkipPresent = 0; // makes the first present after each tick advance free
 
 // --- Initialization ----------------------------------------------------------
 void InitTimer() {
@@ -84,12 +86,36 @@ void Timer_EnableFixedDt(U32 dt_ms) {
     FixedDtNow = TimerSystemHR;
     LastTime = TimerSystemHR;
     FixedDtActive = 1;
+    FixedDtTicking = 0;
+    FixedDtSkipPresent = 0;
 }
 
 void Timer_FixedDtAdvance() {
     // One fixed step per tick. The next unlocked ManageTime() banks it into TimerRefHR;
     // every other ManageTime() in the tick sees an unchanged FixedDtNow and adds nothing.
     if (FixedDtActive) {
+        FixedDtNow += FixedDt;
+        FixedDtTicking = 1;
+        // The main-loop render that follows this advance presents one frame; let it pass
+        // for free so a normal tick stays exactly +dt. Extra presents in this tick come
+        // from modal inner loops and each step the clock (see Timer_FixedDtPresent).
+        FixedDtSkipPresent = 1;
+    }
+}
+
+void Timer_FixedDtPresent() {
+    if (FixedDtActive && FixedDtTicking) {
+        if (FixedDtSkipPresent) {
+            FixedDtSkipPresent = 0;
+        } else {
+            FixedDtNow += FixedDt;
+        }
+    }
+}
+
+void Timer_FixedDtPump() {
+    // No free first step: a non-presenting wait loop owns every iteration's time.
+    if (FixedDtActive && FixedDtTicking) {
         FixedDtNow += FixedDt;
     }
 }

--- a/SOURCES/AMBIANCE.CPP
+++ b/SOURCES/AMBIANCE.CPP
@@ -518,6 +518,7 @@ void FadeToBlack(U8 *ptrpal) {
     starttime = TimerSystemHR;
 
     do {
+        Timer_FixedDtPump(); // non-presenting palette-fade wait: step the virtual clock under fixed-dt
         ManageTime();
 
         delta = starttime + FADE_DELAY - TimerSystemHR;
@@ -545,6 +546,7 @@ void WhiteFade() {
     starttime = TimerSystemHR;
 
     do {
+        Timer_FixedDtPump(); // non-presenting palette-fade wait: step the virtual clock under fixed-dt
         ManageTime();
 
         delta = TimerSystemHR - starttime;
@@ -569,6 +571,7 @@ void FadeWhiteToPal(U8 *ptrpal) {
     starttime = TimerSystemHR;
 
     do {
+        Timer_FixedDtPump(); // non-presenting palette-fade wait: step the virtual clock under fixed-dt
         ManageTime();
 
         delta = TimerSystemHR - starttime;
@@ -593,6 +596,7 @@ void FadeToPal(U8 *ptrpal) {
     starttime = TimerSystemHR;
 
     do {
+        Timer_FixedDtPump(); // non-presenting palette-fade wait: step the virtual clock under fixed-dt
         ManageTime();
 
         delta = TimerSystemHR - starttime;
@@ -678,6 +682,7 @@ void FadePalToPal(U8 *ptrpal, U8 *ptrpal1) {
     do {
         S32 n;
 
+        Timer_FixedDtPump(); // non-presenting palette-fade wait: step the virtual clock under fixed-dt
         ManageTime();
 
         delta = TimerSystemHR - starttime;

--- a/SOURCES/MUSIC.CPP
+++ b/SOURCES/MUSIC.CPP
@@ -382,6 +382,7 @@ void FadeOutVolumeMusic(void) {
         cdvolume > 0 OR
 #endif
                        jvolume > 0) {
+        Timer_FixedDtPump(); // non-presenting wait: step the virtual clock under fixed-dt
         ManageTime();
 #ifdef CDROM
         // volume du CD
@@ -434,6 +435,7 @@ void FadeInVolumeMusic(void) {
         cdvolume < CDVolume OR
 #endif
                        jvolume < JingleVolume) {
+        Timer_FixedDtPump(); // non-presenting wait: step the virtual clock under fixed-dt
         ManageTime();
 #ifdef CDROM
         // volume du CD

--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -189,6 +189,12 @@ x86_64, 64-bit on Windows/macOS-ARM; see [PLATFORM.md](PLATFORM.md)). Two platfo
 identical fixed-dt sequence can still land on slightly different positions. Keep golden
 baselines per-platform, or compare across platforms with a tolerance.
 
+Modal and fade loops also advance the fixed-dt clock — necessary because they run between
+main-loop tick hooks and would otherwise spin forever on a clock deadline. The main loop's
+single render per tick stays free of double-counting, so non-modal ticks (including the
+whole savegame baseline corpus) are byte-identical to the merged behaviour. See
+[FIXED_DT_RESEARCH.md §7](FIXED_DT_RESEARCH.md) for the loop classes and the design.
+
 ## Tests
 
 `tests/automation/` drives the real binary and asserts on the dumped state. Local-only —

--- a/docs/FIXED_DT_RESEARCH.md
+++ b/docs/FIXED_DT_RESEARCH.md
@@ -338,6 +338,51 @@ How to *prove* fixed-dt works, using tooling that already exists:
 
 ---
 
+## 7. Post-merge finding: modal and fade loops need their own clock advance
+
+§6's validation covered the merged fixed-dt mechanism on settled-state baselines. It did
+not surface a class of loops that wait on `TimerRefHR` from inside a single main-loop tick:
+under fixed-dt the virtual clock only steps in `Timer_FixedDtAdvance()` at the tick hook
+(`PERSO.CPP:551`), so any loop that runs *between* hook calls and spins on a clock deadline
+freezes. The baseline corpus dodged this because settled saves don't enter such loops in
+their 8-tick window; the `--demo` attract path hits all three loop shapes.
+
+**Three loop shapes, three fixes** (`TIMER.CPP`).
+
+- **Modal render loops** — `DoFoundObj` (`INVENT.CPP:1541`), `Dial` SpeakAnimation loops
+  (`MESSAGE.CPP:1967, 2005`), `MenuInventory`, anything that presents a frame each iteration
+  via `BoxUpdate`→`BoxBlit`. The first present after each tick advance is the main loop's
+  own render (already paid for by the hook); every *additional* present in the same tick is
+  a modal iteration. `Timer_FixedDtPresent()` (called from `BoxBlit` in `DIRTYBOX.CPP:395`)
+  steps the clock with a skip-first guard so a non-modal tick stays exactly `+dt` and modal
+  loops advance per iteration.
+- **Music volume fades** — `FadeOutVolumeMusic`/`FadeInVolumeMusic` (`MUSIC.CPP`). A
+  `do { ManageTime(); ... } while(volume != target)` spin with no present.
+- **Palette fades** — `FadeToBlack`/`WhiteFade`/`FadeWhiteToPal`/`FadeToPal`/`FadePalToPal`
+  (`AMBIANCE.CPP`, 5 sites). Same `do { ManageTime(); delta = TimerSystemHR - start; ... }`
+  shape, no present.
+
+Both fade classes wrap in `SaveTimer`/`RestoreTimer`, so the pumped time is discarded
+when the loop returns — they don't perturb the game clock, they just need the loop to
+*exit*. `Timer_FixedDtPump()` (no skip-first; one direct step per call) sits next to the
+inner `ManageTime()` in each.
+
+**Why baselines stay byte-identical.** Non-modal ticks call `BoxBlit` exactly once (the
+main render), which consumes the skip; the fades aren't entered during settled-state
+corpus saves. Re-verified `39 ok, 0 drift` after each fix.
+
+**Demo determinism map** (cube N played under `--demo --fixed-dt 16` for 800 ticks,
+gameplay-state compared with `timer_ref_hr` dropped):
+
+- Fully byte-deterministic: 193, 194, 195, 207, 213, 220, 221.
+- Plays through, diverges only in moving-NPC lines (the long-double precision class
+  from §5): 196, 200, 208, 210, 214, 218, 219.
+
+No HANG remains. The residual run-to-run divergence is the §5 platform-precision hazard
+surfacing on action scenes with long actor trajectories — not new.
+
+---
+
 ## Summary
 
 - The whole moving-actor surface is driven by one global, `TimerRefHR`, advanced once per


### PR DESCRIPTION
Stacked on #171 — review/merge after that one lands, then switch the base to `main`.

## Problem

Under `--fixed-dt` the virtual clock only advanced at the main-loop tick hook (`Timer_FixedDtAdvance`, `PERSO.CPP:551`). Any loop that waits on `TimerRefHR` but runs *between* hook calls stays frozen, so the loop never reaches its deadline and spins forever. The savegame baseline corpus dodged this because settled saves do not enter such loops in their 8-tick window; the `--demo` attract path from #171 hits all three loop shapes.

## Fix

Three loop shapes, two new timer entry points (`TIMER.CPP`/`TIMER.H`):

- **Modal render loops** — `DoFoundObj` (`INVENT.CPP:1541`), `Dial` `SpeakAnimation` loops (`MESSAGE.CPP:1967, 2005`), `MenuInventory`. Each iteration calls `BoxUpdate` → `BoxBlit`. Step the clock once per `BoxBlit` (`Timer_FixedDtPresent`), with a skip-first guard so the main loop's single render per tick stays free and non-modal ticks remain exactly `+dt`.
- **Music volume fades** — `FadeOutVolumeMusic`/`FadeInVolumeMusic` (`MUSIC.CPP`). `do { ManageTime(); ... } while(volume != target)` spin with no present.
- **Palette fades** — `FadeToBlack`/`WhiteFade`/`FadeWhiteToPal`/`FadeToPal`/`FadePalToPal` (`AMBIANCE.CPP`, 5 sites). Same shape.

For the fades, `Timer_FixedDtPump` steps the clock with no skip-first (one direct step per call). Both fade classes wrap in `SaveTimer`/`RestoreTimer`, so the pumped time is discarded when the loop returns — they don't perturb the game clock, they just need the loop to exit.

## Verification

- **Savegame baseline corpus**: `39 ok, 0 drift` — re-verified after each fix. The skip-first guard means non-modal ticks (the whole settled-state corpus) present exactly once and consume the skip; the fades aren't entered during those saves.
- **Previously-hanging demo scenes (196, 197, 200-204, 206, 209-212, 221)**: all play through to the tick budget. The HANG category is empty.
- **Determinism map under `--demo --fixed-dt 16`, 800 ticks, gameplay-state compared with `timer_ref_hr` dropped:**
  - Fully byte-deterministic: 193, 194, 195, 207, 213, 220, 221.
  - Plays through, diverges only in moving-NPC lines (the long-double precision class from `FIXED_DT_RESEARCH.md` §5): 196, 200, 208, 210, 214, 218, 219.

## Docs

- `docs/FIXED_DT_RESEARCH.md` §7 — the loop classes, the skip-first design, why baselines stay byte-identical, the determinism map.
- `docs/CONTROL.md` — brief note in the determinism section pointing at §7.

## Diff shape

5 code files, 2 doc files, +103 lines. No new dependencies, no flag changes, opt-in via the existing `--fixed-dt`.