### PR TITLE
fix(widescreen): scale Z-buffer to RESOLUTION_X/Y

### DIFF
--- a/SOURCES/3DEXT/EXTERN.H
+++ b/SOURCES/3DEXT/EXTERN.H
@@ -7,7 +7,15 @@
 #include "LBA_EXT.H"
 #include "VAR_EXT.H"
 
-#define SIZE_Z_BUFFER (640 * 480 * 2)
+#include <SYSTEM/RESOLUTION.H>
+
+// One U16 entry per framebuffer pixel. The exterior renderer indexes this
+// as PtrZBuffer[Y * ModeDesiredX + X] (see LIB386/pol_work/ + GRILLE.CPP),
+// so the buffer must scale with the compiled render width — a hardcoded
+// 640x480 silently drops terrain polygons whose Y projects past
+// SIZE_Z_BUFFER/(2*ModeDesiredX) on any wider build. See Phase 3 of
+// docs/WIDESCREEN.md.
+#define SIZE_Z_BUFFER (RESOLUTION_X * RESOLUTION_Y * 2)
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Fixes the **bottom-band bug** in wide-build exterior scenes spotted in PR #204's screenshots. `SIZE_Z_BUFFER` was hardcoded to `(640*480*2)` = 307200 U16 entries; the exterior renderer addresses `PtrZBuffer` as `Y*ModeDesiredX+X`, so at wider widths the renderer overruns past index 307200 — i.e. past row `307200/ModeDesiredX`. At 768 wide that's row 400. Terrain polygons whose projected Y >= 400 fail the Z-buffer test on garbage memory and get rejected, leaving sky/fog visible in the bottom ~80 rows.

## The diagnosis

| Scene at 768×480 | Bottom-band color | Cause |
|---|---|---|
| Volcano Island | (212, 112, 96) pink/coral | Volcanic sky color showing through where terrain didn't write |
| Anon1 (Citadel night) | (0, 0, 0) black | Citadel night sky color |
| Hacienda | (128, 180, 212) sky-blue | Hacienda sky color |
| Desert Island | (128, 180, 212) sky-blue | Same |

All four hit at Y >= ~400. `307200 / 768 = 400` exactly.

Confirmed via `projrec --capture-projection` diff that **projection coordinates at narrow vs wide are identical** (same world points → same Yp values). The bug isn't in projection — it's in the buffer addressing. Yp = 400+ at wide is a perfectly valid Y, but the Z-buffer entry at `400 * 768 + X` is past the allocated 614400 bytes.

## The fix

```diff
 #include "VAR_EXT.H"

-#define SIZE_Z_BUFFER (640 * 480 * 2)
+#include <SYSTEM/RESOLUTION.H>
+#define SIZE_Z_BUFFER (RESOLUTION_X * RESOLUTION_Y * 2)
```

Same pattern `MEM.CPP` already uses for the Screen / Log / ScreenAux allocations (the work PR #134 did for most render buffers — this one slipped through). Inline comment documents the indexing assumption the renderer makes.

## Verified

| Check | Result |
|---|---|
| `test_projection_corpus` at 640 | **PASS** (hashes unchanged) |
| `test_projection_corpus` at 768 | **PASS** (hashes unchanged — projection output identical, only Z-buffer storage size changed) |
| Volcano + Anon1 + Hacienda wide screenshots | Bottom band gone ✓ |

## Class of bug projrec doesn't catch

The Phase 1 projrec safety net captures projection-pipeline coordinates, not pixel-fill correctness. This bug ships polygons through projection cleanly (the events are identical) but corrupts the rasteriser via under-allocated state. Same class as the `AffOneBrick xmin/ymin` issue #203 closed before Phase 3 — both "render-space sites that don't pass through projrec hooks". Worth keeping in mind as Phase 5 / Phase 3 widens further: visible-output regressions can sneak past green projrec hashes.

The remaining wide-build oddity reported on PR #204 — "missing tiles on left of demo attract" — is **not** fixed by this PR. The Z-buffer expansion doesn't change attract-mode rendering (interior brick blits via AffGraph don't use `PtrZBuffer`). That issue has a different root cause and is the next thing to investigate.