### PR TITLE
fix(build): make run finds the macOS .app bundle binary

### DIFF
--- a/scripts/dev/build-and-run.sh
+++ b/scripts/dev/build-and-run.sh
@@ -8,12 +8,16 @@ BUILD_DIR="${LBA2_BUILD_DIR:-$REPO_ROOT/build}"
 
 cmake -S "$REPO_ROOT" -B "$BUILD_DIR" -G Ninja -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Debug}"
 
-# Resolve the executable name from CMakeCache.txt so this script follows any
-# -DLBA2_EXECUTABLE_NAME override on every platform (Linux/macOS/msys2). The
-# AppImage env file in build/packaging/ is Linux-only and not sourced here.
+# Resolve names from CMakeCache.txt so this script follows any
+# -DLBA2_EXECUTABLE_NAME / -DLBA2_PRODUCT_NAME override on every platform
+# (Linux/macOS/msys2). The AppImage env file in build/packaging/ is Linux-only
+# and not sourced here.
 LBA2_EXECUTABLE_NAME=$(awk -F= '/^LBA2_EXECUTABLE_NAME:[A-Z]+=/{print $2; exit}' \
                           "$BUILD_DIR/CMakeCache.txt" 2>/dev/null || true)
-LBA2_EXECUTABLE_NAME="${LBA2_EXECUTABLE_NAME:-lba2}"
+LBA2_EXECUTABLE_NAME="${LBA2_EXECUTABLE_NAME:-lba2cc}"
+LBA2_PRODUCT_NAME=$(awk -F= '/^LBA2_PRODUCT_NAME:[A-Z]+=/{print $2; exit}' \
+                          "$BUILD_DIR/CMakeCache.txt" 2>/dev/null || true)
+LBA2_PRODUCT_NAME="${LBA2_PRODUCT_NAME:-LBA2 Classic Community}"
 
 cmake --build "$BUILD_DIR"
 
@@ -28,4 +32,16 @@ if [[ -z "$GAME_DIR" ]]; then
   done
 fi
 
-exec "$BUILD_DIR/SOURCES/$LBA2_EXECUTABLE_NAME" "$@"
+# Resolve the binary to exec. On macOS the build produces an .app bundle
+# whose directory is named after LBA2_PRODUCT_NAME, with the inner Mach-O
+# renamed back to LBA2_EXECUTABLE_NAME (see SOURCES/CMakeLists.txt). On
+# Linux/Windows the binary sits directly under build/SOURCES/.
+BIN="$BUILD_DIR/SOURCES/$LBA2_EXECUTABLE_NAME"
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  MACOS_BIN="$BUILD_DIR/SOURCES/$LBA2_PRODUCT_NAME.app/Contents/MacOS/$LBA2_EXECUTABLE_NAME"
+  if [[ -x "$MACOS_BIN" ]]; then
+    BIN="$MACOS_BIN"
+  fi
+fi
+
+exec "$BIN" "$@"


### PR DESCRIPTION

`scripts/dev/build-and-run.sh` — what `make run` shells out to — still tried to exec the pre-bundle path `build/SOURCES/lba2cc`, so the build succeeded and then `exec` failed with `No such file or directory` and `make run` died with exit code 127. That commit updated the CI workflows, DMG/bundle scripts, and macos-readme, but missed the developer-facing build-and-run script.

## What this changes

In `scripts/dev/build-and-run.sh`:

- Also read `LBA2_PRODUCT_NAME` from `CMakeCache.txt` (fallback matches the default in the root `CMakeLists.txt`).
- On `Darwin`, prefer `$LBA2_PRODUCT_NAME.app/Contents/MacOS/$LBA2_EXECUTABLE_NAME` when it exists and is executable; fall back to the old direct path otherwise (handles bundle-disabled builds and stale build dirs).
- Linux and Windows/msys2 keep the old path verbatim — the `uname -s` guard never triggers on them, and the bundle treatment in `SOURCES/CMakeLists.txt` is itself gated on `if(APPLE)`.
- Bump the `LBA2_EXECUTABLE_NAME` fallback from the long-dead `lba2` to `lba2cc` to match the current default in `CMakeLists.txt` (`b40f5fa`, "build: rename default binary lba2 -> lba2cc"). The cache value is what gets used in practice; this only matters when `CMakeCache.txt` is missing or malformed.

## Test plan

- [x] macOS arm64: `make run` boots past "Initialising Sample device" and "LBA2 Classic Community 0.11.0-dev" — the `exec` call that previously failed now succeeds.
- [x] Path resolution dry-run: `BIN` resolves to `…/LBA2 Classic Community.app/Contents/MacOS/lba2cc`, executable, Mach-O arm64.
- [ ] Linux / Windows (msys2): unchanged code path — `uname -s` guard skips the bundle branch, exec target identical to before.