### PR TITLE
docs: point projrec workflow at the corpus + demo tests

### DIFF
--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -346,18 +346,30 @@ lba2cc --load "002 Downtown.LBA" --fixed-dt 16 --tick 5 \
 
 ### Test fixtures and baselines
 
-[`tests/automation/test_projection_baseline.sh`](../tests/automation/test_projection_baseline.sh)
-runs a 5-tick Downtown replay with `--projection-hash` and byte-compares the result
-to a committed golden under [`tests/projection/baselines/`](../tests/projection/baselines/).
-Pattern-matches the UI capture tests above.
+Two committed fixtures under [`tests/projection/baselines/`](../tests/projection/baselines/),
+driven by sibling tests under [`tests/automation/`](../tests/automation/). Coverage
+matrix per save lives in [`tests/projection/README.md`](../tests/projection/README.md).
+
+| Test | Fixture | Scope | Cost |
+|---|---|---|---|
+| [`test_projection_corpus.sh`](../tests/automation/test_projection_corpus.sh) | `corpus_640x480.projrec.hash` | One line per save (50 entries) across the committed save corpus | ~7 s |
+| [`test_projection_demo.sh`](../tests/automation/test_projection_demo.sh) | `demo_640x480.projrec.hash` | 30000-tick attract-mode snapshot; cross-scene transitions saves can't reach | ~35 s, opt-in via `PROJREC_RUN_DEMO=1` |
 
 ```bash
-# Validate the projection baseline (uses LBA2_TEST_SAVE if set, else the default save).
-LBA2_GAME_DIR=/path/to/data bash tests/automation/test_projection_baseline.sh
+# Validate the corpus (covers the projection-pipeline change sites for all 50 saves).
+LBA2_GAME_DIR=/path/to/data bash tests/automation/test_projection_corpus.sh
 
-# Regenerate the golden after an intentional change.
+# Opt in to the demo snapshot too.
+LBA2_GAME_DIR=/path/to/data PROJREC_RUN_DEMO=1 \
+    bash tests/automation/test_projection_demo.sh
+
+# Regenerate everything after an intentional engine change.
+LBA2_BIN=build/SOURCES/lba2cc LBA2_GAME_DIR=/path/to/data \
+    bash scripts/dev/regen_projrec_baselines.sh
+
+# Or regenerate per-test in place.
 LBA2_GAME_DIR=/path/to/data LBA2_PROJECTION_REGEN=1 \
-    bash tests/automation/test_projection_baseline.sh
+    bash tests/automation/test_projection_corpus.sh
 ```
 
 ### Diagnosing a hash divergence

--- a/docs/WIDESCREEN.md
+++ b/docs/WIDESCREEN.md
@@ -46,7 +46,7 @@ The projection 4:3 audit, captured in [WIDESCREEN_PROJECTION_AUDIT.md](WIDESCREE
 
 Before changing projection math, give it a regression net. Phase 1 added a side-channel projection-capture file format that records every projection-pipeline event during a harness run — `SetProjection`, `SetIsoProjection`, per-vertex `LongProjectPoint`, batched `ProjectList`, and isometric `Map2Screen`. Output can be either full text (one event per line, large but diff-able) or a single FNV-1a 64-bit digest (60 bytes, CI-committable). See [`docs/CONTROL.md`'s Projection capture section](CONTROL.md#projection-capture) for the workflow and [`tests/projection/`](../tests/projection/) for the committed baselines.
 
-The contract: the hash for `Downtown.LBA` at 640×480 is `f624dd8a3c79d364`. Phase 2's projection-origin changes must not disturb it.
+The contract: every committed corpus hash at 640×480 must stay stable through Phase 2. The corpus has 22 saves witnessing the exterior path, 28 saves witnessing `Map2Screen`, and all 50 touching `SetIsoProjection` — see [`tests/projection/README.md`](../tests/projection/README.md) for the coverage matrix. If any hash drifts, the failing save name points at which projection path regressed.
 
 This is independent from polyrec (which keeps recording draw calls for ASM↔CPP equivalence); the two harnesses are composable.
 


### PR DESCRIPTION
Follow-up to #197 which retired `test_projection_baseline.sh` and the single `downtown_640x480.projrec.hash` fixture in favor of the 50-save corpus + 30000-tick demo baselines. Cleans up the four stale references #196 left behind.

## What's stale on main right now

| File | Stale because |
|---|---|
| `docs/CONTROL.md:349, 356, 360` | References `test_projection_baseline.sh` (renamed → `test_projection_corpus.sh` in #197) |
| `docs/WIDESCREEN.md:49` | Hash `f624dd8a3c79d364` was tied to the now-retired `downtown_640x480.projrec.hash` |

## What changes

- **`docs/CONTROL.md`** — replaces the single-baseline section with a two-row table (corpus + demo), points at `scripts/dev/regen_projrec_baselines.sh`, mentions the `PROJREC_RUN_DEMO=1` opt-in for the demo test.
- **`docs/WIDESCREEN.md`** — drops the retired Downtown hash from the Phase 1 contract, restates it as 'every committed corpus hash at 640×480' and links to `tests/projection/README.md`'s coverage matrix (22 exterior witnesses + 28 `Map2Screen` witnesses + 50 `SetIsoProjection` witnesses).

No engine changes; just doc fixups so the workflow descriptions reference the files that actually exist on main now.

With this, Phase 1 is fully closed and Phase 2 is unblocked.