### PR TITLE
fix(widescreen): widen iso left clip so off-center hotX bricks draw

### DIFF
--- a/SOURCES/GRILLE.CPP
+++ b/SOURCES/GRILLE.CPP
@@ -735,8 +735,24 @@ void AffBrickBlock(S32 block, S32 brick, S16 x, S16 y, S16 z) {
     if (numbrick AND numbrick != ForbidenBrick) {
         Map2Screen(x - StartXCube, y - StartYCube, z - StartZCube);
 
-        if (XScreen >= -24 AND XScreen < (S32)ModeDesiredX AND YScreen >= -38 AND YScreen < (S32)ModeDesiredY) {
+        // Left clip is -47 (one full brick width minus a pixel), not -24 (half-brick).
+        // Many iso bricks have hotX=0 or +24 — their visible pixel range at XScreen=-32
+        // is [0,15], 16 pixels on screen. The historical -24 threshold assumed
+        // hotX=-24 and was silently correct only at widths where
+        // (ModeDesiredX/2 - 32) % 24 == 0 (4:3 / 640: 288 = 12*24). At wider widths
+        // the iso origin offset slides off that multiple and the rejected bricks
+        // start having visible content. See WIDESCREEN_HARDCODED_DIMS_AUDIT.md.
+        if (XScreen >= -47 AND XScreen < (S32)ModeDesiredX AND YScreen >= -38 AND YScreen < (S32)ModeDesiredY) {
             AffGraph(numbrick - 1, XScreen, YScreen, BufferBrick);
+
+            // ListBrickColon is indexed by `col = (XScreen+24)/24`, which goes
+            // negative below -24 and would corrupt the array. Bricks in the
+            // newly-painted [-47,-24) strip aren't bucketed for DrawOverBrick
+            // re-blits — acceptable, they sit on the leftmost pixel column and
+            // their visible pixels are already painted by AffGraph above.
+            if (XScreen < -24) {
+                return;
+            }
 
             col = (XScreen + 24) / 24; /* 48 / 2 colonne intercalée */
 

--- a/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
+++ b/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
@@ -137,7 +137,36 @@ DefFileBufferInit("…/NAME.ME", BufSpeak, 640 * 480);
 likely truncates the buffer to a 4:3 region. Save/load thumbnails may
 corrupt at wider widths.
 
-### A7. Misc full-framebuffer allocations + sizes
+### A7. Iso AffBrickBlock left clip assumes hotX=-24
+
+[`SOURCES/GRILLE.CPP:738`](../SOURCES/GRILLE.CPP) — `AffBrickBlock` was
+gated on `XScreen >= -24`. The threshold matches iso bricks with
+`hotX = -24` (half-brick centered), but many iso bricks have `hotX = 0`
+or `+24`. Their visible pixel range at `XScreen = -32` is `[0, 15]` —
+16 pixels on-screen — yet they were rejected.
+
+The historical 4:3 hid this. The iso origin offset is
+`ModeDesiredX/2 - 32 = 288 = 12 × 24` at 640, and the integer iso-diagonal
+`x - z` always lands on `XScreen` values that are exact multiples of 24
+relative to that offset — so no iso column ever falls in the "visible
+but rejected" `[-47, -24)` strip. At 768 the offset is `352 = 14 × 24 + 16`;
+the iso diagonal `x - z = -16` projects to `XScreen = -32` and the
+left-edge wall column drops.
+
+The bug pops on any width where `(ModeDesiredX/2 - 32) % 24 != 0` —
+that's 768, 800, 1280, 1366, 1920 (and similar). It silently hides on
+640, 1024, 1600 (all multiples of 48). Same projection-correct /
+consumer-broken pattern as A1/A2/A3 above and as the prior
+[T_COLONB col round-trip fix (#206)](../SOURCES/GRILLE.CPP).
+
+Fix: relax to `XScreen >= -47` and skip `ListBrickColon` bucketing for
+`XScreen < -24` (col index would go negative otherwise — DrawOverBrick
+just won't re-blit the leftmost pixel column, acceptable edge case).
+`AffBrickBlockColon` (the mask-only sibling used by labyrinth mode at
+GRILLE.CPP:820) keeps `>= -24` — relaxing it would be a no-op since
+it can't bucket negative-col bricks anyway.
+
+### A8. Misc full-framebuffer allocations + sizes
 
 | Site | What |
 |---|---|


### PR DESCRIPTION
## Summary
- `AffBrickBlock` rejected iso bricks at `XScreen ∈ [-47, -24)` even when they had 16 visible pixels on screen, dropping whole wall columns at the left edge of the wide build.
- The historical 4:3 hid the bug by alignment: `(ModeDesiredX/2 - 32) = 288 = 12*24` at 640, so no iso column ever landed in the broken range. At 768 the offset is `352 = 14*24 + 16` and the column at iso `x-z = -16` falls in.
- Relaxes the left clip from `>= -24` to `>= -47`. `ListBrickColon` bucketing stays gated on the original threshold (col would go negative below -24); the newly painted leftmost strip just doesn't participate in `DrawOverBrick` re-blits, which is fine at the screen edge.

## Why this is a class of bug worth flagging
Same projection-correct / consumer-broken pattern as #206 (T_COLONB col round-trip). Projrec hashes stay green because `XScreen` is still computed correctly — the silent invariant is "iso origin offset is a multiple of 24," which only happens to hold at widths where `ModeDesiredX % 48 == 16` (640, 1024, 1600). New A7 entry in `docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md` documents the alignment table:

| Width | offset mod 24 | Broken `XScreen` | Visible px lost |
|--|--|--|--|
| 640 | 0 | none | 0 |
| 768 | 16 | -32 | 16 |
| 800 | 8 | -40 | 8 |
| 1024 | 0 | none | 0 |
| 1280 | 8 | -40 | 8 |
| 1366 | 3 | -45 | 3 |
| 1600 | 0 | none | 0 |
| 1920 | 16 | -32 | 16 |

## Test plan
- [x] Wide (768) demo_attract: 16-px-wide vertical strip at `x=[0,16], y=[179,389]` fills in with the wall column at world `(4, y=10..16, z=15..16)` that was previously black. Confirmed by image diff.
- [x] 4:3 (640) demo_attract: byte-identical to the pre-fix baseline (no iso column lands in the relaxed range at this width).
- [x] `make test` (host-only suite): 10/10 pass.
- [x] `apply-format.sh`: clean.
- [ ] Manual playtest at wide: pan camera toward the iso "back-left" diagonal in interior scenes and confirm wall/floor pixels reach the screen edge. (Done locally by the maintainer via `LBA2_DEBUG_RELAX_CLIP=1` during the diagnosis; this PR makes it unconditional.)