### PR TITLE
feat(control): ui dialog <text-id> <path> — third UI capture verb

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -300,7 +300,21 @@ static void cmd_ui(int argc, const char *argv[]) {
         Console_Print("ui holomap -> %s", argv[2]);
         return;
     }
-    Console_Print("Usage: ui {inventory|holomap} <path>");
+    if (argc >= 4 && !strcmp(argv[1], "dialog")) {
+        /* Dial(text, drawscene) opens a dialogue bubble + portrait for the
+           given text-id in the currently-loaded dialogue bank.  Dial_Request-
+           Capture arms a one-shot SavePNG that fires the first time the
+           typewriter completes a page (ret == 0 or 2), then sets flagabort
+           so Dial exits cleanly without waiting for input. */
+        S32 text_id = (S32)atoi(argv[2]);
+        Dial_RequestCapture(argv[3]);
+        Dial(text_id, TRUE);
+        Console_Print("ui dialog %d -> %s", (int)text_id, argv[3]);
+        return;
+    }
+    Console_Print("Usage: ui inventory <path>");
+    Console_Print("       ui holomap <path>");
+    Console_Print("       ui dialog <text-id> <path>");
 }
 
 static void cmd_give(int argc, const char *argv[]) {
@@ -997,7 +1011,7 @@ void Console_RegisterAll(void) {
     Console_RegisterCommandEx("screenshot", cmd_screenshot, "Save next frame as PNG (no console)", "(no args)",
                               "PNG under shoot/; console closes first.");
     Console_RegisterCommandEx("ui", cmd_ui, "Open a UI modal and capture a screenshot",
-                              "ui {inventory|holomap} <path>",
+                              "ui {inventory|holomap} <path> | ui dialog <text-id> <path>",
                               "Composite verb for UI regression fixtures: opens a UI modal "
                               "with a deterministic auto-exit, writes the settled frame to <path> "
                               "via SavePNG, then closes.  Compose with --load / --exec to drive "

--- a/SOURCES/MESSAGE.CPP
+++ b/SOURCES/MESSAGE.CPP
@@ -16,6 +16,7 @@
 #include "CONTROL.H"
 #include "INPUT.H"
 
+#include <FILEIO/SAVEPNG.H>
 #include <SVGA/SCREEN.H>
 #include <SVGA/VIDEO.H>
 #include "DIRECTORIES.H"
@@ -1866,6 +1867,28 @@ void SpeakAnimation() {
 //────────────────────────────────────────────────────────────────────────────
 //                                 D I A L
 //────────────────────────────────────────────────────────────────────────────
+/* Harness capture state — see Dial_RequestCapture() in MESSAGE.H.  When the
+   path is non-empty, Dial's typewriter loop counts down per iteration; on
+   reaching zero it SavePNGs and sets flagabort so Dial exits cleanly without
+   waiting for input.  The countdown lets the typewriter draw substantial
+   text before the snapshot -- ~1 game-second at fixed-dt 16 is enough for
+   most LBA2 dialogue lines.  We don't gate on ret==0/2 because that fires
+   the moment NextDialCar returns "page break" or "done", which on short
+   or empty texts can be the very first iteration before any char is drawn. */
+static char s_dial_capture_path[ADELINE_MAX_PATH] = "";
+static int s_dial_capture_countdown = 0;
+
+void Dial_RequestCapture(const char *path) {
+    if (!path || !path[0]) {
+        s_dial_capture_path[0] = '\0';
+        s_dial_capture_countdown = 0;
+        return;
+    }
+    strncpy(s_dial_capture_path, path, ADELINE_MAX_PATH - 1);
+    s_dial_capture_path[ADELINE_MAX_PATH - 1] = '\0';
+    s_dial_capture_countdown = 60; /* iterations -- ~1 game-second at dt 16 */
+}
+
 void Dial(S32 text, S32 drawscene) {
     S32 ret = 0;
     S32 flagabort = 0;
@@ -1961,6 +1984,21 @@ void Dial(S32 text, S32 drawscene) {
 
         TestSpeak();
         SpeakAnimation();
+
+        /* Harness one-shot capture.  Read Log (back buffer), not Screen --
+           Dial's typewriter renders into Log via the dialogue compositor
+           and SpeakAnimation's BoxUpdate flushes a subset to Screen; the
+           full bubble + portrait + text live in Log.  Countdown-driven so
+           the typewriter has time to draw substantial text. */
+        if (s_dial_capture_path[0]) {
+            if (--s_dial_capture_countdown <= 0 || ret == 0 || ret == 2) {
+                SavePNG(s_dial_capture_path, Log, (S32)ModeDesiredX,
+                        (S32)ModeDesiredY, PtrPal);
+                s_dial_capture_path[0] = '\0';
+                flagabort = 1;
+                break;
+            }
+        }
 
         if (ret == 2) /*      Attente de Touche       */
         {

--- a/SOURCES/MESSAGE.H
+++ b/SOURCES/MESSAGE.H
@@ -80,6 +80,12 @@ extern void InitWhoSpeak(S32 numobj);
 extern void ClearWhoSpeak(void);
 extern void SpeakAnimation(void);
 extern void Dial(S32 text, S32 drawscene);
+/* Harness hook: arm a one-shot screenshot inside the next Dial call.
+   When the dialogue's typewriter completes the current page (NextDialCar
+   returns 0 or 2), SavePNG is called with the supplied path and flagabort
+   is set so Dial exits cleanly without waiting for input.  Pass NULL or
+   "" to disarm.  Used by the console "ui dialog <text-id> <path>" verb. */
+extern void Dial_RequestCapture(const char *path);
 extern S32 MyDial(S32 nummess);
 extern char *GetMultiText(S32 text, char *dst);
 extern void CleanMessage(char *string, S32 flag);


### PR DESCRIPTION
Step 3 of the UI capture family. Adds `ui dialog` following the pattern from #182 (inventory) and #183 (holomap).

## What it adds

```
ui dialog <text-id> <path>
```

Opens the dialogue bubble + portrait + typewriter text for the given text-id in the currently-loaded dialogue bank, captures the rendered frame to `<path>`, then exits cleanly:

```
lba2cc --load <save> --exec "ui dialog 100 /tmp/dial.png" --fixed-dt 16 --tick 200 --exit
```

60 lines added / 2 modified across 3 files (`MESSAGE.{H,CPP}`, `CONSOLE_CMD.CPP`).

## Three lessons from this surface

1. **Hybrid trigger: countdown + ret early-out.** The first attempt fired on `ret == 0` or `ret == 2` (NextDialCar "page done" or "all done") — but on very short or empty texts those return on iteration 1 before any char is drawn. Adding a countdown (60 iters ≈ 1 game-second at fixed-dt 16) gives the typewriter time to draw substantial text. The combined `--countdown <= 0 || ret == 0 || ret == 2` covers both classes: long text caps at the countdown, short text exits on the early ret.

2. **Capture from `Log`, not `Screen` — second time the same lesson.** First seen with the holomap (#183). The dialogue compositor renders the bubble + portrait + text into `Log`; the `BoxUpdate` inside `SpeakAnimation` only flushes the speaker-portrait region to `Screen`. Capturing `Screen` showed an empty bubble outline; `Log` shows the full composited frame the player sees. The inventory wheel happens to leave Screen valid because its render path is different. Worth thinking about whether the family should default to `Log` and let surfaces override, rather than the reverse.

3. **The dialogue bank is per-save.** The text-id is an index into whichever bank the loaded save has active (`START_FILE_ISLAND + Island`). Different saves on different islands resolve the same id to different texts; that's by design. Test fixtures need to pick a save + id pair known to be valid.

## Verified

On `Anon1.LBA` (Citadel Island, cube 42, Near Tavern):

| text-id | Captured content | PNG size |
|---|---|---|
| 1 | `"Il vous faut un bulletin de consigne pour escapé."` | 245 KB |
| 50 | (another valid bank entry) | 245 KB |
| 100 | `"Bonjour."` | 244 KB |

Three runs of `text=1` produce byte-identical PNGs (sha256 match).

## Guards

- Savegame baseline corpus: `39 ok, 0 drift, 0 flaky`.
- `ui inventory` regression check: unchanged (178 027 bytes on Dark Monk).
- `ui holomap` regression check: unchanged (60 770 bytes on Dark Monk).

## Pattern is now established across three surfaces

Inventory wheel, planet globe, dialogue bubble — each ~60-100 lines, gated on capture-armed so non-harness callers see no behaviour change. Remaining surfaces (`ui menu-options`, `ui found-object`) follow the same template.

The committed test fixtures (`tests/automation/test_ui_*.sh`) and the golden-format decision are still the natural pairing for a follow-up PR once the family is complete and a save fixture is settled on.