### PR TITLE
feat(widescreen): route projection origin + brick clips through render dims

### DIFF
--- a/SOURCES/EXTFUNC.CPP
+++ b/SOURCES/EXTFUNC.CPP
@@ -90,7 +90,13 @@ void Clear3dExt() {
 /*──────────────────────────────────────────────────────────────────────────*/
 // Positionne la caméra pour la 3d Extérieure
 void Init3DExtView(void) {
-    SetProjection(320, 240, CLIP_NEAR, ChampX, ChampZ);
+    // Derive the projection origin from the framebuffer dimensions so the 3D
+    // world centres on the rendered area for any render-space width/height.
+    // At the default 640x480 this is the original (320, 240) — the hardcoded
+    // literal Phase 0 of the widescreen plan flagged; see docs/WIDESCREEN.md
+    // and docs/WIDESCREEN_PROJECTION_AUDIT.md.
+    SetProjection((S32)(ModeDesiredX / 2), (S32)(ModeDesiredY / 2),
+                  CLIP_NEAR, ChampX, ChampZ);
     SetFollowCamera(VueOffsetX, VueOffsetY, VueOffsetZ,
                     AlphaCam, BetaCam, GammaCam,
                     VueDistance);

--- a/SOURCES/GRILLE.CPP
+++ b/SOURCES/GRILLE.CPP
@@ -736,7 +736,7 @@ void AffBrickBlock(S32 block, S32 brick, S16 x, S16 y, S16 z) {
     if (numbrick AND numbrick != ForbidenBrick) {
         Map2Screen(x - StartXCube, y - StartYCube, z - StartZCube);
 
-        if (XScreen >= -24 AND XScreen < 640 AND YScreen >= -38 AND YScreen < 480) {
+        if (XScreen >= -24 AND XScreen < (S32)ModeDesiredX AND YScreen >= -38 AND YScreen < (S32)ModeDesiredY) {
             AffGraph(numbrick - 1, XScreen, YScreen, BufferBrick);
 
             col = (XScreen + 24) / 24; /* 48 / 2 colonne intercalée */
@@ -817,7 +817,7 @@ void AffBrickBlockColon(S32 block, S32 brick, S16 x, S16 y, S16 z) {
     if (numbrick AND numbrick != ForbidenBrick) {
         Map2Screen(x - StartXCube, y - StartYCube, z - StartZCube);
 
-        if (XScreen >= -24 AND XScreen < 640 AND YScreen >= -38 AND YScreen < 480) {
+        if (XScreen >= -24 AND XScreen < (S32)ModeDesiredX AND YScreen >= -38 AND YScreen < (S32)ModeDesiredY) {
             col = (XScreen + 24) / 24; /* 48 / 2 colonne intercalée */
 
             nb = NbBrickColon[col];
@@ -898,7 +898,7 @@ void AffBrickBlockOnly(S32 block, S32 brick, S16 x, S16 y, S16 z) {
     if (numbrick AND numbrick != ForbidenBrick) {
         Map2Screen(x - StartXCube, y - StartYCube, z - StartZCube);
 
-        if (XScreen >= -24 AND XScreen < 640 AND YScreen >= -38 AND YScreen < 480) {
+        if (XScreen >= -24 AND XScreen < (S32)ModeDesiredX AND YScreen >= -38 AND YScreen < (S32)ModeDesiredY) {
             AffGraph(numbrick - 1, XScreen, YScreen, BufferBrick);
         }
     }


### PR DESCRIPTION
Phase 2 mechanical work from [the widescreen plan](https://github.com/LBALab/lba2-classic-community/blob/main/docs/WIDESCREEN.md#phase-2--projection-correction). Two of Phase 2's three sites — both behaviour-preserving at the default 640×480, validated by the projrec corpus + demo baselines that landed in #197.

The third site (`Map2Screen` `+288 / +226`) needs working through (the `+288` folds the framebuffer centre with the isometric grid step geometry, can't just become `ModeDesiredX/2`) and lands in a follow-up.

## Changes

```diff
- SetProjection(320, 240, CLIP_NEAR, ChampX, ChampZ);
+ SetProjection((S32)(ModeDesiredX / 2), (S32)(ModeDesiredY / 2),
+               CLIP_NEAR, ChampX, ChampZ);
```
`SOURCES/EXTFUNC.CPP:93` `Init3DExtView()`. At 640×480 this is the original `(320, 240)`. Because `LongProjectPoint` and `ProjectList` share these globals, the one site covers the sort tree + object drawing together.

```diff
  if (XScreen >= -24 AND XScreen < 640 AND YScreen >= -38 AND YScreen < 480) {
+ if (XScreen >= -24 AND XScreen < (S32)ModeDesiredX AND YScreen >= -38 AND YScreen < (S32)ModeDesiredY) {
```
Same line in three places: `SOURCES/GRILLE.CPP` `AffBrickBlock` / `AffBrickBlockColon` / `AffBrickBlockOnly` (lines 739, 820, 901). Mechanical edge substitution, same shape as the existing sort preclip in `SORT.CPP:211`.

8 lines changed across 2 files.

## Verified

| Check | Result |
|---|---|
| `test_projection_corpus` (50 saves) | **PASS** — every committed hash unchanged at 640×480 |
| `test_projection_demo` (30000-tick attract) | **PASS** — hash unchanged |
| `test_load` / `test_tick` / `test_dump` / `test_screenshot` | all PASS |
| `test_polyrec` (ENABLE_POLY_RECORDING build) | PASS |

The corpus has 22 saves witnessing `SETPROJ` and 22 witnessing the brick-clip path (same set — exterior rendering invokes both). If either change had altered output at 640×480, multiple corpus hashes would have flipped and pointed at the regressed save names. They didn't — Phase 2's contract holds.

## What this doesn't do

- No `Map2Screen` change. The `+288 / +226` literals there fold the framebuffer centre with the isometric grid step (24/12/15), so the rework needs algebra not substitution. Separate PR.
- No wider-build validation. Phase 3 introduces `ModeDesiredX > 640` for the first time; until then, this change is exercised only at 640×480 and the corpus tests prove identity. Once Phase 3 lands a wider build, we add wider-resolution baselines (`corpus_853x480.projrec.hash`) to prove the wider path produces *different* but *valid* output.