### PR TITLE
fix(widescreen): store XScreen in T_COLONB so DrawOverBrick re-blits accurately

### DIFF
--- a/SOURCES/GRILLE.CPP
+++ b/SOURCES/GRILLE.CPP
@@ -34,6 +34,14 @@ typedef struct
     S16 Xm;
     S16 Ym;
     S16 Zm;
+    S16 Xs; /* screen X — stored explicitly so DrawOverBrick can re-blit at the exact
+              same position the original AffBrickBlock paint used. The col index
+              alone is insufficient when Map2Screen's iso origin offset is not a
+              multiple of 24 (col*24-24 then loses the remainder, off-by-up-to-23
+              from the original XScreen — manifests as iso bricks 'jittering' under
+              DrawOverBrick at non-traditional render widths). At the historical
+              640x480 the offset is 288 which is 12*24 so the legacy col*24-24
+              reconstruction was exact. */
     S16 Ys;
     S16 Brick;
     S16 Col;
@@ -577,7 +585,6 @@ void InitBufferCube() {
 
 void DrawOverBrick(S32 xm, S32 ym, S32 zm) {
     register T_COLONB *ptrlbc;
-    register S32 colscreen;
     S32 col, i;
     S32 startcol, endcol;
     S32 xw, yw, zw;
@@ -588,8 +595,6 @@ void DrawOverBrick(S32 xm, S32 ym, S32 zm) {
 
     for (col = startcol; col <= endcol; col++) {
         ptrlbc = &ListBrickColon[col][0];
-
-        colscreen = col * 24 - 24;
 
         for (i = 0; i < NbBrickColon[col]; i++) {
             /* bricks devant */
@@ -624,7 +629,7 @@ void DrawOverBrick(S32 xm, S32 ym, S32 zm) {
                                    1
                                        //				AND WorldColBrick(xw+SIZE_BRICK_XZ,yw,zw)==1 ) )
                                        AND WorldColBrick(xw + SIZE_BRICK_XZ, yw, zw) >= 1)) {
-                        CopyMask(ptrlbc->Brick, colscreen, ptrlbc->Ys, BufferMaskBrick, Screen);
+                        CopyMask(ptrlbc->Brick, ptrlbc->Xs, ptrlbc->Ys, BufferMaskBrick, Screen);
                     }
                 }
             }
@@ -638,7 +643,6 @@ void DrawOverBrick(S32 xm, S32 ym, S32 zm) {
 
 void DrawOverBrick3(S32 xm, S32 ym, S32 zm, S32 ymax) {
     register T_COLONB *ptrlbc;
-    register S32 colscreen;
     S32 col, i;
     S32 startcol, endcol;
 
@@ -648,8 +652,6 @@ void DrawOverBrick3(S32 xm, S32 ym, S32 zm, S32 ymax) {
     for (col = startcol; col <= endcol; col++) {
         ptrlbc = &ListBrickColon[col][0];
 
-        colscreen = col * 24 - 24;
-
         for (i = 0; i < NbBrickColon[col]; i++, ptrlbc++) {
             /* bricks devant */
             if (ptrlbc->Ys + 38 > ClipYMin
@@ -657,17 +659,17 @@ void DrawOverBrick3(S32 xm, S32 ym, S32 zm, S32 ymax) {
                 if (ptrlbc->Ym > ymax) {
                     if ((ptrlbc->Zm >= zm)
                             OR(ptrlbc->Xm >= xm)) {
-                        CopyMask(ptrlbc->Brick, colscreen, ptrlbc->Ys, BufferMaskBrick, Screen);
+                        CopyMask(ptrlbc->Brick, ptrlbc->Xs, ptrlbc->Ys, BufferMaskBrick, Screen);
                     }
                 } else if (ptrlbc->Ym >= ym) {
                     if ((ptrlbc->Zm == zm)
                             AND(ptrlbc->Xm == xm)) {
-                        CopyMask(ptrlbc->Brick, colscreen, ptrlbc->Ys, BufferMaskBrick, Screen);
+                        CopyMask(ptrlbc->Brick, ptrlbc->Xs, ptrlbc->Ys, BufferMaskBrick, Screen);
                     }
 
                     if ((ptrlbc->Zm > zm)
                             OR(ptrlbc->Xm > xm)) {
-                        CopyMask(ptrlbc->Brick, colscreen, ptrlbc->Ys, BufferMaskBrick, Screen);
+                        CopyMask(ptrlbc->Brick, ptrlbc->Xs, ptrlbc->Ys, BufferMaskBrick, Screen);
                     }
                 }
             }
@@ -682,7 +684,6 @@ void DrawOverBrick3(S32 xm, S32 ym, S32 zm, S32 ymax) {
 
 void DrawOverBrickCage(S32 xm, S32 ym, S32 zm) {
     register T_COLONB *ptrlbc;
-    register S32 colscreen;
     S32 col, i;
     S32 startcol, endcol;
 
@@ -692,8 +693,6 @@ void DrawOverBrickCage(S32 xm, S32 ym, S32 zm) {
     for (col = startcol; col <= endcol; col++) {
         ptrlbc = &ListBrickColon[col][0];
 
-        colscreen = col * 24 - 24;
-
         for (i = 0; i < NbBrickColon[col]; i++, ptrlbc++) {
             /* bricks devant */
             if (ptrlbc->Ys + 38 > ClipYMin
@@ -702,12 +701,12 @@ void DrawOverBrickCage(S32 xm, S32 ym, S32 zm) {
                                  AND ptrlbc->Ym >= ym) {
                     if ((ptrlbc->Zm == zm)
                             AND(ptrlbc->Xm == xm)) {
-                        CopyMask(ptrlbc->Brick, colscreen, ptrlbc->Ys, BufferMaskBrick, Screen);
+                        CopyMask(ptrlbc->Brick, ptrlbc->Xs, ptrlbc->Ys, BufferMaskBrick, Screen);
                     }
 
                     if ((ptrlbc->Zm > zm)
                             OR(ptrlbc->Xm > xm)) {
-                        CopyMask(ptrlbc->Brick, colscreen, ptrlbc->Ys, BufferMaskBrick, Screen);
+                        CopyMask(ptrlbc->Brick, ptrlbc->Xs, ptrlbc->Ys, BufferMaskBrick, Screen);
                     }
                 }
             }
@@ -749,6 +748,7 @@ void AffBrickBlock(S32 block, S32 brick, S16 x, S16 y, S16 z) {
                 ptrlbc->Xm = x;
                 ptrlbc->Ym = y;
                 ptrlbc->Zm = z;
+                ptrlbc->Xs = (S16)XScreen;
                 ptrlbc->Ys = (S16)YScreen;
                 ptrlbc->Brick = (S16)(numbrick - 1);
                 ptrlbc->Col = brickcol;
@@ -828,6 +828,7 @@ void AffBrickBlockColon(S32 block, S32 brick, S16 x, S16 y, S16 z) {
                 ptrlbc->Xm = x;
                 ptrlbc->Ym = y;
                 ptrlbc->Zm = z;
+                ptrlbc->Xs = (S16)XScreen;
                 ptrlbc->Ys = (S16)YScreen;
                 ptrlbc->Brick = (S16)(numbrick - 1);
                 ptrlbc->Col = brickcol;


### PR DESCRIPTION
One specific iso draw-order bug, surfaced while testing wide builds.

## The bug

`DrawOverBrick` / `DrawOverBrick3` / `DrawOverBrickCage` reconstruct each brick's screen X from its column index via `colscreen = col*24-24`. That round-trip is exact only when the iso origin offset is itself a multiple of 24.

| Width | Map2Screen X offset | Multiple of 24? |
|---|---|---|
| 640 | 288 = 12×24 | ✓ |
| 768 | 352 = 14×24 + 16 | ✗ (off by 16) |

Every brick re-blitted via these over-draw routines lands shifted left by the lost remainder relative to its original `AffBrickBlock` paint, producing visible draw-order glitches in iso scenes at wider widths.

## The fix

Store `Xs` (screen X) alongside `Ys` in `T_COLONB` at write time:

```diff
 typedef struct
 {
     S16 Xm;
     S16 Ym;
     S16 Zm;
+    S16 Xs;
     S16 Ys;
     S16 Brick;
     S16 Col;
 } T_COLONB;
```

Populate from `XScreen` in `AffBrickBlock` + `AffBrickBlockColon` (the two writers). Use `ptrlbc->Xs` directly at the six `CopyMask` call sites in the three over-draw routines instead of reconstructing from `col*24-24`.

## Verified

| Check | Result |
|---|---|
| `test_projection_corpus` at 640 | PASS — projection output unchanged, only re-blit position changed |
| `test_projection_corpus` at 768 | PASS |
| `test_grille` | Unaffected — does not exercise the over-draw path |

## What this *doesn't* fix

This was one site in a deeper wide-build problem. The user confirmed via live demo that other iso anomalies remain — there are more hardcoded 640/480 sites throughout the renderer (inventory pixel-shift macros writing at `src[640*N]` row strides; `PtrBackupAngles = ScreenAux + 640*480`; etc.) that need a systematic audit. That's a separate PR (in progress) — this commit is the one I could prove with code.

**Class of bug projrec hashes can't catch.** Same shape as #205's Z-buffer issue: projection coordinates are byte-identical at narrow vs wide, but downstream consumers of those coordinates assume framebuffer-specific structure. The audit PR will catalogue the full surface.