### PR TITLE
feat(control): Control_End() captures --dump-state at natural MainLoop return

### DIFF
--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -390,7 +390,9 @@ static void control_screenshot(const char *path) {
     SavePNG((char *)path, Screen, (S32)ModeDesiredX, (S32)ModeDesiredY, PtrPal);
 }
 
-static void control_finalize(void) {
+/* The capture half of finalize: dump/screenshot only, no exit. Shared by the tick-budget
+   path (control_finalize) and the natural-return path (Control_End). Idempotent. */
+static void control_capture(void) {
     if (s_finalized)
         return;
     s_finalized = 1;
@@ -399,6 +401,10 @@ static void control_finalize(void) {
         control_dump_state(s_dump_path);
     if (s_have_shot)
         control_screenshot(s_shot_path);
+}
+
+static void control_finalize(void) {
+    control_capture();
 
     if (s_exit) {
         fflush(stdout);
@@ -408,6 +414,18 @@ static void control_finalize(void) {
        otherwise echo every later console line), disarm, and hand control back. */
     Console_SetLineSinkForTests(NULL);
     s_armed = 0;
+}
+
+void Control_End(void) {
+    /* MainLoop returned without hitting the --tick budget (e.g. LM_THE_END at cube 218
+       on the attract reel). Capture the dump/screenshot the caller asked for; main()
+       will then call TheEnd() as it does for any harness run. No-op if the tick-budget
+       path already finalized, the harness was never active, or no capture was asked. */
+    if (!s_active || s_finalized)
+        return;
+    if (!s_have_dump && !s_have_shot)
+        return;
+    control_capture();
 }
 
 void Control_TickHook(void) {

--- a/SOURCES/CONTROL.H
+++ b/SOURCES/CONTROL.H
@@ -46,6 +46,12 @@ int Control_Begin(void);
    TheEnd(). */
 void Control_TickHook(void);
 
+/* Capture final --dump-state / --screenshot when MainLoop returns naturally (e.g. the
+   demo script reaches LM_THE_END before the --tick budget). Call once between MainLoop()
+   and TheEnd() on the harness boot path. No-op if the tick-budget finalize already ran,
+   the harness is not active, or no capture flag was supplied. */
+void Control_End(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2761,6 +2761,7 @@ int main(int argc, char *argv[]) {
     if (Control_IsActive()) {
         if (Control_Begin())
             MainLoop();
+        Control_End();
         TheEnd(PROGRAM_OK, "");
         return 0;
     }

--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -105,6 +105,12 @@ save directory, then with a `.lba` suffix — so both `--load "021 Palace"` and
   gameplay is unaffected. (Note: a demo scene ends on a cutscene/`PLAY_ACF` that `--demo` does not
   auto-advance, so it still blocks a `--exit` run — cap the tick budget before it; see the modal
   caveat above.)
+- **Natural end captures too.** If the simulation ends on its own before the `--tick`
+  budget — e.g. the `--demo` attract reel reaches `LM_THE_END` at cube 218, returning
+  from `MainLoop` — the harness still writes the configured `--dump-state` / `--screenshot`
+  before exit. So you can run `lba2cc --exec "cube 205" --demo --tick 30000 --dump-state
+  end.json --exit` and get a snapshot of the Dark Monk finale at tick ≈ 25 443 without
+  having to pre-compute the right tick.
 - A bad `--load` path exits cleanly with a `save not found` diagnostic.
 
 ## `--dump-state` JSON


### PR DESCRIPTION
The last "ergonomic nit" on the harness roadmap.

When the simulation ends on its own — e.g. the `--demo` attract reel reaches `LM_THE_END` at cube 218 ("The Dark Monk statue (last)") and `MainLoop` returns to `main()` before the `--tick` budget triggers `Control_TickHook`'s finalize — the harness was running `TheEnd()` directly with no `--dump-state` / `--screenshot` written. You had to pre-compute a tick just before `LM_THE_END` to capture the finale, instead of letting the script run to its natural conclusion.

## Fix

Split the existing `control_finalize()` into:

- `control_capture()` — dump + screenshot only, idempotent.
- `control_finalize()` — the tick-budget path; calls `control_capture()` then the existing exit/disarm logic (unchanged behaviour).

Add public `Control_End()` that calls `control_capture()` and nothing else. `main()` follows up with its own `TheEnd()` as it already does for any harness run. No-op if the tick-budget path already finalized, the harness was never active, or no capture flag was supplied.

One-line wire-in at `PERSO.CPP:2763` between `MainLoop()` and `TheEnd()`. 4 files, +32 / -1.

## Verified

```bash
$ lba2cc --exec "cube 205" --demo --tick 30000 --fixed-dt 16 \
         --dump-state end.json --exit
```

now produces `end.json` at `tick=25443 cube=218 hero.anim=8` — the Dark Monk finale snapshot — instead of exiting silently.

## Guards

- `--tick` budget path still captures and exits as before (`tick=1000 cube=206` dump produced when budget < natural end).
- Two natural-end runs byte-identical (#175 already pinned the seed).
- Savegame baseline corpus: `39 ok, 0 drift, 0 flaky`.

## Docs

`docs/CONTROL.md` "Notes and limits" gets one new bullet so users know to expect natural-end capture.