### PR TITLE
docs(control): map the demo attract reel + reframe roadmap phase 3

### DIFF
--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -210,9 +210,20 @@ non-deterministic base.
    restored save clock. This upgrades the baseline tolerance to exact (same-platform) and is the
    prerequisite for replay. See `docs/FIXED_DT_PLAN.md`. Promoting the baseline harness's
    kinematic tier to exact is the remaining follow-up.
-3. **Input record/replay.** Capture input per tick and replay a whole session — the
-   gameplay-regression counterpart to the existing draw-call polyrec. Attaches at the same
-   top-of-loop seam as `Control_TickHook`; depends on (2) to reproduce faithfully.
+3. **Canned playthroughs.** Replay a whole session as a regression fixture — the
+   gameplay-regression counterpart to the existing draw-call polyrec. There are two paths:
+   - *Demo playthrough (effectively achieved).* The game's built-in attract reel is a
+     21-scene scripted tour of the game's locations rooted at cube 201 and ending with
+     `LM_THE_END` at cube 218 ("The Dark Monk statue (last)") — see
+     [SCENES.md](SCENES.md#demo-scenes-193-221). Under `--demo` + `--fixed-dt`, any of the
+     reel's entry cubes replays the same scene chain and dialogue sequence sequentially.
+     This covers the regression-fixture use case without an explicit input layer; the
+     scripted reel *is* the canned input. Parallel runs can flip a long-run script branch
+     via the FP-precision class from `FIXED_DT_RESEARCH.md` §5 — run sequentially for
+     fixture comparisons.
+   - *Explicit input capture/replay (deferred).* For sessions outside the reel — random
+     exploration, tooling-style automation — capture input per tick and replay it.
+     Attaches at the same top-of-loop seam as `Control_TickHook`; depends on (2).
 
 Done (independent of the above): `--polyrec <path>` triggers the existing polygon draw-call
 recording (`tests/SNAPSHOT/`, previously a manual Alt+F9) at a scripted `--load X --tick N`

--- a/docs/SCENES.md
+++ b/docs/SCENES.md
@@ -294,7 +294,67 @@ Scenes connect via type-0 zones (cube-change triggers). The full game has
 
 ## Demo scenes (193-221)
 
-Copies of game scenes used for the non-interactive demo/attract mode.
+Copies of game scenes used for the non-interactive demo/attract mode. They are not 29
+isolated vignettes — most are entry points into a single scripted attract reel that tours
+the game's locations and ends with `LM_THE_END` (the opcode whose own inline comment is
+`// credits`) at cube 218 ("The Dark Monk statue (last)").
+
+### The canonical reel
+
+Rooted at cube 201, the chain visits 21 scenes in this order before exiting:
+
+```
+201 → 202 → 203 → 204 → 205 → 206 → 207 → 220 → 208 → 209 → 210 → 211 →
+      212 → 213 → 214 → 215 → 216 → 221 → 217 → 219 → 218 (LM_THE_END)
+```
+
+Total ≈ 25 000 ticks at fixed-dt 16 ms ≈ 6 m 40 s of in-game time. The hero is driven
+along authored tracks (`DemoSlide` makes dialogues auto-advance); the final tick depends
+on entry depth.
+
+### Three classes of entry point
+
+Each of the 29 demo cubes is one of:
+
+**Reel position (21 cubes)** — enters the canonical reel at its position and plays
+through to `LM_THE_END`. Entry-depth → end-cube ticks (fixed-dt 16):
+
+| Entry | Scenes to end | Ticks to `LM_THE_END` |
+|---|---|---|
+| 218 | 1 | 1 137 |
+| 219 | 2 | 2 383 |
+| 217 | 3 | 2 910 |
+| 221 | 4 | 4 446 |
+| 216 | 5 | 5 765 |
+| 215 | 6 | 6 415 |
+| 214 | 7 | 8 500 |
+| 213 | 8 | 10 429 |
+| 212 | 9 | 11 678 |
+| 211 | 10 | 14 836 |
+| 210 | 11 | 18 536 |
+| 209 | 12 | 18 903 |
+| 208 | 13 | 20 697 |
+| 220 | 14 | 21 801 |
+| 207 | 15 | 24 320 |
+| 206 | 16 | 24 677 |
+| 205 | 17 | 26 428 |
+| 204 | 18 | 26 616 |
+| 203 | 19 | 27 356 |
+| 202 | 20 | > 30 000 (didn't finish in survey budget) |
+| 201 | 21 | > 30 000 |
+
+**Pre-reel branched entries (4 cubes: 193, 194, 196, 200)** — visit 20+ scenes inside
+30 000 ticks but do not reach 218 within that budget. Cubes 193 and 194 even revisit
+themselves (`193 → 194 → 193 → 195 → …`) — an attract-menu-style loop — before joining
+the main reel via 195 → 196 → 197 → 198 → 199 → 200 → 201 → … With a larger budget they
+merge into the canonical reel near cube 201.
+
+**Standalone vignettes (4 cubes: 195, 197, 198, 199)** — stay in their own cube
+indefinitely. They are stations the reel passes through, but each transition requires
+state set up by the preceding scene; entered cold (no preceding scene), no transition
+fires. Cubes 193, 194, and 196 *do* visit these as part of their chain.
+
+Survey data + methodology: see `docs/CONTROL.md` and `docs/FIXED_DT_RESEARCH.md`.
 
 
 | Cube | Scene                                               | Mode     | Obj | Zones |


### PR DESCRIPTION
Two pure-docs edits off `main`. No code, no dependency on the open feature PRs to merge; the deterministic-playthrough *claim* in the roadmap depends on #171 (`--demo`) and #172 (modal/fade clock advance) being in for the demos to actually play through under `--fixed-dt`, so this is best landed after those.

## What the survey found

Ran every demo entry point (cubes 193-221) under `--demo --fixed-dt 16` with a tick budget large enough to reach the end (~6m40s of in-game time at dt=16). The 29 cubes split cleanly into three classes:

- **Reel positions (21 cubes)** — drop in at any cube and play through to `LM_THE_END` at cube 218 ("The Dark Monk statue (last)"). The canonical chain rooted at cube 201 visits:

  ```
  201 → 202 → 203 → 204 → 205 → 206 → 207 → 220 → 208 → 209 → 210 → 211 →
        212 → 213 → 214 → 215 → 216 → 221 → 217 → 219 → 218 (LM_THE_END)
  ```

  Entry-depth-to-end-ticks table is in `SCENES.md` (218 → 1 137 ticks, 219 → 2 383, … 201 → > 30 000).

- **Pre-reel branched entries (193, 194, 196, 200)** — visit 20+ scenes; 193/194 revisit themselves first (attract-menu-style loop) before joining the canonical reel via 195 → 196 → … → 201.

- **Standalone vignettes (195, 197, 198, 199)** — stay in place when entered cold; the reel passes through them only when the preceding scene's setup state is present.

Sequential `--demo --fixed-dt 16` runs of cube 205 (3× verified) hit the *same* 17-cube chain and the *same* 6 dialogue boxes (`Dial(text=205, 34, 508, 508, 435, 445)`). Parallel runs can flip a long-run script branch via the `FIXED_DT_RESEARCH.md` §5 FP-precision class — run sequentially for fixture comparisons.

## Doc changes

- **`docs/SCENES.md`** — expands the "Demo scenes (193-221)" subsection with the reel structure, the three classes, and the depth table.
- **`docs/CONTROL.md`** — rewrites Roadmap §3 (input record/replay) to reflect that *canned playthroughs* are effectively achieved via the demo path (the scripted reel *is* the canned input), with explicit input capture/replay deferred as the fallback for off-reel sessions.

## What's intentionally not here

- The `--demo` Notes block in `CONTROL.md` (added by #171) needs its "ends on a cutscene that blocks --exit" line corrected to reflect the post-#172 reality (plays through to `LM_THE_END`). That fix belongs in #172 since the new behaviour is what #172 enables.
- The expanded sequential-vs-parallel determinism finding belongs in `docs/FIXED_DT_RESEARCH.md` §7, which #172 introduces. Adding it here would conflict.

Both are one-line follow-ups inside #172.