### PR TITLE
docs(widescreen): inventory SCREEN.HQR art and map its callsites

### DIFF
--- a/docs/widescreen/art-catalog.md
+++ b/docs/widescreen/art-catalog.md
@@ -1,0 +1,117 @@
+# Widescreen art catalog — `SCREEN.HQR`
+
+Inventory of every full-screen bitmap shipped in retail `SCREEN.HQR`. This is
+research output for the [widescreen plan](../WIDESCREEN.md) — concretely, the
+"what art do we have to deal with?" deliverable. It does **not** propose any
+re-authoring; copyrighted bitmaps stay where they are.
+
+## How to reproduce
+
+```bash
+scripts/dev/art_catalog_screen.py /path/to/retail/data/SCREEN.HQR \
+    docs/widescreen/catalog-dumps/
+```
+
+The `catalog-dumps/` directory has a `.gitignore` that excludes everything
+except itself, so the rendered PNGs stay local-only. Don't `git add` anything
+under it.
+
+## File layout
+
+`SCREEN.HQR` carries **39 pairs** — 78 entries total. Each pair is a 640×480
+indexed 8-bit bitmap (entry `2k`) followed by its 256×3 RGB palette (entry
+`2k+1`). Several call sites bake the `* 2` index conversion in by hand
+(`numpcx *= 2 ; // car il y a les palettes intercalées` —
+[GAMEMENU.CPP:4597](../../SOURCES/GAMEMENU.CPP)); others pass the raw entry
+index. The script normalises 6-bit palette values (DOS-VGA legacy) so PNGs
+look the same as on-screen.
+
+Sixteen entries have named `PCR_*` defines in
+[SOURCES/COMMON.H:163-179](../../SOURCES/COMMON.H); the rest are addressed
+positionally from script bytecode (`GERELIFE.CPP:2137` reads `num` from
+`*PtrPrg++`) or from the dynamic `ListArdoise[]` slate inventory
+([INVENT.CPP:530-532](../../SOURCES/INVENT.CPP)).
+
+## Inventory
+
+Dimensions are uniform — every bitmap is 640×480, every palette is 768 bytes.
+"Use" is "what game code path is known to surface this entry" — orphan entries
+appear in retail data but no live code path references them.
+
+| # | PCR define | Tag | What it depicts | Use |
+|---|---|---|---|---|
+| 0  | `PCR_LOGO`       | logo       | Adeline logo splash                                      | Boot splash ([GAMEMENU.CPP:4318](../../SOURCES/GAMEMENU.CPP)) |
+| 2  | `PCR_BUMPER`     | bumper     | "LBA2" bumper card                                       | Boot splash ([GAMEMENU.CPP:4463, 4551, 4581](../../SOURCES/GAMEMENU.CPP)) |
+| 4  | `PCR_MENU`       | menu       | Cloudy-sky main-menu background                          | Main menu + save thumbnails ([GAMEMENU.CPP:2375, 2486, 3444, 4133](../../SOURCES/GAMEMENU.CPP)) |
+| 6  | `PCR_ARDOISE`    | ardoise    | Slate (wooden-framed chalkboard, grid)                   | Slate dialog backdrop ([INVENT.CPP:2147](../../SOURCES/INVENT.CPP)) |
+| 8  | `PCR_PEGOUT`     | pegout     | Sewer map — paper-on-wood ("Petit Égouts")               | Orphan in current code; loadable by script |
+| 10 | `PCR_AEGOUT`     | aegout     | Sewer map — black slate grid ("Agrandi Égouts")          | Slate inventory ([INVENT.CPP:2120-2159](../../SOURCES/INVENT.CPP) via `ListArdoise`) |
+| 12 | `PCR_PLABYRT`    | plabyrt    | Labyrinth map — paper                                    | Orphan |
+| 14 | `PCR_ALABYRT`    | alabyrt    | Labyrinth map — slate                                    | Slate inventory |
+| 16 | `PCR_PLUNE`      | plune      | Moon map — paper                                         | Orphan |
+| 18 | `PCR_ALUNE`      | alune      | Moon map — slate                                         | Slate inventory |
+| 20 | `PCR_HACIENDA`   | hacienda   | Hacienda cliff-cove view (framed circular)               | Orphan in current code (named, no caller) |
+| 22 | `PCR_VUPHARE`    | vuphare    | Lighthouse establishing shot (framed)                    | Orphan in current code (named, no caller) |
+| 24 | `PCR_VUPHARE2`   | vuphare2   | Lighthouse, porthole-vignette second take                | Orphan |
+| 26 | —                | unnamed    | Planet + comet through space (cinematic still)           | Script-driven cinematic |
+| 28 | —                | unnamed    | Dr Funfrock & lieutenants in lab interior                | Script-driven cinematic |
+| 30 | —                | unnamed    | Picnic with friends + alien hand (cinematic still)       | Script-driven cinematic |
+| 32 | —                | unnamed    | Emerald Moon close-up through porthole vignette          | Script-driven cinematic |
+| 34 | —                | unnamed    | Dark interior with green-glow Sendell orbs               | Script-driven cinematic |
+| 36 | —                | unnamed    | Celestial diagram — planet sliced into labelled sectors  | Script-driven cinematic |
+| 38 | —                | unnamed    | Mona-Lisa pastiche portrait (gallery)                    | Script-driven cinematic |
+| 40 | —                | unnamed    | Volcano world — paper-style top-down                     | Script-driven cinematic |
+| 42 | —                | unnamed    | Volcano world — black slate-grid top-down                | Script-driven cinematic |
+| 44 | —                | unnamed    | Hand turning album page in front of bald guard           | Script-driven cinematic |
+| 46 | —                | unnamed    | Bicorn-hatted bust on classical plinth                   | Script-driven cinematic |
+| 48 | —                | unnamed    | Three soldier-musicians on parade                        | Script-driven cinematic |
+| 50 | —                | unnamed    | Slaves in checkered prison cell (top-down)               | Script-driven cinematic |
+| 52 | —                | unnamed    | Twinsen vs dragon, fire breath                           | Script-driven cinematic |
+| 54 | —                | unnamed    | Temple/forum with red sky and dragon silhouette          | Script-driven cinematic |
+| 56 | —                | unnamed    | Twinsen's spaceship approaching pink-cloud volcano world | Script-driven cinematic |
+| 58 | —                | unnamed    | Coin/marble explosion celebration                        | Script-driven cinematic |
+| 60 | `PCR_CDROM`      | cdrom      | "Insert CD" plate                                        | Disc-check fallback ([MESSAGE.CPP:592](../../SOURCES/MESSAGE.CPP), [PERSO.CPP:2432](../../SOURCES/PERSO.CPP), [CONFIG.CPP:1444](../../SOURCES/CONFIG.CPP)) |
+| 62 | —                | unnamed    | Glowing Sendell-baby figure inside dark orb              | Script-driven cinematic |
+| 64 | —                | unnamed    | Twinsen's house — paper architectural sketch             | Script-driven cinematic |
+| 66 | —                | unnamed    | Twinsen's house — slate-grid blueprint                   | Script-driven cinematic |
+| 68 | —                | unnamed    | Twinsen close-up with medallion, cloudy backdrop         | Script-driven cinematic |
+| 70 | —                | unnamed    | Sendell-form glowing Twinsen, ocean horizon              | Script-driven cinematic |
+| 72 | `PCR_ACTIVISION` | activision | Activision distributor bumper                            | Boot splash, US version ([GAMEMENU.CPP:4443](../../SOURCES/GAMEMENU.CPP)) |
+| 74 | `PCR_EA`         | ea         | EA distributor bumper                                    | Boot splash, EA version ([GAMEMENU.CPP:4447](../../SOURCES/GAMEMENU.CPP)) |
+| 76 | `PCR_VIRGIN`     | virgin     | Virgin distributor bumper                                | Boot splash, Virgin version ([GAMEMENU.CPP:4452](../../SOURCES/GAMEMENU.CPP)) |
+
+## Observations
+
+**Map P/A pairs.** The first ten map bitmaps are paper / slate-grid renderings
+of the same scene. The slate-grid versions get loaded into the in-game slate
+inventory via `ListArdoise[]` ([INVENT.CPP:530-532](../../SOURCES/INVENT.CPP)
+seeds the default 5/7/9 → entries 10/14/18 = AEGOUT/ALABYRT/ALUNE). The paper
+versions are orphans in the current code path — no live caller, though they
+remain reachable from `GERELIFE.CPP`'s cinematic script opcode. Likely
+historical artwork or kept for a cut feature.
+
+**Porthole-vignette frame.** Several cinematic stills (24, 32, possibly 22)
+share the same circular vignette frame, baked into each bitmap rather than
+drawn as a separate overlay. For widescreen this means letterboxing (or
+black-bordering) is the only "correct" treatment — extending the vignette
+would require re-authoring the frame.
+
+**`PCR_HELP`** is referenced at [GAMEMENU.CPP:4020,4031](../../SOURCES/GAMEMENU.CPP)
+but the whole `Help()` function is wrapped in `/* ... */`. The identifier is
+not defined anywhere; the dead block is the only reason it survives in `grep`.
+Safe to ignore for widescreen.
+
+**Demo bumper.** [GAMEMENU.CPP:4437](../../SOURCES/GAMEMENU.CPP) calls
+`ShowLogo(3*2, 5)` under `#ifdef DEMO`, which would load entry 6
+(`PCR_ARDOISE`). Likely a stub the demo build never actually uses, since 6 is
+the slate not a distributor logo. Not relevant for retail/widescreen.
+
+## Widescreen implications (one-line summary)
+
+Every entry is a fixed 640×480 indexed bitmap. There is no path that
+re-renders these dynamically, so any widescreen treatment is one of:
+**(a) letterbox** to 4:3 inside the wider framebuffer, **(b) extend** the
+existing image by stretching / mirroring / colour-extending edges, or
+**(c) ship an HD pack** as a separate (re-authored) `SCREEN.HQR` later. The
+strategy doc (TBD) triages each entry into one of those buckets. Until then,
+the safe default is (a).

--- a/docs/widescreen/callsite-map.md
+++ b/docs/widescreen/callsite-map.md
@@ -1,0 +1,186 @@
+# Widescreen art callsite map
+
+Inverse view of the [art catalog](art-catalog.md): every code path that pulls
+a full-screen bitmap out of `SCREEN.HQR`, grouped by call site, with the
+surrounding draw flow noted. Use this as the surface area to audit when
+changing render resolution.
+
+Companion to the catalog — read it first for the "what" of each entry.
+
+## Loader primitive
+
+```cpp
+// LIB386/SYSTEM/HQRLOAD.CPP:42
+U32 Load_HQR(const char *name, void *ptr, S32 index);
+```
+
+`ptr` is the destination buffer; for bitmap entries it must be ≥ 640×480 =
+307200 bytes, which all the call sites here satisfy (passing `Log`, `Screen`,
+`PalettePcx`, or `BufSpeak`). The entry index addresses a single entry — the
+caller is responsible for also loading the palette at `index + 1`.
+
+For `EffectPcx(numpcx, …)`, `numpcx` is the *pair index* (i.e. raw entry / 2),
+doubled internally:
+
+```cpp
+// SOURCES/GAMEMENU.CPP:4597
+numpcx *= 2 ;   // car il y a les palettes intercalées
+```
+
+## Call sites
+
+### Boot splash chain — `DistribLogo()` / `ShowLogo()` / `BumperFullscreen()`
+
+[GAMEMENU.CPP:4398-4429 ShowLogo()](../../SOURCES/GAMEMENU.CPP) is the shared
+single-bitmap presenter:
+
+```cpp
+Load_HQR(tmpFilePath, Log, numscr);
+Load_HQR(tmpFilePath, PalettePcx, numscr + 1);
+BoxStaticFullflip();          // mark whole 640×480 dirty
+FadeToPal(PalettePcx);        // fade up
+// wait nsec or input
+FadeToBlack(PalettePcx);
+```
+
+Callers and their entries:
+
+| Caller | Entry loaded | Notes |
+|---|---|---|
+| [GAMEMENU.CPP:4437](../../SOURCES/GAMEMENU.CPP) `DistribLogo()` (`#ifdef DEMO`) | `3*2 = 6` (`PCR_ARDOISE`) | Likely a stale demo stub — entry 6 is the slate |
+| [GAMEMENU.CPP:4443](../../SOURCES/GAMEMENU.CPP) `DistribLogo()` | `PCR_ACTIVISION` (72) | US versions |
+| [GAMEMENU.CPP:4447](../../SOURCES/GAMEMENU.CPP) `DistribLogo()` | `PCR_EA` (74) | EA version |
+| [GAMEMENU.CPP:4452](../../SOURCES/GAMEMENU.CPP) `DistribLogo()` | `PCR_VIRGIN` (76) | Virgin versions |
+| [GAMEMENU.CPP:4494, 4581](../../SOURCES/GAMEMENU.CPP) `BumperFullscreen()` | `PCR_BUMPER` (2) | LBA2 bumper card |
+
+[GAMEMENU.CPP:4463 BumperFullscreen()](../../SOURCES/GAMEMENU.CPP) and
+[GAMEMENU.CPP:4551 BumperFullscreenWithPal()](../../SOURCES/GAMEMENU.CPP) each
+load `PCR_BUMPER + PCR_BUMPER+1` directly (not via `ShowLogo`) with the same
+full-flip fade flow.
+
+[GAMEMENU.CPP:4318 DisplayLogo()](../../SOURCES/GAMEMENU.CPP) loads `PCR_LOGO`
+straight into `Log` with its palette into `PalettePcx`, then `BoxStaticFullflip`
++ `FadeToPal`. Same shape, different entry point.
+
+All splash paths assume the 640×480 bitmap fully covers the framebuffer.
+Widescreen needs a centred-blit / letterbox at every one of these.
+
+### Main menu backdrop — `PCR_MENU`
+
+Four sites all load `PCR_MENU` (4) as the cloudy-sky background that the
+menu UI sits on top of:
+
+| Site | Target buffer | Surrounding code |
+|---|---|---|
+| [GAMEMENU.CPP:2375](../../SOURCES/GAMEMENU.CPP) `MainGameMenu()` opening | `Screen` → `CopyScreen(Screen, Log)` | Initial menu paint |
+| [GAMEMENU.CPP:2486](../../SOURCES/GAMEMENU.CPP) | `Log` → `CopyScreen(Log, Screen)` + `BoxStaticAdd(0,0,ModeDesiredX-1,ModeDesiredY-1)` | Repaint between menu transitions |
+| [GAMEMENU.CPP:3444](../../SOURCES/GAMEMENU.CPP) `RestoreGameMenu()` | `Screen` → `BoxStaticFullflip` + `FadeToPal` | Save/load menu backdrop |
+| [GAMEMENU.CPP:4133](../../SOURCES/GAMEMENU.CPP) (`if (!mode)`) | `Screen` → `CopyScreen(Screen, Log)` + `BoxStaticFullflip` | Conditional repaint |
+
+The menu text and option box-static decorations are drawn *over* this. For
+widescreen we either letterbox the bitmap or extend it (the sky is
+horizontally extendable — see strategy doc TBD).
+
+### Slate inventory — `PCR_ARDOISE` + `ListArdoise[]`
+
+The slate is the only path that loads bitmaps into a non-Log/Screen buffer.
+
+[INVENT.CPP:2120](../../SOURCES/INVENT.CPP):
+```cpp
+Load_HQR(tmpFilePath, Screen, ListArdoise[CurrentArdoise] * 2);   // map content
+```
+
+[INVENT.CPP:2147](../../SOURCES/INVENT.CPP):
+```cpp
+Load_HQR(tmpFilePath, Log, PCR_ARDOISE);   // blank slate frame
+CopyScreen(Log, BufSpeak);                 // stash a clean copy
+```
+
+`ListArdoise[]` is a 5-slot inventory of acquired slate indices, seeded with
+`{5, 7, 9}` at [INVENT.CPP:530-532](../../SOURCES/INVENT.CPP) and extended at
+runtime by script opcode [GERELIFE.CPP:2215](../../SOURCES/GERELIFE.CPP). The
+`* 2` conversion means slot value `5` → entry `10` = `PCR_AEGOUT` (sewer
+slate-grid). The seeded set is sewer / labyrinth / moon.
+
+After loading both, [INVENT.CPP:2120-2160](../../SOURCES/INVENT.CPP) composites
+the map content from `Screen` onto the blank slate from `BufSpeak` via
+`CopyBlock(PLAN_X0, PLAN_Y0, PLAN_X1, PLAN_Y1, …)`. The slate frame is fixed
+640×480; the map content is also full-screen but only a sub-rectangle gets
+blitted to the final slate. Widescreen: the slate frame extends well or
+letterboxes well; the map sub-rect is content-aware.
+
+### Script-driven cinematics — `EffectPcx` / `EffectPcxMess`
+
+Generic single-bitmap presenter at
+[GAMEMENU.CPP:4592 EffectPcx()](../../SOURCES/GAMEMENU.CPP):
+
+```cpp
+numpcx *= 2;                                         // pair → raw entry
+BoxReset();
+Load_HQR(SCREEN.HQR, PalettePcx, numpcx + 1);
+switch (effect) {
+case PCX_FADE:    Load_HQR(SCREEN.HQR, Log, numpcx); BoxStaticFullflip();
+                   FadeToPal(PalettePcx); break;
+case PCX_V_SHADE: Load_HQR(SCREEN.HQR, screen, numpcx);
+                   PaletteSync(PalettePcx);
+                   // venetian-blind row dissolve into Log
+                   for (y = 0..479) { CopyBlock(...); BoxStaticAdd(...);
+                                      WaitVideoSync(); BoxUpdate(); } break;
+}
+```
+
+Callers:
+
+- [GAMEMENU.CPP:4020, 4031](../../SOURCES/GAMEMENU.CPP) — inside a `/* */`-
+  commented-out `Help()`. Dead code; references undefined `PCR_HELP`.
+- [GERELIFE.CPP:2137, 2147](../../SOURCES/GERELIFE.CPP) — script opcode reads
+  `num` and `effect` from `*PtrPrg++` bytecode, then calls `EffectPcx` or
+  `EffectPcxMess`. Every unnamed cinematic still (entries 26-58, 62-70) lands
+  through this one path.
+- [GAMEMENU.CPP:4662](../../SOURCES/GAMEMENU.CPP) `EffectPcxMess()` wrapper
+  for cinematic stills with an overlaid text message.
+
+Implication: there is exactly one bottleneck (`EffectPcx`) that draws every
+script-driven cinematic still. Centre-blit / letterbox here would cover the
+whole "Twinsen's adventure cutscenes" surface in one place.
+
+### Disc-check fallback — `PCR_CDROM`
+
+Loaded into `Log` from three sites:
+
+- [MESSAGE.CPP:592](../../SOURCES/MESSAGE.CPP) — followed by `BoxUpdate()` +
+  `FadeToPal(PtrPalNormal)`.
+- [CONFIG.CPP:1444](../../SOURCES/CONFIG.CPP) — followed by
+  `BoxStaticFullflip()`.
+- [PERSO.CPP:2432](../../SOURCES/PERSO.CPP) — followed by `BoxStaticFullflip()`,
+  inside a Windows CD-scan delay path.
+
+Identical "load and full-flip" shape. Widescreen-safe with a centred blit.
+
+## Coverage gaps in this map
+
+- `GERELIFE.CPP` script opcode 2137/2147 covers most cinematic stills, but the
+  exact entry an opcode loads depends on per-scene bytecode. We don't have a
+  static map of "which scene's life-script calls EffectPcx with which num."
+  Building that would mean parsing `LIFE.HQR` bytecode — TBD.
+- Found-object cinematic (the rotating 3D item) is a different render path
+  (3D, not bitmap-from-`SCREEN.HQR`) and is not in scope here.
+- Holomap, dialog box, found-object are bitmap-composite UI but draw from
+  `RESS.HQR` / `SPRITE.HQR`, not `SCREEN.HQR`. Out of scope for this map.
+
+## Summary surface area
+
+To convert every `SCREEN.HQR` presentation to widescreen-safe, the patch sites
+are:
+
+1. `ShowLogo()` (one)
+2. `DisplayLogo()` (one)
+3. `BumperFullscreen()` / `BumperFullscreenWithPal()` (two)
+4. Four `PCR_MENU` loaders in `GAMEMENU.CPP`
+5. Slate composite in `INVENT.CPP` (two `Load_HQR` calls feeding a `CopyBlock`)
+6. `EffectPcx()` — single point covering all script cinematic stills
+7. Three `PCR_CDROM` loaders
+
+Eight distinct functions, ~twelve call sites. Centralising the centre-blit /
+letterbox into one helper (e.g. `BlitFullscreenBitmap(buf, ptr)`) would touch
+all of them.

--- a/docs/widescreen/catalog-dumps/.gitignore
+++ b/docs/widescreen/catalog-dumps/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/scripts/dev/art_catalog_screen.py
+++ b/scripts/dev/art_catalog_screen.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Extract every full-screen bitmap from SCREEN.HQR as a PNG using its paired palette.
+
+SCREEN.HQR carries 39 pairs: even slots are 640x480 indexed bitmaps (307200 bytes),
+the following odd slot is the 256x3 RGB palette (768 bytes).  Only a few have names
+in COMMON.H (PCR_LOGO/BUMPER/MENU/ARDOISE/...); the rest are unnamed but loaded by
+literal index from various game code paths.
+
+This script is the inventory step of the widescreen art-catalog: it dumps every
+bitmap to a PNG under docs/widescreen/catalog-dumps/ for visual review.  Output is
+local-only (the directory's .gitignore covers it) since the bitmaps are copyrighted.
+
+Usage:
+  scripts/dev/art_catalog_screen.py <SCREEN.HQR> <OUTDIR>
+"""
+import argparse, os, sys
+
+# Reuse decompression from the existing hqr_inspect.py.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _HERE)
+from hqr_inspect import entries, decompress_entry  # noqa: E402
+
+from PIL import Image
+
+# Known names from SOURCES/COMMON.H.  Index -> short tag used in filenames.
+PCR_NAMES = {
+    0:  "logo",        # PCR_LOGO       — Adeline logo
+    2:  "bumper",      # PCR_BUMPER
+    4:  "menu",        # PCR_MENU       — main-menu sky bg (the one in your reference screenshot)
+    6:  "ardoise",     # PCR_ARDOISE    — slate (the in-game slate item Twinsen reads)
+    8:  "pegout",      # PCR_PEGOUT     — Petit map "Egout" (sewer small)
+    10: "aegout",      # PCR_AEGOUT     — Agrandi map "Egout" (sewer enlarged)
+    12: "plabyrt",     # PCR_PLABYRT    — Petit map labyrinth
+    14: "alabyrt",     # PCR_ALABYRT    — Agrandi map labyrinth
+    16: "plune",       # PCR_PLUNE      — Petit map moon (Emerald Moon)
+    18: "alune",       # PCR_ALUNE      — Agrandi map moon
+    20: "hacienda",    # PCR_HACIENDA
+    22: "vuphare",     # PCR_VUPHARE    — "Vue Phare" (lighthouse view, framed)
+    24: "vuphare2",    # PCR_VUPHARE2   — lighthouse view, second frame (porthole vignette)
+    60: "cdrom",       # PCR_CDROM      — CD-ROM splash
+    72: "activision",  # PCR_ACTIVISION — distributor splash
+    74: "ea",          # PCR_EA
+    76: "virgin",      # PCR_VIRGIN
+}
+
+W, H = 640, 480
+
+def render(bitmap, palette, out_path):
+    """Write a single 640x480 PNG from indexed pixels + RGB palette."""
+    assert len(bitmap) == W * H, f"bitmap is {len(bitmap)} bytes, expected {W*H}"
+    assert len(palette) == 256 * 3, f"palette is {len(palette)} bytes, expected 768"
+    img = Image.frombytes("P", (W, H), bitmap)
+    img.putpalette(palette)
+    img.convert("RGB").save(out_path)
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("hqr")
+    ap.add_argument("outdir")
+    args = ap.parse_args()
+
+    os.makedirs(args.outdir, exist_ok=True)
+
+    ents, raw = entries(args.hqr)
+
+    pairs = []
+    for i, off, size, csize, method in ents:
+        if size is None or i % 2 == 1:
+            continue
+        # Expect entry i to be a 640x480 bitmap and entry i+1 its palette.
+        if i + 1 >= len(ents):
+            continue
+        _, poff, psize, pcsize, pmethod = ents[i + 1]
+        if psize is None:
+            print(f"  [{i:>2}] missing palette pair; skipping", file=sys.stderr)
+            continue
+        if size != W * H:
+            print(f"  [{i:>2}] unexpected bitmap size {size}; skipping", file=sys.stderr)
+            continue
+        if psize != 768:
+            print(f"  [{i:>2}] unexpected palette size {psize}; skipping", file=sys.stderr)
+            continue
+        bitmap = decompress_entry(raw, off, size, csize, method)
+        palette = decompress_entry(raw, poff, psize, pcsize, pmethod)
+        # LBA2 palettes are stored as 6-bit values in the original DOS engine; the SDL
+        # port left them as-is and shifts at SetVideoPalette time.  Normalise here so
+        # PNGs look the same as in-engine.
+        palette = bytes(min(c << 2 | c >> 4, 255) for c in palette) \
+                  if max(palette) <= 0x3F else bytes(palette)
+        name = PCR_NAMES.get(i, "unnamed")
+        out = os.path.join(args.outdir, f"screen_{i:03d}_{name}.png")
+        render(bitmap, palette, out)
+        pairs.append((i, name, out))
+
+    print(f"extracted {len(pairs)} bitmaps to {args.outdir}/")
+    for i, name, p in pairs:
+        print(f"  [{i:>2}] {name:<12} -> {os.path.basename(p)}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Research output for the [widescreen plan](https://github.com/LBALab/lba2-classic-community/blob/main/docs/WIDESCREEN.md): "what art do we have to deal with, and where does it land on screen?" No engine changes.

## What's here

- **`scripts/dev/art_catalog_screen.py`** — extracts every 640×480 indexed bitmap in retail `SCREEN.HQR` to a PNG, paired with its 6-bit-normalised palette. All 39 pairs (78 entries) covered.
- **`docs/widescreen/art-catalog.md`** — tables every entry with what it depicts, whether it has a named `PCR_*` define, and which game code path surfaces it.
- **`docs/widescreen/callsite-map.md`** — inverse view: each `Load_HQR` / `EffectPcx` site grouped by render flow, listing every `PCR_MENU` / `PCR_CDROM` / bumper / slate / cinematic still loader.
- **`docs/widescreen/catalog-dumps/.gitignore`** — keeps the extracted PNGs local-only. Adeline retains copyright; we want the inventory output reproducible from the retail data, not redistributed.

## What we learned

- Of the 39 pairs, **16 have `PCR_*` names** in `COMMON.H`. The other 23 are addressed positionally from `GERELIFE` cinematic script bytecode.
- The first five map slots are **paper / slate-grid pairs** (Petit/Agrandi): sewer, labyrinth, moon, volcano world, Twinsen's house. Only the slate-grid versions are reachable from the current code; the paper versions are orphans.
- The **porthole vignette** is baked into several cinematic stills (lighthouse, Emerald Moon), not a runtime overlay. Letterbox is the only "correct" treatment for those.
- `PCR_HELP` survives only because a commented-out `Help()` function references it; the identifier is otherwise undefined.
- Total widescreen surface area for `SCREEN.HQR` presentation is **eight functions, ~twelve call sites**. `EffectPcx()` alone covers every script-driven cinematic still.

## What's next (separate PRs)

- Treatment strategy (letterbox / extend / HD-pack) per entry — `docs/widescreen/art-strategy.md`
- The engine plumbing (centre-blit helper) that consumes this map
- The `RESS.HQR` / `SPRITE.HQR` companion catalogs (UI bitmaps, sprites)