### PR TITLE
feat(control): ui menu-options <path> — fourth UI capture verb

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -322,10 +322,20 @@ static void cmd_ui(int argc, const char *argv[]) {
         Console_Print("ui menu-options -> %s", argv[2]);
         return;
     }
+    if (argc >= 3 && !strcmp(argv[1], "menu-main")) {
+        /* Boot-time main menu (Resume / New / Load / Options / Quit).
+           Menu_MainCapture does the MainGameMenu setup minus the case-driven
+           cinematic side effects, arms the capture, and calls DoGameMenu
+           directly. */
+        Menu_MainCapture(argv[2]);
+        Console_Print("ui menu-main -> %s", argv[2]);
+        return;
+    }
     Console_Print("Usage: ui inventory <path>");
     Console_Print("       ui holomap <path>");
     Console_Print("       ui dialog <text-id> <path>");
     Console_Print("       ui menu-options <path>");
+    Console_Print("       ui menu-main <path>");
 }
 
 static void cmd_give(int argc, const char *argv[]) {
@@ -1022,7 +1032,7 @@ void Console_RegisterAll(void) {
     Console_RegisterCommandEx("screenshot", cmd_screenshot, "Save next frame as PNG (no console)", "(no args)",
                               "PNG under shoot/; console closes first.");
     Console_RegisterCommandEx("ui", cmd_ui, "Open a UI modal and capture a screenshot",
-                              "ui {inventory|holomap|menu-options} <path> | ui dialog <text-id> <path>",
+                              "ui {inventory|holomap|menu-options|menu-main} <path> | ui dialog <text-id> <path>",
                               "Composite verb for UI regression fixtures: opens a UI modal "
                               "with a deterministic auto-exit, writes the settled frame to <path> "
                               "via SavePNG, then closes.  Compose with --load / --exec to drive "

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -312,9 +312,20 @@ static void cmd_ui(int argc, const char *argv[]) {
         Console_Print("ui dialog %d -> %s", (int)text_id, argv[3]);
         return;
     }
+    if (argc >= 3 && !strcmp(argv[1], "menu-options")) {
+        /* OptionsMenu(FALSE) opens the in-game options/pause menu and drives
+           DoGameMenu.  Menu_RequestCapture arms a one-shot SavePNG inside
+           DoGameMenu's loop; on capture, DoGameMenu returns 1000 (ESC
+           sentinel) and OptionsMenu's case-1000 exits cleanly. */
+        Menu_RequestCapture(argv[2]);
+        OptionsMenu(FALSE);
+        Console_Print("ui menu-options -> %s", argv[2]);
+        return;
+    }
     Console_Print("Usage: ui inventory <path>");
     Console_Print("       ui holomap <path>");
     Console_Print("       ui dialog <text-id> <path>");
+    Console_Print("       ui menu-options <path>");
 }
 
 static void cmd_give(int argc, const char *argv[]) {
@@ -1011,7 +1022,7 @@ void Console_RegisterAll(void) {
     Console_RegisterCommandEx("screenshot", cmd_screenshot, "Save next frame as PNG (no console)", "(no args)",
                               "PNG under shoot/; console closes first.");
     Console_RegisterCommandEx("ui", cmd_ui, "Open a UI modal and capture a screenshot",
-                              "ui {inventory|holomap} <path> | ui dialog <text-id> <path>",
+                              "ui {inventory|holomap|menu-options} <path> | ui dialog <text-id> <path>",
                               "Composite verb for UI regression fixtures: opens a UI modal "
                               "with a deterministic auto-exit, writes the settled frame to <path> "
                               "via SavePNG, then closes.  Compose with --load / --exec to drive "

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -331,11 +331,25 @@ static void cmd_ui(int argc, const char *argv[]) {
         Console_Print("ui menu-main -> %s", argv[2]);
         return;
     }
+    if (argc >= 4 && !strcmp(argv[1], "found-object")) {
+        /* DoFoundObj(numvar) opens the found-object cinematic: 3D rotation
+           of the discovered item alongside a typewriter dialogue.  numvar
+           is the TabInv slot index (e.g. FLAG_BALLE_MAGIQUE).
+           DoFoundObj_RequestCapture arms a one-shot SavePNG that fires
+           after the countdown elapses; the hook sets flag=2 so the modal's
+           while-loop exits cleanly. */
+        S32 numvar = (S32)atoi(argv[2]);
+        DoFoundObj_RequestCapture(argv[3]);
+        DoFoundObj(numvar);
+        Console_Print("ui found-object %d -> %s", (int)numvar, argv[3]);
+        return;
+    }
     Console_Print("Usage: ui inventory <path>");
     Console_Print("       ui holomap <path>");
     Console_Print("       ui dialog <text-id> <path>");
     Console_Print("       ui menu-options <path>");
     Console_Print("       ui menu-main <path>");
+    Console_Print("       ui found-object <numvar> <path>");
 }
 
 static void cmd_give(int argc, const char *argv[]) {
@@ -1032,7 +1046,7 @@ void Console_RegisterAll(void) {
     Console_RegisterCommandEx("screenshot", cmd_screenshot, "Save next frame as PNG (no console)", "(no args)",
                               "PNG under shoot/; console closes first.");
     Console_RegisterCommandEx("ui", cmd_ui, "Open a UI modal and capture a screenshot",
-                              "ui {inventory|holomap|menu-options|menu-main} <path> | ui dialog <text-id> <path>",
+                              "ui {inventory|holomap|menu-options|menu-main} <path> | ui {dialog|found-object} <id> <path>",
                               "Composite verb for UI regression fixtures: opens a UI modal "
                               "with a deterministic auto-exit, writes the settled frame to <path> "
                               "via SavePNG, then closes.  Compose with --load / --exec to drive "

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -2348,6 +2348,45 @@ static void GameMenuApplyMouseWheelDoGameMenu(U16 *ptrmenu, S16 selected, S32 wy
     }
 }
 
+/* Forward decl -- defined further down in this file. */
+void BuildGameMainMenu(S32 firstloop);
+
+/* Harness one-shot capture of the boot-time main game menu -- the screen a
+   player sees at launch with Resume / New Game / Load / Options / Quit.
+   The normal entry point MainGameMenu() runs a while-loop with case-driven
+   side effects (Credits, PlayAcf, save-game zoom animations) that we don't
+   want under the harness; instead, replicate just the minimal setup
+   MainGameMenu does before its DoGameMenu(GameMainMenu) call, arm the
+   capture, and call DoGameMenu directly.  The capture site inside
+   DoGameMenu (added for ui menu-options) fires and returns 1000, so this
+   function returns cleanly without entering MainGameMenu's outer loop. */
+void Menu_MainCapture(const char *path) {
+    char tmpFilePathScreen[ADELINE_MAX_PATH];
+
+    /* Setup mirrors MainGameMenu() lines 3373-3416 minus the audio start
+       (CD music) and minus the goto-load_game / firstloop logic.  All the
+       visual setup (background bitmap, plasma, palette, menu data, dial bank)
+       runs so the captured frame matches what a player sees at launch. */
+    HQ_StopSample();
+    StopMusic();
+    InitPlasmaMenu();
+    FlagShadeMenu = FALSE;
+
+    GetResPath(tmpFilePathScreen, ADELINE_MAX_PATH, SCREEN_HQR_NAME);
+    Load_HQR(tmpFilePathScreen, Screen, PCR_MENU);
+    CopyScreen(Screen, Log);
+    BoxStaticFullflip();
+    PtrPal = PtrPalNormal;
+    PaletteSync(PtrPalNormal);
+
+    BuildGameMainMenu(TRUE);
+    InitDial(0);
+
+    Menu_RequestCapture(path);
+    DoGameMenu(GameMainMenu);
+    Menu_RequestCapture(NULL); /* disarm if DoGameMenu somehow exited without firing it */
+}
+
 /* Harness capture state — see Menu_RequestCapture() in GAMEMENU.H.  When the
    path is non-empty, DoGameMenu's modal loop counts down per iteration;
    on reaching zero it SavePNGs and returns 1000 (the "ESC" sentinel) so the

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -3012,6 +3012,19 @@ S32 OptionsMenu(S32 flagflip) {
     S32 select;
     S32 flag = 0;
 
+    /* Harness capture pre-pass: under the harness, OptionsMenu can be opened
+       on the first tick after --load with no prior frame having rendered.
+       The options menu's normal flow ShadeBoxBlk's whatever Screen contains
+       (line ~3022) -- a player sees that as "shaded live scene" because the
+       prior tick already drew the scene; under the harness Screen is stale
+       and the player-visible scene-behind-the-menu is missing.  Run one
+       AffScene pass (NO_FLIP -- pixels in Screen, no extra BoxBlit) so the
+       menu shades a freshly-rendered scene, matching what a player who
+       presses ESC mid-game would see. */
+    if (s_menu_capture_path[0]) {
+        AffScene(AFF_ALL_NO_FLIP);
+    }
+
     BackupScreen(TRUE);
 
     /*        CopyScreen( Log, Screen ) ;

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -6,6 +6,7 @@
 #include "SAVENAME_VALIDATION.H"
 #include "CONSOLE/CONSOLE.H"
 
+#include <FILEIO/SAVEPNG.H>
 #include <SVGA/SCREEN.H>
 #include <SVGA/VIDEO.H>
 #include <SYSTEM/KEYBOARD.H>
@@ -2347,6 +2348,27 @@ static void GameMenuApplyMouseWheelDoGameMenu(U16 *ptrmenu, S16 selected, S32 wy
     }
 }
 
+/* Harness capture state — see Menu_RequestCapture() in GAMEMENU.H.  When the
+   path is non-empty, DoGameMenu's modal loop counts down per iteration;
+   on reaching zero it SavePNGs and returns 1000 (the "ESC" sentinel) so the
+   wrapping menu loop (OptionsMenu, MainGameMenu, ...) sees a clean exit.
+   The countdown gives the menu's fade-in and any per-frame text/sprite
+   animations time to settle into a steady visual state. */
+static char s_menu_capture_path[ADELINE_MAX_PATH] = "";
+static int s_menu_capture_countdown = 0;
+
+void Menu_RequestCapture(const char *path) {
+    if (!path || !path[0]) {
+        s_menu_capture_path[0] = '\0';
+        s_menu_capture_countdown = 0;
+        return;
+    }
+    strncpy(s_menu_capture_path, path, ADELINE_MAX_PATH - 1);
+    s_menu_capture_path[ADELINE_MAX_PATH - 1] = '\0';
+    s_menu_capture_countdown = 60; /* iterations -- ~1 s at fixed-dt 16, past any
+                                      menu fade-in and dynamic-item initial draws */
+}
+
 S32 DoGameMenu(U16 *ptrmenu) {
     S32 flag = 1;
     U32 chrono;
@@ -2733,6 +2755,21 @@ S32 DoGameMenu(U16 *ptrmenu) {
         if (MyKey == K_ESC
                          OR Input &
             I_MENUS) {
+            AsciiMode = FALSE;
+            return 1000;
+        }
+
+        /* Harness one-shot capture: count down per iteration; on reaching
+           zero SavePNG the rendered menu and return the ESC sentinel so
+           the wrapping menu loop exits cleanly.  Read Log (back buffer),
+           not Screen -- DrawGameMenu composites the menu into Log, and the
+           BoxUpdate inside only flushes dirty regions to Screen; without a
+           prior frame populating Screen, the unflushed regions stay black.
+           The third surface to need this (after holomap and dialog). */
+        if (s_menu_capture_path[0] && --s_menu_capture_countdown <= 0) {
+            SavePNG(s_menu_capture_path, Log, (S32)ModeDesiredX,
+                    (S32)ModeDesiredY, PtrPal);
+            s_menu_capture_path[0] = '\0';
             AsciiMode = FALSE;
             return 1000;
         }

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -3012,16 +3012,31 @@ S32 OptionsMenu(S32 flagflip) {
     S32 select;
     S32 flag = 0;
 
-    /* Harness capture pre-pass: under the harness, OptionsMenu can be opened
-       on the first tick after --load with no prior frame having rendered.
-       The options menu's normal flow ShadeBoxBlk's whatever Screen contains
-       (line ~3022) -- a player sees that as "shaded live scene" because the
-       prior tick already drew the scene; under the harness Screen is stale
-       and the player-visible scene-behind-the-menu is missing.  Run one
-       AffScene pass (NO_FLIP -- pixels in Screen, no extra BoxBlit) so the
-       menu shades a freshly-rendered scene, matching what a player who
-       presses ESC mid-game would see. */
+    /* Harness capture pre-pass.  The normal in-game ESC -> OptionsMenu path
+       (PERSO.CPP:846) does explicit setup before OptionsMenu that the
+       harness skips when --exec calls OptionsMenu directly:
+
+           StopSpeak()       -- terminate any active dialogue speech so its
+                                portrait / strip does not bleed through the
+                                menu (visible on saves with an active dialog).
+           InitDial(0)       -- switch the dialogue text bank to SYS (the menu
+                                strings live there).  Without this the menu's
+                                first item -- "Volume du son" -- reads junk or
+                                empty from whatever bank the save had loaded.
+           InitPlasmaMenu()  -- initialise the plasma/fire-bar texture in
+                                SkySeaTexture; otherwise the bar at the top of
+                                the menu renders whatever junk was in that
+                                texture region.
+           AffScene(NO_FLIP) -- render the live scene to Screen so the menu's
+                                ShadeBoxBlk has the player-visible background
+                                to darken.  Mirrors the inventory pre-pass.
+
+       All gated on capture-armed; non-harness callers see no behaviour
+       change. */
     if (s_menu_capture_path[0]) {
+        StopSpeak();
+        InitDial(0);
+        InitPlasmaMenu();
         AffScene(AFF_ALL_NO_FLIP);
     }
 

--- a/SOURCES/GAMEMENU.H
+++ b/SOURCES/GAMEMENU.H
@@ -47,6 +47,13 @@ extern void DrawGameMenu(U16 *ptrmenu, S32 justone);
 extern S32 DoGameMenu(U16 *ptrmenu);
 /*--------------------------------------------------------------------------*/
 extern S32 OptionsMenu(S32 flagflip);
+/* Harness hook: arm a one-shot screenshot inside the next DoGameMenu call.
+   After a countdown of iterations (long enough for the menu to fade in and
+   settle), SavePNG is called with the supplied path and DoGameMenu returns
+   1000 (the "ESC" sentinel) so the wrapping menu loop exits cleanly.
+   Pass NULL or "" to disarm.  Used by the console "ui menu-options <path>"
+   verb. */
+extern void Menu_RequestCapture(const char *path);
 /*--------------------------------------------------------------------------*/
 extern void VolumeOptions(void);
 /*--------------------------------------------------------------------------*/

--- a/SOURCES/GAMEMENU.H
+++ b/SOURCES/GAMEMENU.H
@@ -54,6 +54,14 @@ extern S32 OptionsMenu(S32 flagflip);
    Pass NULL or "" to disarm.  Used by the console "ui menu-options <path>"
    verb. */
 extern void Menu_RequestCapture(const char *path);
+/* Harness hook: capture the boot-time main game menu (Resume / New Game /
+   Load / Options / Quit -- the screen the player sees at launch).  Does
+   the minimal MainGameMenu setup (loads the PCR_MENU background bitmap,
+   InitPlasmaMenu, BuildGameMainMenu, InitDial(0)), arms Menu_RequestCapture,
+   then drives DoGameMenu(GameMainMenu) which captures and returns 1000.
+   Skips the surrounding MainGameMenu while-loop, fade transitions, and any
+   case-driven cinematic playback so the verb is non-blocking. */
+extern void Menu_MainCapture(const char *path);
 /*--------------------------------------------------------------------------*/
 extern void VolumeOptions(void);
 /*--------------------------------------------------------------------------*/

--- a/SOURCES/HOLOGLOB.CPP
+++ b/SOURCES/HOLOGLOB.CPP
@@ -1174,6 +1174,15 @@ void HoloMap() {
        body draws kick in.  Gated on capture-armed so normal callers (player
        pressing the holomap key after gameplay) see no behaviour change. */
     if (s_holo_capture_path[0]) {
+        /* Match the normal in-game caller's pre-HoloMap setup
+           (PERSO.CPP:1405-1414): StopSpeak terminates any active speech
+           and InitWaitNoInput/NoKey clear pending input state so the
+           holomap's input handler doesn't see leftover state from before
+           the harness call.  Under null sound StopSpeak is a no-op; added
+           for symmetry with the menu-options sweep finding. */
+        StopSpeak();
+        InitWaitNoInput(I_HOLOMAP | I_MENUS | I_RETURN | I_ACTION);
+        InitWaitNoKey();
         PtrMap = ObjPtrMap = BufferTexture;
         RepMask = 0xFFFF;
     }

--- a/SOURCES/INVENT.CPP
+++ b/SOURCES/INVENT.CPP
@@ -1404,6 +1404,26 @@ void MenuInventory(U32 tempo) {
 extern S32 Dial_Y0;
 
 /*──────────────────────────────────────────────────────────────────────────*/
+/* Harness capture state — see DoFoundObj_RequestCapture() in INVENT.H.  When
+   the path is non-empty, DoFoundObj's modal loop counts down per iteration;
+   on reaching zero it SavePNGs and sets flag=2 so the loop exits cleanly
+   without waiting for input.  Countdown gives the open-rotation animation
+   and the typewriter text time to settle into the steady "item showcase"
+   state a player sees mid-cinematic. */
+static char s_found_capture_path[ADELINE_MAX_PATH] = "";
+static int s_found_capture_countdown = 0;
+
+void DoFoundObj_RequestCapture(const char *path) {
+    if (!path || !path[0]) {
+        s_found_capture_path[0] = '\0';
+        s_found_capture_countdown = 0;
+        return;
+    }
+    strncpy(s_found_capture_path, path, ADELINE_MAX_PATH - 1);
+    s_found_capture_path[ADELINE_MAX_PATH - 1] = '\0';
+    s_found_capture_countdown = 60; /* iterations -- ~1 game-second at dt 16 */
+}
+
 void DoFoundObj(S32 numvar) {
 #ifndef COMPILATOR
     if (Control_IsVerbose())
@@ -1703,6 +1723,18 @@ void DoFoundObj(S32 numvar) {
         UnsetClip();
 
         BoxUpdate();
+
+        /* Harness one-shot capture: count down per iteration; on reaching
+           zero SavePNG (read Log -- the cinematic composites the rotating
+           item and dialogue strip there, same pattern as ui dialog and ui
+           holomap) and set flag=2 so the modal loop exits cleanly. */
+        if (s_found_capture_path[0] && --s_found_capture_countdown <= 0) {
+            SavePNG(s_found_capture_path, Log, (S32)ModeDesiredX,
+                    (S32)ModeDesiredY, PtrPal);
+            s_found_capture_path[0] = '\0';
+            flag = 2;
+            break;
+        }
 
         MyGetInput();
 

--- a/SOURCES/INVENT.CPP
+++ b/SOURCES/INVENT.CPP
@@ -1110,6 +1110,13 @@ void MenuInventory(U32 tempo) {
        Both are conditional on the capture being armed; normal callers see no
        behaviour change. */
     if (s_inv_capture_path[0]) {
+        /* Match the normal in-game caller's pre-MenuInventory setup
+           (PERSO.CPP:1045-1048): StopSpeak terminates any active speech
+           so its overlay doesn't bleed.  Under null sound this is a no-op;
+           added for symmetry with the menu-options sweep finding so the
+           verb's frame matches what a player pressing inventory mid-game
+           sees regardless of pre-load state. */
+        StopSpeak();
         PtrMap = ObjPtrMap = BufferTexture;
         RepMask = 0xFFFF;
         AffScene(AFF_ALL_NO_FLIP);

--- a/SOURCES/INVENT.H
+++ b/SOURCES/INVENT.H
@@ -82,6 +82,14 @@ extern void MenuInventory(U32 tempo);
 extern void Inv_RequestCapture(const char *path);
 /*--------------------------------------------------------------------------*/
 extern void DoFoundObj(S32 numobj);
+/* Harness hook: arm a one-shot screenshot inside the next DoFoundObj call.
+   The found-object cinematic shows a 3D rotation of the discovered item
+   alongside a typewriter-text dialogue.  After a countdown of iterations
+   (long enough for the rotation to settle into a steady frame and the text
+   to draw), SavePNG is called with the supplied path and flag=2 is set so
+   the modal loop exits cleanly without waiting for input.  Pass NULL or ""
+   to disarm.  Used by the console "ui found-object <numvar> <path>" verb. */
+extern void DoFoundObj_RequestCapture(const char *path);
 /*--------------------------------------------------------------------------*/
 extern void DrawArdoiseArrows(void);
 /*--------------------------------------------------------------------------*/

--- a/SOURCES/MESSAGE.CPP
+++ b/SOURCES/MESSAGE.CPP
@@ -1900,6 +1900,16 @@ void Dial(S32 text, S32 drawscene) {
                 (int)text, (int)DemoSlide);
 #endif
 
+    /* Harness capture pre-arm.  Match the normal LM_MESSAGE caller
+       (GERELIFE.CPP:1246-1257): NumObjDial set explicitly (otherwise the
+       speaker's portrait/bubble follows whatever NumObjDial happened to be
+       at save-load time), and Palette(PtrPal) restores the palette in case
+       the save's state had an eclair-effect palette active. */
+    if (s_dial_capture_path[0]) {
+        NumObjDial = NUM_PERSO;
+        Palette(PtrPal);
+    }
+
 #ifndef LBA_EDITOR
     ClearIncrusts(INCRUST_SYS_TEXT);
     ClearIncrusts(INCRUST_TEXT);


### PR DESCRIPTION
Stacks on #184 (ui dialog). Switch base to \`main\` once that lands.

## What it adds

```
ui menu-options <path>
```

Opens the in-game options/pause menu (`OptionsMenu(FALSE)`), captures the rendered menu to `<path>`, then exits cleanly via the menu's own ESC handling. Composable:

```
lba2cc --load <save> --exec "ui menu-options /tmp/menu.png" --fixed-dt 16 --tick 120 --exit
```

56 lines across 3 files (`GAMEMENU.{H,CPP}`, `CONSOLE_CMD.CPP`).

## Same pattern as #182/#183/#184

- **`Menu_RequestCapture(path)`** setter, static state next to `DoGameMenu`.
- Capture hook in `DoGameMenu`'s modal loop, gated on countdown reaching zero.
- Returns 1000 (the ESC sentinel) from `DoGameMenu` so the wrapping `OptionsMenu`'s `case 1000` exits cleanly.
- `cmd_ui` dispatcher gets a fourth subcommand branch.

## Same `Log`-vs-`Screen` lesson (third time)

Capture reads `Log`, not `Screen`. `DrawGameMenu` composites the menu into `Log` and its inner `BoxUpdate` only flushes dirty regions to `Screen`; without a prior frame populating `Screen`, the unflushed regions stay black. Holomap (#183), dialog (#184), and now this menu — three of four surfaces need `Log`. **Worth promoting `Log` to the default capture buffer** when this family's documentation pass happens; inventory is the outlier.

## Verified

| Save | Captured menu state | PNG size |
|---|---|---|
| Anon1 | French menu + lingering dialogue text in Log | 23 KB |
| School of Magic | French menu | 22 KB |
| Dark Monk | French menu only | 20 KB |

All show "Choix de la langue", "Options avancées", "Contrôles" plus the fire-bar decoration. Three runs of Dark Monk → byte-identical sha256.

Per-save content varies (Anon1's Log holds a lingering dialogue strip from the save's scene context; Dark Monk's doesn't) — deterministic per save, which is what the regression net wants.

## Guards

- Savegame baseline corpus: `39 ok, 0 drift, 0 flaky`.
- `ui inventory`, `ui holomap`, `ui dialog` regression captures all unchanged.

## State of the family

Four surfaces now: inventory, holomap, dialog, menu-options. One remaining (`ui found-object`). Plus the deferred `test_ui_*.sh` golden fixtures.