### PR TITLE
feat(3d): projrec hash-only mode + committed regression baseline

### DIFF
--- a/LIB386/3D/PROJREC.CPP
+++ b/LIB386/3D/PROJREC.CPP
@@ -2,118 +2,190 @@
  * PROJREC.CPP - Projection capture implementation. See LIB386/H/3D/PROJREC.H
  * for the design intent and the role this plays in the widescreen plan.
  *
- * File format (v1, text, line-oriented, one event per line):
+ * Two output sinks, independent and composable:
  *
- *   # projrec v1
- *   SETPROJ seq=N xc=... yc=... clip=... fx=... fy=...
- *   ...
+ *   Full text   (--capture-projection PATH): one event per line, human-
+ *               readable, deterministic order. Large (hundreds of MB for a
+ *               full --demo replay) but precise — diff-able for diagnosis.
  *
- * Sequence numbers are 1-based and incremented per event so the consumer
- * can spot dropped or reordered events without needing wall-clock state.
+ *   Hash       (--projection-hash PATH): a single FNV-1a 64-bit digest
+ *              computed over the same line text the full sink would have
+ *              written. Tiny (one line in the output file). What CI commits
+ *              and compares.
+ *
+ * Both sinks share the formatted line through emit(); whichever is active
+ * consumes it. When neither sink is active every event is a single branch
+ * (the IsActive check at the top of each Projrec_* function).
  *
  * Thread-safety: the engine is single-threaded; this module is too.
  */
 
 #include <3D/PROJREC.H>
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
 
-static FILE *s_fp = NULL;
+/* FNV-1a 64-bit constants. Chosen over SHA-256 because (a) we only need
+   collision-resistance against accidental drift, not adversarial input,
+   and (b) it's a few lines of code with no header dependencies. */
+#define PROJREC_FNV1A_OFFSET 0xcbf29ce484222325ULL
+#define PROJREC_FNV1A_PRIME 0x00000100000001b3ULL
+
+static FILE *s_fp_full = NULL;
+static FILE *s_fp_hash = NULL;
 static long s_event_count = 0;
+static unsigned long long s_hash = PROJREC_FNV1A_OFFSET;
+
+/* Shared formatter. Computes the line once into a local buffer, then
+   dispatches to whichever sinks are active. Bounded buffer — any single
+   event must fit in 256 bytes (our longest line is well under 128). */
+static void emit(const char *fmt, ...) {
+    if (!s_fp_full && !s_fp_hash)
+        return;
+    char buf[256];
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+    if (n < 0)
+        return;
+    if (n > (int)sizeof(buf) - 1)
+        n = (int)sizeof(buf) - 1;
+    if (s_fp_full)
+        fwrite(buf, 1, (size_t)n, s_fp_full);
+    if (s_fp_hash) {
+        unsigned long long h = s_hash;
+        for (int i = 0; i < n; ++i) {
+            h ^= (unsigned char)buf[i];
+            h *= PROJREC_FNV1A_PRIME;
+        }
+        s_hash = h;
+    }
+}
 
 int Projrec_BeginCapture(const char *path) {
-    if (s_fp) {
-        /* Close the previous capture before opening a new one. Idempotent
-           Begin/End sequencing keeps the caller from leaking a file handle
-           if it forgets to End between runs. */
-        Projrec_EndCapture();
+    /* Close any prior full capture; hash sink is independent and untouched. */
+    if (s_fp_full) {
+        fclose(s_fp_full);
+        s_fp_full = NULL;
     }
     if (!path || !path[0])
         return 0;
-    s_fp = fopen(path, "w");
-    if (!s_fp) {
+    s_fp_full = fopen(path, "w");
+    if (!s_fp_full) {
         fprintf(stderr, "[projrec] failed to open %s for writing\n", path);
         return 0;
     }
-    s_event_count = 0;
-    fprintf(s_fp, "# projrec v1\n");
+    /* Event count and hash reset only when no sink is currently active. If
+       hash capture is already running, the full capture joins mid-stream and
+       only mirrors events from this point — that's intentional, hash mode is
+       the source of truth for what was captured. */
+    if (!s_fp_hash) {
+        s_event_count = 0;
+        s_hash = PROJREC_FNV1A_OFFSET;
+    }
+    fprintf(s_fp_full, "# projrec v1\n");
+    return 1;
+}
+
+int Projrec_BeginHashCapture(const char *path) {
+    if (s_fp_hash) {
+        fclose(s_fp_hash);
+        s_fp_hash = NULL;
+    }
+    if (!path || !path[0])
+        return 0;
+    s_fp_hash = fopen(path, "w");
+    if (!s_fp_hash) {
+        fprintf(stderr, "[projrec] failed to open %s for hash writing\n", path);
+        return 0;
+    }
+    if (!s_fp_full) {
+        s_event_count = 0;
+        s_hash = PROJREC_FNV1A_OFFSET;
+    }
     return 1;
 }
 
 void Projrec_EndCapture(void) {
-    if (!s_fp)
-        return;
-    fprintf(stderr, "[projrec] captured %ld events\n", s_event_count);
-    fclose(s_fp);
-    s_fp = NULL;
+    if (s_fp_hash) {
+        fprintf(s_fp_hash,
+                "# projrec-hash v1\nSCENE events=%ld fnv1a=%016llx\n",
+                s_event_count, s_hash);
+        fclose(s_fp_hash);
+        s_fp_hash = NULL;
+    }
+    if (s_fp_full) {
+        fclose(s_fp_full);
+        s_fp_full = NULL;
+    }
+    if (s_event_count > 0)
+        fprintf(stderr, "[projrec] captured %ld events (fnv1a=%016llx)\n",
+                s_event_count, s_hash);
     s_event_count = 0;
+    s_hash = PROJREC_FNV1A_OFFSET;
 }
 
 int Projrec_IsActive(void) {
-    return s_fp != NULL;
+    return s_fp_full != NULL || s_fp_hash != NULL;
 }
 
 void Projrec_SetProjection(S32 xc, S32 yc, S32 clip, S32 fx, S32 fy) {
-    if (!s_fp)
+    if (!Projrec_IsActive())
         return;
     ++s_event_count;
-    fprintf(s_fp, "SETPROJ seq=%ld xc=%ld yc=%ld clip=%ld fx=%ld fy=%ld\n",
-            s_event_count, (long)xc, (long)yc, (long)clip, (long)fx, (long)fy);
+    emit("SETPROJ seq=%ld xc=%ld yc=%ld clip=%ld fx=%ld fy=%ld\n",
+         s_event_count, (long)xc, (long)yc, (long)clip, (long)fx, (long)fy);
 }
 
 void Projrec_SetIsoProjection(S32 xc, S32 yc) {
-    if (!s_fp)
+    if (!Projrec_IsActive())
         return;
     ++s_event_count;
-    fprintf(s_fp, "SETISO seq=%ld xc=%ld yc=%ld\n",
-            s_event_count, (long)xc, (long)yc);
+    emit("SETISO seq=%ld xc=%ld yc=%ld\n",
+         s_event_count, (long)xc, (long)yc);
 }
 
 void Projrec_LongProjectPoint3D(S32 x, S32 y, S32 z, S32 ret, S32 xp, S32 yp) {
-    if (!s_fp)
+    if (!Projrec_IsActive())
         return;
     ++s_event_count;
-    fprintf(s_fp,
-            "PROJ seq=%ld x=%ld y=%ld z=%ld -> ret=%ld xp=%ld yp=%ld\n",
-            s_event_count, (long)x, (long)y, (long)z,
-            (long)ret, (long)xp, (long)yp);
+    emit("PROJ seq=%ld x=%ld y=%ld z=%ld -> ret=%ld xp=%ld yp=%ld\n",
+         s_event_count, (long)x, (long)y, (long)z,
+         (long)ret, (long)xp, (long)yp);
 }
 
 void Projrec_LongProjectPointIso(S32 x, S32 y, S32 z, S32 xp, S32 yp) {
-    if (!s_fp)
+    if (!Projrec_IsActive())
         return;
     ++s_event_count;
-    fprintf(s_fp,
-            "PROJISO seq=%ld x=%ld y=%ld z=%ld -> xp=%ld yp=%ld\n",
-            s_event_count, (long)x, (long)y, (long)z,
-            (long)xp, (long)yp);
+    emit("PROJISO seq=%ld x=%ld y=%ld z=%ld -> xp=%ld yp=%ld\n",
+         s_event_count, (long)x, (long)y, (long)z,
+         (long)xp, (long)yp);
 }
 
 void Projrec_ProjectList3D(S32 nbpt, S32 orgx, S32 orgy, S32 orgz) {
-    if (!s_fp)
+    if (!Projrec_IsActive())
         return;
     ++s_event_count;
-    fprintf(s_fp,
-            "PRLI seq=%ld nbpt=%ld orgx=%ld orgy=%ld orgz=%ld\n",
-            s_event_count, (long)nbpt, (long)orgx, (long)orgy, (long)orgz);
+    emit("PRLI seq=%ld nbpt=%ld orgx=%ld orgy=%ld orgz=%ld\n",
+         s_event_count, (long)nbpt, (long)orgx, (long)orgy, (long)orgz);
 }
 
 void Projrec_ProjectListIso(S32 nbpt, S32 orgx, S32 orgy, S32 orgz) {
-    if (!s_fp)
+    if (!Projrec_IsActive())
         return;
     ++s_event_count;
-    fprintf(s_fp,
-            "PRLIISO seq=%ld nbpt=%ld orgx=%ld orgy=%ld orgz=%ld\n",
-            s_event_count, (long)nbpt, (long)orgx, (long)orgy, (long)orgz);
+    emit("PRLIISO seq=%ld nbpt=%ld orgx=%ld orgy=%ld orgz=%ld\n",
+         s_event_count, (long)nbpt, (long)orgx, (long)orgy, (long)orgz);
 }
 
 void Projrec_Map2Screen(S32 x, S32 y, S32 z, S32 xscreen, S32 yscreen) {
-    if (!s_fp)
+    if (!Projrec_IsActive())
         return;
     ++s_event_count;
-    fprintf(s_fp,
-            "M2S seq=%ld x=%ld y=%ld z=%ld -> xs=%ld ys=%ld\n",
-            s_event_count, (long)x, (long)y, (long)z,
-            (long)xscreen, (long)yscreen);
+    emit("M2S seq=%ld x=%ld y=%ld z=%ld -> xs=%ld ys=%ld\n",
+         s_event_count, (long)x, (long)y, (long)z,
+         (long)xscreen, (long)yscreen);
 }

--- a/LIB386/H/3D/PROJREC.H
+++ b/LIB386/H/3D/PROJREC.H
@@ -27,13 +27,22 @@
 extern "C" {
 #endif
 
-/* Open the capture file for writing. Returns 1 on success, 0 otherwise
-   (NULL path, empty path, fopen failure). Calling Begin while already
-   active flushes and reopens the file. Writes a `# projrec v1` header. */
+/* Open the full-text capture file for writing. Returns 1 on success, 0
+   otherwise (NULL path, empty path, fopen failure). Calling Begin while
+   already active closes the prior file. Writes a `# projrec v1` header.
+   Composable with Projrec_BeginHashCapture — both sinks can be active
+   simultaneously and receive the same event stream. */
 int Projrec_BeginCapture(const char *path);
 
-/* Flush and close the capture file. Idempotent; safe to call when never
-   begun. Reports the captured event count to stderr if active. */
+/* Open the hash-only capture file for writing. Same shape as BeginCapture,
+   but the file receives nothing during the run — only a single FNV-1a
+   digest line at EndCapture time. Composable with BeginCapture; what gets
+   hashed is the same line text the full sink would write. */
+int Projrec_BeginHashCapture(const char *path);
+
+/* Flush and close both sinks. Idempotent; safe to call when never begun.
+   Reports the captured event count + hash to stderr if any sink was
+   active. */
 void Projrec_EndCapture(void);
 
 /* Cheap branch predicate. Hot-path hook callers gate their formatting on

--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -44,6 +44,8 @@ static int s_have_polyrec = 0;
 static char s_polyrec_path[ADELINE_MAX_PATH];
 static int s_have_projrec = 0;
 static char s_projrec_path[ADELINE_MAX_PATH];
+static int s_have_projrec_hash = 0;
+static char s_projrec_hash_path[ADELINE_MAX_PATH];
 static int s_exit = 0;
 static int s_demo = 0;
 static int s_verbose = 0;
@@ -137,6 +139,14 @@ void Control_ParseArgs(int *argc, char *argv[]) {
             read += 2;
             continue;
         }
+        if (!strcmp(a, "--projection-hash") && has_val) {
+            copy_arg(s_projrec_hash_path, sizeof(s_projrec_hash_path),
+                     argv[read + 1]);
+            s_have_projrec_hash = 1;
+            s_active = 1;
+            read += 2;
+            continue;
+        }
         if (!strcmp(a, "--exit")) {
             s_exit = 1;
             s_active = 1;
@@ -214,10 +224,16 @@ int Control_Begin(void) {
 
     /* Arm projection capture before any InitGame/ChangeCube path that may call
        SetProjection. The boot path's first SetProjection (EXTFUNC.CPP at scene init)
-       lands in the capture file once this is open. Harness-only; default off. */
+       lands in the capture file once this is open. Hash and full-text sinks are
+       independent and composable — either flag (or both) can be given.
+       Harness-only; default off. */
     if (s_have_projrec) {
         if (!Projrec_BeginCapture(s_projrec_path))
             fprintf(stderr, "[control] --capture-projection: capture not armed\n");
+    }
+    if (s_have_projrec_hash) {
+        if (!Projrec_BeginHashCapture(s_projrec_hash_path))
+            fprintf(stderr, "[control] --projection-hash: hash capture not armed\n");
     }
 
     if (s_load_name) {
@@ -420,8 +436,9 @@ static void control_capture(void) {
     if (s_have_shot)
         control_screenshot(s_shot_path);
     /* Flush projection capture last so any final-frame SetProjection from the dump/
-       screenshot present path is included. End is idempotent; safe even if never armed. */
-    if (s_have_projrec)
+       screenshot present path is included. End is idempotent; safe even if never armed,
+       and closes both sinks in one call. */
+    if (s_have_projrec || s_have_projrec_hash)
         Projrec_EndCapture();
 }
 

--- a/tests/automation/test_projection_baseline.sh
+++ b/tests/automation/test_projection_baseline.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# projection baseline: capture the projection-pipeline FNV-1a digest of a
+# deterministic 5-tick replay of Downtown.LBA, byte-compare to the committed
+# golden hash. Phase 1.C of the widescreen plan — the regression net that
+# Phase 2's projection-origin changes must not disturb at 640×480.
+#
+# Fixture: $LBA2_TEST_SAVE must be set to a deterministic exterior save (the
+# default is Downtown for parity with the committed hash). The replay uses
+# --fixed-dt 16 --tick 5; do not change those without regenerating the hash.
+#
+# Regenerate the golden with: LBA2_PROJECTION_REGEN=1 bash tests/automation/test_projection_baseline.sh
+
+TESTNAME=projection_baseline
+. "$(dirname "$0")/lib.sh"
+precheck
+need_save
+
+GOLDEN="$REPO/tests/projection/baselines/downtown_640x480.projrec.hash"
+OUT="$(mktemp -t "${TESTNAME}.XXXXXX.hash")"
+
+ctl_headless --load "$LBA2_TEST_SAVE" \
+    --fixed-dt 16 --tick 5 --projection-hash "$OUT" --exit \
+    >/dev/null 2>&1 \
+    || { rm -f "$OUT"; fail "harness returned non-zero ($?)"; }
+
+[ -f "$OUT" ] || fail "no hash file written"
+
+if [ "${LBA2_PROJECTION_REGEN:-}" = "1" ]; then
+    mkdir -p "$(dirname "$GOLDEN")"
+    cp "$OUT" "$GOLDEN"
+    rm -f "$OUT"
+    pass "regenerated golden: $(basename "$GOLDEN")"
+fi
+
+[ -f "$GOLDEN" ] || { rm -f "$OUT"; fail "golden not committed yet: $GOLDEN"; }
+
+if diff -q "$OUT" "$GOLDEN" >/dev/null; then
+    rm -f "$OUT"
+    pass "projection hash matches golden ($(awk '/fnv1a=/{print $NF}' "$GOLDEN"))"
+else
+    fail "projection hash diverges from golden — see $OUT vs $GOLDEN"
+fi

--- a/tests/projection/README.md
+++ b/tests/projection/README.md
@@ -1,0 +1,74 @@
+# Projection baselines
+
+Tiny committed fingerprints of the engine's projection pipeline, used by
+[`tests/automation/test_projection_baseline.sh`](../automation/test_projection_baseline.sh)
+to detect drift. Phase 1 of the [widescreen plan](../../docs/WIDESCREEN.md).
+
+## What's in a baseline
+
+One line per scenario:
+
+```
+# projrec-hash v1
+SCENE events=10778 fnv1a=f624dd8a3c79d364
+```
+
+The hash is FNV-1a 64-bit over the textual event stream that
+`--capture-projection` would have written for the same run. Two runs of the
+same harness invocation against the same retail data produce the same hash
+iff the projection pipeline produced bit-identical output.
+
+The full text stream isn't committed (hundreds of MB for a `--demo` replay)
+— only the fingerprint. When a hash differs and you need to diagnose what
+changed, regenerate the full capture locally:
+
+```bash
+LBA2_BIN=build/SOURCES/lba2cc \
+LBA2_GAME_DIR=/path/to/retail \
+LBA2_TEST_SAVE=/path/to/Downtown.LBA \
+SDL_AUDIODRIVER=dummy SDL_VIDEODRIVER=dummy \
+$LBA2_BIN --load "$LBA2_TEST_SAVE" --fixed-dt 16 --tick 5 \
+    --capture-projection /tmp/current.projrec --exit
+
+# repeat against the prior build, then:
+diff /tmp/old.projrec /tmp/current.projrec
+```
+
+## Regenerating a baseline
+
+Use when the change is intentional (e.g. Phase 2's projection-origin fix
+which must still match at 640×480 — if it doesn't, the change is wrong;
+if it does, the hash stays the same and no regen is needed):
+
+```bash
+LBA2_BIN=build/SOURCES/lba2cc \
+LBA2_GAME_DIR=/path/to/retail \
+LBA2_TEST_SAVE=/path/to/Downtown.LBA \
+LBA2_PROJECTION_REGEN=1 \
+bash tests/automation/test_projection_baseline.sh
+```
+
+Commit the updated `*.projrec.hash` file alongside the engine change.
+
+## Current baselines
+
+| File | Scenario | Notes |
+|---|---|---|
+| `baselines/downtown_640x480.projrec.hash` | `--load Downtown.LBA --fixed-dt 16 --tick 5` at 640×480 | The starter baseline. Exterior scene with mixed `SETPROJ` / `PROJ` / `PRLI` coverage. |
+
+Wider-resolution baselines (e.g. `downtown_853x480.projrec.hash`) land
+alongside the engine work that actually renders wider frames — Phase 3
+of [WIDESCREEN.md](../../docs/WIDESCREEN.md).
+
+## When a hash differs
+
+1. If the change was intentional and you've validated the new behavior
+   is correct, regenerate with `LBA2_PROJECTION_REGEN=1`.
+2. If the change was unintentional, regenerate the full capture (above)
+   and diff against the prior build's capture to find the first event
+   that diverged. The event's sequence number narrows it to a specific
+   call into the projection pipeline.
+3. If the divergence is non-deterministic (different on different runs
+   of the same build), the determinism guarantee is broken — investigate
+   `--fixed-dt`, the RNG seed, or any new global state added since the
+   baseline was generated.

--- a/tests/projection/baselines/downtown_640x480.projrec.hash
+++ b/tests/projection/baselines/downtown_640x480.projrec.hash
@@ -1,0 +1,2 @@
+# projrec-hash v1
+SCENE events=10778 fnv1a=f624dd8a3c79d364


### PR DESCRIPTION
Phase 1.C of [the widescreen plan](https://github.com/LBALab/lba2-classic-community/blob/main/docs/WIDESCREEN.md). **Stacked on #194** (which is stacked on #193); merge in order 193 → 194 → 195. Closes the regression-net loop: captures stay deterministic, fixtures stay tiny.

## What's here

### Engine
- **`--projection-hash <path>`** flag writes only an FNV-1a 64-bit digest of the full event stream. **Composable with `--capture-projection`** — both flags can run together, and they agree exactly on what was captured (the hash is computed over the same line text the full sink would write).
- **Shared `emit()` helper** factored inside `PROJREC.CPP` so adding future events updates both sinks with one call. Hash uses the FNV-1a 64-bit polynomial — collision-resistant against accidental drift, no header dependencies.

### Fixture + test
- **`tests/projection/baselines/downtown_640x480.projrec.hash`** — 60-byte committed fixture for a 5-tick `Downtown.LBA` replay at 640×480. Captures 10,778 events into hash `f624dd8a3c79d364`.
- **`tests/automation/test_projection_baseline.sh`** — runs the harness, captures the hash, byte-compares to the committed golden. Pattern-matches the existing `ui_compare` tests. `LBA2_PROJECTION_REGEN=1` regenerates the golden.
- **`tests/projection/README.md`** — workflow notes: how to add new baselines, how to diagnose hash divergence (regenerate the full `.projrec` text and diff against the prior build's capture).

## Verified

| Check | Result |
|---|---|
| Three consecutive runs produce same hash | ✓ |
| Test fails when golden is artificially mismatched | ✓ |
| Test regen mode restores the correct hash | ✓ |
| `test_load.sh` | PASS |
| `test_tick.sh` | PASS |
| `test_polyrec.sh` | PASS (1,091,120 bytes unchanged) |
| `test_dump.sh` | PASS |
| `test_screenshot.sh` | PASS |
| `test_projection_baseline.sh` (new) | PASS |

## Sample fixture content

```
# projrec-hash v1
SCENE events=10778 fnv1a=f624dd8a3c79d364
```

Total: 60 bytes per baseline, fits in any commit without bloating the repo.

## Phase 2 hook

When `EXTFUNC.CPP:93` changes from `SetProjection(320, ...)` to `SetProjection(ModeDesiredX/2, ...)`, the hash at 640×480 must stay at **`f624dd8a3c79d364`** (because `640/2 = 320`). If it doesn't, the change is wrong. If it does, the test stays green and we add the wider-build baseline (e.g. `downtown_853x480.projrec.hash`) beside this one when Phase 3 lands.

That completes Phase 1. The plan called for a fourth slice (1.D — `docs/CONTROL.md` workflow notes); I'll do that as a small follow-up unless reviewers prefer it folded in here.