### PR TITLE
docs(widescreen): mark Phase 2 done, record open xmin/ymin follow-up

### DIFF
--- a/docs/WIDESCREEN.md
+++ b/docs/WIDESCREEN.md
@@ -50,15 +50,23 @@ The contract: every committed corpus hash at 640×480 must stay stable through P
 
 This is independent from polyrec (which keeps recording draw calls for ASM↔CPP equivalence); the two harnesses are composable.
 
-### Phase 2 — projection correction
+### Phase 2 — projection correction (done)
 
-Fix the projection origin and the brick renderer, the two render-space areas Phase 0 found. All of it is behaviour-preserving at the default 640×480:
+Routed every render-space projection constant through `ModeDesiredX/Y`. All behaviour-preserving at 640×480; validated against the Phase 1 projrec corpus + demo baselines on each PR.
 
-- Derive `XCentre` from `ModeDesiredX / 2` (keep `YCentre` at half-height) at `SOURCES/EXTFUNC.CPP:93`, so the 3D world centres on the framebuffer instead of on a fixed `320`. Because `LongProjectPoint` and `ProjectList` share these globals, the one change covers the sort tree and object drawing together.
-- Route the `SOURCES/GRILLE.CPP` brick clips (`XScreen < 640 ... YScreen < 480` in `AffBrickBlock` / `AffBrickBlockColon` / `AffBrickBlockOnly`) to the render width — mechanical edge replacements, like the sort preclip.
-- Re-centre the `Map2Screen` isometric origin (`+288` / `+226`, `GRILLE.CPP:1370`) — design work, not a find-replace. These constants fold the screen centre together with the isometric grid geometry (the `24` / `12` / `15` brick steps), so `288` is not the framebuffer centre and cannot simply become `ModeDesiredX / 2`. Widening shifts the X origin to keep the grid centred; the Y origin (`226`) holds while height stays 480. This is the one site in Phase 2 that needs working through rather than substituting.
+The three sites the Phase 0 audit called out:
 
-Validate against the Phase 1 baseline: at 640×480 the output must be unchanged.
+- **PR #199** — `SOURCES/EXTFUNC.CPP:93` `SetProjection(320, 240, ...)` → `SetProjection((S32)(ModeDesiredX/2), (S32)(ModeDesiredY/2), ...)`. Because `LongProjectPoint` and `ProjectList` share these globals, the one change covers the sort tree and object drawing together.
+- **PR #199** — `SOURCES/GRILLE.CPP` brick clips (`XScreen < 640 ... YScreen < 480` in `AffBrickBlock` / `AffBrickBlockColon` / `AffBrickBlockOnly`) routed through `(S32)ModeDesiredX/Y`. Same shape as the existing sort preclip.
+- **PR #200** — `Map2Screen` `+288` / `+226` (`GRILLE.CPP:1370`) routed through `(S32)ModeDesiredX/2 - 32` / `(S32)ModeDesiredY/2 - 14`. The `-32` and `-14` are iso-grid geometry shims (not the framebuffer centre minus a clean offset); documented inline so the next maintainer doesn't have to re-derive them. Also fixed the `test_grille` ASM-equivalence test to pin `ModeDesiredX/Y` (the ASM half still bakes in `288 / 226`).
+
+Plus one site the original audit missed, surfaced while writing #200's inline docs:
+
+- **PR #201** — iso projection-setup analog of `EXTFUNC.CPP:93`. `SetIsoProjection(320 - 8 - 1, 240)` in `SOURCES/GAMEMENU.CPP:515` (`Init3DView`, boot init) and `SOURCES/COMPORTE.CPP:351` (`DrawMenuComportement`, behaviour menu wheel) routed through `(S32)ModeDesiredX/2 - 9, (S32)ModeDesiredY/2`. The `-9` is the iso-grid horizontal shim that pairs with Map2Screen's `-32`; the two iso sites must move together to keep interior scene composition coherent.
+
+Net: eight call sites across four files, ~30 lines of code change. The corpus + demo projrec hashes stayed identical at 640×480 throughout, and `test_grille` is green again.
+
+One render-space site the original audit flagged remains open: `SOURCES/GRILLE.CPP:954-955` `xmin = 639; ymin = 479;` — bounding-box sentinel seeds in `AffOneBrick`. At 640×480 the seeds work as upper bounds; at any wider render width they'd cap `xmin` at 639 and miss bricks beyond. Two-line fix; tracked as a Phase 2 follow-up so it lands before Phase 3 widens the framebuffer.
 
 ### Phase 3 — widen the framebuffer
 

--- a/docs/WIDESCREEN_PROJECTION_AUDIT.md
+++ b/docs/WIDESCREEN_PROJECTION_AUDIT.md
@@ -68,15 +68,22 @@ These configure the same globals for non-gameplay views. Most are UI-space and o
 
 There is no screen-space "neighbour cube radius." Cube and decor visibility comes from the world-space camera distance, the near plane, and per-primitive screen clips (the GRILLE clips below, plus the already-fixed sort preclip).
 
-## Render-space sites still hardcoded
+## Render-space sites the audit flagged
 
-`SOURCES/GRILLE.CPP` is the render subsystem PR #134 did not cover. None of these route through the resolution constants:
+`SOURCES/GRILLE.CPP` was the render subsystem PR #134 did not cover. Status of each site after Phase 2:
 
-- `GRILLE.CPP:738`, `:819`, `:900` (`AffBrickBlock` / `AffBrickBlockColon` / `AffBrickBlockOnly`): `if (XScreen >= -24 AND XScreen < 640 AND YScreen >= -38 AND YScreen < 480)`. Bricks projecting to screen-X ≥ 640 are dropped, clipping grid scenery at x=640 on a wider canvas.
-- `GRILLE.CPP:953`: `xmin = 639; ymin = 479;` — seeds a bounding-box min-finder at the 4:3 edges.
-- `GRILLE.CPP:1370` (`Map2Screen`): `XScreen = 24 * (x - z) + 288; YScreen = 12 * (z + x) - 15 * y + 226;` — the isometric brick-to-screen centre offsets `288` / `226` are baked in.
+- `GRILLE.CPP:738`, `:819`, `:900` (`AffBrickBlock` / `AffBrickBlockColon` / `AffBrickBlockOnly`): brick clips — **closed by PR #199**. Now `XScreen < (S32)ModeDesiredX AND YScreen < (S32)ModeDesiredY`.
+- `GRILLE.CPP:953`: `xmin = 639; ymin = 479;` — bounding-box sentinel seeds in `AffOneBrick`. **Still open.** At 640×480 the seeds work as upper bounds; at any wider render width they'd cap `xmin` at 639 and miss bricks beyond. Two-line fix queued as a Phase 2 follow-up before Phase 3 widens the framebuffer.
+- `GRILLE.CPP:1370` (`Map2Screen`): iso brick-to-screen origin — **closed by PR #200**. Now `(S32)ModeDesiredX/2 - 32` / `(S32)ModeDesiredY/2 - 14`; the `-32` / `-14` are iso-grid geometry shims that pair with `SetIsoProjection`'s `-9` shim.
 
-The projection origin (`EXTFUNC.CPP:93`) is the other render-space gap; see above.
+The projection origin (`EXTFUNC.CPP:93`) was the other render-space gap; **closed by PR #199** (now derives `XCentre` / `YCentre` from `ModeDesiredX` / `ModeDesiredY`).
+
+## Reclassified during Phase 2
+
+The "Other `SetProjection` / `SetIsoProjection` callers" table above listed these as UI-space / out of scope, but writing the `Map2Screen` inline docs in PR #200 surfaced that they're the iso analog of `EXTFUNC.CPP:93` and need to move together with `Map2Screen` to keep interior scene composition coherent. **Closed by PR #201:**
+
+- `SOURCES/GAMEMENU.CPP:514` `Init3DView` — `SetIsoProjection(320 - 8 - 1, 240)` → `(S32)ModeDesiredX/2 - 9, (S32)ModeDesiredY/2`.
+- `SOURCES/COMPORTE.CPP:351` `DrawMenuComportement` — same substitution. Initial state overridden per-tile by the parameterised call at `:164`, but routed for consistency.
 
 ## Render-space sites already routed (PR #134)
 


### PR DESCRIPTION
Phase 2 of the widescreen plan landed across #199 / #200 / #201. This PR updates the two widescreen docs to reflect the new state. No engine work.

## docs/WIDESCREEN.md

Phase 2 section header changed to '(done)'. The three planned sites get annotated with their landing PR; plus the iso projection-setup sites #201 reclassified from the audit's UI-space table.

## docs/WIDESCREEN_PROJECTION_AUDIT.md

'Render-space sites still hardcoded' retitled to 'Render-space sites the audit flagged' with per-site status (closed by which PR, or still open). New 'Reclassified during Phase 2' section records that `COMPORTE.CPP:351` + `GAMEMENU.CPP:514` were promoted from UI-space to render-space during PR #200's inline-docs writing.

## One open follow-up surfaced

While writing the audit-doc update, one render-space site the original audit flagged is still hardcoded:

```cpp
// SOURCES/GRILLE.CPP:954-955 (AffOneBrick)
xmin = 639;
ymin = 479;
```

Bounding-box sentinel seeds. At 640×480 they act as upper bounds and Min() converges correctly. At any wider render width they'd cap `xmin` at 639 and miss bricks beyond. Two-line fix; queued as a Phase 2 follow-up that should land before Phase 3 widens the framebuffer.

The four Phase 2 PRs missed it (it's not a projection-pipeline site so it doesn't show up in the projrec hashes — the safety net designed for Phase 2's projection changes can't catch this kind of geometry-bound regression). Worth fixing now while the context is fresh.