### PR TITLE
feat(control): ui inventory <path> — first UI capture verb for regression goldens

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -272,6 +272,26 @@ static void cmd_screenshot(int argc, const char *argv[]) {
     Console_Print("Screenshot (no console): %s", path);
 }
 
+/* ui <surface> <path> — open a UI modal in headless-harness mode, capture a
+   PNG of a settled frame, then auto-exit.  The first regression surface for
+   the widescreen / UI-layout work, designed so each new surface (holomap,
+   dialog, menu-options, ...) plugs in as a parallel subcommand using the
+   same composite "open / wait / screenshot / close" pattern. */
+static void cmd_ui(int argc, const char *argv[]) {
+    if (argc >= 3 && !strcmp(argv[1], "inventory")) {
+        /* MenuInventory's `tempo` argument is virtual game-ms; under fixed-dt
+           16 that's ~31 frames of modal loop -- plenty of room past the
+           5-frame capture countdown for the wheel to settle into its base
+           state.  Without input the wheel just sits on InvSelect (default 0)
+           with no per-item zoom (TIME_BEFORE_ZOOM = 1000 ms is past tempo). */
+        Inv_RequestCapture(argv[2]);
+        MenuInventory(500);
+        Console_Print("ui inventory -> %s", argv[2]);
+        return;
+    }
+    Console_Print("Usage: ui inventory <path>");
+}
+
 static void cmd_give(int argc, const char *argv[]) {
     if (argc < 2) {
         Console_Print("Usage: give <item> [count]");
@@ -965,6 +985,12 @@ void Console_RegisterAll(void) {
                               "Snapshot of current game state.");
     Console_RegisterCommandEx("screenshot", cmd_screenshot, "Save next frame as PNG (no console)", "(no args)",
                               "PNG under shoot/; console closes first.");
+    Console_RegisterCommandEx("ui", cmd_ui, "Open a UI modal and capture a screenshot",
+                              "ui inventory <path>",
+                              "Composite verb for UI regression fixtures: opens the inventory wheel "
+                              "with a virtual-time auto-exit, writes the settled frame to <path> via "
+                              "SavePNG, then closes.  Compose with --load / --exec to drive headless "
+                              "captures of UI state.");
     Console_RegisterCommandEx("savebug", cmd_savebug, "Save current game to bugs dir (optional name)", "savebug [name]",
                               "Requires in-game loaded cube (not during video); writes bugs/<name>.lba.");
 

--- a/SOURCES/INVENT.CPP
+++ b/SOURCES/INVENT.CPP
@@ -1092,17 +1092,27 @@ void MenuInventory(U32 tempo) {
 
     InvCoul = COUL_SELECT_MENU;
 
-    /* PtrMap/ObjPtrMap are normally set by the prior frame's render before the
-       inventory key is pressed; the original code re-sets them at line 1102
-       below.  But OpenInventory drills into BodyDisplay -> Filler_Texture for
-       each owned item, which dereferences PtrMap.  Under the harness capture
-       path the wheel can be opened on the very first tick after a --load, with
-       no prior frame having run, so PtrMap is stale/null and the filler
-       segfaults.  Move the texture-buffer init up to cover that case; the
-       redundant re-assignment below is harmless. */
+    /* Harness capture pre-arm.  Two things normally come from the prior frame's
+       render but aren't there yet on the first tick after --load:
+
+         * PtrMap/ObjPtrMap -- OpenInventory drills into BodyDisplay ->
+           Filler_Texture for each owned item, which dereferences PtrMap.  The
+           original code re-sets these at line 1102 below; that's late.  Hoist.
+
+         * The Screen framebuffer behind the wheel -- normal callers see the
+           live scene because the prior tick's AffScene rendered it.  Without a
+           prior frame, Screen has stale or zeroed bytes, and the captured
+           PNG shows un-rendered stripes around the wheel.  Run one AffScene
+           pass here (NO_FLIP -- we want pixels in Screen, not a BoxBlit) so
+           the wheel composites over the proper background, matching what a
+           player presses-inventory-mid-game would see.
+
+       Both are conditional on the capture being armed; normal callers see no
+       behaviour change. */
     if (s_inv_capture_path[0]) {
         PtrMap = ObjPtrMap = BufferTexture;
         RepMask = 0xFFFF;
+        AffScene(AFF_ALL_NO_FLIP);
     }
 
     OpenInventory(); // draw all

--- a/SOURCES/INVENT.CPP
+++ b/SOURCES/INVENT.CPP
@@ -3,11 +3,13 @@
 #include "DIRECTORIES.H"
 #include "INPUT.H"
 
+#include <FILEIO/SAVEPNG.H>
 #include <SVGA/SCREEN.H>
 #include <SVGA/VIDEO.H>
 #include <SYSTEM/KEYBOARD.H>
 #include <SYSTEM/KEYBOARD_KEYS.H>
 #include <stdint.h>
+#include <string.h>
 
 #define SHADE_INVENT_LVL 8
 
@@ -1009,6 +1011,27 @@ void CheckProtoPack(void) {
 /*──────────────────────────────────────────────────────────────────────────*/
 U32 NextBox = 0;
 
+/* Harness capture state — see Inv_RequestCapture() in INVENT.H.  When the path
+   is non-empty, the next MenuInventory() call captures the rendered framebuffer
+   to that path after the wheel settles, then disarms.  The countdown picks a
+   frame past the first-iteration setup (CopyScreen Log->Screen on flagname=1)
+   but well before TIME_BEFORE_ZOOM (1000 ms) kicks in any per-item animation,
+   so the captured frame is the wheel in its base state on the default
+   selection -- the deterministic shot regression goldens want. */
+static char s_inv_capture_path[ADELINE_MAX_PATH] = "";
+static int s_inv_capture_countdown = 0;
+
+void Inv_RequestCapture(const char *path) {
+    if (!path || !path[0]) {
+        s_inv_capture_path[0] = '\0';
+        s_inv_capture_countdown = 0;
+        return;
+    }
+    strncpy(s_inv_capture_path, path, ADELINE_MAX_PATH - 1);
+    s_inv_capture_path[ADELINE_MAX_PATH - 1] = '\0';
+    s_inv_capture_countdown = 5; /* iterations to advance before SavePNG */
+}
+
 void MenuInventory(U32 tempo) {
     if (Control_IsVerbose())
         fprintf(stderr, "[control] modal: MenuInventory (tempo=%u, DemoSlide=%d) -- "
@@ -1083,6 +1106,15 @@ void MenuInventory(U32 tempo) {
 
     InitWaitNoInput(I_INVENTORY | I_RETURN | I_MENUS); // fait dans la boucle du jeu
     InitWaitNoKey();
+
+    /* OpenInventory above runs the wheel's open animation, which under fixed-dt
+       steps the virtual clock by ~600 ms via BoxBlit's present hook (#172) before
+       the loop is reached.  For the harness capture path, that means tempo-based
+       exit doesn't work -- we extend the budget here so the capture hook gets a
+       few loop iterations before timerslide.  Existing callers (GERELIFE:276
+       passes tempo=4000) are unaffected. */
+    if (s_inv_capture_path[0] && tempo && timerslide < TimerRefHR + 1000)
+        timerslide = TimerRefHR + 1000;
 
     while (MyKey != K_ESC AND !(Input & I_MENUS)
                         AND(!tempo OR TimerRefHR <= timerslide)) {
@@ -1278,6 +1310,18 @@ void MenuInventory(U32 tempo) {
                 break;
             } else
                 PlayErrorSample();
+        }
+
+        /* Harness one-shot capture: at the configured countdown, write the
+           rendered framebuffer to the requested path then disarm and exit the
+           modal -- the loop's tempo-driven exit doesn't help here because the
+           clock stops advancing in the loop once flagname falls to 0 (no more
+           AffObjName BoxUpdate per iteration), so we break out explicitly. */
+        if (s_inv_capture_path[0] && --s_inv_capture_countdown <= 0) {
+            SavePNG(s_inv_capture_path, Screen, (S32)ModeDesiredX,
+                    (S32)ModeDesiredY, PtrPal);
+            s_inv_capture_path[0] = '\0';
+            break;
         }
     }
 

--- a/SOURCES/INVENT.CPP
+++ b/SOURCES/INVENT.CPP
@@ -1092,6 +1092,19 @@ void MenuInventory(U32 tempo) {
 
     InvCoul = COUL_SELECT_MENU;
 
+    /* PtrMap/ObjPtrMap are normally set by the prior frame's render before the
+       inventory key is pressed; the original code re-sets them at line 1102
+       below.  But OpenInventory drills into BodyDisplay -> Filler_Texture for
+       each owned item, which dereferences PtrMap.  Under the harness capture
+       path the wheel can be opened on the very first tick after a --load, with
+       no prior frame having run, so PtrMap is stale/null and the filler
+       segfaults.  Move the texture-buffer init up to cover that case; the
+       redundant re-assignment below is harmless. */
+    if (s_inv_capture_path[0]) {
+        PtrMap = ObjPtrMap = BufferTexture;
+        RepMask = 0xFFFF;
+    }
+
     OpenInventory(); // draw all
 
     InitDial(2); // game divers txt

--- a/SOURCES/INVENT.H
+++ b/SOURCES/INVENT.H
@@ -74,6 +74,13 @@ extern void CheckProtoPack(void);
 /*--------------------------------------------------------------------------*/
 extern void MenuInventory(U32 tempo);
 /*--------------------------------------------------------------------------*/
+/* Harness hook: arm a one-shot screenshot inside the next MenuInventory call.
+   At a settled frame inside the wheel's modal loop, SavePNG is called with the
+   supplied path and the request is cleared. Pass NULL or "" to disarm.  Used by
+   the console "ui inventory <path>" verb to drive UI-state regression fixtures
+   without a tick budget for the modal. */
+extern void Inv_RequestCapture(const char *path);
+/*--------------------------------------------------------------------------*/
 extern void DoFoundObj(S32 numobj);
 /*--------------------------------------------------------------------------*/
 extern void DrawArdoiseArrows(void);


### PR DESCRIPTION
Step 1 of the UI/HUD regression strategy. Establishes the pattern for `ui <surface>` console verbs that open a UI modal in headless harness mode, capture the settled-frame framebuffer, and exit cleanly — the primitive widescreen work and future menu-rendering changes need.

## What it adds

A new console verb:

```
ui inventory <path>
```

When run from the harness or interactive console, opens `MenuInventory` with a virtual-time auto-exit, lets the wheel's open animation settle, captures the next frame via `SavePNG`, then closes. Composable with the rest of the harness:

```
lba2cc --load "021 Palace" --exec "ui inventory /tmp/inv.png" --fixed-dt 16 --tick 60 --exit
```

77 lines across 3 files; no flag changes, no engine behaviour changes for existing callers.

## How it works

- **`INVENT.H` / `INVENT.CPP`** — `Inv_RequestCapture(path)` arms a one-shot capture; a static path + iteration countdown lives next to `MenuInventory`. When armed and the countdown reaches zero (5 iterations in, past the first-iteration `CopyScreen Log→Screen` on `flagname=1` but well before `TIME_BEFORE_ZOOM` would kick per-item animation), the modal loop calls `SavePNG(Screen, ModeDesiredX, ModeDesiredY, PtrPal)` and breaks. Existing callers (`PERSO.CPP:1048` inventory keypress, `GERELIFE.CPP:276` inventory-via-script) are unaffected — when the path is empty, the new hook is a no-op.
- One tempo extension matters only when capture is armed. `OpenInventory` above the loop runs the wheel's open animation, which under `--fixed-dt` steps the virtual clock by ~600 ms via `BoxBlit`'s present hook (#172) before the loop is reached. Without the extension, `timerslide` (computed pre-animation) is already past `TimerRefHR` at loop entry and the loop body never runs. Gated on `s_inv_capture_path[0]` so non-harness callers see the original behaviour.
- **`CONSOLE_CMD.CPP`** — `cmd_ui` dispatcher registered as `"ui"`. Parses `ui inventory <path>`, calls `Inv_RequestCapture(<path>)` and `MenuInventory(500)`, reports via `Console_Print`. Other UI surfaces will add as parallel subcommands (`ui holomap`, `ui dialog`, `ui menu-options`, ...).

## Verified

```
$ lba2cc --exec "cube 0; ui inventory /tmp/inv.png" --fixed-dt 16 --tick 60 --exit
[control] Cube 0 (change on next frame)
[control] ui inventory -> /tmp/inv.png

$ file /tmp/inv.png
/tmp/inv.png: PNG image data, 640 x 480, 8-bit/color RGB, non-interlaced
```

Captured 640×480 PNG of the wheel's settled state — 7×5 grid, top-left cell selected, item-name strip at the bottom. Empty slots because `cube 0` doesn't load a save with items; a real fixture would use `--load` to seed the inventory.

## Guards

- Savegame baseline corpus: `39 ok, 0 drift, 0 flaky` — `MenuInventory`'s tempo extension is gated on capture-armed, so save-loaded runs are byte-identical.
- `tests/automation/test_demo.sh` passes: cube 193 deterministic, cube 218 `LM_THE_END` via `Control_End`.

## Why no test fixture in this PR

A `test_ui_inventory.sh` golden needs a save with a known inventory state to be meaningful, and the right shape for that golden (PNG byte-identical? perceptual diff? both?) is best decided as the pattern extends to other UI surfaces. This PR establishes the mechanism; a follow-up adds the first committed golden plus the test_ui_inventory.sh wrapper.

## Next surfaces (one PR each on the same template)

`ui holomap`, `ui dialog <text-id>`, `ui menu-options`, `ui found-object <item>` — each follows the same shape: open modal, advance to a settled frame, capture, exit.

For *behavioural* menu testing (navigation logic, cursor moves, page transitions), an input-simulation primitive (`--input "down,enter"` or a `press <key>` verb) would extend on top — explicitly deferred until needed; the foundation here doesn't preclude it.