### PR TITLE
feat(control): add --verbose for self-explaining headless runs

### DIFF
--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -43,6 +43,7 @@ static int s_have_polyrec = 0;
 static char s_polyrec_path[ADELINE_MAX_PATH];
 static int s_exit = 0;
 static int s_demo = 0;
+static int s_verbose = 0;
 
 /* --- Runtime ---------------------------------------------------------------- */
 static long s_hook_calls = 0;
@@ -138,6 +139,12 @@ void Control_ParseArgs(int *argc, char *argv[]) {
             read += 1;
             continue;
         }
+        if (!strcmp(a, "--verbose")) {
+            s_verbose = 1;
+            s_active = 1;
+            read += 1;
+            continue;
+        }
 
         argv[write++] = argv[read++];
     }
@@ -147,6 +154,10 @@ void Control_ParseArgs(int *argc, char *argv[]) {
 
 int Control_IsActive(void) {
     return s_active;
+}
+
+int Control_IsVerbose(void) {
+    return s_verbose;
 }
 
 /* --- Boot ------------------------------------------------------------------- */
@@ -407,6 +418,27 @@ void Control_TickHook(void) {
        per loop-body iteration, before this tick's ManageTime() banks the step. */
     if (s_have_fixed_dt)
         Timer_FixedDtAdvance();
+    /* --verbose: log the scene/hero state to stderr when it changes, so a headless run is
+       self-explaining (which scene, what the hero is doing) and the last line before a hang
+       shows where the loop got stuck. The hook runs once per tick; a modal (cinematic/dialogue)
+       blocks the loop, so the modal markers below announce those before they hang. */
+    if (s_verbose) {
+        static S32 last_cube = -2, last_beh = -2, last_anim = -2, last_move = -2;
+        T_OBJET *h = &ListObjet[NUM_PERSO];
+        /* A periodic heartbeat (every 250 ticks) on top of the change-triggered line: it
+           proves the main loop is still ticking through a long idle/cinematic, and
+           distinguishes "loop alive but state static" from "stuck in a modal" (no hook). */
+        if (NumCube != last_cube || Comportement != last_beh || h->Obj.Anim.Num != last_anim ||
+            h->Move != last_move || ((s_hook_calls - 1) % 250) == 0) {
+            fprintf(stderr, "[control] t=%-4ld cube=%-3d beh=%d anim=%d move=%d hero=(%d,%d)\n",
+                    s_hook_calls - 1, (int)NumCube, (int)Comportement, (int)h->Obj.Anim.Num,
+                    (int)h->Move, (int)h->Obj.X, (int)h->Obj.Z);
+            last_cube = NumCube;
+            last_beh = Comportement;
+            last_anim = h->Obj.Anim.Num;
+            last_move = h->Move;
+        }
+    }
     if (s_hook_calls == 1)
         control_run_exec();
 #ifdef ENABLE_POLY_RECORDING

--- a/SOURCES/CONTROL.H
+++ b/SOURCES/CONTROL.H
@@ -29,6 +29,10 @@ void Control_ParseArgs(int *argc, char *argv[]);
 /* Non-zero if any harness flag was supplied this run. */
 int Control_IsActive(void);
 
+/* Non-zero if --verbose was supplied: log scene/hero progress and modal entries to stderr,
+   so a headless run is self-explaining and a hang shows what blocked it. */
+int Control_IsVerbose(void);
+
 /* Set up the boot path and arm the tick hook. Call once, instead of MainGameMenu(),
    when active: applies --load (InitGame(-1) + ChangeCube while FlagLoadGame is set)
    or a fresh InitGame(1), then arms Control_TickHook. Returns 1 on success (caller

--- a/SOURCES/INVENT.CPP
+++ b/SOURCES/INVENT.CPP
@@ -1,4 +1,5 @@
 #include "C_EXTERN.H"
+#include "CONTROL.H"
 #include "DIRECTORIES.H"
 #include "INPUT.H"
 
@@ -1009,6 +1010,10 @@ void CheckProtoPack(void) {
 U32 NextBox = 0;
 
 void MenuInventory(U32 tempo) {
+    if (Control_IsVerbose())
+        fprintf(stderr, "[control] modal: MenuInventory (tempo=%u, DemoSlide=%d) -- "
+                        "blocks the loop until dismissed/auto-advanced\n",
+                tempo, (int)DemoSlide);
     S32 flag = 1, t, i;
     S32 flagname = 1;
     S32 oldselect;
@@ -1327,6 +1332,11 @@ extern S32 Dial_Y0;
 /*──────────────────────────────────────────────────────────────────────────*/
 void DoFoundObj(S32 numvar) {
 #ifndef COMPILATOR
+    if (Control_IsVerbose())
+        fprintf(stderr, "[control] modal: DoFoundObj(numvar=%d, DemoSlide=%d) -- found-object "
+                        "cinematic; under DemoSlide it auto-advances on a timer\n",
+                (int)numvar, (int)DemoSlide);
+
     S16 *ptr3do;
     T_OBJET *ptrobj;
     S32 x0, y0, x1, y1;

--- a/SOURCES/MESSAGE.CPP
+++ b/SOURCES/MESSAGE.CPP
@@ -13,6 +13,7 @@
 
 #include "C_EXTERN.H"
 
+#include "CONTROL.H"
 #include "INPUT.H"
 
 #include <SVGA/SCREEN.H>
@@ -1868,6 +1869,13 @@ void SpeakAnimation() {
 void Dial(S32 text, S32 drawscene) {
     S32 ret = 0;
     S32 flagabort = 0;
+
+#ifndef COMPILATOR
+    if (Control_IsVerbose())
+        fprintf(stderr, "[control] modal: Dial(text=%d, DemoSlide=%d) -- dialogue; under DemoSlide "
+                        "auto-advances when TimerRefHR>=endtimer\n",
+                (int)text, (int)DemoSlide);
+#endif
 
 #ifndef LBA_EDITOR
     ClearIncrusts(INCRUST_SYS_TEXT);

--- a/SOURCES/PLAYACF.CPP
+++ b/SOURCES/PLAYACF.CPP
@@ -1,4 +1,5 @@
 #include "C_EXTERN.H"
+#include "CONTROL.H"
 
 #include "DIRECTORIES.H"
 
@@ -319,6 +320,8 @@ static void PushCurrentFrameVideoAudio(smk smkObject, const int *tracksToPlay, i
 //---------------------------------------------------------------------------
 
 S32 PlayAcf(const char *name) {
+    if (Control_IsVerbose())
+        fprintf(stderr, "[control] modal: PlayAcf '%s' -- cutscene, blocks --exit\n", name);
 #ifdef USE_MVIDEO_SMACKER
     {
         static int s_playacf_playing = 0;


### PR DESCRIPTION
Stacked on #171. Independent of #172 (the engine fix) — they share the demo base but touch disjoint files.

## What

Adds `--verbose` to the control harness. With the flag, the binary logs to `stderr` so a hang or long modal in a headless run isn't silent.

- **Per-tick scene/hero state when it changes**, plus a **heartbeat every 250 ticks**. The heartbeat proves the main loop is still ticking through a long idle/cinematic and distinguishes "loop alive but state static" from "stuck in a modal" (where the tick hook stops firing).
- **Modal-entry markers** at `DoFoundObj`, `Dial`, `PlayAcf`, and `MenuInventory`. A hang inside a modal announces itself instead of looking like the main loop froze.

## Why

This was the diagnostic that found the deadlocks fixed in #172: a silent `--demo --fixed-dt` run that just sat there became a one-line root cause (\`modal: DoFoundObj ...\` followed by a frozen `TimerRefHR`). Worth landing on its own so future harness work has the same lens.

## Example

```
$ lba2cc --exec \"cube 194\" --demo --verbose --tick 600 --fixed-dt 16 --exit
[control] t=0    cube=0   beh=0 anim=0 move=1 hero=(10496,4352)
[control] t=1    cube=194 beh=0 anim=0 move=1 hero=(9722,1060)
[control] t=250  cube=194 beh=0 anim=1 move=0 hero=(5911,1841)
[control] t=325  cube=194 beh=0 anim=0 move=0 hero=(5475,1818)
[control] modal: DoFoundObj(numvar=1, DemoSlide=1) -- found-object cinematic; under DemoSlide it auto-advances on a timer
[control] t=389  cube=194 beh=0 anim=60 move=0 hero=(5475,1818)
...
```

## Diff shape

5 files, +57 lines. Opt-in; default behaviour is byte-for-byte unchanged.