### PR TITLE
fix(timer): reset TimerRefHR in fixed-dt enable so fresh-start RNG is deterministic

### DIFF
--- a/LIB386/SYSTEM/TIMER.CPP
+++ b/LIB386/SYSTEM/TIMER.CPP
@@ -80,11 +80,18 @@ void SetTimerHR(U32 time) {
 void Timer_EnableFixedDt(U32 dt_ms) {
     // Seed the virtual clock and force LastTime to agree with it, so the first
     // ManageTime() delta (FixedDtNow - LastTime) is exactly 0 and no residual
-    // wall-clock interval banked during boot/load leaks into the first tick. From here
-    // the clock only moves via Timer_FixedDtAdvance(). Keeps the FPS accumulator sane.
+    // wall-clock interval banked during boot/load leaks into the first tick. Also reset
+    // TimerRefHR -- the existing accumulated value before this call carries whatever
+    // wall-clock interval elapsed between InitTimer() at engine boot and the harness
+    // arming fixed-dt, and that residual would otherwise reach srand(TimerRefHR) at
+    // ChangeCube (OBJECT.CPP) and seed RNG-driven wanderers differently each run on the
+    // fresh-start path (--demo without --load). The --load path overrides TimerRefHR from
+    // the save after this, so save-loaded runs are unaffected. From here the clock only
+    // moves via Timer_FixedDtAdvance(). Keeps the FPS accumulator sane.
     FixedDt = dt_ms;
     FixedDtNow = TimerSystemHR;
     LastTime = TimerSystemHR;
+    TimerRefHR = 0;
     FixedDtActive = 1;
     FixedDtTicking = 0;
     FixedDtSkipPresent = 0;


### PR DESCRIPTION
One line. Closes the "FP-precision moving-actor caveat" from `docs/FIXED_DT_RESEARCH.md` §5 and the bat-scene class flagged in project memory — they were the same bug.

## What was misdiagnosed

`InitTimer()` at engine boot calls `ManageTime()` once, banking the wall-clock interval from `SDL_GetTicks()`'s epoch into `TimerRefHR`. When the harness arms fixed-dt, `Timer_EnableFixedDt()` was seeding `FixedDtNow`/`LastTime` correctly (first delta = 0) but **left `TimerRefHR`'s pre-enable boot accumulation in place**. `ChangeCube()` at `OBJECT.CPP:1171` then does `srand(TimerRefHR)`, so on the fresh-start path (`--demo` without `--load`) the RNG seed varied run-to-run by however many ms elapsed between `InitTimer()` and `Control_Begin()` — typically 125-470ms here. Wandering creatures driven by `rand()` (the only divergent actors) walked different paths; under parallel CPU jitter the seed shift was sometimes enough to flip a script-branch dialogue choice. Everything looked exactly like the long-double FP class until the smoking gun was visible.

The `--load` path is unaffected because it overrides `TimerRefHR` from the saved game's clock *after* `Timer_EnableFixedDt()`. That's why baselines (which all use `--load`) were 0-drift while `--demo` runs of action scenes drifted.

## Fix

Add `TimerRefHR = 0;` next to the `FixedDtNow`/`LastTime` seeding in `Timer_EnableFixedDt()` (LIB386/SYSTEM/TIMER.CPP). Comment expanded to call out why. 9 insertions, 2 deletions.

## Measured

| | Before | After |
|---|---|---|
| `cube 196 --tick 4000` 3× sequential | actors 6 & 7 diverge (Δz up to 1500, Δβ up to 1300) | byte-identical |
| `cube 205` attract reel 3× **parallel** | chain identical, modal `Dial(text=507)` vs `Dial(text=508)` would flip | chain identical, modals identical (`507×2`) |
| 7 previously-flaky demo scenes (196, 200, 208, 210, 214, 218, 219) parallel | flagged "moving-actor FP caveat" | all deterministic |
| savegame baseline corpus | `39 ok, 0 drift, 4-6 flaky` (varied) | `39 ok, 0 drift, **0 flaky**` |

## What it doesn't change

`--load` runs: `TimerRefHR` is overridden by the save load after this, so save-restored corpus runs are byte-identical to before. Default builds and any run that does not call `Timer_EnableFixedDt()` are byte-for-byte unaffected (the line is inside the function).

## Follow-ups (one-line doc edits, separate)

- `docs/FIXED_DT_RESEARCH.md` §5: the "platform precision" hazard can stand, but the "moving-actor" callout is no longer same-platform; same-platform exactness is now real even for moving NPCs.
- `docs/CONTROL.md` Roadmap §1: "in progress" → "done" — the baseline gallery's last residual flake was this.