### PR TITLE
docs(scenes): correct demo-reel root — it's cube 193, not cube 201

### DIFF
--- a/docs/SCENES.md
+++ b/docs/SCENES.md
@@ -301,22 +301,25 @@ the game's locations and ends with `LM_THE_END` (the opcode whose own inline com
 
 ### The canonical reel
 
-Rooted at cube 201, the chain visits 21 scenes in this order before exiting:
+Rooted at **cube 193 (Twinsen's House)** — the retail menu's attract entry, hard-coded at
+`GAMEMENU.CPP:2435`. The chain visits 30 scenes in this order before exiting:
 
 ```
-201 → 202 → 203 → 204 → 205 → 206 → 207 → 220 → 208 → 209 → 210 → 211 →
-      212 → 213 → 214 → 215 → 216 → 221 → 217 → 219 → 218 (LM_THE_END)
+193 → 194 → 193 → 195 → 196 → 197 → 198 → 199 → 200 → 201 → 202 → 203 → 204 →
+205 → 206 → 207 → 220 → 208 → 209 → 210 → 211 → 212 → 213 → 214 → 215 → 216 →
+221 → 217 → 219 → 218 (LM_THE_END)
 ```
 
-Total ≈ 25 000 ticks at fixed-dt 16 ms ≈ 6 m 40 s of in-game time. The hero is driven
-along authored tracks (`DemoSlide` makes dialogues auto-advance); the final tick depends
-on entry depth.
+Total ≈ 42 600 ticks at fixed-dt 16 ms ≈ 11 m 22 s of in-game time. The `193 → 194 → 193`
+prefix at the top is an attract-menu-style self-revisit before the reel proper begins.
+The hero is driven along authored tracks (`DemoSlide` makes dialogues auto-advance); the
+final tick depends on entry depth.
 
-### Three classes of entry point
+### Two classes of entry point
 
 Each of the 29 demo cubes is one of:
 
-**Reel position (21 cubes)** — enters the canonical reel at its position and plays
+**Reel position (25 cubes)** — enters the canonical reel at its position and plays
 through to `LM_THE_END`. Entry-depth → end-cube ticks (fixed-dt 16):
 
 | Entry | Scenes to end | Ticks to `LM_THE_END` |
@@ -340,19 +343,17 @@ through to `LM_THE_END`. Entry-depth → end-cube ticks (fixed-dt 16):
 | 205 | 17 | 26 428 |
 | 204 | 18 | 26 616 |
 | 203 | 19 | 27 356 |
-| 202 | 20 | > 30 000 (didn't finish in survey budget) |
-| 201 | 21 | > 30 000 |
-
-**Pre-reel branched entries (4 cubes: 193, 194, 196, 200)** — visit 20+ scenes inside
-30 000 ticks but do not reach 218 within that budget. Cubes 193 and 194 even revisit
-themselves (`193 → 194 → 193 → 195 → …`) — an attract-menu-style loop — before joining
-the main reel via 195 → 196 → 197 → 198 → 199 → 200 → 201 → … With a larger budget they
-merge into the canonical reel near cube 201.
+| 202 | 20 | (not measured in the survey) |
+| 201 | 21 | (not measured in the survey) |
+| 200 | 22 | 31 908 |
+| 196 | 26 | 38 056 |
+| 194 | 29 | 40 250 |
+| 193 | 30 | 42 635 |
 
 **Standalone vignettes (4 cubes: 195, 197, 198, 199)** — stay in their own cube
-indefinitely. They are stations the reel passes through, but each transition requires
-state set up by the preceding scene; entered cold (no preceding scene), no transition
-fires. Cubes 193, 194, and 196 *do* visit these as part of their chain.
+indefinitely. They are stations the reel passes through (cubes 193, 194, and 196 *do*
+visit them as part of their chain), but each transition requires state set up by the
+preceding scene; entered cold (no preceding scene), no transition fires.
 
 Survey data + methodology: see `docs/CONTROL.md` and `docs/FIXED_DT_RESEARCH.md`.
 


### PR DESCRIPTION
Small correction to the "Demo scenes" subsection added in #174.

#174 described the canonical attract reel as *"rooted at cube 201, 21 scenes"*. That's correct as a **suffix** but not as the actual root — the reel's real entry is **cube 193 (Twinsen's House)**, the retail menu's attract entry hardcoded at `GAMEMENU.CPP:2435`. From 193 the chain is **30 scenes** long, takes **≈ 42 600 ticks (≈ 11 m 22 s)** at fixed-dt 16, and starts with a `193 → 194 → 193` self-revisit — an attract-menu-style loop — before flowing through 195-221 and ending at `LM_THE_END` on cube 218.

## Why we missed it the first time

The #174 survey ran each entry point with `--tick 30 000`. That's enough for any entry from cube 201 onward to reach `LM_THE_END`, but cubes 193/194/196/200 visit additional scenes before joining 201 and need more budget. So they got tagged as a separate "pre-reel branched entries" class. A re-run at `--tick 60 000` shows them all merging cleanly into the canonical chain:

```
cube 193 (30 scenes, t=42 635): 193 → 194 → 193 → 195 → … → 218
cube 194 (29 scenes, t=40 250): 194 → 193 → 195 → … → 218
cube 196 (26 scenes, t=38 056): 196 → 197 → 198 → 199 → 200 → 201 → … → 218
cube 200 (22 scenes, t=31 908): 200 → 201 → … → 218
```

## Changes to SCENES.md

- Replace "rooted at cube 201, 21 scenes" with "rooted at cube 193, 30 scenes"; show the full canonical chain.
- Collapse the "three classes" framing (reel position / pre-reel branched / standalone) to **two** (reel position / standalone) — the "pre-reel branched" cubes turn out to be the longer earlier portion of the same reel, just at deeper entry depth.
- Extend the depth table with the four new entries (193 → 30 scenes, 194 → 29, 196 → 26, 200 → 22).

The "standalone vignettes" set (195, 197, 198, 199) is unchanged: they show correctly when the reel visits them via 193/194/196 but stall when entered cold because the preceding scene's setup state is missing.

Pure docs; no code.