### PR TITLE
docs(widescreen): companion catalogs for RESS.HQR, sprites, and HQR overview

### DIFF
--- a/docs/widescreen/hqr-overview.md
+++ b/docs/widescreen/hqr-overview.md
@@ -1,0 +1,54 @@
+# Widescreen HQR overview
+
+Retail data is sixteen `.HQR` archives. This doc triages each one by
+widescreen relevance, so the asset-side work is bounded before we start on
+treatment. Read [art-catalog.md](art-catalog.md) for `SCREEN.HQR` (done) and
+[ress-catalog.md](ress-catalog.md) / [sprite-hud-sites.md](sprite-hud-sites.md)
+for the next two in-scope archives.
+
+Companion to the SCREEN.HQR catalog; same evidence-first style.
+
+## Archive table
+
+Names from [SOURCES/COMMON.H:66-81](../../SOURCES/COMMON.H). "Scope" is "does
+the rendered output land at fixed pixel coordinates on a 4:3-assumed framebuffer."
+
+| HQR | Slots | Content | Scope | Notes |
+|---|---|---|---|---|
+| `screen.hqr`  | 78 (39 pairs)   | Full-screen indexed bitmaps + palettes        | **Yes**       | See [art-catalog.md](art-catalog.md). Catalogued. |
+| `ress.hqr`    | 50 (40 present) | Mixed engine assets — fonts, palettes, sky/sea + 3D textures, manifests | **Partial** | See [ress-catalog.md](ress-catalog.md). Only the font hits fixed UI coords; other entries are textures (game-space) or data tables. |
+| `sprites.hqr` | 426             | Variable-size sprites, on-demand-loaded       | **Partial**   | Most are game-world (auto-scaled by projection). HUD-fixed call sites enumerated in [sprite-hud-sites.md](sprite-hud-sites.md). |
+| `spriraw.hqr` | 168             | Raw (uncompressed) sprite variants            | **Partial**   | Same shape as sprites.hqr; same triage. |
+| `scrshot.hqr` | (varies)        | 640×480 + palette pairs — attract-mode slideshow | **Yes**     | Same shape and treatment as `screen.hqr`. Loaded by [GAMEMENU.CPP:4163 `SlideShow()`](../../SOURCES/GAMEMENU.CPP). |
+| `holomap.hqr` | 47 (41 present) | Holomap globe textures + 3D arrow/vehicle models + per-planet height/grid maps | **Render-path** | Globe is 3D; only overlaid UI text/arrows are 2D. See HOLO.H for indices. Out of asset scope, in render-pipeline scope. |
+| `lba_bkg.hqr` | 18102           | Isometric tile backgrounds for indoor scenes  | **Render-path** | Drawn into viewport, not fixed coords. Phase 5 of widescreen plan covers this — see [docs/WIDESCREEN.md](../WIDESCREEN.md). |
+| `lba2.hqr`    | (varies)        | Credits text/data                             | No (text-only) | `CREDITS_HQR_NAME` despite the generic name. |
+| `video.hqr`   | (varies)        | Smacker video bitstreams (cutscenes)          | **Render-path** | Videos render into a viewport; scaling concern not asset concern. |
+| `samples.hqr` | (varies)        | PCM audio samples                             | No | |
+| `anim.hqr`    | (varies)        | Animation keyframe data                       | No (game-space) | |
+| `anim3ds.hqr` | (varies)        | 3DS-style animation tracks                    | No (game-space) | |
+| `body.hqr`    | (varies)        | 3D character/object meshes                    | No (game-space) | |
+| `objfix.hqr`  | (varies)        | Static prop meshes                            | No (game-space) | |
+| `scene.hqr`   | (varies)        | Scene layouts, entity placements, life/track scripts | No | |
+| `text.hqr`    | (varies)        | Localised dialog strings                      | No | |
+
+## Scope summary
+
+**Asset catalog needed:** `screen.hqr` (done), `scrshot.hqr` (same shape as
+screen.hqr — same treatment), `ress.hqr` (mostly engine data, font is the
+relevant asset), `sprites.hqr` + `spriraw.hqr` (only a handful of HUD-fixed
+sites).
+
+**Render-path needed but not asset work:** `holomap.hqr`, `lba_bkg.hqr`,
+`video.hqr`. The bitmap content is in the right shape (tiles, viewport-bound
+videos, 3D models); what needs work is the engine code that draws them.
+Covered by the engine-side phases of [WIDESCREEN.md](../WIDESCREEN.md).
+
+**Out of scope entirely:** `lba2.hqr`, `samples.hqr`, `anim.hqr`,
+`anim3ds.hqr`, `body.hqr`, `objfix.hqr`, `scene.hqr`, `text.hqr`. No pixels,
+or pixels are game-space.
+
+That leaves the **two** companion catalogs called for here: RESS (data-heavy,
+small actual UI surface) and SPRITE HUD sites (precise enumeration of where
+sprites land at fixed coords). `scrshot.hqr` doesn't get its own catalog
+because the SCREEN.HQR analysis applies verbatim.

--- a/docs/widescreen/ress-catalog.md
+++ b/docs/widescreen/ress-catalog.md
@@ -1,0 +1,106 @@
+# RESS.HQR catalog
+
+Companion to [art-catalog.md](art-catalog.md). Where SCREEN.HQR is "39 pairs
+of full-screen bitmaps", RESS.HQR is the engine's mixed-asset bag — palettes,
+textures, manifests, and a font. Most entries are **not** UI bitmaps that hit
+fixed pixel coordinates, so the widescreen surface is much smaller than the
+slot count suggests.
+
+## File layout
+
+50 slots, 40 present (10 reserved holes; see [SOURCES/COMMON.H:109-159](../../SOURCES/COMMON.H)
+for the comment-marked gaps). Every entry has a named `RESS_*` define in
+`COMMON.H`. Entries are addressed by index from C code only; no script
+bytecode reaches in here.
+
+## Inventory
+
+`#` = entry index. **Category** column: `palette` (LUT-only), `tex-3d`
+(game-space 3D texture, no fixed-pixel concern), `tex-bg` (sky/sea wraparound
+tile), `font` (glyph atlas, drawn at game-chosen coords), `manifest`
+(bbox/index lookup table, not pixel content), `mesh-3d` (3D model),
+`data` (other engine table).
+
+| #  | Define | Category | What it is | Consumer |
+|---|---|---|---|---|
+| 0  | `RESS_PAL`            | palette   | Normal game palette                          | [AMBIANCE.CPP:425](../../SOURCES/AMBIANCE.CPP) → `PtrPalNormal` |
+| 1  | `RESS_FONT_GPM`       | font      | Font glyph mask atlas (variable-width)       | [PERSO.CPP:2474](../../SOURCES/PERSO.CPP) → `LbaFont` + `SetFont(LbaFont, 2, 8)` |
+| 2  | `RESS_EXT_SIZE_INFO`  | data      | 16-byte sizing table for HQ buffer allocations | [MEM.CPP:88](../../SOURCES/MEM.CPP) |
+| 3  | —                     | —         | (hole)                                       | — |
+| 4  | —                     | —         | (hole — was `RESS_INIT_PLASMA`)              | — |
+| 5  | `RESS_GOODIES_GPC`    | manifest  | Bbox manifest for sprites in `sprites.hqr`   | [PERSO.CPP:2537](../../SOURCES/PERSO.CPP) → `PtrZvExtra[N*8 + {x,y,…}]` |
+| 6  | `RESS_TEXTURES`       | tex-3d    | 256×256 indexed texture page for 3D objects  | [PERSO.CPP:2529](../../SOURCES/PERSO.CPP) → `BufferTexture` |
+| 7  | `RESS_GAME_OVER`      | mesh-3d   | 3D model rendered with `SetProjection(320,240,…)` zoom | [GAMEMENU.CPP:3924](../../SOURCES/GAMEMENU.CPP) |
+| 8  | `RESS_GOODRAW_GPC`    | manifest  | Bbox manifest for sprites in `spriraw.hqr`   | [PERSO.CPP:2542](../../SOURCES/PERSO.CPP) → `PtrZvExtraRaw` |
+| 9  | `RESS_PAL_BLACK`      | palette   | All-black palette (fade target)              | [AMBIANCE.CPP:433](../../SOURCES/AMBIANCE.CPP) → `PtrPalBlack` |
+| 10 | `RESS_PAL_ECLAIR`     | palette   | Lightning-flash palette                      | [AMBIANCE.CPP:429](../../SOURCES/AMBIANCE.CPP) → `PtrPalEclair` |
+| 11 | `RESS_SKYSEA0`        | tex-bg    | Citadel sky/sea 256×256 wraparound tile       | [EXTFUNC.CPP:152-174](../../SOURCES/EXTFUNC.CPP) → `SkySeaTexture` |
+| 12 | `RESS_SKYSEA1`        | tex-bg    | Puits de Sendell sky/sea                     | same path, `Island`-indexed |
+| 13 | `RESS_SKYSEA2`        | tex-bg    | Desert sky/sea                                | " |
+| 14 | `RESS_SKYSEA3`        | tex-bg    | Emerald Moon sky/sea                          | " |
+| 15 | `RESS_SKYSEA4`        | tex-bg    | Otringal sky/sea                              | " |
+| 16 | `RESS_SKYSEA5`        | tex-bg    | Celebrat sky/sea                              | " |
+| 17 | `RESS_SKYSEA6`        | tex-bg    | Blafards/Plateforme sky/sea                   | " |
+| 18 | `RESS_SKYSEA7`        | tex-bg    | Mosquibees sky/sea                            | " |
+| 19 | `RESS_SKYSEA8`        | tex-bg    | Knartas sky/sea                               | " |
+| 20 | `RESS_SKYSEA9`        | tex-bg    | Îlot CX sky/sea                               | " |
+| 21 | `RESS_SKYSEA10`       | tex-bg    | Ascenseur sky/sea                             | " |
+| 22-25 | —                 | —         | (holes)                                      | — |
+| 26 | `RESS_SKYSEA00`       | tex-bg    | Citabau sky/sea (special citadel variant)    | [EXTFUNC.CPP:160](../../SOURCES/EXTFUNC.CPP) |
+| 27 | `RESS_XPL0`           | palette   | Citadel XPL pack — palette + fog + transparency | [AMBIANCE.CPP:446-451](../../SOURCES/AMBIANCE.CPP) → `PtrXplPalette` |
+| 28-37 | `RESS_XPL1..10`   | palette   | Per-island XPL packs (same layout as XPL0)   | same path, `Island`-indexed |
+| 38-41 | —                 | —         | (holes)                                      | — |
+| 42 | `RESS_XPL00`          | palette   | Citabau XPL pack                              | [AMBIANCE.CPP:444](../../SOURCES/AMBIANCE.CPP) |
+| 43 | `RESS_ANIM3DS_GPC`    | manifest  | Bbox manifest for 3DS animation sprites      | [PERSO.CPP:2548](../../SOURCES/PERSO.CPP) → `PtrZvAnim3DS` |
+| 44 | `RESS_FILE3D`         | data      | 3D file directory                             | [PERSO.CPP:2519](../../SOURCES/PERSO.CPP) → `BufferFile3D` |
+| 45 | `RESS_FLOW`           | data      | Flow-particle effect descriptions            | [FLOW.CPP:112](../../SOURCES/FLOW.CPP) → `TabPartFlow[]` |
+| 46 | `RESS_POF`            | data      | POF data table (offset-indexed)              | [PERSO.CPP:2588](../../SOURCES/PERSO.CPP), [POF.CPP:14](../../SOURCES/POF.CPP) → `BufferPof` |
+| 47 | `RESS_IMPACT`         | data      | Impact (collision FX) effect table           | [PERSO.CPP:2592](../../SOURCES/PERSO.CPP), [IMPACT.CPP:434](../../SOURCES/IMPACT.CPP) → `BufferImpact` |
+| 48 | `RESS_ACFLIST`        | data      | ACF (Adeline Cinematic Format) playlist      | [PLAYACF.CPP:63](../../SOURCES/PLAYACF.CPP) → `ListAcf` |
+| 49 | —                     | —         | (hole)                                       | — |
+
+## Widescreen relevance, by category
+
+**`font` (1 entry)** — `RESS_FONT_GPM`. Glyphs are drawn at game-chosen XY
+via `Font(x, y, str)` → [LIB386/SYSTEM/SYSFONT.CPP](../../LIB386/SYSTEM/SYSFONT.CPP).
+The font *bitmap* is fine for widescreen; what needs auditing is the
+hardcoded XY positions of text calls (separate effort, not asset-side).
+
+**`tex-bg` (12 entries — `RESS_SKYSEA*`)** — Each is a 256×256 wraparound
+tile rendered by `DrawSkySeaZBuf()` and the sky-fill pipeline. The tile is
+already in the right shape for widescreen; what needs to change is the engine
+math that wraps it across the framebuffer. Render-pipeline scope, not asset
+scope.
+
+**`tex-3d` (1 entry — `RESS_TEXTURES`)** — 256×256 texture page consumed by
+the 3D pipeline. Game-space — projection scales it for free.
+
+**`mesh-3d` (1 entry — `RESS_GAME_OVER`)** — 3D model. Caller hardcodes
+`SetProjection(320, 240, …)` at [GAMEMENU.CPP:3932](../../SOURCES/GAMEMENU.CPP).
+The model is fine; the projection centre needs fixing — already tracked in
+the `[[project_projection_4_3_audit]]` line of the widescreen plan.
+
+**`palette` (15 entries)** — `RESS_PAL`, `RESS_PAL_BLACK`, `RESS_PAL_ECLAIR`,
+and the twelve per-island `RESS_XPL*` packs. LUT-only; no pixel data; no
+widescreen concern.
+
+**`manifest` (3 entries)** — `RESS_GOODIES_GPC`, `RESS_GOODRAW_GPC`,
+`RESS_ANIM3DS_GPC`. Bbox/index lookup tables that point into the sprite
+HQRs. No pixels here, but the offsets they encode are content-dependent —
+see [sprite-hud-sites.md](sprite-hud-sites.md) for where those sprites
+actually land on screen.
+
+**`data` (5 entries)** — `RESS_EXT_SIZE_INFO`, `RESS_FILE3D`, `RESS_FLOW`,
+`RESS_POF`, `RESS_IMPACT`, `RESS_ACFLIST`. Engine tables. No pixels.
+
+## Summary
+
+Of 40 present entries, the asset-side widescreen surface is:
+1. **`RESS_FONT_GPM`** — font as-is, callers need XY audit
+2. **`RESS_GAME_OVER`** — model as-is, projection centre needs fix
+3. **`RESS_SKYSEA*`** — tiles as-is, render pipeline needs wider wrap
+
+Three entries, two of which are render-pipeline work that doesn't touch the
+asset. **There is no `RESS_HQR_NAME` work to do for widescreen on the asset
+side.** This was the deliverable: confirmation that the engine-resources
+archive is not a blocker for widescreen art treatment.

--- a/docs/widescreen/sprite-hud-sites.md
+++ b/docs/widescreen/sprite-hud-sites.md
@@ -1,0 +1,185 @@
+# Sprite HUD callsite map
+
+Companion to [art-catalog.md](art-catalog.md) and [ress-catalog.md](ress-catalog.md).
+SPRITES.HQR (426 entries) and SPRIRAW.HQR (168 entries) hold the engine's
+small bitmaps — items, projectiles, item frames, UI corners. Most are drawn
+in game space (XY derived from 3D projection of a world-space anchor) and
+auto-scale with the viewport; a smaller number land at **hardcoded HUD
+coordinates** and need widescreen attention.
+
+This doc enumerates the hardcoded HUD sites. The game-space majority is
+covered implicitly by Phase 2 (projection correction) of the
+[widescreen plan](../WIDESCREEN.md).
+
+## Loader / blit primitives
+
+```cpp
+// SOURCES/INTEXT.CPP:285
+void PtrAffGraph(S32 xp, S32 yp, S32 sprite);   // looks up sprite in HQRPtrSprite by index
+// LIB386/H/SVGA/MASK.H
+void AffGraph(S32 num, S32 x, S32 y, const void *gph);  // raw blit, num is frame in atlas
+```
+
+Both ultimately call `AffGraph` which blits a mask-format sprite to `Log` at
+the given screen XY, honouring `ScaleFactorSprite` (`DEF_SCALE_FACTOR = 256`
+for HUD; scaled for game-world).
+
+Sprite indices are named in [SOURCES/COMMON.H:409-459](../../SOURCES/COMMON.H):
+`SYS_SPRITE_*` for system/UI sprites (frames, radio portraits) and `SPRITE_*`
+for game-world ones (life heart, magic ball, coins, projectile balls, etc.).
+
+## Hardcoded HUD sites
+
+Coordinates inferred from the call sites and their surrounding code. "Anchor"
+is the screen-space anchor the offsets are computed against — `(0, 0)`
+top-left or a CTRL/PLAN region inside.
+
+### Behaviour-menu HUD ([COMPORTE.CPP:251 `DrawInfoMenu`](../../SOURCES/COMPORTE.CPP))
+
+The "info bar" shown alongside the behaviour wheel (Twinsen's pause menu).
+Caller at [COMPORTE.CPP:368](../../SOURCES/COMPORTE.CPP) passes
+`(CTRL_X0, CTRL_Y1 + 10)` = `(100, 300)`. The bar itself is **450 × 80**,
+hardcoded at lines 89-92:
+
+```cpp
+#define CTRL_X0 100
+#define CTRL_Y0 100
+#define CTRL_X1 550
+#define CTRL_Y1 290
+```
+
+Sprites inside the bar (relative to `(x0, y0) = (100, 300)`):
+
+| Sprite | Offset | Define |
+|---|---|---|
+| Life heart icon         | `(x0+9, y0+13)`   | `SPRITE_COEUR` |
+| Magic ball icon         | `(x0+9, y0+36)`   | `SPRITE_MAGIE` |
+| Coin/Kashes icon        | `(x0+340, y0+15)` | `SPRITE_PIECE` |
+| Little-key icon         | `(x0+340, y0+55)` | `SPRITE_CLE` |
+| Clover (filled)         | `(x1, y0+58)`     | `SPRITE_FULL_CLOVER_BOX` (loop, x1 from `RegleTrois`) |
+| Clover (box)            | `(x1, y0+58)`     | `SPRITE_CLOVER_BOX` |
+
+`CTRL_X1 = 550` means the bar's right edge is **already at 550** — only 90px
+shy of the 4:3 right edge. In a wider framebuffer this needs to slide right
+or stretch.
+
+### Behaviour-wheel options ([COMPORTE.CPP:187](../../SOURCES/COMPORTE.CPP))
+
+```cpp
+x0 = CTRL_X0 + DebComportement + num * 110 - 1;
+y0 = CTRL_Y0 + 10 - 1;
+```
+
+Five behaviour tiles spread horizontally at 110px stride from `CTRL_X0`.
+Stride is hardcoded.
+
+### Dialog speech bubble ([INCRUST.CPP:139-145](../../SOURCES/INCRUST.CPP))
+
+```cpp
+SpriteX = Xp + 10;   // or Xp - 10 - DX_BULLE on the other side
+SpriteY = Yp - 20;
+PtrAffGraph(SpriteX, SpriteY, SpriteBulle);
+```
+
+`Xp`/`Yp` are projected from the speaker's world position. **Game-space
+anchor** — auto-scales with viewport (no widescreen action needed at the
+sprite level; projection handles it).
+
+### Inventory grid ([INVENT.CPP](../../SOURCES/INVENT.CPP))
+
+Multiple sites, all relative to `PLAN_X0/Y0/X1/Y1` (the inventory window
+rect, hardcoded in `DEFINES.H`):
+
+- Frame corners ([INVENT.CPP:2467-2485](../../SOURCES/INVENT.CPP)):
+  `SYS_SPRITE_SG/IG/ID/SD` at `(x0+2, y0+2)`, `(x0+2, y1-27)`,
+  `(x1-27, y1-27)`, `(x1-27, y0+2)`.
+- Found-object icon ([INVENT.CPP:806](../../SOURCES/INVENT.CPP)):
+  `SYS_SPRITE_INV` centred at `(x0 + (x1-x0)/2, y0 + (y1-y0)/2)`.
+- Slate arrows ([INVENT.CPP:1880-1881](../../SOURCES/INVENT.CPP)):
+  `SPRITE_ARDOISE_LEFT_UP+on` / `SPRITE_ARDOISE_RIGHT_UP+on` at `(L_X0, L_Y0)`
+  and `(R_X0, R_Y0)` (slate margin coordinates).
+
+All relative to a hardcoded UI rect. Widescreen needs the rect re-centred (or
+the inventory layout rethought); the sprites follow the rect for free.
+
+### Menu cursor + sprite incrustation ([GAMEMENU.CPP](../../SOURCES/GAMEMENU.CPP))
+
+```cpp
+// 883:
+#define DrawCursor() AffGraph(0, CursorX + 4, CursorY, HQR_Get(HQRPtrSprite, 9));
+
+// 2762-2770:
+SpriteX = 10 + PtrZvExtra[MenuIncrustSprite * 8 + 0];
+SpriteY = 10 + PtrZvExtra[MenuIncrustSprite * 8 + 1];
+// (or PtrZvExtraRaw branch)
+PtrAffGraph(SpriteX, SpriteY, MenuIncrustSprite);
+```
+
+`CursorX`/`Y` move with selection (game-derived). The menu-incrust sprite
+lands at `(10 + zv_offset, 10 + zv_offset)` — a hardcoded top-left
+incrustation slot.
+
+### Mouse cursor ([DIRTYBOX.CPP:452](../../LIB386/SVGA/DIRTYBOX.CPP))
+
+```cpp
+AffGraph(MouseSpriteGraphicNum, sx, sy, MouseSpriteGraphic);
+```
+
+`sx`/`sy` come from `MouseX`/`Y`. Game-space-screen (already scales with
+window); no widescreen action.
+
+### Slideshow logo overlay ([GAMEMENU.CPP:4201](../../SOURCES/GAMEMENU.CPP))
+
+```cpp
+// AffGraph( 0, 639-105, 3, HQR_Get(HQRPtrSprite,11) ) ;
+```
+
+Commented out — the LBA2 logo overlay at `(639-105, 3)` was disabled because
+of a palette conflict. The `639 -` anchor is the kind of pattern that
+widescreen needs to audit if it ever gets re-enabled.
+
+## Out-of-scope (game-space anchors)
+
+Confirmed via grep that these compute `SpriteX/Y` from 3D projection, not
+hardcoded UI:
+
+- [OBJECT.CPP:5011, 5016, 5097-5111, 5169-5181, 5925-5933](../../SOURCES/OBJECT.CPP)
+  — all object/sprite blits via projected `Xp/Yp`. Auto-scales with viewport.
+- [GRILLE.CPP:739, 901](../../SOURCES/GRILLE.CPP) — isometric brick blits at
+  computed `XScreen/YScreen`. Viewport-relative; covered by Phase 5.
+- [MESSAGE.CPP:1415](../../SOURCES/MESSAGE.CPP) — typewriter glyph rendering;
+  XY computed from dialog box rect (which is hardcoded — see below).
+
+## Hardcoded UI rects (sprite-adjacent, not sprite themselves)
+
+These rectangles drive almost every HUD sprite anchor:
+
+| Define | Value (search [SOURCES/DEFINES.H](../../SOURCES/DEFINES.H) / per-CPP) | Function |
+|---|---|---|
+| `CTRL_X0/Y0/X1/Y1`     | 100,100 — 550,290 | Behaviour menu |
+| `PLAN_X0/Y0/X1/Y1`     | (slate panel rect)| Inventory slate composite (see [INVENT.CPP](../../SOURCES/INVENT.CPP)) |
+| `L_X0/Y0`, `R_X0/Y0`   | (slate arrow margins) | Slate left/right arrows |
+
+Widescreen needs these recentred or rescaled (per the projection-correction
+phase). Sprites then follow the rect for free.
+
+## Summary
+
+The sprite-as-HUD surface is roughly:
+
+1. **Behaviour-menu info bar** — hardcoded 450×80 rect at (100, 300), six
+   sprite slots inside.
+2. **Behaviour wheel** — five tiles at 110px stride from `CTRL_X0`.
+3. **Inventory window** — frame corners + arrows, all relative to a fixed
+   `PLAN_*` rect.
+4. **Menu cursor + sprite incrustation** — fixed `(10 + offset)` top-left
+   slot, cursor follows selection.
+5. **Slideshow logo** — currently disabled; would need a widescreen audit if
+   restored.
+
+Everything else (game-world sprite blits, mouse cursor, dialog bubble,
+typewriter glyphs) is anchor-derived and auto-scales with the viewport. The
+"asset" itself never needs rework — what needs work is the **hardcoded
+rectangles** that drive the anchors, which is render-pipeline scope, not
+asset scope. The companion catalog confirms there is no SPRITE.HQR /
+SPRIRAW.HQR asset-side widescreen work either.


### PR DESCRIPTION
Companion to #188. Three more research docs that scope the widescreen art surface **beyond** SCREEN.HQR.

## Net finding

There is little to no asset-side work outside SCREEN.HQR. What remains is render-pipeline scope already covered by [the widescreen plan](https://github.com/LBALab/lba2-classic-community/blob/main/docs/WIDESCREEN.md).

## What's here

- **`docs/widescreen/hqr-overview.md`** — tables all 16 retail HQRs and triages each as in-scope (`screen`, `scrshot`), partial (`ress`, `sprites`, `spriraw`), render-path (`holomap`, `lba_bkg`, `video`), or out (`lba2`, `samples`, `anim*`, `body`, `objfix`, `scene`, `text`). `scrshot.hqr` uses the same 640×480-pair layout as `screen.hqr` — same treatment, no separate catalog needed.
- **`docs/widescreen/ress-catalog.md`** — walks RESS.HQR's 50 slots (40 present) by named index from `COMMON.H`. Categorised: 15 palettes, 12 per-island sky/sea tiles, 3 bbox manifests, 5 data tables, plus one each of font, 3D-object texture page, and game-over 3D model. **Conclusion: zero true fixed-pixel UI bitmaps. The asset side is a no-op for widescreen.**
- **`docs/widescreen/sprite-hud-sites.md`** — enumerates the hardcoded HUD sprite-blit sites: behaviour-menu info bar (`CTRL_X0=100 .. CTRL_X1=550`), behaviour wheel tiles at 110px stride, inventory frame corners + slate arrows (`PLAN_X0/Y0/X1/Y1`), menu cursor, slideshow logo overlay (currently commented out). Game-world sprites (life heart, magic ball, projectile trail, dialog bubble) compute XY from 3D projection and auto-scale.

## What changes for the widescreen plan

After this PR + #188, the widescreen surface narrows to three concrete buckets:

1. **SCREEN.HQR** — letterbox / extend / HD-pack treatment per entry (see #188 callsite map). The next deliverable here is the treatment strategy doc.
2. **Hardcoded UI rects** — `CTRL_*`, `PLAN_*`, `L_X0/Y0`, `R_X0/Y0` need recentring or rescaling. Sprites and corner frames follow for free.
3. **Engine-side phases** already on the plan — projection centre fix (Phase 2), brick wrap (Phase 5), sky tile wrapping.

No engine changes in this PR. Pure research output.

> Depends on #188 conceptually (the docs link to `art-catalog.md`); cross-references resolve once both merge.