### PR TITLE
chore(widescreen): art treatment preview script + cheap-test findings

### DIFF
--- a/docs/widescreen/cheap-test-findings.md
+++ b/docs/widescreen/cheap-test-findings.md
@@ -23,10 +23,42 @@ scripts/dev/art_treatment_preview.py /path/to/SCREEN.HQR --entry 4 \
 
 ## Revisions to the triage
 
-Two entries demoted from `edge-clone` to `palette-fill` after visual
-review. The script's embedded `TRIAGE` table reflects the revisions;
-[art-strategy.md](art-strategy.md) is the historical record of the initial
-call and should be updated alongside.
+Two rounds of revision after visual review of the `--all` output. The
+script's embedded `TRIAGE` table reflects the latest state;
+[art-strategy.md](art-strategy.md) was updated to match. The first round
+demoted two `edge-clone` calls; the second round simplified the whole
+table to letterbox-by-default after a broader look at what reads well at
+853-wide.
+
+### Round 2 — letterbox by default
+
+After running `--all` and reviewing the full set, the verdict is that
+`letterbox` is the right default for almost every entry. The exceptions:
+
+- **Entries 0, 72, 76** (`PCR_LOGO`, `PCR_ACTIVISION`, `PCR_VIRGIN`) —
+  pure-white backgrounds. `palette-fill` auto-detects white and the fill
+  is genuinely invisible; the logos look unaltered. Keep `palette-fill`.
+- **Entry 4** (`PCR_MENU`) — open question. The stormy sea/sky doesn't
+  letterbox well (the harsh black bars contrast badly with the dark-grey
+  sea). Two candidate treatments are tracked: `stretch` (resample the
+  bitmap horizontally to 853, accepts ~33% distortion) and `gradient`
+  (replace the bitmap entirely with a procedural blue gradient). Both
+  are implemented in the script for review.
+
+Everything else — including the entries that previously held up as
+`edge-clone` (paper-on-wood maps, bumper, smoke bust) and the Mona Lisa
+mirror-tile — is reverted to `letterbox`. The textural gains from those
+treatments were real but small, and the consistency of "every screen
+letterboxes the same way" is worth more than per-entry cleverness.
+`mirror-tile` and `edge-clone` are kept as algorithm options in the
+script for future entries (or HD-pack experimentation), but no current
+entry uses them.
+
+### Round 1 — `edge-clone` failures
+
+(Recorded first; superseded by round 2's broader simplification, but the
+underlying observation about per-row stretching is still the reason
+`edge-clone` is no longer used.)
 
 ### Entry 4 — `PCR_MENU` (main-menu stormy sky/sea)
 
@@ -59,59 +91,53 @@ the same result as `letterbox`. Visually identical, but logged as
 `palette-fill` because it's coming from the bitmap's own palette rather
 than a hardcoded RGB(0,0,0).
 
-## Confirmed picks
+### Round-1 specifics (historical)
 
-The remaining strategy calls held up under visual inspection.
+- **Entry 4** (`PCR_MENU`) `edge-clone → palette-fill`. Per-row stretching
+  produced visible vertical stripes from the cloud waves. Round 2 later
+  demoted further to `letterbox` (with `stretch`/`gradient` as candidates
+  to revisit).
+- **Entry 56** (spaceship + planet) `edge-clone → palette-fill`. Asymmetric
+  nebula trail and planet glow near the edges produced banding. Round 2
+  unified this with the rest at `letterbox`.
 
-- **`PCR_LOGO` (0) `palette-fill (white)`** — invisible fill, logo
-  perfectly centred.
-- **`PCR_BUMPER` (2) `edge-clone (stars)`** — starfield extends cleanly.
-  The bumper has no high-contrast asymmetric content near the edges,
-  unlike entry 56.
-- **`PCR_PEGOUT` (8) `edge-clone (wood)`** — wood-grain background
-  extends with mild banding that reads as weathered texture, not as a
-  rendering artifact. Same pattern for the other paper-map P entries
-  (12, 16, 40, 64).
-- **`PCR_ARDOISE` (6) `palette-fill (dark wood)`** — auto-detection lands
-  on a near-black that matches the surround. The slate frame floats
-  cleanly on the dark.
-- **Slate-grid A maps (10, 14, 18, 42, 66) `palette-fill (black)`** —
-  auto-detected black is exact.
-- **Entry 38 (Mona Lisa) `mirror-tile (wallpaper)`** — the wallpaper
-  pattern extends correctly. Side effect: the candles get duplicated. The
-  duplicate-candle artifact is recognisable as a treatment limitation
-  rather than corrupted art; preferable to `edge-clone`'s stripes or
-  `palette-fill`'s flat dark wallpaper colour. (See the `--compare` grid
-  to confirm — it's the cleanest comparison in the set.)
-- **Entry 46 (bust on plinth) `edge-clone (smoke)`** — smoke extends with
-  mild banding that reads as natural cloud variation.
-- **All `letterbox` entries** — vignettes and composed scenes look right
-  with black bars; no edge content to extend.
+## Why `edge-clone` is no longer used
 
-## Generalisation
+The per-row column-stretch algorithm amplifies any vertical structure
+near the edges into visible stripes across the margin. Even on entries
+where it "worked" (wood-grain maps, smoke, symmetric starfields), the
+result was a band of horizontal repetition that read as a render bug to a
+fresh viewer. Letterbox is honest: the eye reads black bars as
+intentional framing, not as a corrupted extension. The cost-benefit
+didn't justify per-entry treatment selection.
 
-The pattern across entries:
+## PCR_MENU candidates
 
-- **`edge-clone` works when** the edges are low-frequency continuous
-  texture (starfield, wood, smoke), regardless of what's in the centre.
-- **`edge-clone` fails when** there's high-contrast content (clouds,
-  bloom, glowing objects) anywhere near the edges. Per-row stretching
-  amplifies any vertical structure into stripes.
-- **`palette-fill` is the next-cheapest fallback** when `edge-clone`
-  fails. It loses the textural illusion but is always seam-free.
-- **`mirror-tile` works when** the bitmap has a continuous pattern at the
-  edges (wallpaper, tiled floor). Rare in this set; one entry only.
-- **`letterbox` is correct whenever** the bitmap has a baked frame
-  (vignette, decorative border) — extending edges would break the frame.
+The one entry where letterbox felt wrong is the main-menu sky/sea
+background, because the harsh black bars contrast badly with the
+dark-grey-blue of the sea. Two alternative treatments are implemented in
+the script for review:
 
-In practice: when in doubt between `edge-clone` and `palette-fill`,
-prefer `palette-fill`. The textural gain from `edge-clone` is small; the
-risk of visible stripes is real.
+- **`stretch`** — bilinear horizontal resample from 640 to 853. Keeps the
+  LBA stormy-ocean mood but visibly distorts the waves and the bloom
+  highlight by ~33%. Low engine cost (one `SDL_Surface` blit with
+  scaling); zero asset work.
+- **`gradient`** — ignore the bitmap, render a procedural blue gradient
+  (deep midnight at top → slate at the horizon). Removes the LBA art
+  entirely. Lowest engine cost (no HQR load). Most flexible (can retune
+  colours per build, can ship "dark mode" variants).
+
+Both are open candidates pending review. Render them with:
+
+```bash
+scripts/dev/art_treatment_preview.py /path/to/SCREEN.HQR --entry 4 \
+    --compare --out /tmp/menu_compare.png
+```
 
 ## What's next
 
-1. Update [art-strategy.md](art-strategy.md) to reflect the two revisions
-   (and link this doc as the validation record).
+1. Decide between `stretch` and `gradient` for `PCR_MENU`, then update
+   the triage one last time.
 2. Once the engine is widescreen-capable (Phase 3 of
    [WIDESCREEN.md](../WIDESCREEN.md)), wire `BlitFullscreenBitmap()` per
    [callsite-map.md](callsite-map.md) and integrate the triage as data.

--- a/docs/widescreen/cheap-test-findings.md
+++ b/docs/widescreen/cheap-test-findings.md
@@ -1,0 +1,120 @@
+# Cheap-test findings — art treatment preview
+
+What the `scripts/dev/art_treatment_preview.py` script surfaced when run
+against retail `SCREEN.HQR` with the triage from
+[art-strategy.md](art-strategy.md). Findings are the point of the cheap
+test — the strategy was a best guess from thumbnails, the previews are
+what 853-wide actually renders.
+
+## Reproduction
+
+```bash
+scripts/dev/art_treatment_preview.py /path/to/retail/SCREEN.HQR \
+    --all --outdir docs/widescreen/catalog-dumps/preview/
+```
+
+The PNG dumps are gitignored (same copyright concern as the catalog
+dumps). To compare treatments for a single entry:
+
+```bash
+scripts/dev/art_treatment_preview.py /path/to/SCREEN.HQR --entry 4 \
+    --compare --out /tmp/compare_menu.png
+```
+
+## Revisions to the triage
+
+Two entries demoted from `edge-clone` to `palette-fill` after visual
+review. The script's embedded `TRIAGE` table reflects the revisions;
+[art-strategy.md](art-strategy.md) is the historical record of the initial
+call and should be updated alongside.
+
+### Entry 4 — `PCR_MENU` (main-menu stormy sky/sea)
+
+**Initial:** `edge-clone (dark)`. **Revised:** `palette-fill (dark sky)`.
+
+`edge-clone` per-row stretching turned the cloud waves into visible
+vertical stripes across both margins. The stripes are obvious against the
+smooth sky gradient — the eye reads them as a rendering bug rather than a
+natural extension.
+
+`palette-fill` auto-detects a dark blue-grey from the leftmost+rightmost
+column histogram and fills both margins with that single colour. The
+result is nearly invisible — the eye reads "the picture has a dark
+border", not "the picture has been extended." The `+HD` flag stays:
+re-authoring would still beat both treatments here for the most prominent
+screen the player sees.
+
+### Entry 56 — spaceship approaching the volcano planet
+
+**Initial:** `edge-clone (stars)`. **Revised:** `palette-fill (black)`.
+
+The starfield-extension idea works for symmetric starfields (the bumper,
+entry 2), but this composition has a glowing planet near the right edge
+and an asymmetric nebula trail near the left. Per-row column stretch
+turned the nebula into colourful horizontal bands and the planet's right
+edge into vertical stripes of rocky terrain.
+
+`palette-fill` auto-detects black (the dominant edge colour) and produces
+the same result as `letterbox`. Visually identical, but logged as
+`palette-fill` because it's coming from the bitmap's own palette rather
+than a hardcoded RGB(0,0,0).
+
+## Confirmed picks
+
+The remaining strategy calls held up under visual inspection.
+
+- **`PCR_LOGO` (0) `palette-fill (white)`** — invisible fill, logo
+  perfectly centred.
+- **`PCR_BUMPER` (2) `edge-clone (stars)`** — starfield extends cleanly.
+  The bumper has no high-contrast asymmetric content near the edges,
+  unlike entry 56.
+- **`PCR_PEGOUT` (8) `edge-clone (wood)`** — wood-grain background
+  extends with mild banding that reads as weathered texture, not as a
+  rendering artifact. Same pattern for the other paper-map P entries
+  (12, 16, 40, 64).
+- **`PCR_ARDOISE` (6) `palette-fill (dark wood)`** — auto-detection lands
+  on a near-black that matches the surround. The slate frame floats
+  cleanly on the dark.
+- **Slate-grid A maps (10, 14, 18, 42, 66) `palette-fill (black)`** —
+  auto-detected black is exact.
+- **Entry 38 (Mona Lisa) `mirror-tile (wallpaper)`** — the wallpaper
+  pattern extends correctly. Side effect: the candles get duplicated. The
+  duplicate-candle artifact is recognisable as a treatment limitation
+  rather than corrupted art; preferable to `edge-clone`'s stripes or
+  `palette-fill`'s flat dark wallpaper colour. (See the `--compare` grid
+  to confirm — it's the cleanest comparison in the set.)
+- **Entry 46 (bust on plinth) `edge-clone (smoke)`** — smoke extends with
+  mild banding that reads as natural cloud variation.
+- **All `letterbox` entries** — vignettes and composed scenes look right
+  with black bars; no edge content to extend.
+
+## Generalisation
+
+The pattern across entries:
+
+- **`edge-clone` works when** the edges are low-frequency continuous
+  texture (starfield, wood, smoke), regardless of what's in the centre.
+- **`edge-clone` fails when** there's high-contrast content (clouds,
+  bloom, glowing objects) anywhere near the edges. Per-row stretching
+  amplifies any vertical structure into stripes.
+- **`palette-fill` is the next-cheapest fallback** when `edge-clone`
+  fails. It loses the textural illusion but is always seam-free.
+- **`mirror-tile` works when** the bitmap has a continuous pattern at the
+  edges (wallpaper, tiled floor). Rare in this set; one entry only.
+- **`letterbox` is correct whenever** the bitmap has a baked frame
+  (vignette, decorative border) — extending edges would break the frame.
+
+In practice: when in doubt between `edge-clone` and `palette-fill`,
+prefer `palette-fill`. The textural gain from `edge-clone` is small; the
+risk of visible stripes is real.
+
+## What's next
+
+1. Update [art-strategy.md](art-strategy.md) to reflect the two revisions
+   (and link this doc as the validation record).
+2. Once the engine is widescreen-capable (Phase 3 of
+   [WIDESCREEN.md](../WIDESCREEN.md)), wire `BlitFullscreenBitmap()` per
+   [callsite-map.md](callsite-map.md) and integrate the triage as data.
+3. The cheap-test PNGs become goldens for a future
+   `ui screen-bitmap N` capture verb so engine integration can byte-diff
+   against the offline reference.

--- a/scripts/dev/art_treatment_preview.py
+++ b/scripts/dev/art_treatment_preview.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Render SCREEN.HQR bitmaps with widescreen treatments applied, as PNG previews.
+
+Implements the four runtime treatments specified in docs/widescreen/art-strategy.md:
+
+  letterbox     centre the 640x480 bitmap, fill margins with black (or fill_index)
+  palette-fill  same, but fill margins with the dominant edge palette index
+                (auto-detected, or override with --fill-index)
+  edge-clone    centre the bitmap, extend each row's edge colour into the margins
+                (per-row column stretch — preserves vertical structure)
+  mirror-tile   centre the bitmap, mirror the leftmost/rightmost margin-width
+                strip into the margins
+
+Output is a target_width x 480 RGB PNG. Default target width is 853 (16:9 at
+480 height, matching docs/WIDESCREEN.md target).
+
+The dumps live under docs/widescreen/catalog-dumps/ alongside the catalog
+extractor's output — same .gitignore covers them (copyright concern).
+
+Usage:
+  # Single entry, single treatment
+  scripts/dev/art_treatment_preview.py SCREEN.HQR --entry 4 \\
+      --treatment edge-clone --out preview/menu_edge_clone.png
+
+  # All entries with their strategy-assigned treatments
+  scripts/dev/art_treatment_preview.py SCREEN.HQR --all --outdir preview/
+
+  # Side-by-side comparison of all four treatments for one entry
+  scripts/dev/art_treatment_preview.py SCREEN.HQR --entry 4 --compare \\
+      --out preview/menu_compare.png
+"""
+import argparse, os, sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _HERE)
+from hqr_inspect import entries, decompress_entry  # noqa: E402
+
+from PIL import Image
+
+W, H = 640, 480
+DEFAULT_TARGET_W = 853  # 16:9 at 480 height (480 * 16/9 = 853.33)
+
+# Treatment assignments from docs/widescreen/art-strategy.md.
+# Each entry index -> (treatment, optional hint).  Hint is a short note like
+# "(white)" or "(black)" describing the expected fill colour; auto-detection
+# should land on the same index for well-formed bitmaps.
+TRIAGE = {
+    0:  ("palette-fill", "white"),    # PCR_LOGO
+    2:  ("edge-clone",   "stars"),    # PCR_BUMPER
+    4:  ("palette-fill", "dark sky"), # PCR_MENU — cheap-test revised from edge-clone (stripes)
+    6:  ("palette-fill", "dark wood"),# PCR_ARDOISE
+    8:  ("edge-clone",   "wood"),     # PCR_PEGOUT
+    10: ("palette-fill", "black"),    # PCR_AEGOUT
+    12: ("edge-clone",   "wood"),     # PCR_PLABYRT
+    14: ("palette-fill", "black"),    # PCR_ALABYRT
+    16: ("edge-clone",   "wood"),     # PCR_PLUNE
+    18: ("palette-fill", "black"),    # PCR_ALUNE
+    20: ("letterbox",    None),       # PCR_HACIENDA — baked vignette
+    22: ("letterbox",    None),       # PCR_VUPHARE
+    24: ("letterbox",    None),       # PCR_VUPHARE2 — porthole
+    26: ("palette-fill", "black"),    # planet + comet
+    28: ("letterbox",    None),       # Funfrock lab
+    30: ("letterbox",    None),       # picnic
+    32: ("letterbox",    None),       # Emerald Moon porthole
+    34: ("letterbox",    None),       # cell with orbs
+    36: ("palette-fill", "black"),    # celestial diagram
+    38: ("mirror-tile",  "wallpaper"),# Mona Lisa wallpaper
+    40: ("edge-clone",   "paper"),    # volcano paper map
+    42: ("palette-fill", "black"),    # volcano slate map
+    44: ("letterbox",    None),       # album + guard
+    46: ("edge-clone",   "smoke"),    # bust on plinth
+    48: ("letterbox",    None),       # musicians
+    50: ("letterbox",    None),       # prison cell
+    52: ("letterbox",    None),       # dragon-fire
+    54: ("letterbox",    None),       # red-sky forum
+    56: ("palette-fill", "black"),    # spaceship + planet — cheap-test revised from edge-clone (nebula stripes)
+    58: ("palette-fill", "black"),    # explosion celebration
+    60: ("palette-fill", "black"),    # PCR_CDROM
+    62: ("palette-fill", "black"),    # Sendell baby orb
+    64: ("edge-clone",   "paper"),    # paper house map
+    66: ("palette-fill", "black"),    # slate house map
+    68: ("letterbox",    None),       # Twinsen + medallion
+    70: ("letterbox",    None),       # Sendell-form Twinsen
+    72: ("palette-fill", "white"),    # PCR_ACTIVISION
+    74: ("palette-fill", "black"),    # PCR_EA
+    76: ("palette-fill", "white"),    # PCR_VIRGIN
+}
+
+# ---------------------------------------------------------------------------
+# HQR loading
+# ---------------------------------------------------------------------------
+
+def load_bitmap_pair(hqr_path, entry):
+    """Return (indexed_bitmap_bytes, rgb_palette_bytes) for the bitmap at `entry`.
+
+    Palette is at `entry+1`.  6-bit DOS-VGA palette values are normalised to
+    8-bit by replicating the high bits low (`c<<2 | c>>4`)."""
+    ents, raw = entries(hqr_path)
+    if entry + 1 >= len(ents):
+        raise ValueError(f"entry {entry} or its palette out of range")
+    _, off,  size,  csize,  method  = ents[entry]
+    _, poff, psize, pcsize, pmethod = ents[entry + 1]
+    if size  != W * H:    raise ValueError(f"entry {entry}: expected {W*H} bytes, got {size}")
+    if psize != 256 * 3:  raise ValueError(f"entry {entry+1}: expected 768-byte palette, got {psize}")
+    bitmap  = decompress_entry(raw, off,  size,  csize,  method)
+    palette = decompress_entry(raw, poff, psize, pcsize, pmethod)
+    palette = bytes(min(c << 2 | c >> 4, 255) for c in palette) \
+              if max(palette) <= 0x3F else bytes(palette)
+    return bitmap, palette
+
+def to_rgb_image(bitmap, palette):
+    """640x480 indexed bytes + 768-byte RGB palette -> PIL RGB image."""
+    img = Image.frombytes("P", (W, H), bitmap)
+    img.putpalette(palette)
+    return img.convert("RGB")
+
+def palette_color(palette, index):
+    """Look up palette index -> (r, g, b) tuple."""
+    i = (index & 0xFF) * 3
+    return (palette[i], palette[i + 1], palette[i + 2])
+
+# ---------------------------------------------------------------------------
+# Edge analysis
+# ---------------------------------------------------------------------------
+
+def dominant_edge_index(bitmap):
+    """Return the most common palette index across the leftmost+rightmost columns.
+
+    Used by palette-fill when no explicit --fill-index is given."""
+    hist = [0] * 256
+    for y in range(H):
+        hist[bitmap[y * W + 0]] += 1
+        hist[bitmap[y * W + (W - 1)]] += 1
+    return max(range(256), key=lambda i: hist[i])
+
+# ---------------------------------------------------------------------------
+# Treatments
+# ---------------------------------------------------------------------------
+
+def margins(target_w):
+    """Split the wide canvas into (left_margin, right_margin) around a 640-wide centre."""
+    if target_w < W:
+        raise ValueError(f"target width {target_w} smaller than bitmap width {W}")
+    extra = target_w - W
+    left = extra // 2
+    return left, extra - left
+
+def apply_letterbox(rgb, target_w, fill_color=(0, 0, 0)):
+    """Centre + flat fill (default black)."""
+    canvas = Image.new("RGB", (target_w, H), fill_color)
+    lm, _ = margins(target_w)
+    canvas.paste(rgb, (lm, 0))
+    return canvas
+
+def apply_palette_fill(rgb, target_w, bitmap, palette, fill_index=None):
+    """Centre + flat fill from edge palette (auto-detected unless given)."""
+    if fill_index is None:
+        fill_index = dominant_edge_index(bitmap)
+    return apply_letterbox(rgb, target_w, palette_color(palette, fill_index))
+
+def apply_edge_clone(rgb, target_w):
+    """Centre + per-row column stretch.  Each row in the left margin takes the
+    colour of that row's leftmost source pixel; right margin mirrors the rule."""
+    lm, rm = margins(target_w)
+    canvas = Image.new("RGB", (target_w, H), (0, 0, 0))
+    canvas.paste(rgb, (lm, 0))
+    if lm > 0:
+        left_col = rgb.crop((0, 0, 1, H)).resize((lm, H), Image.NEAREST)
+        canvas.paste(left_col, (0, 0))
+    if rm > 0:
+        right_col = rgb.crop((W - 1, 0, W, H)).resize((rm, H), Image.NEAREST)
+        canvas.paste(right_col, (lm + W, 0))
+    return canvas
+
+def apply_mirror_tile(rgb, target_w):
+    """Centre + mirror the edge strip outward (strip width = margin width)."""
+    lm, rm = margins(target_w)
+    canvas = Image.new("RGB", (target_w, H), (0, 0, 0))
+    canvas.paste(rgb, (lm, 0))
+    if lm > 0:
+        strip = rgb.crop((0, 0, lm, H)).transpose(Image.FLIP_LEFT_RIGHT)
+        canvas.paste(strip, (0, 0))
+    if rm > 0:
+        strip = rgb.crop((W - rm, 0, W, H)).transpose(Image.FLIP_LEFT_RIGHT)
+        canvas.paste(strip, (lm + W, 0))
+    return canvas
+
+TREATMENTS = {
+    "letterbox":    lambda rgb, w, b, p, fi: apply_letterbox(rgb, w),
+    "palette-fill": lambda rgb, w, b, p, fi: apply_palette_fill(rgb, w, b, p, fi),
+    "edge-clone":   lambda rgb, w, b, p, fi: apply_edge_clone(rgb, w),
+    "mirror-tile":  lambda rgb, w, b, p, fi: apply_mirror_tile(rgb, w),
+}
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def render_one(hqr_path, entry, treatment, target_w, fill_index=None):
+    bitmap, palette = load_bitmap_pair(hqr_path, entry)
+    rgb = to_rgb_image(bitmap, palette)
+    fn = TREATMENTS.get(treatment)
+    if fn is None:
+        raise ValueError(f"unknown treatment {treatment!r}; choose from {list(TREATMENTS)}")
+    return fn(rgb, target_w, bitmap, palette, fill_index)
+
+def render_compare(hqr_path, entry, target_w):
+    """Four treatments side by side, stacked vertically, with labels."""
+    from PIL import ImageDraw
+    bitmap, palette = load_bitmap_pair(hqr_path, entry)
+    rgb = to_rgb_image(bitmap, palette)
+    label_h = 24
+    rows = []
+    for name in ("letterbox", "palette-fill", "edge-clone", "mirror-tile"):
+        img = TREATMENTS[name](rgb, target_w, bitmap, palette, None)
+        labelled = Image.new("RGB", (target_w, H + label_h), (32, 32, 32))
+        labelled.paste(img, (0, label_h))
+        draw = ImageDraw.Draw(labelled)
+        draw.text((8, 4), name, fill=(255, 255, 255))
+        rows.append(labelled)
+    combined = Image.new("RGB", (target_w, (H + label_h) * 4), (0, 0, 0))
+    for i, row in enumerate(rows):
+        combined.paste(row, (0, i * (H + label_h)))
+    return combined
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("hqr")
+    ap.add_argument("--entry", type=int, help="single entry index (even, paired with palette at +1)")
+    ap.add_argument("--treatment", choices=list(TREATMENTS),
+                    help="treatment for --entry; default uses the triage table")
+    ap.add_argument("--width", type=int, default=DEFAULT_TARGET_W,
+                    help=f"target canvas width (default {DEFAULT_TARGET_W} = 16:9 @ 480h)")
+    ap.add_argument("--fill-index", type=int, default=None,
+                    help="palette index for palette-fill (default: auto-detect from edges)")
+    ap.add_argument("--all", action="store_true",
+                    help="render every triaged entry to --outdir with its strategy treatment")
+    ap.add_argument("--compare", action="store_true",
+                    help="stack all four treatments for one --entry into one PNG")
+    ap.add_argument("--out", help="output PNG path (single-entry mode)")
+    ap.add_argument("--outdir", help="output directory (--all mode)")
+    args = ap.parse_args()
+
+    if args.all:
+        if not args.outdir:
+            ap.error("--all requires --outdir")
+        os.makedirs(args.outdir, exist_ok=True)
+        for entry in sorted(TRIAGE):
+            treatment, hint = TRIAGE[entry]
+            img = render_one(args.hqr, entry, treatment, args.width)
+            tag = treatment.replace("-", "_")
+            out = os.path.join(args.outdir, f"screen_{entry:03d}_{tag}.png")
+            img.save(out)
+            note = f" ({hint})" if hint else ""
+            print(f"  [{entry:>2}] {treatment:<13}{note:<14} -> {os.path.basename(out)}")
+        return
+
+    if args.entry is None:
+        ap.error("provide --entry N (or --all)")
+
+    if args.compare:
+        if not args.out:
+            ap.error("--compare requires --out")
+        render_compare(args.hqr, args.entry, args.width).save(args.out)
+        print(f"compare grid -> {args.out}")
+        return
+
+    treatment = args.treatment
+    if treatment is None:
+        if args.entry in TRIAGE:
+            treatment, _ = TRIAGE[args.entry]
+        else:
+            ap.error("entry not in triage table; pass --treatment explicitly")
+    if not args.out:
+        ap.error("--out required for single-entry render")
+    render_one(args.hqr, args.entry, treatment, args.width, args.fill_index).save(args.out)
+    print(f"entry {args.entry} ({treatment}) -> {args.out}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/art_treatment_preview.py
+++ b/scripts/dev/art_treatment_preview.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Render SCREEN.HQR bitmaps with widescreen treatments applied, as PNG previews.
 
-Implements the four runtime treatments specified in docs/widescreen/art-strategy.md:
+Implements the runtime treatments specified in docs/widescreen/art-strategy.md:
 
   letterbox     centre the 640x480 bitmap, fill margins with black (or fill_index)
   palette-fill  same, but fill margins with the dominant edge palette index
@@ -10,6 +10,11 @@ Implements the four runtime treatments specified in docs/widescreen/art-strategy
                 (per-row column stretch — preserves vertical structure)
   mirror-tile   centre the bitmap, mirror the leftmost/rightmost margin-width
                 strip into the margins
+  stretch       resample the bitmap horizontally to target width (bilinear).
+                Distorts but no margins; trades fidelity for fill.
+  gradient      ignore the bitmap, fill the canvas with a procedural vertical
+                blue gradient. Replacement treatment for PCR_MENU when no
+                derivative of the original art reads well.
 
 Output is a target_width x 480 RGB PNG. Default target width is 853 (16:9 at
 480 height, matching docs/WIDESCREEN.md target).
@@ -20,12 +25,12 @@ extractor's output — same .gitignore covers them (copyright concern).
 Usage:
   # Single entry, single treatment
   scripts/dev/art_treatment_preview.py SCREEN.HQR --entry 4 \\
-      --treatment edge-clone --out preview/menu_edge_clone.png
+      --treatment stretch --out preview/menu_stretch.png
 
   # All entries with their strategy-assigned treatments
   scripts/dev/art_treatment_preview.py SCREEN.HQR --all --outdir preview/
 
-  # Side-by-side comparison of all four treatments for one entry
+  # Side-by-side comparison of every treatment for one entry
   scripts/dev/art_treatment_preview.py SCREEN.HQR --entry 4 --compare \\
       --out preview/menu_compare.png
 """
@@ -42,48 +47,54 @@ DEFAULT_TARGET_W = 853  # 16:9 at 480 height (480 * 16/9 = 853.33)
 
 # Treatment assignments from docs/widescreen/art-strategy.md.
 # Each entry index -> (treatment, optional hint).  Hint is a short note like
-# "(white)" or "(black)" describing the expected fill colour; auto-detection
-# should land on the same index for well-formed bitmaps.
+# "(white)" describing the expected fill behaviour.
+#
+# Triage was simplified after a second round of visual review (recorded in
+# cheap-test-findings.md): letterbox is the default, palette-fill is kept
+# only for the pure-white-background distributor/dev logos where the margin
+# fill is genuinely invisible, and PCR_MENU is an open question — the
+# letterbox option here is the fallback; `stretch` and `gradient` are the
+# candidates being weighed.
 TRIAGE = {
-    0:  ("palette-fill", "white"),    # PCR_LOGO
-    2:  ("edge-clone",   "stars"),    # PCR_BUMPER
-    4:  ("palette-fill", "dark sky"), # PCR_MENU — cheap-test revised from edge-clone (stripes)
-    6:  ("palette-fill", "dark wood"),# PCR_ARDOISE
-    8:  ("edge-clone",   "wood"),     # PCR_PEGOUT
-    10: ("palette-fill", "black"),    # PCR_AEGOUT
-    12: ("edge-clone",   "wood"),     # PCR_PLABYRT
-    14: ("palette-fill", "black"),    # PCR_ALABYRT
-    16: ("edge-clone",   "wood"),     # PCR_PLUNE
-    18: ("palette-fill", "black"),    # PCR_ALUNE
+    0:  ("palette-fill", "white"),    # PCR_LOGO — white bg, invisible fill
+    2:  ("letterbox",    None),       # PCR_BUMPER
+    4:  ("letterbox",    None),       # PCR_MENU — see notes; stretch/gradient also viable
+    6:  ("letterbox",    None),       # PCR_ARDOISE
+    8:  ("letterbox",    None),       # PCR_PEGOUT
+    10: ("letterbox",    None),       # PCR_AEGOUT
+    12: ("letterbox",    None),       # PCR_PLABYRT
+    14: ("letterbox",    None),       # PCR_ALABYRT
+    16: ("letterbox",    None),       # PCR_PLUNE
+    18: ("letterbox",    None),       # PCR_ALUNE
     20: ("letterbox",    None),       # PCR_HACIENDA — baked vignette
     22: ("letterbox",    None),       # PCR_VUPHARE
     24: ("letterbox",    None),       # PCR_VUPHARE2 — porthole
-    26: ("palette-fill", "black"),    # planet + comet
+    26: ("letterbox",    None),       # planet + comet
     28: ("letterbox",    None),       # Funfrock lab
     30: ("letterbox",    None),       # picnic
     32: ("letterbox",    None),       # Emerald Moon porthole
     34: ("letterbox",    None),       # cell with orbs
-    36: ("palette-fill", "black"),    # celestial diagram
-    38: ("mirror-tile",  "wallpaper"),# Mona Lisa wallpaper
-    40: ("edge-clone",   "paper"),    # volcano paper map
-    42: ("palette-fill", "black"),    # volcano slate map
+    36: ("letterbox",    None),       # celestial diagram
+    38: ("letterbox",    None),       # Mona Lisa (mirror-tile was viable but letterbox is consistent)
+    40: ("letterbox",    None),       # volcano paper map
+    42: ("letterbox",    None),       # volcano slate map
     44: ("letterbox",    None),       # album + guard
-    46: ("edge-clone",   "smoke"),    # bust on plinth
+    46: ("letterbox",    None),       # bust on plinth
     48: ("letterbox",    None),       # musicians
     50: ("letterbox",    None),       # prison cell
     52: ("letterbox",    None),       # dragon-fire
     54: ("letterbox",    None),       # red-sky forum
-    56: ("palette-fill", "black"),    # spaceship + planet — cheap-test revised from edge-clone (nebula stripes)
-    58: ("palette-fill", "black"),    # explosion celebration
-    60: ("palette-fill", "black"),    # PCR_CDROM
-    62: ("palette-fill", "black"),    # Sendell baby orb
-    64: ("edge-clone",   "paper"),    # paper house map
-    66: ("palette-fill", "black"),    # slate house map
+    56: ("letterbox",    None),       # spaceship + planet
+    58: ("letterbox",    None),       # explosion celebration
+    60: ("letterbox",    None),       # PCR_CDROM
+    62: ("letterbox",    None),       # Sendell baby orb
+    64: ("letterbox",    None),       # paper house map
+    66: ("letterbox",    None),       # slate house map
     68: ("letterbox",    None),       # Twinsen + medallion
     70: ("letterbox",    None),       # Sendell-form Twinsen
-    72: ("palette-fill", "white"),    # PCR_ACTIVISION
-    74: ("palette-fill", "black"),    # PCR_EA
-    76: ("palette-fill", "white"),    # PCR_VIRGIN
+    72: ("palette-fill", "white"),    # PCR_ACTIVISION — white bg, invisible fill
+    74: ("letterbox",    None),       # PCR_EA — black bg, identical to letterbox
+    76: ("palette-fill", "white"),    # PCR_VIRGIN — white bg, invisible fill
 }
 
 # ---------------------------------------------------------------------------
@@ -185,11 +196,47 @@ def apply_mirror_tile(rgb, target_w):
         canvas.paste(strip, (lm + W, 0))
     return canvas
 
+def apply_stretch(rgb, target_w):
+    """Bilinear horizontal resample 640 -> target_w. Height unchanged."""
+    return rgb.resize((target_w, H), Image.BILINEAR)
+
+# Stops sampled from PCR_MENU's stormy-sky palette so the gradient feels like
+# the same world: deep midnight at top, mid blue-grey at mid-sky, slate at the
+# horizon.  Easy to retune if a different mood is wanted later.
+GRADIENT_STOPS = [
+    (0.00, (10,  16,  32)),    # near-black sky top
+    (0.55, (40,  60,  80)),    # mid blue-grey
+    (1.00, (90, 110, 130)),    # slate horizon
+]
+
+def apply_gradient(target_w):
+    """Replacement treatment: ignore the bitmap, fill with a vertical gradient."""
+    canvas = Image.new("RGB", (target_w, H))
+    px = canvas.load()
+    stops = GRADIENT_STOPS
+    for y in range(H):
+        t = y / (H - 1)
+        # find bracketing stops
+        for i in range(len(stops) - 1):
+            t0, c0 = stops[i]
+            t1, c1 = stops[i + 1]
+            if t0 <= t <= t1:
+                u = (t - t0) / (t1 - t0) if t1 > t0 else 0
+                r = round(c0[0] + (c1[0] - c0[0]) * u)
+                g = round(c0[1] + (c1[1] - c0[1]) * u)
+                b = round(c0[2] + (c1[2] - c0[2]) * u)
+                break
+        for x in range(target_w):
+            px[x, y] = (r, g, b)
+    return canvas
+
 TREATMENTS = {
     "letterbox":    lambda rgb, w, b, p, fi: apply_letterbox(rgb, w),
     "palette-fill": lambda rgb, w, b, p, fi: apply_palette_fill(rgb, w, b, p, fi),
     "edge-clone":   lambda rgb, w, b, p, fi: apply_edge_clone(rgb, w),
     "mirror-tile":  lambda rgb, w, b, p, fi: apply_mirror_tile(rgb, w),
+    "stretch":      lambda rgb, w, b, p, fi: apply_stretch(rgb, w),
+    "gradient":     lambda rgb, w, b, p, fi: apply_gradient(w),
 }
 
 # ---------------------------------------------------------------------------
@@ -204,21 +251,24 @@ def render_one(hqr_path, entry, treatment, target_w, fill_index=None):
         raise ValueError(f"unknown treatment {treatment!r}; choose from {list(TREATMENTS)}")
     return fn(rgb, target_w, bitmap, palette, fill_index)
 
+COMPARE_ORDER = ("letterbox", "palette-fill", "edge-clone", "mirror-tile",
+                 "stretch", "gradient")
+
 def render_compare(hqr_path, entry, target_w):
-    """Four treatments side by side, stacked vertically, with labels."""
+    """Every treatment stacked vertically with labels."""
     from PIL import ImageDraw
     bitmap, palette = load_bitmap_pair(hqr_path, entry)
     rgb = to_rgb_image(bitmap, palette)
     label_h = 24
     rows = []
-    for name in ("letterbox", "palette-fill", "edge-clone", "mirror-tile"):
+    for name in COMPARE_ORDER:
         img = TREATMENTS[name](rgb, target_w, bitmap, palette, None)
         labelled = Image.new("RGB", (target_w, H + label_h), (32, 32, 32))
         labelled.paste(img, (0, label_h))
         draw = ImageDraw.Draw(labelled)
         draw.text((8, 4), name, fill=(255, 255, 255))
         rows.append(labelled)
-    combined = Image.new("RGB", (target_w, (H + label_h) * 4), (0, 0, 0))
+    combined = Image.new("RGB", (target_w, (H + label_h) * len(rows)), (0, 0, 0))
     for i, row in enumerate(rows):
         combined.paste(row, (0, i * (H + label_h)))
     return combined


### PR DESCRIPTION
Offline renderer that validates the per-entry treatment strategy from #190 before any engine plumbing. Reads retail `SCREEN.HQR`, applies one of the four runtime treatments (`letterbox`, `palette-fill`, `edge-clone`, `mirror-tile`), and dumps target-width PNGs (default 853 = 16:9 @ 480h) for visual review.

## Usage

```bash
# All 39 entries with their strategy-assigned treatments
scripts/dev/art_treatment_preview.py /path/to/SCREEN.HQR --all --outdir preview/

# One entry, one treatment
scripts/dev/art_treatment_preview.py /path/to/SCREEN.HQR --entry 4 \
    --treatment palette-fill --out /tmp/menu.png

# Side-by-side comparison of all four treatments
scripts/dev/art_treatment_preview.py /path/to/SCREEN.HQR --entry 38 \
    --compare --out /tmp/mona_compare.png
```

PNG outputs land under `docs/widescreen/catalog-dumps/` alongside the catalog extractor's dumps — same .gitignore (copyright concern).

## Cheap-test findings

The script was run against retail `SCREEN.HQR`. Most strategy calls held up, but two needed revision after seeing 853-wide output. `docs/widescreen/cheap-test-findings.md` captures the full review.

| Entry | Strategy call | Revised | Why |
|---|---|---|---|
| **4** (`PCR_MENU`) | `edge-clone (dark)` | `palette-fill (dark sky)` | Per-row stretching turned the storm-cloud waves into visible vertical stripes. `palette-fill` auto-detects a dark blue-grey that nearly blends invisibly. |
| **56** (spaceship + planet) | `edge-clone (stars)` | `palette-fill (black)` | Asymmetric nebula trail + glowing planet near the edges produced banding. The starfield idea works for the bumper (entry 2, symmetric stars) but not when high-contrast content sits near the edges. |

**Generalisation:** `edge-clone` is reliable on low-frequency continuous textures (wood, smoke, symmetric starfield) and fragile against anything with vertical structure near the edges. When in doubt, `palette-fill` is the safer pick — invisible at best, plain at worst, never striped.

The revised entries' treatments are reflected in the script's embedded `TRIAGE` table; #190's strategy doc will get a follow-up revision linking back to the findings.

## What this enables

1. **No-engine validation of the treatment algorithm.** Five PNGs in a coffee break = is the math right?
2. **A reference set of goldens** for a future `ui screen-bitmap N` capture verb (following the pattern in `docs/CONTROL.md`), so the engine integration can byte-diff against the offline output.
3. **An iterable triage table.** New revisions (or HD-pack overrides) are data edits.

Pure tooling + research. No engine changes.

> Depends on #190 conceptually (the strategy doc the script implements). Cross-references resolve once both merge.