### PR TITLE
feat(widescreen): route AffOneBrick bounding-box seeds through render dims

### DIFF
--- a/SOURCES/GRILLE.CPP
+++ b/SOURCES/GRILLE.CPP
@@ -951,8 +951,13 @@ void AffOneBrick(S32 x, S32 y, S32 z) {
     S16 zdeb;
     U8 codejeu;
 
-    xmin = 639;
-    ymin = 479;
+    // Sentinel seeds for the min-accumulator below. Must be at least as large as
+    // any ScreenXMin/YMin a drawn brick could produce, i.e. the framebuffer right
+    // and bottom edges. At 640x480 these are the original 639/479; route through
+    // ModeDesiredX/Y so wider builds catch bricks past x=640. See Phase 2 in
+    // docs/WIDESCREEN.md.
+    xmin = (S32)ModeDesiredX - 1;
+    ymin = (S32)ModeDesiredY - 1;
     xmax = 0;
     ymax = 0;
 


### PR DESCRIPTION
Closes the last render-space site from the Phase 0 audit (recorded in [`docs/WIDESCREEN_PROJECTION_AUDIT.md`](https://github.com/LBALab/lba2-classic-community/blob/main/docs/WIDESCREEN_PROJECTION_AUDIT.md)). With this, Phase 2 of [the widescreen plan](https://github.com/LBALab/lba2-classic-community/blob/main/docs/WIDESCREEN.md) is **genuinely complete** and Phase 3 unblocks.

## The change

```diff
- xmin = 639;
- ymin = 479;
+ xmin = (S32)ModeDesiredX - 1;
+ ymin = (S32)ModeDesiredY - 1;
```

Two lines + inline doc. `SOURCES/GRILLE.CPP:951-955` (`AffOneBrick`).

## Why this site matters

`xmin` / `ymin` are min-accumulator seeds for a bounding box computed across a 3×3 brick neighborhood:

```cpp
if (ScreenXMin < xmin) xmin = ScreenXMin;
```

At 640×480 the literal seeds `639` / `479` correctly bound any drawn brick's `ScreenXMin`/`YMin`. At any wider render width the literal would cap `xmin` at 639 — bricks drawn past x=640 would never pull `xmin` up above the seed, breaking the `SetClip(xmin, ymin, xmax, ymax)` call at the end of the function.

Routing through `(S32)ModeDesiredX - 1` / `(S32)ModeDesiredY - 1` keeps the seeds correct at any render-space size. At 640×480 they evaluate to the original 639/479.

## Why the Phase 2 PRs missed it

This isn't a projection-pipeline site — `xmin/ymin/xmax/ymax` are local bounding-box state, not values that get logged to projrec. The corpus + demo regression net designed for Phase 2's projection changes can't see geometry-bound regressions. The audit doc was the actual source of truth here, and #202 surfaced this when updating the audit's status table.

## Verified

| Check | Result |
|---|---|
| `test_projection_corpus` (50 saves) | **PASS** — unchanged at 640×480 |
| `test_projection_demo` | **PASS** |
| `test_load` / `test_tick` / `test_dump` / `test_screenshot` | all **PASS** |

## Phase 2 — truly done after this

| PR | Site |
|---|---|
| #199 | `EXTFUNC.CPP:93` exterior projection + `GRILLE.CPP` brick clips |
| #200 | `GRILLE.CPP` `Map2Screen` iso grid origin + `test_grille` fix |
| #201 | `GAMEMENU.CPP` + `COMPORTE.CPP` iso `SetIsoProjection` |
| #202 | docs: Phase 2 done, audit status update |
| **this PR** | `GRILLE.CPP` `AffOneBrick` bounding-box seeds |

The audit's four render-space findings are now all closed. Phase 3 — widen the framebuffer — unblocks.