### PR TITLE
chore(control): post-#175 cleanup — retract FP misdiagnosis, tighten demo fixture

### DIFF
--- a/docs/FIXED_DT_PLAN.md
+++ b/docs/FIXED_DT_PLAN.md
@@ -163,6 +163,17 @@ claim to *verify* in validation (a 3× repeat that crosses a cube boundary), not
 counterexample surfaces, the fallback is a fixed reseed in `Control_Begin`, but the research and
 the existing measurement both indicate it is unnecessary.
 
+> **As-built (PR #175):** the counterexample did surface — on the fresh-start path (`--demo`
+> without `--load`), `TimerRefHR` at engine boot already carries the wall-clock interval
+> banked by `InitTimer()`'s first `ManageTime()` since `SDL_GetTicks()`'s epoch. That residual
+> reached `srand(TimerRefHR)` and varied the seed run-to-run by however many ms elapsed
+> before the harness armed fixed-dt (measured 125-470 ms). The fix is functionally the
+> fallback this section anticipated: `Timer_EnableFixedDt()` now resets `TimerRefHR = 0`
+> alongside its `FixedDtNow`/`LastTime` seeding, so the seed is canonical on the fresh-start
+> path. The `--load` path is unaffected (the save's clock overrides `TimerRefHR` after the
+> reset). See PR #175 commit and `docs/FIXED_DT_RESEARCH.md` §7. The misdiagnosis trail is
+> recorded in `docs/INPUT_REPLAY_RESEARCH.md` §2d.
+
 ---
 
 ## 5. Files, signatures, pin sites

--- a/docs/INPUT_REPLAY_RESEARCH.md
+++ b/docs/INPUT_REPLAY_RESEARCH.md
@@ -266,6 +266,38 @@ underlying original bug — turning bat-afflicted scenes from FLAKY into usable 
 a concrete, low-risk path to a scripted-playthrough regression net, parallel to (and simpler
 than) chasing the FP precision bug to ground.
 
+> **RESOLVED (PR #175): the cause was RNG after all.** Adding to the corrections list above —
+> the "RNG ruled out" conclusion in this section was wrong. The rand-call counter compared
+> the *call sequence* across runs, which was identical, and on that basis the seed itself was
+> taken as not the variable. It was. `InitTimer()` at engine boot banks the wall-clock
+> interval since `SDL_GetTicks()`'s epoch into `TimerRefHR`. Before #175, `Timer_EnableFixedDt()`
+> seeded `FixedDtNow`/`LastTime` correctly but left `TimerRefHR`'s pre-enable value alone, so
+> `srand(TimerRefHR)` at the first `ChangeCube` saw a different seed each run on the
+> fresh-start path (typically 125-470 ms of variation). Same call sequence, different seeds →
+> different stream outputs → different bat trajectories. Under `--load`, the save's restored
+> clock overrode `TimerRefHR` after enable, so save-loaded runs already had a stable seed —
+> which is why the `Desert Island.LBA` measurement here showed "identical clock, identical
+> RNG stream" yet diverged: clock + call sequence agreed across save-loaded runs, but the
+> divergence-versus-no-divergence flip in 8-10× parallel batches was a different perturbation
+> source (likely scheduler timing affecting some other state, not the seed itself in this
+> particular setup). The simpler `--demo` fresh-start path made the seed leak visible at
+> ±300 ms scale. The fix (`TimerRefHR = 0` next to the existing `FixedDtNow`/`LastTime` seeding
+> in `Timer_EnableFixedDt()`) closes both the fresh-start divergence and the bat scene; cube
+> 65 (the canonical Desert Island bat) and cube 196 (sister wanderers in the cube-193 attract
+> reel) are byte-deterministic post-#175 across sequential and parallel runs.
+>
+> The FP-precision investigation chase was wasted effort, but the corrections trail above is
+> kept as a record of how to *not* eliminate a hypothesis: the rand-call counter measures
+> call sequences, which is one slice of "is the RNG stream identical"; the seed itself is the
+> other slice and was overlooked. Future investigations of this class should print the seed
+> at `srand` time, not just the call count.
+>
+> The "demo invincibility" idea remains useful as a *separate* concept — it would let the
+> harness golden a deterministic playthrough even if the bat *did* hit the hero — but it is
+> no longer needed to neutralise the original bug. The original bug is fixable at the source,
+> with the same `TimerRefHR`-reset mechanism extended to `DemoSlide` rather than `--fixed-dt`
+> (tracked in issue #176 for the SHIFT+D / in-game attract path).
+
 ## 2e. Mapping the demo scenes
 
 Where the engine's demo/attract content lives, and which is usable as a deterministic fixture

--- a/tests/automation/test_demo.sh
+++ b/tests/automation/test_demo.sh
@@ -7,21 +7,28 @@
 # regression guardrail far broader than an 8-tick settled save — it exercises the Life/Track
 # interpreters, animation, and movement over time.
 #
-# 500 ticks (~8 s of game time) stays clear of the cutscene the demo ends on (which would block a
-# --exit run; the demo scenes are short clips). Asserts (1) the run is reproducible — two runs
-# byte-identical on simulation state — and (2) it is live — state at tick N differs from tick 1
-# (scripts ran, did not idle or hang). timer_ref_hr is dropped: a fresh-start cube jump (no
-# --load) does not pin the absolute clock the way a restored save does, but every simulation
-# field is deterministic (verified serial and 5-way parallel).
+# Two assertions:
+#   (1) Two $TICKS runs are byte-identical on simulation state (and including timer_ref_hr
+#       since Timer_EnableFixedDt() resets it -- PR #175 -- so the fresh-start clock is pinned
+#       to 0 just like a restored save).
+#   (2) The simulation advanced between tick 1 and tick $TICKS (scripts ran, not frozen).
+# Plus a separate fixture for the natural-end path:
+#   (3) Cube 218 ("The Dark Monk statue (last)") with a generous tick budget reaches
+#       LM_THE_END before the budget, MainLoop returns to main(), and Control_End() (PR #178)
+#       still produces a --dump-state with scene.cube == 218 and tick < budget. This covers
+#       the Control_End wiring that the (1)/(2) test by design avoids (cube 193 with 500 ticks
+#       stays clear of any natural exit).
 TESTNAME=demo
 . "$(dirname "$0")/lib.sh"
 precheck
 
 DEMO_CUBE=193
 TICKS=500
+END_CUBE=218
+END_BUDGET=3000
 
-a="$(mktemp)"; b="$(mktemp)"; c="$(mktemp)"
-trap 'rm -f "$a" "$b" "$c"' EXIT
+a="$(mktemp)"; b="$(mktemp)"; c="$(mktemp)"; e="$(mktemp)"
+trap 'rm -f "$a" "$b" "$c" "$e"' EXIT
 
 ctl --exec "cube $DEMO_CUBE" --demo --tick 1     --fixed-dt 16 --dump-state "$a" --exit >/dev/null 2>&1 \
     || fail "demo tick 1 run: non-zero exit ($?)"
@@ -30,13 +37,13 @@ ctl --exec "cube $DEMO_CUBE" --demo --tick $TICKS --fixed-dt 16 --dump-state "$b
 ctl --exec "cube $DEMO_CUBE" --demo --tick $TICKS --fixed-dt 16 --dump-state "$c" --exit >/dev/null 2>&1 \
     || fail "demo tick $TICKS rerun: non-zero exit ($?)"
 
-# Determinism: the two $TICKS runs must agree on all simulation state. Drop wall-clock-derived
-# fields (fps, timer_ref_hr) and the console log.
+# Determinism: the two $TICKS runs must agree on all simulation state including timer_ref_hr.
+# Drop only fps (wall-clock-derived) and the console log (run-specific).
 python3 - "$b" "$c" <<'PY' || fail "scripted playthrough not reproducible (runs differ)"
 import json, sys
 def norm(p):
     d = json.load(open(p))
-    for k in ("fps", "timer_ref_hr", "log"):
+    for k in ("fps", "log"):
         d.pop(k, None)
     return d
 sys.exit(0 if norm(sys.argv[1]) == norm(sys.argv[2]) else 1)
@@ -47,11 +54,29 @@ python3 - "$a" "$b" <<'PY' || fail "scene did not advance (tick 1 == tick N): de
 import json, sys
 def norm(p):
     d = json.load(open(p))
-    for k in ("fps", "timer_ref_hr", "log", "tick"):
+    for k in ("fps", "log", "tick"):
         d.pop(k, None)
     return d
 sys.exit(0 if norm(sys.argv[1]) != norm(sys.argv[2]) else 1)
 PY
 
 hl=$(jget "$a" "d['hero']['last_frame']"); hl2=$(jget "$b" "d['hero']['last_frame']")
-pass "cube $DEMO_CUBE demo: $TICKS ticks reproducible and advancing (hero anim frame $hl->$hl2)"
+
+# Natural-end: cube 218's Life script fires LM_THE_END (// credits) within ~1100 ticks, so
+# with --tick $END_BUDGET MainLoop returns naturally, well before the budget. Control_End()
+# should capture the final state. The dump must show (a) tick < budget (natural exit, not
+# budget hit) and (b) scene.cube == 218.
+ctl --exec "cube $END_CUBE" --demo --tick $END_BUDGET --fixed-dt 16 --dump-state "$e" --exit >/dev/null 2>&1 \
+    || fail "natural-end run for cube $END_CUBE: non-zero exit ($?)"
+
+python3 - "$e" "$END_BUDGET" "$END_CUBE" <<'PY' || fail "Control_End did not capture LM_THE_END natural exit"
+import json, sys
+d = json.load(open(sys.argv[1]))
+budget = int(sys.argv[2]); want_cube = int(sys.argv[3])
+if d["tick"] >= budget: sys.exit(2)            # budget was hit, no natural exit
+if d["scene"]["cube"] != want_cube: sys.exit(3) # ended in wrong cube
+sys.exit(0)
+PY
+
+et=$(jget "$e" "d['tick']")
+pass "cube $DEMO_CUBE $TICKS ticks reproducible+advancing (anim $hl->$hl2); cube $END_CUBE LM_THE_END at t=$et captured via Control_End"


### PR DESCRIPTION
Three small follow-ups to #175 (seed leak fix) and #178 (`Control_End` hook). No code changes.

## Docs: retract the FP-precision misdiagnosis

**`docs/FIXED_DT_PLAN.md` §4** predicted *"if a counterexample surfaces, the fallback is a fixed reseed in `Control_Begin`"*. Add an "as-built" block recording that the counterexample *did* surface on the fresh-start path (`TimerRefHR` was carrying the wall-clock interval banked by `InitTimer()`'s first `ManageTime()` since the `SDL_GetTicks()` epoch — measured 125-470 ms of variation), and that the fix is functionally that fallback.

**`docs/INPUT_REPLAY_RESEARCH.md` §2d** ("The Desert Island bat") concluded *"the cause is not the clock and not RNG"* and proposed FP-precision sensitivity as the leading hypothesis. That was wrong. The rand-call counter the section used compared call *sequences* (identical across save-loaded runs) but not the *seed itself*, which was the variable on the fresh-start path. Add a "RESOLVED (#175)" block retracting the FP hypothesis with the actual mechanism, and a lesson noted for future investigations of this class: print the seed at `srand` time, not just the call count.

## Test fixture tightening

**`tests/automation/test_demo.sh`**:

- Update the comment block: `timer_ref_hr` *is* pinned on the fresh-start path now (#175), not dropped because of a non-pin.
- Stricter determinism diff: drop only `fps` and `log` (keep `timer_ref_hr` in the comparison).
- New natural-end assertion exercising `Control_End` (#178): cube 218 with a 3000-tick budget reaches `LM_THE_END` before the budget; the dump must show `scene.cube=218` and `tick<budget`. This was the one code path of #178 that the test suite wasn't covering.

Verified locally:

```
PASS: demo — cube 193 500 ticks reproducible+advancing (anim 0->2);
      cube 218 LM_THE_END at t=1144 captured via Control_End
```

Full `tests/automation/run.sh` suite: 2 passed, 6 skipped (no save fixture set locally), 0 failed.