### PR TITLE
feat(3d): projrec full screen-coordinate coverage (PROJ/PRLI/M2S)

### DIFF
--- a/LIB386/3D/LPROJ3DF.CPP
+++ b/LIB386/3D/LPROJ3DF.CPP
@@ -2,6 +2,7 @@
 
 #include <math.h>
 #include <3D/CAMERA.H>
+#include <3D/PROJREC.H>
 #include <SYSTEM/DEBUG_TRACES.H>
 
 /*
@@ -19,6 +20,7 @@ S32 LongProjectPoint3D(S32 x, S32 y, S32 z) {
         Yp = -2147483647 - 1;
 
         LIB386_TRACE_CPP("LongProjectPoint3DF", "2", "ret=%d Xp=%d Yp=%d", 0, Xp, Yp);
+        Projrec_LongProjectPoint3D(x, y, z, 0, Xp, Yp);
         return 0;
     }
 
@@ -28,6 +30,7 @@ S32 LongProjectPoint3D(S32 x, S32 y, S32 z) {
     Yp = YCentre + (S32)lrintl((long double)(y - CameraYr) * factor * (long double)FRatioY);
 
     LIB386_TRACE_CPP("LongProjectPoint3DF", "2", "ret=%d Xp=%d Yp=%d", 1, Xp, Yp);
+    Projrec_LongProjectPoint3D(x, y, z, 1, Xp, Yp);
     return 1;
 }
 

--- a/LIB386/3D/LPROJISO.CPP
+++ b/LIB386/3D/LPROJISO.CPP
@@ -1,11 +1,13 @@
 #include <3D/LPROJ.H>
 #include <3D/CAMERA.H>
+#include <3D/PROJREC.H>
 #include <3D/SINTAB.H>
 #include <3D/CAMERA.H>
 #include <stdio.h>
 #include <SYSTEM/DEBUG_TRACES.H>
 
 S32 LongProjectPointIso(S32 x, S32 y, S32 z) {
+    S32 origX = x, origY = y, origZ = z;
     LIB386_TRACE_CPP("LongProjectPointIso", "1", "x=%d y=%d z=%d", x, y, z);
     x -= CameraX;
     y -= CameraY;
@@ -33,5 +35,6 @@ S32 LongProjectPointIso(S32 x, S32 y, S32 z) {
     Yp = z;
 
     LIB386_TRACE_CPP("LongProjectPointIso", "2", "ret=%d Xp=%d Yp=%d", -1, Xp, Yp);
+    Projrec_LongProjectPointIso(origX, origY, origZ, Xp, Yp);
     return -1;
 }

--- a/LIB386/3D/PRLI3DF.CPP
+++ b/LIB386/3D/PRLI3DF.CPP
@@ -2,6 +2,7 @@
 
 #include <math.h>
 #include <3D/CAMERA.H>
+#include <3D/PROJREC.H>
 #include <SVGA/SCREENXY.H>
 #include <SYSTEM/DEBUG_TRACES.H>
 
@@ -11,6 +12,7 @@
 void ProjectList3DF(TYPE_PT *Dst, TYPE_VT16 *Src, S32 NbPt,
                     S32 OrgX, S32 OrgY, S32 OrgZ) {
     LIB386_TRACE_CPP("ProjectList3DF", "1", "Dst=%p Src=%p n=%d", (void *)Dst, (void *)Src, NbPt);
+    Projrec_ProjectList3D(NbPt, OrgX, OrgY, OrgZ);
     for (S32 i = 0; i < NbPt; i++) {
         S32 z = OrgZ - (S32)Src[i].Z;
 

--- a/LIB386/3D/PRLIISO.CPP
+++ b/LIB386/3D/PRLIISO.CPP
@@ -1,6 +1,7 @@
 #include <3D/LPROJ.H>
 
 #include <3D/CAMERA.H>
+#include <3D/PROJREC.H>
 #include <SVGA/SCREENXY.H>
 
 #include <string.h>
@@ -10,6 +11,7 @@
 void ProjectListIso(TYPE_PT *Dst, TYPE_VT16 *Src, S32 NbPt, S32 OrgX,
                     S32 OrgY, S32 OrgZ) {
     LIB386_TRACE_CPP("ProjectListIso", "1", "Dst=%p Src=%p n=%d", (void *)Dst, (void *)Src, NbPt);
+    Projrec_ProjectListIso(NbPt, OrgX, OrgY, OrgZ);
     /* The original ASM walks the packed TYPE_VT16 array in place and assumes
 	   NbPt > 0. Tests intentionally keep to that valid ASM input domain. */
     for (int i = 0; i < NbPt; i++) {

--- a/LIB386/3D/PROJREC.CPP
+++ b/LIB386/3D/PROJREC.CPP
@@ -69,3 +69,51 @@ void Projrec_SetIsoProjection(S32 xc, S32 yc) {
     fprintf(s_fp, "SETISO seq=%ld xc=%ld yc=%ld\n",
             s_event_count, (long)xc, (long)yc);
 }
+
+void Projrec_LongProjectPoint3D(S32 x, S32 y, S32 z, S32 ret, S32 xp, S32 yp) {
+    if (!s_fp)
+        return;
+    ++s_event_count;
+    fprintf(s_fp,
+            "PROJ seq=%ld x=%ld y=%ld z=%ld -> ret=%ld xp=%ld yp=%ld\n",
+            s_event_count, (long)x, (long)y, (long)z,
+            (long)ret, (long)xp, (long)yp);
+}
+
+void Projrec_LongProjectPointIso(S32 x, S32 y, S32 z, S32 xp, S32 yp) {
+    if (!s_fp)
+        return;
+    ++s_event_count;
+    fprintf(s_fp,
+            "PROJISO seq=%ld x=%ld y=%ld z=%ld -> xp=%ld yp=%ld\n",
+            s_event_count, (long)x, (long)y, (long)z,
+            (long)xp, (long)yp);
+}
+
+void Projrec_ProjectList3D(S32 nbpt, S32 orgx, S32 orgy, S32 orgz) {
+    if (!s_fp)
+        return;
+    ++s_event_count;
+    fprintf(s_fp,
+            "PRLI seq=%ld nbpt=%ld orgx=%ld orgy=%ld orgz=%ld\n",
+            s_event_count, (long)nbpt, (long)orgx, (long)orgy, (long)orgz);
+}
+
+void Projrec_ProjectListIso(S32 nbpt, S32 orgx, S32 orgy, S32 orgz) {
+    if (!s_fp)
+        return;
+    ++s_event_count;
+    fprintf(s_fp,
+            "PRLIISO seq=%ld nbpt=%ld orgx=%ld orgy=%ld orgz=%ld\n",
+            s_event_count, (long)nbpt, (long)orgx, (long)orgy, (long)orgz);
+}
+
+void Projrec_Map2Screen(S32 x, S32 y, S32 z, S32 xscreen, S32 yscreen) {
+    if (!s_fp)
+        return;
+    ++s_event_count;
+    fprintf(s_fp,
+            "M2S seq=%ld x=%ld y=%ld z=%ld -> xs=%ld ys=%ld\n",
+            s_event_count, (long)x, (long)y, (long)z,
+            (long)xscreen, (long)yscreen);
+}

--- a/LIB386/H/3D/PROJREC.H
+++ b/LIB386/H/3D/PROJREC.H
@@ -51,6 +51,30 @@ void Projrec_SetProjection(S32 xc, S32 yc, S32 clip, S32 fx, S32 fy);
    capturing both gives a full per-scene record. No-op when inactive. */
 void Projrec_SetIsoProjection(S32 xc, S32 yc);
 
+/* Per-point projection captures. Hot path — fired once per vertex/point per
+   frame. Each gates on the IsActive predicate before formatting.
+
+   Two variants because LongProjectPoint is a function pointer that swaps
+   between LongProjectPoint3D (perspective, with a far-clip return code)
+   and LongProjectPointIso (orthographic, always returns -1). Phase 2's
+   XCentre/YCentre change ripples through both, so both need coverage. */
+void Projrec_LongProjectPoint3D(S32 x, S32 y, S32 z, S32 ret, S32 xp, S32 yp);
+void Projrec_LongProjectPointIso(S32 x, S32 y, S32 z, S32 xp, S32 yp);
+
+/* Batched projection list captures. Called once per ProjectList3DF /
+   ProjectListIso invocation; the captured event includes the call's input
+   (NbPt + origin) but not the per-vertex output — per-vertex coverage is
+   already provided by LongProjectPoint hooks above. */
+void Projrec_ProjectList3D(S32 nbpt, S32 orgx, S32 orgy, S32 orgz);
+void Projrec_ProjectListIso(S32 nbpt, S32 orgx, S32 orgy, S32 orgz);
+
+/* Map2Screen capture. Called from SOURCES/GRILLE.CPP::Map2Screen, the
+   isometric world-to-screen translation that bakes the +288 / +226 origin
+   offsets Phase 2 will re-derive from the framebuffer width. Captures the
+   input world coords and the computed screen X/Y for byte-comparable
+   regression. */
+void Projrec_Map2Screen(S32 x, S32 y, S32 z, S32 xscreen, S32 yscreen);
+
 #ifdef __cplusplus
 }
 #endif

--- a/SOURCES/GRILLE.CPP
+++ b/SOURCES/GRILLE.CPP
@@ -1,6 +1,7 @@
 #include "C_EXTERN.H"
 #include "DIRECTORIES.H"
 
+#include <3D/PROJREC.H>
 #include <SVGA/SCREEN.H>
 
 /*══════════════════════════════════════════════════════════════════════════*
@@ -1369,6 +1370,7 @@ void DecompColonne(U8 *pts, U8 *ptd) {
 void Map2Screen(S32 x, S32 y, S32 z) {
     XScreen = 24 * (x - z) + 288;
     YScreen = 12 * (z + x) - 15 * y + 226;
+    Projrec_Map2Screen(x, y, z, XScreen, YScreen);
 }
 
 //-------------------------------------------------------------------


### PR DESCRIPTION
Phase 1.B of [the widescreen plan](https://github.com/LBALab/lba2-classic-community/blob/main/docs/WIDESCREEN.md). **Stacked on #193**; this branch's base is `feat/projrec-capture-1a`, so the diff here only shows the 1.B work. Merge after #193.

Adds five hooks on top of 1.A's scaffolding, giving full per-vertex coverage of the screen-coordinate output that Phase 2's projection-origin changes will affect.

## Hooks

| Hook | Source | Captures |
|---|---|---|
| `LongProjectPoint3D` | `LIB386/3D/LPROJ3DF.CPP` | per-point perspective projection — input `(x,y,z)`, output `(ret, Xp, Yp)` |
| `LongProjectPointIso` | `LIB386/3D/LPROJISO.CPP` | per-point orthographic projection — same shape minus ret |
| `ProjectList3DF` | `LIB386/3D/PRLI3DF.CPP` | batched perspective — per-call `(NbPt, OrgX, OrgY, OrgZ)` (per-vertex output is covered by the point-projection hook above) |
| `ProjectListIso` | `LIB386/3D/PRLIISO.CPP` | batched orthographic — same shape |
| `Map2Screen` | `SOURCES/GRILLE.CPP` | isometric brick world-to-screen — input `(x,y,z)`, output `(XScreen, YScreen)`. **This is where Phase 2 re-derives the `+288 / +226` origin offsets from the framebuffer width.** |

## Smoke test (retail data)

### Exterior — `002 Downtown.LBA`, 5 ticks
- **10,778 events** captured, 667 KB.
- Opcode mix: 1 `SETISO`, 1 `SETPROJ`, 10,687 `PROJ`, 89 `PRLI`.
- Three consecutive runs → byte-identical ✓

### Interior — `001 Start.LBA`, 5 ticks
- **2,497 events** captured, 154 KB.
- Opcode mix: 2 `SETISO`, 274 `PROJISO`, 10 `PRLIISO`, 2,211 `M2S`.
- Three consecutive runs → byte-identical ✓

Sample lines from each:
```
PROJ seq=3 x=-17646 y=6096 z=6842 -> ret=0 xp=-2147483648 yp=-2147483648
M2S seq=4 x=-12 y=17 z=-34 -> xs=816 ys=-581
```

The `M2S` `xs=816 ys=-581` line is exactly the kind of output Phase 2 will need to keep stable at 640×480 (since `288 + 24*(x-z) = 288 + 24*(-12+34) = 816` for that brick). After Phase 2 ships, this line must still read `xs=816 ys=-581` because `640/2 - 32 = 288`.

## No-touch sanity

| Existing piece | Status |
|---|---|
| polyrec recording size for `002 Downtown.LBA` | unchanged (1,091,120 bytes) |
| `test_load.sh` | PASS |
| `test_tick.sh` | PASS |
| Default builds without `--capture-projection` | zero capture cost; one branch per call site |

## What's next

Output volume is now meaningful — a full `--demo` replay will produce hundreds of MB. **PR 1.C** adds a `--projection-hash` mode (per-scene SHA-256 / FNV-1a fingerprint) so the committed CI fixture stays tiny while full diagnosis remains available locally.