### PR TITLE
docs(widescreen): art treatment strategy for SCREEN.HQR

### DIFF
--- a/docs/widescreen/art-strategy.md
+++ b/docs/widescreen/art-strategy.md
@@ -78,7 +78,7 @@ candidates for a future re-author initiative.
 |---|---|---|---|---|
 | 0  | `PCR_LOGO`       | `palette-fill` (white) |   | Pure white background; flat fill is invisible. |
 | 2  | `PCR_BUMPER`     | `edge-clone`           | ✓ | Starfield extends naturally; bumper is a one-shot intro card so HD bumps would be felt. |
-| 4  | `PCR_MENU`       | `edge-clone` (dark)    | ✓ | Stormy sea/sky; left edge clones cleanly, right has a bloom that may seam — verify in cheap test. Prominent (main menu) → HD candidate. |
+| 4  | `PCR_MENU`       | `palette-fill` (dark sky) | ✓ | Stormy sea/sky. **Revised from `edge-clone` after cheap-test review** (see [cheap-test-findings.md](cheap-test-findings.md)): per-row stretching produced visible vertical stripes from the cloud waves. Auto-detected dark blue-grey blends invisibly. Prominent (main menu) → HD candidate. |
 | 6  | `PCR_ARDOISE`    | `palette-fill` (dark wood) |   | The slate frame is the content; surrounding wood is dark and uniform. |
 | 8  | `PCR_PEGOUT`     | `edge-clone` (wood)    |   | Paper-on-wood map; wood grain extends. Orphan in current code — low priority. |
 | 10 | `PCR_AEGOUT`     | `palette-fill` (black) |   | Slate-grid sewer map on black; flat fill matches. |
@@ -104,7 +104,7 @@ candidates for a future re-author initiative.
 | 50 | —                | `letterbox`            |   | Prison cell, top-down composition. |
 | 52 | —                | `letterbox`            |   | Twinsen vs dragon, fire breath. |
 | 54 | —                | `letterbox`            |   | Forum/temple with red sky and dragon silhouette. |
-| 56 | —                | `edge-clone` (stars)   |   | Spaceship + planet on starfield; stars extend naturally. |
+| 56 | —                | `palette-fill` (black) |   | Spaceship + planet on starfield. **Revised from `edge-clone` after cheap-test review** (see [cheap-test-findings.md](cheap-test-findings.md)): asymmetric nebula trail and planet glow near the edges produced banding. Auto-detected black is visually equivalent to `letterbox` here. |
 | 58 | —                | `palette-fill` (black) |   | Coin/marble celebration centred on black. |
 | 60 | `PCR_CDROM`      | `palette-fill` (black) |   | Dancing couple on disc, pure black background. Player sees this often (CD check) — keep it crisp. |
 | 62 | —                | `palette-fill` (black) |   | Sendell-baby orb on black. |
@@ -120,9 +120,9 @@ candidates for a future re-author initiative.
 
 | Treatment | Count | Where it applies |
 |---|---|---|
-| `palette-fill` | 16 | All slate maps (black), splash logos (white/black), centred-on-black cinematic stills. The dominant treatment because LBA leans on flat backgrounds. |
+| `palette-fill` | 18 | All slate maps (black), splash logos (white/black), centred-on-black cinematic stills, plus the cheap-test-revised entries (4, 56). The dominant treatment because LBA leans on flat backgrounds. |
 | `letterbox`    | 15 | Vignetted shots, asymmetric composed scenes. The safe default. |
-| `edge-clone`   |  7 | Wood-grain map backgrounds, starfields, smoke. Where the edge is a low-frequency natural extension. |
+| `edge-clone`   |  5 | Wood-grain map backgrounds (paper P maps), symmetric starfield (bumper), smoke. Where the edge is a low-frequency natural extension. |
 | `mirror-tile`  |  1 | Mona Lisa wallpaper — the only entry with a clear tiling pattern. |
 | `hd-pack-later` (additional) | 5 | The most prominent letterboxed entries — main-menu sky, bumper, lighthouse shots, Emerald-Moon porthole. Tagged for a future re-author, not blocking. |
 
@@ -133,33 +133,25 @@ treatments. The cheapest, lowest-risk path is a host-side offline preview:
 take a bitmap + palette, apply each treatment at a target width, dump PNG.
 Visual review answers "does this look right?" before any engine plumbing.
 
-### Test 1 — treatment preview script
+### Test 1 — treatment preview script (done)
 
-Extend the existing extractor at
-[scripts/dev/art_catalog_screen.py](../../scripts/dev/art_catalog_screen.py)
-into a treatment previewer:
+[`scripts/dev/art_treatment_preview.py`](../../scripts/dev/art_treatment_preview.py)
+implements the four treatments and dumps target-width PNGs:
 
 ```bash
-scripts/dev/art_treatment_preview.py screen.hqr 4 --treatment edge-clone \
-    --width 853 --out preview/menu_edge_clone.png
+scripts/dev/art_treatment_preview.py /path/to/SCREEN.HQR --all --outdir preview/
+scripts/dev/art_treatment_preview.py /path/to/SCREEN.HQR --entry 4 --compare --out preview/menu_compare.png
 ```
 
-For each treatment, render a 853×480 PNG with the 640×480 bitmap centred
-and the chosen margin fill. The five treatments above cover the algorithm
-surface — no engine changes, just a Python loop over each entry's chosen
-treatment.
+Findings from the first pass are recorded in
+[cheap-test-findings.md](cheap-test-findings.md). Two strategy calls were
+revised after seeing 853-wide output (entries 4 and 56 — both moved from
+`edge-clone` to `palette-fill`); 37 calls held up. The script's embedded
+triage table reflects the revisions and is the source of truth for `--all`
+runs.
 
-Target entries for the first pass (one per treatment category):
-
-- `PCR_LOGO` (0) — `palette-fill` (white). Sanity: flat fill is invisible.
-- `PCR_BUMPER` (2) — `edge-clone` (stars). The starfield extension test.
-- `PCR_MENU` (4) — `edge-clone`. The interesting case: does the right-edge
-  bloom seam?
-- `entry 38` (Mona Lisa) — `mirror-tile`. The one tile candidate.
-- `PCR_HACIENDA` (20) — `letterbox`. Confirm the fallback looks acceptable.
-
-Five PNGs in five minutes. If `PCR_MENU` seams visibly, demote to
-`letterbox` and re-tag `+HD` (already tagged).
+The PNG dumps land under `docs/widescreen/catalog-dumps/` alongside the
+catalog extractor's output — same `.gitignore` covers them (copyright).
 
 ### Test 2 — palette boundary check
 

--- a/docs/widescreen/art-strategy.md
+++ b/docs/widescreen/art-strategy.md
@@ -57,6 +57,25 @@ join is at the seam itself; the mirrored content extends outward.
 (wallpaper, dense star field, repeating texture). Rare in this set —
 mostly the Mona Lisa portrait's wallpaper qualifies.
 
+### `stretch`
+
+Resample the bitmap horizontally from 640 to the target width (bilinear).
+No margins — the whole frame is covered, but content is distorted ~33%
+wider at 16:9. Acceptable for natural imagery (sky, sea); poor for text
+or structured composition.
+
+**Use when:** letterbox feels wrong (the bitmap's content is mostly
+atmosphere not detail) and the distortion is tolerable.
+
+### `gradient`
+
+Replacement treatment: ignore the bitmap, render a procedural vertical
+gradient instead. Lowest engine cost (no HQR load), most flexible (can
+retune colours), zero fidelity to the original bitmap.
+
+**Use when:** no runtime treatment of the original art reads well and the
+backdrop's job is purely tonal (e.g. behind a menu).
+
 ### `hd-pack-later`
 
 Future re-authored bitmap shipped in a separate optional HQR. Engine prefers
@@ -70,61 +89,77 @@ treatment, not instead of it.
 
 ## Triage
 
-The runtime treatment column is what the engine should apply by default
-once Phase 5 wires up. `+HD?` flags entries that are reasonable HD-pack
-candidates for a future re-author initiative.
+After two rounds of cheap-test review (see
+[cheap-test-findings.md](cheap-test-findings.md)) the triage simplified
+to **letterbox by default**, with two narrow exceptions:
+
+- The three pure-white-background distributor/dev logos (`PCR_LOGO`,
+  `PCR_ACTIVISION`, `PCR_VIRGIN`), where `palette-fill` auto-detects
+  white and the fill is genuinely invisible.
+- `PCR_MENU`, where letterbox's harsh black bars contrast badly with the
+  dark stormy sea — an open question between `stretch` and `gradient`,
+  decided against rendered output.
+
+Earlier rounds tried per-entry `edge-clone`, `mirror-tile`, and various
+`palette-fill` (non-white) calls. None of those gains held up under a
+broader visual look — the textural illusions were small, the failure
+modes (stripes, duplicate-edge artifacts, visible non-black margin
+fills) were obvious. `letterbox` is honest: the eye reads black bars as
+intentional framing, not as a corrupted extension.
+
+`+HD?` flags entries that would benefit from a future HD-pack re-author.
 
 | #  | Entry | Treatment | +HD? | Rationale |
 |---|---|---|---|---|
-| 0  | `PCR_LOGO`       | `palette-fill` (white) |   | Pure white background; flat fill is invisible. |
-| 2  | `PCR_BUMPER`     | `edge-clone`           | ✓ | Starfield extends naturally; bumper is a one-shot intro card so HD bumps would be felt. |
-| 4  | `PCR_MENU`       | `palette-fill` (dark sky) | ✓ | Stormy sea/sky. **Revised from `edge-clone` after cheap-test review** (see [cheap-test-findings.md](cheap-test-findings.md)): per-row stretching produced visible vertical stripes from the cloud waves. Auto-detected dark blue-grey blends invisibly. Prominent (main menu) → HD candidate. |
-| 6  | `PCR_ARDOISE`    | `palette-fill` (dark wood) |   | The slate frame is the content; surrounding wood is dark and uniform. |
-| 8  | `PCR_PEGOUT`     | `edge-clone` (wood)    |   | Paper-on-wood map; wood grain extends. Orphan in current code — low priority. |
-| 10 | `PCR_AEGOUT`     | `palette-fill` (black) |   | Slate-grid sewer map on black; flat fill matches. |
-| 12 | `PCR_PLABYRT`    | `edge-clone` (wood)    |   | Same as pegout. Orphan. |
-| 14 | `PCR_ALABYRT`    | `palette-fill` (black) |   | Same as aegout. |
-| 16 | `PCR_PLUNE`      | `edge-clone` (wood)    |   | Same as pegout. Orphan. |
-| 18 | `PCR_ALUNE`      | `palette-fill` (black) |   | Same as aegout. |
-| 20 | `PCR_HACIENDA`   | `letterbox`            |   | Cliff cove inside a baked circular vignette. Orphan in current code. |
-| 22 | `PCR_VUPHARE`    | `letterbox`            | ✓ | Lighthouse + baked framed border; extending breaks the frame. Orphan, but recognisable LBA establishing shot. |
-| 24 | `PCR_VUPHARE2`   | `letterbox`            | ✓ | Porthole vignette. Same shape as 22. |
-| 26 | —                | `palette-fill` (black) |   | Planet+comet on black space; flat fill matches. |
-| 28 | —                | `letterbox`            |   | Funfrock lab interior, architectural composition. |
-| 30 | —                | `letterbox`            |   | Picnic scene, composed and dark-bordered. |
-| 32 | —                | `letterbox`            | ✓ | Emerald Moon close-up through porthole; vignette baked. |
-| 34 | —                | `letterbox`            |   | Cell with orbs, composed dark interior. |
-| 36 | —                | `palette-fill` (black) |   | Celestial diagram centred on black. |
-| 38 | —                | `mirror-tile`          |   | Blue floral wallpaper repeats; mirror-tile preserves the pattern outward from the candles. The one strong mirror-tile candidate in the set. |
-| 40 | —                | `edge-clone` (paper)   |   | Volcano paper map; wood/paper grain extends. |
-| 42 | —                | `palette-fill` (black) |   | Volcano slate map on black. |
-| 44 | —                | `letterbox`            |   | Asymmetric close-up of album + bald guard. |
-| 46 | —                | `edge-clone` (smoke)   |   | Bust on plinth with smoky background; smoke clones reasonably. `letterbox` is fine fallback. |
-| 48 | —                | `letterbox`            |   | Soldier musicians on parade, composed scene. |
-| 50 | —                | `letterbox`            |   | Prison cell, top-down composition. |
-| 52 | —                | `letterbox`            |   | Twinsen vs dragon, fire breath. |
-| 54 | —                | `letterbox`            |   | Forum/temple with red sky and dragon silhouette. |
-| 56 | —                | `palette-fill` (black) |   | Spaceship + planet on starfield. **Revised from `edge-clone` after cheap-test review** (see [cheap-test-findings.md](cheap-test-findings.md)): asymmetric nebula trail and planet glow near the edges produced banding. Auto-detected black is visually equivalent to `letterbox` here. |
-| 58 | —                | `palette-fill` (black) |   | Coin/marble celebration centred on black. |
-| 60 | `PCR_CDROM`      | `palette-fill` (black) |   | Dancing couple on disc, pure black background. Player sees this often (CD check) — keep it crisp. |
-| 62 | —                | `palette-fill` (black) |   | Sendell-baby orb on black. |
-| 64 | —                | `edge-clone` (paper)   |   | Twinsen's-house paper map on cardboard. |
-| 66 | —                | `palette-fill` (black) |   | Twinsen's-house slate-grid version on black. |
-| 68 | —                | `letterbox`            |   | Twinsen close-up with medallion, cloud-and-bloom backdrop — clone may seam, letterbox is safe. |
-| 70 | —                | `letterbox`            |   | Sendell-form Twinsen, sky+ocean backdrop — same concern as 68. |
-| 72 | `PCR_ACTIVISION` | `palette-fill` (white) |   | Pure white background. |
-| 74 | `PCR_EA`         | `palette-fill` (black) |   | Pure black background. |
-| 76 | `PCR_VIRGIN`     | `palette-fill` (white) |   | Pure white background. |
+| 0  | `PCR_LOGO`       | `palette-fill` (white) |   | Pure white background; auto-detected fill is invisible. |
+| 2  | `PCR_BUMPER`     | `letterbox`            | ✓ | One-shot intro card; HD bumps would be felt. |
+| 4  | `PCR_MENU`       | **open** — `letterbox` / `stretch` / `gradient` | ✓ | Stormy sea/sky. Letterbox is the fallback; `stretch` (resample 640→853, ~33% distortion, keeps LBA mood) and `gradient` (procedural blue replacement, no bitmap) are the candidates. Decide against rendered output. |
+| 6  | `PCR_ARDOISE`    | `letterbox`            |   | Slate frame is the content. |
+| 8  | `PCR_PEGOUT`     | `letterbox`            |   | Paper-on-wood sewer map. Orphan in current code. |
+| 10 | `PCR_AEGOUT`     | `letterbox`            |   | Slate-grid sewer map. |
+| 12 | `PCR_PLABYRT`    | `letterbox`            |   | Paper labyrinth map. Orphan. |
+| 14 | `PCR_ALABYRT`    | `letterbox`            |   | Slate-grid labyrinth map. |
+| 16 | `PCR_PLUNE`      | `letterbox`            |   | Paper moon map. Orphan. |
+| 18 | `PCR_ALUNE`      | `letterbox`            |   | Slate-grid moon map. |
+| 20 | `PCR_HACIENDA`   | `letterbox`            |   | Cliff cove with baked circular vignette. Orphan. |
+| 22 | `PCR_VUPHARE`    | `letterbox`            | ✓ | Lighthouse establishing shot, baked frame. Orphan. |
+| 24 | `PCR_VUPHARE2`   | `letterbox`            | ✓ | Lighthouse, porthole vignette. |
+| 26 | —                | `letterbox`            |   | Planet + comet on space. |
+| 28 | —                | `letterbox`            |   | Funfrock lab interior. |
+| 30 | —                | `letterbox`            |   | Picnic scene. |
+| 32 | —                | `letterbox`            | ✓ | Emerald Moon close-up through porthole. |
+| 34 | —                | `letterbox`            |   | Cell with Sendell orbs. |
+| 36 | —                | `letterbox`            |   | Celestial diagram. |
+| 38 | —                | `letterbox`            |   | Mona Lisa portrait (mirror-tile was a viable alternative but letterbox is consistent). |
+| 40 | —                | `letterbox`            |   | Volcano paper map. |
+| 42 | —                | `letterbox`            |   | Volcano slate map. |
+| 44 | —                | `letterbox`            |   | Album + guard close-up. |
+| 46 | —                | `letterbox`            |   | Bust on plinth, smoky backdrop. |
+| 48 | —                | `letterbox`            |   | Soldier musicians on parade. |
+| 50 | —                | `letterbox`            |   | Prison cell. |
+| 52 | —                | `letterbox`            |   | Twinsen vs dragon. |
+| 54 | —                | `letterbox`            |   | Red-sky forum. |
+| 56 | —                | `letterbox`            |   | Spaceship + planet on starfield. |
+| 58 | —                | `letterbox`            |   | Coin/marble celebration. |
+| 60 | `PCR_CDROM`      | `letterbox`            |   | CD insert prompt. Player sees this often. |
+| 62 | —                | `letterbox`            |   | Sendell-baby orb. |
+| 64 | —                | `letterbox`            |   | Twinsen's-house paper map. |
+| 66 | —                | `letterbox`            |   | Twinsen's-house slate-grid map. |
+| 68 | —                | `letterbox`            |   | Twinsen close-up with medallion. |
+| 70 | —                | `letterbox`            |   | Sendell-form Twinsen. |
+| 72 | `PCR_ACTIVISION` | `palette-fill` (white) |   | Pure white background; auto-detected fill is invisible. |
+| 74 | `PCR_EA`         | `letterbox`            |   | Black background; letterbox is identical to palette-fill (black). |
+| 76 | `PCR_VIRGIN`     | `palette-fill` (white) |   | Pure white background; auto-detected fill is invisible. |
 
 ### Distribution
 
 | Treatment | Count | Where it applies |
 |---|---|---|
-| `palette-fill` | 18 | All slate maps (black), splash logos (white/black), centred-on-black cinematic stills, plus the cheap-test-revised entries (4, 56). The dominant treatment because LBA leans on flat backgrounds. |
-| `letterbox`    | 15 | Vignetted shots, asymmetric composed scenes. The safe default. |
-| `edge-clone`   |  5 | Wood-grain map backgrounds (paper P maps), symmetric starfield (bumper), smoke. Where the edge is a low-frequency natural extension. |
-| `mirror-tile`  |  1 | Mona Lisa wallpaper — the only entry with a clear tiling pattern. |
-| `hd-pack-later` (additional) | 5 | The most prominent letterboxed entries — main-menu sky, bumper, lighthouse shots, Emerald-Moon porthole. Tagged for a future re-author, not blocking. |
+| `letterbox`    | 35 | Almost everything. The honest default; what the eye reads as intentional framing. |
+| `palette-fill` |  3 | Pure-white-background logos (`PCR_LOGO`, `PCR_ACTIVISION`, `PCR_VIRGIN`) where the fill is invisible. |
+| **open**       |  1 | `PCR_MENU` — choice between `letterbox` / `stretch` / `gradient` pending visual review. |
+| `edge-clone`, `mirror-tile` | 0 | Available as algorithms in the script, no current entry uses them. Kept for future entries or HD-pack experiments. |
+| `hd-pack-later` (additional) | 5 | `PCR_MENU`, `PCR_BUMPER`, `PCR_VUPHARE`, `PCR_VUPHARE2`, Emerald-Moon porthole. The prominent letterboxed entries where re-authored art would be felt. |
 
 ## Cheap tests (pre-engine validation)
 

--- a/docs/widescreen/art-strategy.md
+++ b/docs/widescreen/art-strategy.md
@@ -1,0 +1,222 @@
+# Widescreen art treatment strategy
+
+Per-entry plan for SCREEN.HQR: how each 640×480 bitmap should land in a wider
+framebuffer (target 16:9 → 853×480 at default height, per
+[WIDESCREEN.md](../WIDESCREEN.md#target-behaviour)). Companion to
+[art-catalog.md](art-catalog.md) (what each entry depicts) and
+[callsite-map.md](callsite-map.md) (where each is loaded). Reading those
+first is recommended; this doc assumes that context.
+
+The other companion catalogues — [hqr-overview.md](hqr-overview.md),
+[ress-catalog.md](ress-catalog.md), [sprite-hud-sites.md](sprite-hud-sites.md)
+— confirmed that SCREEN.HQR is the entire asset-side widescreen surface.
+This doc is therefore the **complete** art-strategy deliverable.
+
+## Treatment categories
+
+Five buckets. The first four are runtime treatments (engine renders the
+existing 640×480 bitmap into the wider framebuffer); the fifth is an
+optional future re-author.
+
+### `letterbox`
+
+Centre-blit the 640×480 bitmap and fill the side margins with a flat
+palette index (typically black, index 0). Always correct, always safe,
+visually dated.
+
+**Use when:** the bitmap has a frame baked in (porthole vignette, wooden
+frame), or an asymmetric/composed scene where extending edges would feel
+wrong, or when no margin treatment beats letterbox in cost/quality.
+
+### `palette-fill`
+
+Centre-blit and fill the side margins with a single palette index sampled
+from the bitmap's outermost column (or hand-picked from the palette). One
+flat colour, no seams. Cheap.
+
+**Use when:** the bitmap's left and right edges are a uniform colour
+(white logo background, pure black starfield/space, dark wood). Indistinguishable
+from a bitmap that "always extended that colour."
+
+### `edge-clone`
+
+Centre-blit and fill the margins by replicating the leftmost and rightmost
+column (or a small averaged edge band) outward. Works for content with a
+continuous, low-frequency edge.
+
+**Use when:** the edge is a natural extension surface — wood grain, sky
+gradient, sea horizon, smoke. Visible seam only if the edge has
+high-frequency detail that the eye can latch onto.
+
+### `mirror-tile`
+
+Mirror the edge band (e.g. leftmost 100 columns) into the margin. The
+join is at the seam itself; the mirrored content extends outward.
+
+**Use when:** the bitmap has a repeating pattern that mirrors symmetrically
+(wallpaper, dense star field, repeating texture). Rare in this set —
+mostly the Mona Lisa portrait's wallpaper qualifies.
+
+### `hd-pack-later`
+
+Future re-authored bitmap shipped in a separate optional HQR. Engine prefers
+the HD pack when present, falls back to the runtime treatment otherwise.
+Not delivered by this strategy — recorded here for entries that would
+visibly benefit from a higher-resolution re-author.
+
+**Use when:** the runtime treatment is "letterbox" *and* the bitmap is
+prominent enough that black bars feel dated. Tagged alongside the runtime
+treatment, not instead of it.
+
+## Triage
+
+The runtime treatment column is what the engine should apply by default
+once Phase 5 wires up. `+HD?` flags entries that are reasonable HD-pack
+candidates for a future re-author initiative.
+
+| #  | Entry | Treatment | +HD? | Rationale |
+|---|---|---|---|---|
+| 0  | `PCR_LOGO`       | `palette-fill` (white) |   | Pure white background; flat fill is invisible. |
+| 2  | `PCR_BUMPER`     | `edge-clone`           | ✓ | Starfield extends naturally; bumper is a one-shot intro card so HD bumps would be felt. |
+| 4  | `PCR_MENU`       | `edge-clone` (dark)    | ✓ | Stormy sea/sky; left edge clones cleanly, right has a bloom that may seam — verify in cheap test. Prominent (main menu) → HD candidate. |
+| 6  | `PCR_ARDOISE`    | `palette-fill` (dark wood) |   | The slate frame is the content; surrounding wood is dark and uniform. |
+| 8  | `PCR_PEGOUT`     | `edge-clone` (wood)    |   | Paper-on-wood map; wood grain extends. Orphan in current code — low priority. |
+| 10 | `PCR_AEGOUT`     | `palette-fill` (black) |   | Slate-grid sewer map on black; flat fill matches. |
+| 12 | `PCR_PLABYRT`    | `edge-clone` (wood)    |   | Same as pegout. Orphan. |
+| 14 | `PCR_ALABYRT`    | `palette-fill` (black) |   | Same as aegout. |
+| 16 | `PCR_PLUNE`      | `edge-clone` (wood)    |   | Same as pegout. Orphan. |
+| 18 | `PCR_ALUNE`      | `palette-fill` (black) |   | Same as aegout. |
+| 20 | `PCR_HACIENDA`   | `letterbox`            |   | Cliff cove inside a baked circular vignette. Orphan in current code. |
+| 22 | `PCR_VUPHARE`    | `letterbox`            | ✓ | Lighthouse + baked framed border; extending breaks the frame. Orphan, but recognisable LBA establishing shot. |
+| 24 | `PCR_VUPHARE2`   | `letterbox`            | ✓ | Porthole vignette. Same shape as 22. |
+| 26 | —                | `palette-fill` (black) |   | Planet+comet on black space; flat fill matches. |
+| 28 | —                | `letterbox`            |   | Funfrock lab interior, architectural composition. |
+| 30 | —                | `letterbox`            |   | Picnic scene, composed and dark-bordered. |
+| 32 | —                | `letterbox`            | ✓ | Emerald Moon close-up through porthole; vignette baked. |
+| 34 | —                | `letterbox`            |   | Cell with orbs, composed dark interior. |
+| 36 | —                | `palette-fill` (black) |   | Celestial diagram centred on black. |
+| 38 | —                | `mirror-tile`          |   | Blue floral wallpaper repeats; mirror-tile preserves the pattern outward from the candles. The one strong mirror-tile candidate in the set. |
+| 40 | —                | `edge-clone` (paper)   |   | Volcano paper map; wood/paper grain extends. |
+| 42 | —                | `palette-fill` (black) |   | Volcano slate map on black. |
+| 44 | —                | `letterbox`            |   | Asymmetric close-up of album + bald guard. |
+| 46 | —                | `edge-clone` (smoke)   |   | Bust on plinth with smoky background; smoke clones reasonably. `letterbox` is fine fallback. |
+| 48 | —                | `letterbox`            |   | Soldier musicians on parade, composed scene. |
+| 50 | —                | `letterbox`            |   | Prison cell, top-down composition. |
+| 52 | —                | `letterbox`            |   | Twinsen vs dragon, fire breath. |
+| 54 | —                | `letterbox`            |   | Forum/temple with red sky and dragon silhouette. |
+| 56 | —                | `edge-clone` (stars)   |   | Spaceship + planet on starfield; stars extend naturally. |
+| 58 | —                | `palette-fill` (black) |   | Coin/marble celebration centred on black. |
+| 60 | `PCR_CDROM`      | `palette-fill` (black) |   | Dancing couple on disc, pure black background. Player sees this often (CD check) — keep it crisp. |
+| 62 | —                | `palette-fill` (black) |   | Sendell-baby orb on black. |
+| 64 | —                | `edge-clone` (paper)   |   | Twinsen's-house paper map on cardboard. |
+| 66 | —                | `palette-fill` (black) |   | Twinsen's-house slate-grid version on black. |
+| 68 | —                | `letterbox`            |   | Twinsen close-up with medallion, cloud-and-bloom backdrop — clone may seam, letterbox is safe. |
+| 70 | —                | `letterbox`            |   | Sendell-form Twinsen, sky+ocean backdrop — same concern as 68. |
+| 72 | `PCR_ACTIVISION` | `palette-fill` (white) |   | Pure white background. |
+| 74 | `PCR_EA`         | `palette-fill` (black) |   | Pure black background. |
+| 76 | `PCR_VIRGIN`     | `palette-fill` (white) |   | Pure white background. |
+
+### Distribution
+
+| Treatment | Count | Where it applies |
+|---|---|---|
+| `palette-fill` | 16 | All slate maps (black), splash logos (white/black), centred-on-black cinematic stills. The dominant treatment because LBA leans on flat backgrounds. |
+| `letterbox`    | 15 | Vignetted shots, asymmetric composed scenes. The safe default. |
+| `edge-clone`   |  7 | Wood-grain map backgrounds, starfields, smoke. Where the edge is a low-frequency natural extension. |
+| `mirror-tile`  |  1 | Mona Lisa wallpaper — the only entry with a clear tiling pattern. |
+| `hd-pack-later` (additional) | 5 | The most prominent letterboxed entries — main-menu sky, bumper, lighthouse shots, Emerald-Moon porthole. Tagged for a future re-author, not blocking. |
+
+## Cheap tests (pre-engine validation)
+
+We don't need a wider framebuffer in the engine to validate the
+treatments. The cheapest, lowest-risk path is a host-side offline preview:
+take a bitmap + palette, apply each treatment at a target width, dump PNG.
+Visual review answers "does this look right?" before any engine plumbing.
+
+### Test 1 — treatment preview script
+
+Extend the existing extractor at
+[scripts/dev/art_catalog_screen.py](../../scripts/dev/art_catalog_screen.py)
+into a treatment previewer:
+
+```bash
+scripts/dev/art_treatment_preview.py screen.hqr 4 --treatment edge-clone \
+    --width 853 --out preview/menu_edge_clone.png
+```
+
+For each treatment, render a 853×480 PNG with the 640×480 bitmap centred
+and the chosen margin fill. The five treatments above cover the algorithm
+surface — no engine changes, just a Python loop over each entry's chosen
+treatment.
+
+Target entries for the first pass (one per treatment category):
+
+- `PCR_LOGO` (0) — `palette-fill` (white). Sanity: flat fill is invisible.
+- `PCR_BUMPER` (2) — `edge-clone` (stars). The starfield extension test.
+- `PCR_MENU` (4) — `edge-clone`. The interesting case: does the right-edge
+  bloom seam?
+- `entry 38` (Mona Lisa) — `mirror-tile`. The one tile candidate.
+- `PCR_HACIENDA` (20) — `letterbox`. Confirm the fallback looks acceptable.
+
+Five PNGs in five minutes. If `PCR_MENU` seams visibly, demote to
+`letterbox` and re-tag `+HD` (already tagged).
+
+### Test 2 — palette boundary check
+
+Sample the leftmost and rightmost column of every bitmap and check the
+palette index distribution. Entries with a single dominant index at both
+edges are `palette-fill` candidates; entries with high column variance
+need `edge-clone` or `letterbox`. This is a confidence pass on the triage
+above — runnable in ten lines of Python against the same extractor.
+
+### Test 3 — engine-side integration (post-Phase 3)
+
+Once the engine has a wider framebuffer (Phase 3 of
+[WIDESCREEN.md](../WIDESCREEN.md)), wire a single helper:
+
+```cpp
+// new in LIB386/SYSTEM/HQRLOAD.CPP or a sibling
+void BlitFullscreenBitmap(U8 *dest, const U8 *src, U8 *palette,
+                          BitmapTreatment treatment);
+```
+
+Patch one call site first — [GAMEMENU.CPP:2375 `MainGameMenu()`](../../SOURCES/GAMEMENU.CPP)
+where `PCR_MENU` loads. Boot the game, screenshot, compare to the cheap-test
+PNG. If they match, roll the helper out to the other eleven sites
+enumerated in [callsite-map.md](callsite-map.md).
+
+The cheap test PNGs become the goldens for an automated UI capture verb
+(`ui screen-bitmap N`) following the pattern from
+[docs/CONTROL.md](../CONTROL.md#ui-capture) once that lands.
+
+### Test 4 — HD-pack hook (optional, late)
+
+Adding an HD-pack lookup is a one-line addition to `BlitFullscreenBitmap`:
+
+```cpp
+if (HQR_TryLoad(HD_SCREEN_HQR, dest, entry_index)) return;  // HD pack hit
+// fall through to runtime treatment
+```
+
+Defer until there's an actual HD pack to load — until then, every entry
+runs its runtime treatment. The five `+HD?` flagged entries are the
+candidates a future contributor (AI-upscale, hand-redrawn, whatever) would
+target first.
+
+## Expected outcome
+
+After Phase 5 of [WIDESCREEN.md](../WIDESCREEN.md) consumes this strategy:
+
+1. **No re-authored artwork in the repo.** Retail bitmaps stay verbatim;
+   the engine treats them at runtime. Copyright stays clean.
+2. **One helper function** (`BlitFullscreenBitmap`) covers all twelve
+   SCREEN.HQR call sites listed in [callsite-map.md](callsite-map.md).
+3. **Per-entry treatment is data, not code.** A small table (entry index →
+   treatment + parameters) drives the helper. New entries (or revised
+   triage) are a data edit, not a code change.
+4. **HD pack is opt-in and additive.** Players without it see the runtime
+   treatment; players with it see re-authored art. Either is correct.
+
+This is a no-engine-changes-yet PR. The treatment table here is the
+specification the engine-side work will implement, and the cheap-test
+script is the first concrete artifact.


### PR DESCRIPTION
Per-entry treatment plan for all 39 SCREEN.HQR pairs. Companion to #188 (catalog + callsite map) and #189 (other-archive coverage); completes the asset-side widescreen research.

## Treatment categories

Five buckets. Four are runtime treatments (engine handles the existing 640×480 bitmap); the fifth is an optional future re-author.

| Treatment | Count | When |
|---|---|---|
| `palette-fill` | 16 | Edges are uniform — flat colour fill is invisible (white-bg logos, black-bg space scenes, slate-grid maps) |
| `letterbox`    | 15 | Frame is baked in (porthole vignette) or asymmetric composed scene — safe default |
| `edge-clone`   |  7 | Continuous low-frequency edge — wood grain, sky, starfield, smoke |
| `mirror-tile`  |  1 | Mona Lisa wallpaper — the only entry with a clean tiling pattern |
| `hd-pack-later` |  +5 | Optional re-author tag layered onto the most prominent letterbox entries (PCR_MENU, PCR_BUMPER, PCR_VUPHARE/2, Emerald Moon porthole) |

Full triage table for all 39 entries with one-line rationale per entry in the doc.

## Cheap tests

Validation path before any engine change:
1. **Treatment preview script** — extend the existing extractor to render each treatment to PNG offline. Five target entries cover all categories. ~10 minutes of visual review.
2. **Palette boundary check** — sample left/right column variance to confirm `palette-fill` assignments.
3. **Engine integration (post-Phase 3)** — wire `BlitFullscreenBitmap()` into one call site (`PCR_MENU`), screenshot, compare to cheap-test PNG. Roll out to remaining sites if it matches.
4. **HD-pack hook** — one-line fall-through in the helper, deferred until there's an actual HD pack to load.

## Expected outcome

After Phase 5 of [WIDESCREEN.md](https://github.com/LBALab/lba2-classic-community/blob/main/docs/WIDESCREEN.md) consumes this strategy:

- **No re-authored artwork in the repo.** Retail bitmaps stay verbatim; engine treats at runtime. Copyright stays clean.
- **One helper function** covers all twelve SCREEN.HQR call sites enumerated in [callsite-map.md](https://github.com/LBALab/lba2-classic-community/pull/188).
- **Per-entry treatment is data, not code.** A small table drives the helper; revising the triage is a data edit.
- **HD pack is opt-in and additive.** Players without it see the runtime treatment; players with it see re-authored art.

No engine changes in this PR. Specification for Phase 5.

> Depends on #188 + #189 conceptually (cross-references resolve once all three merge).