### PR TITLE
feat(widescreen): route Map2Screen iso grid origin through render dims

### DIFF
--- a/SOURCES/GRILLE.CPP
+++ b/SOURCES/GRILLE.CPP
@@ -1367,9 +1367,21 @@ void DecompColonne(U8 *pts, U8 *ptd) {
 }
 
 //-------------------------------------------------------------------
+// Map a brick's (x, y, z) world position onto the screen. The 24/12/15
+// factors are the isometric step geometry: each grid step shifts the
+// brick 24 px horizontally / 12 px vertically (the 2:1 iso tile shape),
+// and each vertical world unit shifts -15 px screen-down. The constant
+// offset places brick (0, 0, 0) on screen — historically at (288, 226)
+// at the default 640×480, which is the framebuffer centre minus a
+// (32, 14) shim from the iso grid's geometry (not a derivable formula;
+// the shim is where the retail content expects the iso grid origin to
+// land relative to the projection centre at SetIsoProjection's
+// 320-9 = 311). Derive both axes from the framebuffer dimensions so the
+// iso grid stays centred at any render-space size; at 640×480 this is
+// the original (288, 226). See docs/WIDESCREEN.md Phase 2.
 void Map2Screen(S32 x, S32 y, S32 z) {
-    XScreen = 24 * (x - z) + 288;
-    YScreen = 12 * (z + x) - 15 * y + 226;
+    XScreen = 24 * (x - z) + ((S32)ModeDesiredX / 2 - 32);
+    YScreen = 12 * (z + x) - 15 * y + ((S32)ModeDesiredY / 2 - 14);
     Projrec_Map2Screen(x, y, z, XScreen, YScreen);
 }
 

--- a/tests/test_grille.cpp
+++ b/tests/test_grille.cpp
@@ -44,6 +44,14 @@ extern "C" PTR_U8 BufCube;
 extern "C" PTR_U8 BufMap;
 extern "C" PTR_U8 TabBlock;
 extern "C" PTR_U8 BufferBrick;
+/* Phase 2 of the widescreen plan routed Map2Screen's hardcoded 288/226
+   origin offsets through the framebuffer dimensions. The ASM half of the
+   equivalence test still uses the 288/226 literals, so the CPP path must
+   evaluate to the same values — i.e. ModeDesiredX/2-32 = 288 (so X=640)
+   and ModeDesiredY/2-14 = 226 (so Y=480). main() pins them before any
+   Map2Screen call. */
+extern "C" U32 ModeDesiredX;
+extern "C" U32 ModeDesiredY;
 
 extern "C" U8 asm_CodeJeu;
 extern "C" S32 asm_XMap;
@@ -462,6 +470,11 @@ static void test_grille_random_stress(void) {
 }
 
 int main(void) {
+    /* Pin render dims to the default 4:3 so Map2Screen's framebuffer-derived
+       origin offsets evaluate to the original 288/226 the ASM compares against. */
+    ModeDesiredX = 640;
+    ModeDesiredY = 480;
+
     RUN_TEST(test_getadrblock_equivalence);
     RUN_TEST(test_map2screen_equivalence);
     RUN_TEST(test_map2screen_random_stress);


### PR DESCRIPTION
Closes Phase 2's three planned sites from [the widescreen plan](https://github.com/LBALab/lba2-classic-community/blob/main/docs/WIDESCREEN.md#phase-2--projection-correction) (after the mechanical pair in #199). Byte-identical at 640×480, validated by the corpus + demo projrec baselines.

## The change

```diff
 void Map2Screen(S32 x, S32 y, S32 z) {
-    XScreen = 24 * (x - z) + 288;
-    YScreen = 12 * (z + x) - 15 * y + 226;
+    XScreen = 24 * (x - z) + ((S32)ModeDesiredX / 2 - 32);
+    YScreen = 12 * (z + x) - 15 * y + ((S32)ModeDesiredY / 2 - 14);
```

Plus a documentation block on what the magic numbers mean — see below.

## The algebra

`Map2Screen` projects a brick's world `(x, y, z)` onto the screen for the isometric (interior) renderer. The 24/12/15 factors are the iso tile step geometry — each grid step shifts the brick 24 px horizontally / 12 px vertically (the 2:1 iso tile shape), and each vertical world unit shifts −15 px screen-down. The constant offset places brick `(0, 0, 0)` somewhere on screen.

At default 640×480 that origin is `(288, 226)` = `(320 − 32, 240 − 14)` = framebuffer centre minus a `(32, 14)` shim. The shim **isn't a derivable formula** — it's where the retail content expects the iso grid origin to land relative to `SetIsoProjection`'s projection centre at `320 − 9 = 311` (called from `GAMEMENU.CPP:515`). The two iso sites must move together to keep the scene composition coherent.

The fix: derive both axes from the framebuffer dimensions and keep the shim. Centres the iso grid at any render-space size; identical to 288/226 at 640×480.

## Verified

| Check | Result |
|---|---|
| `test_projection_corpus` (50 saves) | **PASS** — every committed hash unchanged at 640×480 |
| `test_projection_demo` (30000-tick attract) | **PASS** — hash unchanged |
| `test_load` / `test_tick` / `test_dump` / `test_screenshot` | all PASS |

28 corpus saves witness `M2S` (102K events total) and the demo run produces 5142 more. None drifted at 640×480.

## Phase 2 complete — and one gap the audit missed

This PR closes Phase 2's three planned sites:

| Site | PR |
|---|---|
| `EXTFUNC.CPP:93` `SetProjection` derivation | #199 |
| `GRILLE.CPP` brick clips (×3) | #199 |
| `GRILLE.CPP:1370` `Map2Screen` origin | **this PR** |

While digging for this, three more hardcoded `(320, 240)`-style sites surfaced that **weren't in the original audit** — the iso analog of `EXTFUNC.CPP:93`:

- `GAMEMENU.CPP:515` `Init3DView` — `SetIsoProjection(320 − 8 − 1, 240)` (boot init)
- `COMPORTE.CPP:351` `DrawMenuComportement` — same value (behaviour menu wheel)
- `COMPORTE.CPP:164` — already parameterised (takes a rect centre)

These need the same `ModeDesiredX/Y` routing so iso scenes render correctly in wider frames. Out of scope for this PR (the plan was explicit about its three sites), but a small follow-up — same byte-identity contract at 640×480 means it can land any time without disturbing the contract.

After that follow-up, Phase 2 is **really** done and Phase 3 (widen the framebuffer) unblocks.