### PR TITLE
feat(widescreen): route iso projection-setup sites through render dims

### DIFF
--- a/SOURCES/COMPORTE.CPP
+++ b/SOURCES/COMPORTE.CPP
@@ -348,7 +348,12 @@ void DrawMenuComportement(S32 beta) {
     S32 n;
     T_MENU_COMP *ptrmcomp = &ListMenuComp[ComportementMenu];
 
-    SetIsoProjection(320 - 8 - 1, 240);
+    // Initial iso projection centre — overridden per-tile by DrawObjComportement
+    // (line 164) for each behaviour-wheel thumbnail, so this matters only as
+    // initial state. Routed through ModeDesiredX/Y to stay consistent with the
+    // other Init3DView/Map2Screen iso sites and survive any future refactor that
+    // removes the per-tile override. At 640x480 this is the original (311, 240).
+    SetIsoProjection((S32)ModeDesiredX / 2 - 9, (S32)ModeDesiredY / 2);
     SetPosCamera(0, 0, 0);
     SetAngleCamera(0, 0, 0);
     SetLightVector(AlphaLight, BetaLight, 0);

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -512,7 +512,13 @@ static void CycleVoiceLanguage(S32 step) {
 /*──────────────────────────────────────────────────────────────────────────*/
 
 void Init3DView(void) {
-    SetIsoProjection(320 - 8 - 1, 240);
+    // Iso projection centre = framebuffer centre - 9px horizontal shim. The -9 is
+    // an iso-grid offset that pairs with Map2Screen's -32 origin shim (see
+    // GRILLE.CPP::Map2Screen) — the two iso sites must move together to keep
+    // interior scene composition coherent. Routing through ModeDesiredX/Y so
+    // iso scenes stay centred at any render-space size; at 640x480 this is the
+    // original (311, 240). See docs/WIDESCREEN.md Phase 2.
+    SetIsoProjection((S32)ModeDesiredX / 2 - 9, (S32)ModeDesiredY / 2);
     SetPosCamera(0, 0, 0);
     SetAngleCamera(0, 0, 0);
     SetLightVector(AlphaLight, BetaLight, 0);


### PR DESCRIPTION
Closes the iso analog of `EXTFUNC.CPP:93` (which #199 routed for the exterior perspective path). The original Phase 0 audit missed these two sites; they surfaced while writing #200's `Map2Screen` documentation.

Both behaviour-preserving at 640×480, validated by the corpus + demo projrec baselines. Independent of #200 (different files) — can land in either order.

## Changes

```diff
-    SetIsoProjection(320 - 8 - 1, 240);
+    SetIsoProjection((S32)ModeDesiredX / 2 - 9, (S32)ModeDesiredY / 2);
```

Two call sites, same substitution + inline documentation:

| File | Function | Notes |
|---|---|---|
| `SOURCES/GAMEMENU.CPP:515` | `Init3DView` | Boot init — fires for every loaded save. `-9` is the iso-grid horizontal shim that pairs with `Map2Screen`'s `-32` origin shim (#200). |
| `SOURCES/COMPORTE.CPP:351` | `DrawMenuComportement` | Initial state that gets overridden per-tile by `DrawObjComportement` (line 164, already parameterised). Effectively a no-op today; routed for consistency. |

The third `SetIsoProjection` call site (`COMPORTE.CPP:164`) already takes a rect centre — no change needed.

## Verified

| Check | Result |
|---|---|
| `test_projection_corpus` (50 saves) | **PASS** — `SETISO` events still `xc=311 yc=240` (= 640/2 - 9) |
| `test_projection_demo` (30000-tick attract) | **PASS** — hash unchanged |
| `test_load` / `test_tick` / `test_dump` / `test_screenshot` | all PASS |

## Phase 2 complete

After this + #200 merge:

| Site | PR |
|---|---|
| `EXTFUNC.CPP:93` exterior projection | #199 |
| `GRILLE.CPP` brick clips (×3) | #199 |
| `GRILLE.CPP` `Map2Screen` iso grid origin | #200 |
| `GAMEMENU.CPP` / `COMPORTE.CPP` iso projection setup | **this PR** |

Phase 3 (widen the framebuffer) unblocks.