### PR TITLE
docs(control): retire the FP-precision caveat; roadmap phase 1 done

### DIFF
--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -216,28 +216,27 @@ The harness is built so these are additive, not rewrites. Ordered by dependency 
 makes the next more valuable, and faithful input replay must not be built on a
 non-deterministic base.
 
-1. **Baseline gallery** *(in progress)*. Golden `--dump-state` (+ screenshots) over the
+1. **Baseline gallery** *(done)*. Golden `--dump-state` (+ screenshots) over the
    committed save corpus, living alongside it at `tests/savegame/corpus/baselines/`. A
    regression net for the widescreen / projection work: the world-space dump is the
    guardrail that rendering changes don't perturb the simulation; screenshots are the
    human-reviewed visual. See `docs/AUTOMATION_PLAN.md`.
 2. **`--fixed-dt` deterministic mode** *(done)*. Pin the per-tick timer step so the simulation
    is independent of wall-clock — the determinism measurements pointed at variable dt as the
-   lever. No RNG reseed was needed: the only seed (`srand(TimerRefHR)`) is already pinned by the
-   restored save clock. This upgrades the baseline tolerance to exact (same-platform) and is the
-   prerequisite for replay. See `docs/FIXED_DT_PLAN.md`. Promoting the baseline harness's
-   kinematic tier to exact is the remaining follow-up.
+   lever. The only RNG seed (`srand(TimerRefHR)` at `OBJECT.CPP:1171`) is pinned by the
+   restored save clock on `--load`; on the fresh-start path `Timer_EnableFixedDt()` also
+   resets `TimerRefHR` so the seed is deterministic there too. This upgrades the baseline
+   tolerance to exact (same-platform) and is the prerequisite for replay. See
+   `docs/FIXED_DT_PLAN.md`.
 3. **Canned playthroughs.** Replay a whole session as a regression fixture — the
    gameplay-regression counterpart to the existing draw-call polyrec. There are two paths:
    - *Demo playthrough (effectively achieved).* The game's built-in attract reel is a
      21-scene scripted tour of the game's locations rooted at cube 201 and ending with
      `LM_THE_END` at cube 218 ("The Dark Monk statue (last)") — see
      [SCENES.md](SCENES.md#demo-scenes-193-221). Under `--demo` + `--fixed-dt`, any of the
-     reel's entry cubes replays the same scene chain and dialogue sequence sequentially.
-     This covers the regression-fixture use case without an explicit input layer; the
-     scripted reel *is* the canned input. Parallel runs can flip a long-run script branch
-     via the FP-precision class from `FIXED_DT_RESEARCH.md` §5 — run sequentially for
-     fixture comparisons.
+     reel's entry cubes replays the same scene chain, dialogue sequence, and gameplay state
+     — sequential or parallel. This covers the regression-fixture use case without an
+     explicit input layer; the scripted reel *is* the canned input.
    - *Explicit input capture/replay (deferred).* For sessions outside the reel — random
      exploration, tooling-style automation — capture input per tick and replay it.
      Attaches at the same top-of-loop seam as `Control_TickHook`; depends on (2).

--- a/docs/FIXED_DT_RESEARCH.md
+++ b/docs/FIXED_DT_RESEARCH.md
@@ -372,14 +372,20 @@ main render), which consumes the skip; the fades aren't entered during settled-s
 corpus saves. Re-verified `39 ok, 0 drift` after each fix.
 
 **Demo determinism map** (cube N played under `--demo --fixed-dt 16` for 800 ticks,
-gameplay-state compared with `timer_ref_hr` dropped):
+gameplay-state compared including `timer_ref_hr`):
 
-- Fully byte-deterministic: 193, 194, 195, 207, 213, 220, 221.
-- Plays through, diverges only in moving-NPC lines (the long-double precision class
-  from §5): 196, 200, 208, 210, 214, 218, 219.
-
-No HANG remains. The residual run-to-run divergence is the §5 platform-precision hazard
-surfacing on action scenes with long actor trajectories — not new.
+All 14 reel-position cubes surveyed (193, 194, 195, 196, 200, 207, 208, 210, 213, 214, 218,
+219, 220, 221) are byte-deterministic. No HANG remains and no run-to-run divergence
+remains. An earlier revision of this section listed seven cubes as a "plays-through but
+moving-NPC FP caveat" class; that was a misdiagnosis — the divergence was an RNG seed
+leak, not floating-point. `srand(TimerRefHR)` at `ChangeCube` (`OBJECT.CPP:1171`) was
+reading whatever wall-clock interval had elapsed between `InitTimer()` at engine boot and
+the harness arming fixed-dt, and that residual leaked into the seed only on the fresh-
+start path (`--demo` without `--load`; the `--load` path overrides `TimerRefHR` from the
+saved game's clock after enable). Closed in `Timer_EnableFixedDt()` by resetting
+`TimerRefHR` alongside `FixedDtNow`/`LastTime`. The §5 platform-precision hazard
+(`long double` 80- vs 64-bit) is a separate cross-platform concern; same-platform
+exactness is now real for moving actors too.
 
 ---
 


### PR DESCRIPTION
Follow-up to #175. Pure docs, no code.

After the seed-leak fix landed in #175, several places in our docs that framed the demo-mode moving-actor divergence as "long-double FP precision" need to be retired — that framing was wrong; it was an RNG seed leak on the fresh-start path. This PR brings the docs in line with reality.

## Changes

**`docs/FIXED_DT_RESEARCH.md` §7** — the "demo determinism map" no longer splits cubes into a "byte-deterministic" set and a "plays-through but FP caveat" set. All 14 reel-position cubes surveyed are byte-deterministic, sequential or parallel. The section now notes the misdiagnosis explicitly with a pointer to the #175 mechanism so future readers see the trap.

**`docs/CONTROL.md` Roadmap**
- §1 (Baseline gallery): `(in progress)` → `(done)`. Corpus is committed, kinematic tier exact under `--fixed-dt` (#165), `0 flaky` after #175.
- §2 (`--fixed-dt`): clarifies the `srand(TimerRefHR)` seed is pinned on the `--load` path (by the save's restored clock) AND on the fresh-start path (by `Timer_EnableFixedDt()` resetting `TimerRefHR`). The trailing "kinematic tier to exact is the remaining follow-up" sentence is deleted (#165 landed it).
- §3 (Canned playthroughs): drops the "Parallel runs can flip a long-run script branch … run sequentially for fixture comparisons" warning — parallel is now deterministic.

## Out of scope

The in-game SHIFT+D attract demo still inherits the original engine's timing-dependent seed (`Timer_EnableFixedDt()` only fires under the harness). That's separately tracked in #176 with a proposed extension to gate the reset on `DemoSlide` instead of `--fixed-dt`.