### PR TITLE
fix(widescreen): route inventory-corner + holomap-Z row strides through ModeDesiredX

### DIFF
--- a/SOURCES/HOLOGLOB.CPP
+++ b/SOURCES/HOLOGLOB.CPP
@@ -998,10 +998,15 @@ void HoloGlobe(S32 planet) {
         ManageTime();
         MyGetInput();
 
-        // Clear une bande du ZBuffer
+        // Clear une bande du ZBuffer. The Z-buffer is sized RESOLUTION_X *
+        // RESOLUTION_Y per PR #205 and addressed Y*ModeDesiredX+X, so the
+        // per-row stride must match the actual render width — was hardcoded
+        // 640, which left the rightmost (ModeDesiredX-640) cols of each row
+        // un-cleared and the holomap depth-tested against stale values.
+        // Phase 3 Tier-1 fix; see docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md.
         memset((PtrZBuffer + TabOffLine[ZBufYMin]), // PtrZBuffer est un (U16 *)
                255,
-               (ZBufYMax - ZBufYMin + 1) * 640 * 2); // Clear ZBuffer
+               (ZBufYMax - ZBufYMin + 1) * ModeDesiredX * 2); // Clear ZBuffer
 
         ClearZBufMinMax();
 

--- a/SOURCES/INVENT.CPP
+++ b/SOURCES/INVENT.CPP
@@ -2255,14 +2255,22 @@ void GereArdoise() {
  *══════════════════════════════════════════════════════════════════════════*/
 /*──────────────────────────────────────────────────────────────────────────*/
 
-// On se place sur la RECOVER_AREA de ScreenAux car on a besoin de 48 octets (4*12)
-#define PtrBackupAngles (ScreenAux + 640 * 480)
+// On se place sur la RECOVER_AREA de ScreenAux car on a besoin de 48 octets (4*12).
+// The offset lands past the active framebuffer pixels — routed through
+// ModeDesiredX/Y so the macro stays correct at any render-space width. At the
+// default 640x480 this evaluates to the historical (ScreenAux + 640*480).
+#define PtrBackupAngles (ScreenAux + ModeDesiredX * ModeDesiredY)
 
 //──────────────────────────────────────────────────────────────────────────
 
 void BackupAngles(S32 x0, S32 y0, S32 x1, S32 y1) {
     U8 *dest = PtrBackupAngles;
     U8 *src;
+    // Log row pitch — was hardcoded 640 (correct at the original 4:3 framebuffer);
+    // now derive from TabOffLine so the per-row arithmetic below tracks the
+    // back buffer's actual width. Phase 3 Tier-1 fix; see
+    // docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md.
+    const S32 stride = TabOffLine[1];
 
     //----- Angle Superieur Gauche
     src = (U8 *)Log + TabOffLine[y0] + x0;
@@ -2270,29 +2278,29 @@ void BackupAngles(S32 x0, S32 y0, S32 x1, S32 y1) {
     *(U32 *)dest = *(U32 *)src; // 1ere ligne
     dest[4] = src[4];
 
-    dest[5] = src[640]; // 2nd ligne
-    *(S16 *)(dest + 6) = *(S16 *)(src + 640 + 1);
+    dest[5] = src[stride]; // 2nd ligne
+    *(S16 *)(dest + 6) = *(S16 *)(src + stride + 1);
 
-    *(S16 *)(dest + 8) = *(S16 *)(src + 640 * 2); // 3eme ligne
+    *(S16 *)(dest + 8) = *(S16 *)(src + stride * 2); // 3eme ligne
 
-    dest[10] = src[640 * 3]; // 4eme ligne
-    dest[11] = src[640 * 4]; // 5eme ligne
+    dest[10] = src[stride * 3]; // 4eme ligne
+    dest[11] = src[stride * 4]; // 5eme ligne
 
     dest += 12;
 
     //----- Angle Inferieur Gauche
     src = (U8 *)Log + TabOffLine[y1 - 4] + x0;
 
-    dest[0] = src[0];   // 1ere ligne
-    dest[1] = src[640]; // 2eme ligne
+    dest[0] = src[0];      // 1ere ligne
+    dest[1] = src[stride]; // 2eme ligne
 
-    *(S16 *)(dest + 2) = *(S16 *)(src + 640 * 2); // 3eme ligne
+    *(S16 *)(dest + 2) = *(S16 *)(src + stride * 2); // 3eme ligne
 
-    *(S16 *)(dest + 4) = *(S16 *)(src + 640 * 3); // 4eme ligne
-    dest[6] = src[640 * 3 + 2];
+    *(S16 *)(dest + 4) = *(S16 *)(src + stride * 3); // 4eme ligne
+    dest[6] = src[stride * 3 + 2];
 
-    dest[7] = src[640 * 4]; // 5eme ligne
-    *(U32 *)(dest + 8) = *(U32 *)(src + 640 * 4 + 1);
+    dest[7] = src[stride * 4]; // 5eme ligne
+    *(U32 *)(dest + 8) = *(U32 *)(src + stride * 4 + 1);
 
     dest += 12;
 
@@ -2302,29 +2310,29 @@ void BackupAngles(S32 x0, S32 y0, S32 x1, S32 y1) {
     *(U32 *)dest = *(U32 *)(src - 4); // 1ere ligne
     dest[4] = src[0];
 
-    dest[5] = src[640 - 2]; // 2nd ligne
-    *(S16 *)(dest + 6) = *(S16 *)(src + 640 - 1);
+    dest[5] = src[stride - 2]; // 2nd ligne
+    *(S16 *)(dest + 6) = *(S16 *)(src + stride - 1);
 
-    *(S16 *)(dest + 8) = *(S16 *)(src + 640 * 2 - 1); // 3eme ligne
+    *(S16 *)(dest + 8) = *(S16 *)(src + stride * 2 - 1); // 3eme ligne
 
-    dest[10] = src[640 * 3]; // 4eme ligne
-    dest[11] = src[640 * 4]; // 5eme ligne
+    dest[10] = src[stride * 3]; // 4eme ligne
+    dest[11] = src[stride * 4]; // 5eme ligne
 
     dest += 12;
 
     //----- Angle Inferieur Droit
     src = (U8 *)Log + TabOffLine[y1 - 4] + x1;
 
-    dest[0] = src[0];   // 1ere ligne
-    dest[1] = src[640]; // 2eme ligne
+    dest[0] = src[0];      // 1ere ligne
+    dest[1] = src[stride]; // 2eme ligne
 
-    *(S16 *)(dest + 2) = *(S16 *)(src + 640 * 2 - 1); // 3eme ligne
+    *(S16 *)(dest + 2) = *(S16 *)(src + stride * 2 - 1); // 3eme ligne
 
-    *(S16 *)(dest + 4) = *(S16 *)(src + 640 * 3 - 1); // 4eme ligne
-    dest[6] = src[640 * 3 - 2];
+    *(S16 *)(dest + 4) = *(S16 *)(src + stride * 3 - 1); // 4eme ligne
+    dest[6] = src[stride * 3 - 2];
 
-    dest[7] = src[640 * 4 - 4]; // 5eme ligne
-    *(U32 *)(dest + 8) = *(U32 *)(src + 640 * 4 - 3);
+    dest[7] = src[stride * 4 - 4]; // 5eme ligne
+    *(U32 *)(dest + 8) = *(U32 *)(src + stride * 4 - 3);
 }
 
 //──────────────────────────────────────────────────────────────────────────
@@ -2332,6 +2340,7 @@ void BackupAngles(S32 x0, S32 y0, S32 x1, S32 y1) {
 void RestoreAngles(S32 x0, S32 y0, S32 x1, S32 y1) {
     U8 *src = PtrBackupAngles;
     U8 *dest;
+    const S32 stride = TabOffLine[1]; // Log row pitch — see BackupAngles above.
 
     //----- Angle Superieur Gauche
     dest = (U8 *)Log + TabOffLine[y0] + x0;
@@ -2339,29 +2348,29 @@ void RestoreAngles(S32 x0, S32 y0, S32 x1, S32 y1) {
     *(U32 *)dest = *(U32 *)src; // 1ere ligne
     dest[4] = src[4];
 
-    dest[640] = src[5]; // 2nd ligne
-    *(S16 *)(dest + 640 + 1) = *(S16 *)(src + 6);
+    dest[stride] = src[5]; // 2nd ligne
+    *(S16 *)(dest + stride + 1) = *(S16 *)(src + 6);
 
-    *(S16 *)(dest + 640 * 2) = *(S16 *)(src + 8); // 3eme ligne
+    *(S16 *)(dest + stride * 2) = *(S16 *)(src + 8); // 3eme ligne
 
-    dest[640 * 3] = src[10]; // 4eme ligne
-    dest[640 * 4] = src[11]; // 5eme ligne
+    dest[stride * 3] = src[10]; // 4eme ligne
+    dest[stride * 4] = src[11]; // 5eme ligne
 
     src += 12;
 
     //----- Angle Inferieur Gauche
     dest = (U8 *)Log + TabOffLine[y1 - 4] + x0;
 
-    dest[0] = src[0];   // 1ere ligne
-    dest[640] = src[1]; // 2eme ligne
+    dest[0] = src[0];      // 1ere ligne
+    dest[stride] = src[1]; // 2eme ligne
 
-    *(S16 *)(dest + 640 * 2) = *(S16 *)(src + 2); // 3eme ligne
+    *(S16 *)(dest + stride * 2) = *(S16 *)(src + 2); // 3eme ligne
 
-    *(S16 *)(dest + 640 * 3) = *(S16 *)(src + 4); // 4eme ligne
-    dest[640 * 3 + 2] = src[6];
+    *(S16 *)(dest + stride * 3) = *(S16 *)(src + 4); // 4eme ligne
+    dest[stride * 3 + 2] = src[6];
 
-    dest[640 * 4] = src[7]; // 5eme ligne
-    *(U32 *)(dest + 640 * 4 + 1) = *(U32 *)(src + 8);
+    dest[stride * 4] = src[7]; // 5eme ligne
+    *(U32 *)(dest + stride * 4 + 1) = *(U32 *)(src + 8);
 
     src += 12;
 
@@ -2371,29 +2380,29 @@ void RestoreAngles(S32 x0, S32 y0, S32 x1, S32 y1) {
     *(U32 *)(dest - 4) = *(U32 *)src; // 1ere ligne
     dest[0] = src[4];
 
-    dest[640 - 2] = src[5]; // 2nd ligne
-    *(S16 *)(dest + 640 - 1) = *(S16 *)(src + 6);
+    dest[stride - 2] = src[5]; // 2nd ligne
+    *(S16 *)(dest + stride - 1) = *(S16 *)(src + 6);
 
-    *(S16 *)(dest + 640 * 2 - 1) = *(S16 *)(src + 8); // 3eme ligne
+    *(S16 *)(dest + stride * 2 - 1) = *(S16 *)(src + 8); // 3eme ligne
 
-    dest[640 * 3] = src[10]; // 4eme ligne
-    dest[640 * 4] = src[11]; // 5eme ligne
+    dest[stride * 3] = src[10]; // 4eme ligne
+    dest[stride * 4] = src[11]; // 5eme ligne
 
     src += 12;
 
     //----- Angle Inferieur Droit
     dest = (U8 *)Log + TabOffLine[y1 - 4] + x1;
 
-    dest[0] = src[0];   // 1ere ligne
-    dest[640] = src[1]; // 2eme ligne
+    dest[0] = src[0];      // 1ere ligne
+    dest[stride] = src[1]; // 2eme ligne
 
-    *(S16 *)(dest + 640 * 2 - 1) = *(S16 *)(src + 2); // 3eme ligne
+    *(S16 *)(dest + stride * 2 - 1) = *(S16 *)(src + 2); // 3eme ligne
 
-    *(S16 *)(dest + 640 * 3 - 1) = *(S16 *)(src + 4); // 4eme ligne
-    dest[640 * 3 - 2] = src[6];
+    *(S16 *)(dest + stride * 3 - 1) = *(S16 *)(src + 4); // 4eme ligne
+    dest[stride * 3 - 2] = src[6];
 
-    dest[640 * 4 - 4] = src[7]; // 5eme ligne
-    *(U32 *)(dest + 640 * 4 - 3) = *(U32 *)(src + 8);
+    dest[stride * 4 - 4] = src[7]; // 5eme ligne
+    *(U32 *)(dest + stride * 4 - 3) = *(U32 *)(src + 8);
 }
 
 //──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Tier 1 of the [hardcoded-dim audit](https://github.com/LBALab/lba2-classic-community/blob/main/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md) (landed in #207 + #208). Three sites that corrupt memory at any non-640 framebuffer width — **independent of the C1 vs C2 UI architecture question**. All byte-identical at 640×480.

## The three sites

| Site | What was wrong | Fix |
|---|---|---|
| **A1** `INVENT.CPP` `BackupAngles` / `RestoreAngles` (~28 hits) | `src[640]` / `dest[640*N]` as Log row pitch. At 768 wide, `src[640]` lands at column `x0+640` on the *same* row | `const S32 stride = TabOffLine[1];` (= `ModeDesiredX`), substitute |
| **A2** `INVENT.CPP:2259` `PtrBackupAngles` macro | `(ScreenAux + 640*480)` — meant to land past active pixels of ScreenAux. At 768×480 ScreenAux it's *inside* the pixel region. 48-byte backup writes corrupt the rendered scene behind dialogs/inventory | `(ScreenAux + ModeDesiredX * ModeDesiredY)` |
| **A3** `HOLOGLOB.CPP:1004` Z-buffer band clear | `memset(..., (rows) * 640 * 2)` — Z-buffer pitch hardcoded to 640. At 768 wide the rightmost 128 cols of each row stay un-cleared; holomap depth-tests against stale Z values | `memset(..., (rows) * ModeDesiredX * 2)` |

## Why these are bugs under either C1 or C2

The audit refinement in #208 made the distinction: row-stride / past-pixels arithmetic addresses the actual back-buffer, regardless of how the UI itself is laid out. Even if we letterbox the 4:3 inventory into a centred sub-region (C1), the source pointer for `BackupAngles` still indexes into the wider `Log` — one row down is `ModeDesiredX` bytes forward, never literal 640. Same shape for the `PtrBackupAngles` past-pixels offset and the holomap Z-buffer pitch.

So these can land before the C1/C2 decision is made.

## Verified

| Check | Result |
|---|---|
| `test_projection_corpus` at 640 | **PASS** — unchanged hash (the fixed sites don't pass through projection anyway) |
| `test_projection_corpus` at 768 | **PASS** |
| `test_ui_inventory` at 640 (committed golden) | **PASS** — byte-identical at 640×480 |
| `test_ui_holomap` at 640 | **PASS** |
| `test_ui_menu_options` at 640 | **PASS** |
| Wide 768×480 inventory screenshot | Corners render cleanly (no garbage from stride-misaligned backup/restore) |
| Wide 768×480 holomap screenshot | Right edge clear, no Z-test garbage |

## What this does *not* touch

C1/C2-dependent layout coords (`INV_DELTA_X`, the 14 `ShadeBoxBlk(0, 0, 639, 479, …)` sites in GAMEMENU, ~30 `DrawOneString(320, …)` calls, etc.). Those wait on the UI-strategy decision per [`WIDESCREEN.md` Phase 5](https://github.com/LBALab/lba2-classic-community/blob/main/docs/WIDESCREEN.md#ui-strategy-c1-vs-c2). Audit doc tracks the surface.

After this lands: wide builds no longer scramble the inventory corner-backup or holomap Z-buffer. Wide-build inventory is still 4:3-anchored (sitting at the left of the wider canvas with the scene showing on the right) — that's the expected C1 starting state, addressed separately when the strategy lands.