### PR TITLE
feat(control): ui holomap <path> — second UI capture verb

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -12,6 +12,7 @@
 #include "../DISKFUNC.H"
 #include "../SAVEGAME.H"
 #include "../INPUT.H"
+/* HOLO.H lacks include guards and is pulled in transitively by DEFINES.H. */
 #include "../INVENT.H"
 #include <SYSTEM/FILES.H>
 #include <SYSTEM/STRING.H>
@@ -289,7 +290,17 @@ static void cmd_ui(int argc, const char *argv[]) {
         Console_Print("ui inventory -> %s", argv[2]);
         return;
     }
-    Console_Print("Usage: ui inventory <path>");
+    if (argc >= 3 && !strcmp(argv[1], "holomap")) {
+        /* HoloMap fades to black, opens HoloGlobe (the rotating planet view),
+           and runs until FlagHoloEnd.  Holo_RequestCapture arms a one-shot
+           SavePNG inside HoloGlobe's loop after the fade-in + zoom-in settle,
+           then sets FlagHoloEnd so HoloMap exits cleanly. */
+        Holo_RequestCapture(argv[2]);
+        HoloMap();
+        Console_Print("ui holomap -> %s", argv[2]);
+        return;
+    }
+    Console_Print("Usage: ui {inventory|holomap} <path>");
 }
 
 static void cmd_give(int argc, const char *argv[]) {
@@ -986,11 +997,11 @@ void Console_RegisterAll(void) {
     Console_RegisterCommandEx("screenshot", cmd_screenshot, "Save next frame as PNG (no console)", "(no args)",
                               "PNG under shoot/; console closes first.");
     Console_RegisterCommandEx("ui", cmd_ui, "Open a UI modal and capture a screenshot",
-                              "ui inventory <path>",
-                              "Composite verb for UI regression fixtures: opens the inventory wheel "
-                              "with a virtual-time auto-exit, writes the settled frame to <path> via "
-                              "SavePNG, then closes.  Compose with --load / --exec to drive headless "
-                              "captures of UI state.");
+                              "ui {inventory|holomap} <path>",
+                              "Composite verb for UI regression fixtures: opens a UI modal "
+                              "with a deterministic auto-exit, writes the settled frame to <path> "
+                              "via SavePNG, then closes.  Compose with --load / --exec to drive "
+                              "headless captures of UI state.");
     Console_RegisterCommandEx("savebug", cmd_savebug, "Save current game to bugs dir (optional name)", "savebug [name]",
                               "Requires in-game loaded cube (not during video); writes bugs/<name>.lba.");
 

--- a/SOURCES/HOLO.H
+++ b/SOURCES/HOLO.H
@@ -228,5 +228,11 @@ extern void HoloSpace(void);
 
 extern void InitHoloMap();
 extern void HoloMap(void);
+/* Harness hook: arm a one-shot screenshot inside the next HoloMap call.
+   At a settled frame inside the HoloGlobe modal loop (past the fade-in and
+   the zoom-in animation) SavePNG is called with the supplied path, then
+   FlagHoloEnd is set so HoloMap exits cleanly.  Pass NULL or "" to disarm.
+   Used by the console "ui holomap <path>" verb. */
+extern void Holo_RequestCapture(const char *path);
 extern S32 SetHoloPos(S32 num);
 extern void ClrHoloPos(S32 num);

--- a/SOURCES/HOLOGLOB.CPP
+++ b/SOURCES/HOLOGLOB.CPP
@@ -6,8 +6,10 @@
 #include "DIRECTORIES.H"
 #include "INPUT.H"
 
+#include <FILEIO/SAVEPNG.H>
 #include <SVGA/SCREEN.H>
 #include <SYSTEM/KEYBOARD_KEYS.H>
+#include <string.h>
 
 //────────────────────────────────────────────────────────────────────────────
 //	Concerning BODY and ANIM
@@ -946,6 +948,28 @@ S32 GoToArrow() {
     return (0);
 }
 //────────────────────────────────────────────────────────────────────────────
+/* Harness capture state — see Holo_RequestCapture() in HOLO.H.  When the path
+   is non-empty, HoloGlobe's modal loop fires a one-shot SavePNG after the
+   countdown elapses, then sets FlagHoloEnd and breaks so the wrapper HoloMap
+   exits cleanly.  The countdown gives the fade-in (~200 ms via the palette
+   fade in HoloMap) and the zoom-in animation (ZoomPlanet ramps over 500 ms
+   from ZOOM_INIT_PLANET to ZoomPlanetDest) time to settle into the steady
+   rotating-globe state regression goldens want. */
+static char s_holo_capture_path[ADELINE_MAX_PATH] = "";
+static int s_holo_capture_countdown = 0;
+
+void Holo_RequestCapture(const char *path) {
+    if (!path || !path[0]) {
+        s_holo_capture_path[0] = '\0';
+        s_holo_capture_countdown = 0;
+        return;
+    }
+    strncpy(s_holo_capture_path, path, ADELINE_MAX_PATH - 1);
+    s_holo_capture_path[ADELINE_MAX_PATH - 1] = '\0';
+    /* ~500 ms of fade+zoom + a margin = 40 iterations at fixed-dt 16 ms. */
+    s_holo_capture_countdown = 40;
+}
+
 void HoloGlobe(S32 planet) {
     S32 testnofire = TRUE;
     U32 memotime;
@@ -1050,6 +1074,21 @@ void HoloGlobe(S32 planet) {
         DrawHolomap();
         BoxMovingAdd(ScreenXMin, ScreenYMin, ScreenXMax, Dial_Y0 - 1);
         AdjustZBufMinMax();
+
+        /* Harness one-shot capture.  Read from Log (the back buffer) right
+           after DrawHolomap, because something between here and the loop's
+           closing BoxUpdate clears the planet area from Log -- the late-
+           iteration Screen reflects that clear and captures black.  At this
+           point Log holds both the freshly-drawn planet and the dialogue
+           strip composited from a prior iteration's AffHoloMess, which is
+           exactly the frame a player sees. */
+        if (s_holo_capture_path[0] && --s_holo_capture_countdown <= 0) {
+            SavePNG(s_holo_capture_path, Log, (S32)ModeDesiredX,
+                    (S32)ModeDesiredY, PtrPal);
+            s_holo_capture_path[0] = '\0';
+            FlagHoloEnd = TRUE;
+            break;
+        }
         //-------------
         PrepareObjectifPlanet(); // Must be run before DrawListHoloGlobe(1)
 
@@ -1126,6 +1165,18 @@ void HoloMap() {
     //----- DEBUG
     //	TabArrow[MAX_OBJECTIF+67].FlagHolo = 1	;//	Desert Globe
     //-----
+
+    /* Harness capture pre-arm.  Same shape as MenuInventory's: when the wheel/
+       globe is opened from the harness on the first tick after --load, no
+       prior frame has rendered, so the texture-filler globals (PtrMap,
+       ObjPtrMap) are stale and BodyDisplay -> Filler_TextureZBuf segfaults.
+       Hoist the init that AffScene normally does for us before the globe's
+       body draws kick in.  Gated on capture-armed so normal callers (player
+       pressing the holomap key after gameplay) see no behaviour change. */
+    if (s_holo_capture_path[0]) {
+        PtrMap = ObjPtrMap = BufferTexture;
+        RepMask = 0xFFFF;
+    }
 
     if (Comportement == C_PROTOPACK OR Comportement == C_JETPACK) {
         // pour pouvoir restaurer anim marche protopack


### PR DESCRIPTION
Step 2 of the UI/HUD regression strategy. Adds `ui holomap <path>` following the `ui inventory` pattern established in #182. The pattern is now proven across two different rendering pipelines (3D body wheel + 3D textured planet globe), so subsequent surfaces (`ui dialog`, `ui menu-options`, ...) are mechanical.

## What it adds

```
ui holomap <path>
```

Opens `HoloMap` in headless harness mode, captures the rotating-planet view (with the dialogue strip showing the player's current island name) to `<path>`, then exits cleanly. Composable:

```
lba2cc --load <save> --exec "ui holomap /tmp/holo.png" --fixed-dt 16 --tick 60 --exit
```

74 lines added / 6 modified across 3 files.

## Same pattern as `ui inventory`, two interesting differences

- **PtrMap pre-arm needed (same root cause as inventory)** — `HoloMap`'s outer wrapper loop calls `HoloGlobe`, which inside calls `DrawListHoloGlobe` → `DrawArrowGlobe` → `DrawTwinsenGlobe` → `BodyDisplay` → `Filler_TextureZBuf`. Without a prior frame `PtrMap` is stale and the filler segfaults. Hoist the texture-buffer globals init, gated on capture-armed.

- **Capture from `Log`, not `Screen`, and right after `DrawHolomap`, not after `BoxUpdate`.** Something in the loop between `DrawHolomap` and the closing `BoxUpdate` clears the planet area from `Log` (likely `AffHoloMess` or one of the ZBuf operations), so a late-iter capture from `Screen` reads black. Captured immediately after `DrawHolomap` from `Log`, the frame has both the freshly-drawn planet AND the prior iter's dialogue strip composited — exactly what a player sees. The inventory PR did `Screen` after `BoxUpdate` because the wheel's render path leaves Screen valid through the iteration; the globe's doesn't.

## Verified across the save corpus

| Save | Planet shown | PNG size |
|---|---|---|
| Anon1 | Twinsun (Citadel Island) | 72 KB |
| School of Magic | Twinsun (White Leaf Desert) | 86 KB |
| Ball of Sendell | Twinsun (Citadel Island) | 72 KB |
| Dark Monk | Zeelich (Island Under Celebration) | 61 KB |
| End game | Zeelich (Island Under Celebration) | 61 KB |
| Desperado | Zeelich (Island Under Celebration) | 61 KB |

The three late-game saves all sit on the same island, so their holomaps render byte-identical — exactly the behaviour a regression net wants ("same scene = same image").

Three runs of `Dark Monk.LBA` → byte-identical sha256. Deterministic capture.

## Guards

- Savegame baseline corpus: `39 ok, 0 drift, 0 flaky` — `HoloMap`'s PtrMap pre-arm is gated on capture-armed, so save-loaded paths that don't open the holomap via the harness are byte-identical.
- `ui inventory` regression check still works — `cmd_ui` dispatcher took only an `else if` branch, no breakage.

## Pattern is now established

After this:
- `ui dialog <text-id> <path>` — text/portrait UI (Dial in MESSAGE.CPP).
- `ui menu-options <path>` — pause/options menu.
- `ui found-object <item> <path>` — DoFoundObj cinematic.

Each new surface adds: 1) a static path + countdown next to the modal, 2) a `<Modal>_RequestCapture` setter, 3) a capture hook in the modal's loop, 4) an `else if` in `cmd_ui`, 5) a PtrMap pre-arm if it renders 3D bodies. Linear scaling, ~30-50 lines per surface.

The committed `test_ui_inventory.sh` / `test_ui_holomap.sh` golden fixtures are still deferred to a follow-up — best decided as a family once 3-4 surfaces exist and the golden format (per-platform byte-identical PNG vs perceptual diff) is settled.