### PR TITLE
fix(widescreen): widen DrawOverBrick col scan so south walls re-blit

### DIFF
--- a/SOURCES/GRILLE.CPP
+++ b/SOURCES/GRILLE.CPP
@@ -590,7 +590,23 @@ void DrawOverBrick(S32 xm, S32 ym, S32 zm) {
     S32 xw, yw, zw;
     S32 recouvre;
 
-    startcol = (ClipXMin + 24) / 24 - 1;
+    // Bias -2, not -1: a wall one iso-cube south of the actor projects to
+    // XScreen = actor_iso_XScreen - 24, i.e. col = actor_iso_col - 1. The
+    // historical -1 only catches that wall when the actor's iso center happens
+    // to land on a col-bucket boundary — true at widths where
+    // (ModeDesiredX/2 - 32) % 24 == 0 (640 / 1024 / 1600). At 768 (offset
+    // 352 = 14*24 + 16) the actor's iso center lands inside a col bucket and
+    // the clip-derived `col(ClipXMin) - 1` sits in the *same* col as the
+    // actor, missing the south-wall col entirely — DrawOverBrick never re-blits
+    // those walls and they appear under the actor. -2 reliably covers one
+    // extra col regardless of alignment. The extra col is a free harmless
+    // scan when no walls live in it; when walls do live in it but don't
+    // overlap the actor, CopyMask paints offscreen of the actor (same
+    // wasted-CPU pattern the 640 build was already doing). See
+    // WIDESCREEN_HARDCODED_DIMS_AUDIT.md.
+    startcol = (ClipXMin + 24) / 24 - 2;
+    if (startcol < 0)
+        startcol = 0;
     endcol = (ClipXMax + 24) / 24;
 
     for (col = startcol; col <= endcol; col++) {

--- a/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
+++ b/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
@@ -166,7 +166,49 @@ just won't re-blit the leftmost pixel column, acceptable edge case).
 GRILLE.CPP:820) keeps `>= -24` — relaxing it would be a no-op since
 it can't bucket negative-col bricks anyway.
 
-### A8. Misc full-framebuffer allocations + sizes
+### A8. DrawOverBrick col-scan miss for south walls
+
+[`SOURCES/GRILLE.CPP:593`](../SOURCES/GRILLE.CPP) — `DrawOverBrick` is the
+per-object re-blit that paints bricks in front of an actor *over* the
+actor's already-drawn pixels (so a wall correctly occludes the lower body
+of a character standing behind it). It scans the per-col `ListBrickColon`
+buckets covering the actor's screen bounding box:
+
+```cpp
+startcol = (ClipXMin + 24) / 24 - 1;   // historical
+endcol   = (ClipXMax + 24) / 24;
+```
+
+The `-1` was meant to cover one extra col to the left so that a wall at
+the actor's iso-cube *south* neighbour (which projects to
+`XScreen = actor_iso_XScreen - 24`, i.e. `col = actor_iso_col - 1`) is
+included.
+
+That `-1` only works when the actor's iso center lands exactly on a
+col-bucket boundary — true at widths where the iso origin offset
+`(ModeDesiredX/2 - 32)` is a multiple of 24. At 640 that's
+`288 = 12 × 24`, so the actor's clip box left edge and the wall-south
+col line up such that `col(ClipXMin) - 1 == wall_south_col`. At 768 the
+offset is `352 = 14 × 24 + 16` — actor centers slide off the boundary,
+`col(ClipXMin) - 1` ends up *in the same col as the actor*, and the
+south-wall col is missed entirely. The character is then drawn on top
+of walls he should be behind.
+
+Same `(offset % 24 != 0)` alignment class as `A7` and the prior
+[T_COLONB col round-trip fix (#206)](../SOURCES/GRILLE.CPP). Confirmed
+empirically: instrumented log of 874 hero-`DrawOverBrick` calls at 768
+fired `CopyMask` exactly **0** times for walls south of the hero; an
+equivalent narrow run fired it 287 times across 82 calls.
+
+Fix: widen the bias to `-2` and clamp `startcol >= 0`. The extra col is
+a harmless scan when empty; when populated, the per-brick
+`recouvre`/`infront` filter (world-cube coords, alignment-independent)
+keeps wrong walls out of the re-blit. `DrawOverBrick3` and
+`DrawOverBrickCage` use the same `-1` formula but apply to different
+object classes (sprites and the end-of-game cage) — not yet observed to
+manifest the visual bug at any width, so left alone pending evidence.
+
+### A9. Misc full-framebuffer allocations + sizes
 
 | Site | What |
 |---|---|


### PR DESCRIPTION
## Summary
- At widths where `(ModeDesiredX/2 - 32) % 24 != 0` (768, 800, 1280, 1366, 1920, …), `DrawOverBrick` was failing to re-blit walls one iso-cube *south* of the hero over the hero's just-rendered pixels — the character is drawn on top of walls he should stand behind.
- Empirically: 874 hero-DrawOverBrick calls at 768 fired `CopyMask` **0** times for south walls; the equivalent narrow run fired it 287 times across 82 calls.
- Widens the `startcol` bias from `-1` to `-2` and clamps to `0`. One-line behaviour change.

## Why it only shows in wide
The historical `startcol = (ClipXMin + 24) / 24 - 1` reached the south-wall col only when the actor's iso center landed exactly on a col-bucket boundary, which holds at 640 (offset 288 = 12×24) and silently fails wherever the iso origin offset slides off a multiple of 24. Same alignment class as `#206` (T_COLONB col round-trip) and `#210` (iso left clip). Documented in `WIDESCREEN_HARDCODED_DIMS_AUDIT.md` as new section `A8`.

| Width | offset mod 24 | South-wall reach |
|--|--|--|
| 640 | 0 | ✓ |
| 768 | 16 | ✗ |
| 800 | 8 | ✗ |
| 1024 | 0 | ✓ |
| 1280 | 8 | ✗ |
| 1600 | 0 | ✓ |
| 1920 | 16 | ✗ |

## Risk
- `DrawOverBrick`/`AffBrickBlock` are not on the ASM-equivalence test surface — `test_grille` doesn't exercise them.
- The extra col scan is a free no-op when empty; when populated, the per-brick `recouvre`/`infront` filter (world-cube coords, alignment-independent) keeps wrong walls out of the re-blit. Same wasted-CPU pattern narrow was already running 287 times per second without anyone noticing.
- `DrawOverBrick3` and `DrawOverBrickCage` use the same `-1` formula but apply to sprites and the end-of-game cage; the visual symptom hasn't been observed there at any width, so left alone pending evidence.

## Test plan
- [x] Interactive verification on the maintainer's `tile draw issue` save at 768: visible bug (hero drawn over wall divider) disappears with the fix.
- [x] 640 build: byte-identical headless demo_attract image to pre-fix baseline (no behaviour change where alignment is correct).
- [x] `make test`: 10/10 host tests pass.
- [x] `apply-format.sh` / clang-format clean.
- [x] Recommended before merge: `./run_tests_docker.sh test_grille` for ASM equivalence (untouched surface; expected to pass).