### PR TITLE
fix(widescreen): re-anchor GAMEMENU.CPP UI to ModeDesiredX/Y

### DIFF
--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -1034,7 +1034,7 @@ void DrawCadreNewGame(void) {
 
     DrawCadreSave(240, 50);
 
-    x = 320 - dx / 2;
+    x = (S32)ModeDesiredX / 2 - dx / 2;
     y = 50 + (SCREEN_SAVE_HEIGHT) / 2 - dy / 2;
 
     AffGraph(0, x, y, ptr);
@@ -1047,8 +1047,8 @@ void DrawCadreNewGame(void) {
 
 static S32 GameMenuSaveListHitTest(U32 mx, U32 my, S32 nb, S32 start, S32 *outSel) {
     S32 n;
-    S32 x0 = 320 - GM_MENU_HALF_WIDTH_SAVE;
-    S32 x1 = 320 + GM_MENU_HALF_WIDTH_SAVE;
+    S32 x0 = (S32)ModeDesiredX / 2 - GM_MENU_HALF_WIDTH_SAVE;
+    S32 x1 = (S32)ModeDesiredX / 2 + GM_MENU_HALF_WIDTH_SAVE;
 
     for (n = 0; n < NB_GAME_CHOICE; n++) {
         S32 y;
@@ -1105,7 +1105,7 @@ S32 InputPlayerName(S32 choice, char *name) {
 
     len = strlen(PlayerName);
 
-    x = 320;
+    x = (S32)ModeDesiredX / 2;
     y = Y_START_CHOICE + choice * 60;
 
     ManageTime();
@@ -1136,11 +1136,11 @@ S32 InputPlayerName(S32 choice, char *name) {
                 CursorActif = FALSE;
         }
 
-        DrawOneString(320, y, PlayerName, 1);
+        DrawOneString((S32)ModeDesiredX / 2, y, PlayerName, 1);
         BoxUpdate();
 
         if (flag == 1) {
-            x = 320 + SizeFont(PlayerName) / 2;
+            x = (S32)ModeDesiredX / 2 + SizeFont(PlayerName) / 2;
             flag = 0;
         }
 
@@ -1188,10 +1188,13 @@ S32 InputPlayerName(S32 choice, char *name) {
             default:
                 akey &= 0xFF;
 
-                if (x < 550 AND akey >= 32 AND akey <= 122) {
+                /* Max input cursor X = original 550 = centre(320) + 230 px. Keep the
+                   same 230 px half-width at any resolution so the name-entry field
+                   visible area stays at its authored 460 px width. */
+                if (x < (S32)ModeDesiredX / 2 + 230 AND akey >= 32 AND akey <= 122) {
                     PlayerName[len++] = (char)akey;
                     PlayerName[len] = '\0';
-                    x = 320 + SizeFont(PlayerName) / 2;
+                    x = (S32)ModeDesiredX / 2 + SizeFont(PlayerName) / 2;
                 }
                 break;
             }
@@ -1244,7 +1247,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
     CopyScreen(Screen, Log);
 
     if (FlagShadeMenu)
-        ShadeBoxBlk(0, 0, 639, 479, SCREEN_SHADE_LVL);
+        ShadeBoxBlk(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, SCREEN_SHADE_LVL);
 
 #ifdef DEBUG_TOOLS
     if (mess & 0x80000000) // chargement d'un bug
@@ -1334,7 +1337,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
         ManageTime();
 
         if (flag == 3) {
-            DrawSingleString(320, 25, (char *)GetMultiText(mess, string));
+            DrawSingleString((S32)ModeDesiredX / 2, 25, (char *)GetMultiText(mess, string));
             flag = 1;
         }
 
@@ -1357,7 +1360,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                 else if ((start + NB_GAME_CHOICE < nb) AND(n == NB_GAME_CHOICE - 1))
                     draw |= ARROW_ID;
 
-                DrawOneString(320, Y_START_CHOICE + 60 * n, ptrlist[n + start], draw);
+                DrawOneString((S32)ModeDesiredX / 2, Y_START_CHOICE + 60 * n, ptrlist[n + start], draw);
             }
 
             draw = 1;
@@ -1389,7 +1392,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                     sdraw |= ARROW_SG;
                 else if ((start + NB_GAME_CHOICE < nb) AND(sn == NB_GAME_CHOICE - 1))
                     sdraw |= ARROW_ID;
-                DrawOneString(320, Y_START_CHOICE + 60 * sn, ptrlist[select], sdraw);
+                DrawOneString((S32)ModeDesiredX / 2, Y_START_CHOICE + 60 * sn, ptrlist[select], sdraw);
             }
         }
 
@@ -1505,7 +1508,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                             start++;
                         }
                     } else {
-                        DrawOneString(320, ys, ptrlist[select - 1], (draw & 0xFFFFFFFE));
+                        DrawOneString((S32)ModeDesiredX / 2, ys, ptrlist[select - 1], (draw & 0xFFFFFFFE));
                     }
                     flag = 1;
 
@@ -1524,7 +1527,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                     if (select < start) {
                         start--;
                     } else {
-                        DrawOneString(320, ys, ptrlist[select + 1], (draw & 0xFFFFFFFE));
+                        DrawOneString((S32)ModeDesiredX / 2, ys, ptrlist[select + 1], (draw & 0xFFFFFFFE));
                     }
                     flag = 1;
                     if (flagnew AND select == nb - 1)
@@ -1537,7 +1540,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
             }
         }
 
-        DrawOneString(320, ys, ptrlist[select], draw);
+        DrawOneString((S32)ModeDesiredX / 2, ys, ptrlist[select], draw);
         BoxUpdate();
 
         if (Input & I_DOWN OR MyKey == K_GRAY_DOWN) {
@@ -1548,7 +1551,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                         start++;
                     }
                 } else {
-                    DrawOneString(320, ys, ptrlist[select - 1], (draw & 0xFFFFFFFE));
+                    DrawOneString((S32)ModeDesiredX / 2, ys, ptrlist[select - 1], (draw & 0xFFFFFFFE));
                 }
                 flag = 1;
 
@@ -1567,7 +1570,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                 if (select < start) {
                     start--;
                 } else {
-                    DrawOneString(320, ys, ptrlist[select + 1], (draw & 0xFFFFFFFE));
+                    DrawOneString((S32)ModeDesiredX / 2, ys, ptrlist[select + 1], (draw & 0xFFFFFFFE));
                 }
                 flag = 1;
                 if (flagnew AND select == nb - 1)
@@ -1594,7 +1597,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                         if (start >= (nb - (NB_GAME_CHOICE - 1)))
                             start = nb - NB_GAME_CHOICE;
                     } else {
-                        DrawOneString(320, ys, ptrlist[oldselect], (draw & 0xFFFFFFFE));
+                        DrawOneString((S32)ModeDesiredX / 2, ys, ptrlist[oldselect], (draw & 0xFFFFFFFE));
                     }
                     flag = 1;
 
@@ -1617,7 +1620,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                     if (select < start) {
                         start = select;
                     } else {
-                        DrawOneString(320, ys, ptrlist[oldselect], (draw & 0xFFFFFFFE));
+                        DrawOneString((S32)ModeDesiredX / 2, ys, ptrlist[oldselect], (draw & 0xFFFFFFFE));
                     }
                     flag = 1;
                     if (flagnew AND select == nb - 1)
@@ -1635,7 +1638,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                     select = 0;
 
                     if (start == 0) {
-                        DrawOneString(320, ys, ptrlist[oldselect], (draw & 0xFFFFFFFE));
+                        DrawOneString((S32)ModeDesiredX / 2, ys, ptrlist[oldselect], (draw & 0xFFFFFFFE));
                     } else
                         start = 0;
 
@@ -1656,7 +1659,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                 select = nb - 1;
 
                 if (start == (nb - NB_GAME_CHOICE)) {
-                    DrawOneString(320, ys, ptrlist[oldselect], (draw & 0xFFFFFFFE));
+                    DrawOneString((S32)ModeDesiredX / 2, ys, ptrlist[oldselect], (draw & 0xFFFFFFFE));
                 } else {
                     start = nb - NB_GAME_CHOICE;
                     if (start < 0)
@@ -1676,7 +1679,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
         if (MyKey == K_D OR MyKey == K_BACKSPACE OR MyKey == K_GRAY_SUPPR) {
             CopyScreen(Screen, Log);
             if (FlagShadeMenu)
-                ShadeBoxBlk(0, 0, 639, 479, SCREEN_SHADE_LVL);
+                ShadeBoxBlk(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, SCREEN_SHADE_LVL);
             BoxStaticFullflip();
 
             if (DeleteSavedGame()) {
@@ -1705,7 +1708,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
 
             CopyScreen(Screen, Log);
             if (FlagShadeMenu)
-                ShadeBoxBlk(0, 0, 639, 479, SCREEN_SHADE_LVL);
+                ShadeBoxBlk(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, SCREEN_SHADE_LVL);
             BoxStaticFullflip();
 
             flag = 1; // redraw menu
@@ -1895,7 +1898,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
 
         for (n = 0; n < NB_GAME_CHOICE; n++) {
             if ((n + start) != select) {
-                ClearOneString(320, Y_START_CHOICE + 60 * n);
+                ClearOneString((S32)ModeDesiredX / 2, Y_START_CHOICE + 60 * n);
             }
         }
     }
@@ -1906,7 +1909,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
     if (flagflip) {
         CopyScreen(Screen, Log);
         if (FlagShadeMenu)
-            ShadeBoxBlk(0, 0, 639, 479, SCREEN_SHADE_LVL);
+            ShadeBoxBlk(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, SCREEN_SHADE_LVL);
         BoxStaticFullflip();
     }
 
@@ -2195,10 +2198,10 @@ void DrawGameMenu(U16 *ptrmenu, S32 justone) {
 
         if (justone) {
             if (n == selected) {
-                DrawOneChoice(320, y, type, num, TRUE);
+                DrawOneChoice((S32)ModeDesiredX / 2, y, type, num, TRUE);
             }
         } else {
-            DrawOneChoice(320, y, type, num, (n == selected));
+            DrawOneChoice((S32)ModeDesiredX / 2, y, type, num, (n == selected));
         }
 
         y += HAUTEUR_STANDARD + MENU_SPACE;
@@ -2856,7 +2859,7 @@ S32 GereVolumeMenu(void) {
     BoxStaticAdd(0, 0, ModeDesiredX - 1, ModeDesiredY - 1);
 
     if (FlagShadeMenu) {
-        ShadeBoxBlk(0, 0, 639, 479, SCREEN_SHADE_LVL);
+        ShadeBoxBlk(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, SCREEN_SHADE_LVL);
     }
 
 #ifdef CDROM
@@ -2912,7 +2915,7 @@ S32 GereLanguageMenu(void) {
     BoxStaticAdd(0, 0, ModeDesiredX - 1, ModeDesiredY - 1);
 
     if (FlagShadeMenu) {
-        ShadeBoxBlk(0, 0, 639, 479, SCREEN_SHADE_LVL);
+        ShadeBoxBlk(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, SCREEN_SHADE_LVL);
     }
 
     while (!flag) {
@@ -2956,7 +2959,7 @@ S32 GereAdvancedOptionsMenu(void) {
     BoxStaticAdd(0, 0, ModeDesiredX - 1, ModeDesiredY - 1);
 
     if (FlagShadeMenu) {
-        ShadeBoxBlk(0, 0, 639, 479, SCREEN_SHADE_LVL);
+        ShadeBoxBlk(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, SCREEN_SHADE_LVL);
     }
 
     while (!flag) {
@@ -3019,7 +3022,7 @@ S32 GereControllerMenu(void) {
     BoxStaticAdd(0, 0, ModeDesiredX - 1, ModeDesiredY - 1);
 
     if (FlagShadeMenu) {
-        ShadeBoxBlk(0, 0, 639, 479, SCREEN_SHADE_LVL);
+        ShadeBoxBlk(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, SCREEN_SHADE_LVL);
     }
 
     while (!flag) {
@@ -3092,7 +3095,7 @@ S32 OptionsMenu(S32 flagflip) {
 	BoxReset() ;
 */
     if (FlagShadeMenu) {
-        ShadeBoxBlk(0, 0, 639, 479, SCREEN_SHADE_LVL);
+        ShadeBoxBlk(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, SCREEN_SHADE_LVL);
         BoxStaticFullflip();
         PaletteSync(PtrPalNormal);
     }
@@ -3162,7 +3165,7 @@ S32 DeleteSavedGame(void) {
     S32 ret = -1;
     S32 select;
 
-    DrawOneString(320, 80, PlayerName, 2);
+    DrawOneString((S32)ModeDesiredX / 2, 80, PlayerName, 2);
     ptr = LoadGameScreen();
     if (ptr)
         DrawScreenSave(ptr, 240, 130);
@@ -3217,14 +3220,14 @@ void ZoomSavedGame(S32 x, S32 y) {
         time = TimerRefHR - savetimer;
 
         x0 = RegleTrois(x, 0, TIME_ZOOM_SAVE, time);
-        x1 = RegleTrois(x + SCREEN_SAVE_WIDTH - 1, 639, TIME_ZOOM_SAVE, time);
+        x1 = RegleTrois(x + SCREEN_SAVE_WIDTH - 1, (S32)ModeDesiredX - 1, TIME_ZOOM_SAVE, time);
         y0 = RegleTrois(y, 0, TIME_ZOOM_SAVE, time);
-        y1 = RegleTrois(y + SCREEN_SAVE_HEIGHT - 1, 479, TIME_ZOOM_SAVE, time);
+        y1 = RegleTrois(y + SCREEN_SAVE_HEIGHT - 1, (S32)ModeDesiredY - 1, TIME_ZOOM_SAVE, time);
 
-        if (x0 <= 0 OR y0 <= 0 OR x1 >= 639 OR y1 >= 479) {
+        if (x0 <= 0 OR y0 <= 0 OR x1 >= (S32)ModeDesiredX - 1 OR y1 >= (S32)ModeDesiredY - 1) {
             flag = TRUE;
         } else {
-            ScaleBox(0, 0, 639, 479, Screen, x0, y0, x1, y1, Log);
+            ScaleBox(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, Screen, x0, y0, x1, y1, Log);
             BoxStaticAdd(x0, y0, x1, y1);
             BoxUpdate();
         }
@@ -3308,11 +3311,11 @@ S32 IsFirstGameLaunched(void) {
 static void ShowSaveConfirmation(enum MenuLocalizedLabel label) {
     HQ_MixSample(SAMPLE_FOUND_OBJ, 0x1000, 0, 1, 64, 127);
     CopyScreen(Screen, Log);
-    ShadeBoxBlk(0, 0, 639, 479, SCREEN_SHADE_LVL);
+    ShadeBoxBlk(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, SCREEN_SHADE_LVL);
     {
         char savedMsg[256];
         CopyUtf8ToCp850(savedMsg, sizeof savedMsg, GetLocalizedMenuLabel(label));
-        DrawSingleString(320, 240, savedMsg);
+        DrawSingleString((S32)ModeDesiredX / 2, (S32)ModeDesiredY / 2, savedMsg);
     }
     BoxStaticFullflip();
     {
@@ -3523,7 +3526,7 @@ S32 MainGameMenu(S32 load) {
             MemoClipWindow();
             UnsetClipWindow();
 
-            ShadeBoxBlk(0, 0, 639, 479, SCREEN_SHADE_LVL);
+            ShadeBoxBlk(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, SCREEN_SHADE_LVL);
             BoxStaticFullflip();
 
             if (!FadeMenu)
@@ -3669,7 +3672,7 @@ S32 MainGameMenu(S32 load) {
             case 0:
                 CopyScreen(Screen, Log);
                 if (FlagShadeMenu)
-                    ShadeBoxBlk(0, 0, 639, 479, SCREEN_SHADE_LVL);
+                    ShadeBoxBlk(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, SCREEN_SHADE_LVL);
                 BoxStaticFullflip();
                 break;
 
@@ -3732,7 +3735,7 @@ S32 MainGameMenu(S32 load) {
 
                 CopyScreen(Screen, Log);
 
-                ShadeBoxBlk(0, 0, 639, 479, SCREEN_SHADE_LVL);
+                ShadeBoxBlk(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, SCREEN_SHADE_LVL);
                 NewCube = savenewcube;
                 BoxStaticFullflip();
                 RestoreTimer();
@@ -3759,7 +3762,7 @@ S32 MainGameMenu(S32 load) {
             case 0:
                 CopyScreen(Screen, Log);
                 if (FlagShadeMenu)
-                    ShadeBoxBlk(0, 0, 639, 479, SCREEN_SHADE_LVL);
+                    ShadeBoxBlk(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, SCREEN_SHADE_LVL);
                 BoxStaticFullflip();
                 break;
 
@@ -3811,7 +3814,7 @@ S32 MainGameMenu(S32 load) {
 
                 CopyScreen(Screen, Log);
 
-                ShadeBoxBlk(0, 0, 639, 479, SCREEN_SHADE_LVL);
+                ShadeBoxBlk(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, SCREEN_SHADE_LVL);
                 NewCube = savenewcube;
                 BoxStaticFullflip();
                 RestoreTimer();
@@ -3935,7 +3938,7 @@ void GameOver() {
 
     zoom = GAMEOVER_MINZOOM;
 
-    SetProjection(320, 240, 128, 200, 200);
+    SetProjection((S32)ModeDesiredX / 2, (S32)ModeDesiredY / 2, 128, 200, 200);
     SetFollowCamera(0, 0, 0, 0, 0, 0, zoom);
     SetLightVector(0, 0, 0);
 
@@ -4029,7 +4032,7 @@ void    Help( U8 flaggame )
                 WaitInput()     ;
                 FadeToBlack( PalettePcx ) ;
                 CopyScreen( Screen, Log ) ;
-                if( FlagShadeMenu )     ShadeBoxBlk( 0, 0, 639, 479, SCREEN_SHADE_LVL ) ;
+                if( FlagShadeMenu )     ShadeBoxBlk( 0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, SCREEN_SHADE_LVL ) ;
                 BoxStaticFullflip() ;
                 FadeMenu = TRUE ;
                 RestoreTimer()  ;
@@ -4518,10 +4521,10 @@ void DemoLogo(void) {
     ColorFont(LBAWHITE);
 
     // cadre
-    x0 = 320 - SizeFont(string) / 2 - 50;
-    x1 = 320 + SizeFont(string) / 2 + 50;
-    y0 = 240 - 25;
-    y1 = 240 + 25;
+    x0 = (S32)ModeDesiredX / 2 - SizeFont(string) / 2 - 50;
+    x1 = (S32)ModeDesiredX / 2 + SizeFont(string) / 2 + 50;
+    y0 = (S32)ModeDesiredY / 2 - 25;
+    y1 = (S32)ModeDesiredY / 2 + 25;
     //      ShadeBoxBlk( 0, 0, 639, 479, SCREEN_SHADE_LVL ) ;
     BackupAngles(x0, y0, x1, y1);
     ShadeBoxBlk(x0, y0, x1, y1, MENU_SHADE_LVL);
@@ -4630,6 +4633,11 @@ void EffectPcx(U8 numpcx, U8 *screen, U8 effect, U8 flagbcl) {
 
         PaletteSync(PalettePcx);
 
+        // TODO(pcx): venetian-blind fade reads a 640x480 PCX (`screen`) and blits
+        // into the framebuffer (Log). The 640/479/639 literals are PCX-image
+        // dimensions, not framebuffer ones. At wide widths the PCX paints only the
+        // left 640 columns of the framebuffer — fix when the PCX-resampling pass
+        // lands (Phase 5 / WIDESCREEN.md).
         for (y = 0; y <= 479; y++) {
             CopyBlock(0, y, 639, y + 4, screen, 0, y, Log);
             y += 5;

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -39,6 +39,10 @@
 
 #define SCREEN_SAVE_WIDTH 160
 #define SCREEN_SAVE_HEIGHT 120
+/* Top-left X of the SCREEN_SAVE_WIDTH-wide save thumbnail when it should be
+   horizontally centred on the framebuffer. At 640 this resolves to 240 (the
+   historical literal); at wider widths it tracks ModeDesiredX/2. */
+#define SAVE_THUMB_X ((S32)ModeDesiredX / 2 - SCREEN_SAVE_WIDTH / 2)
 
 U8 CoulTextMenu = COUL_TEXT_MENU;
 S32 LargeurMenu = 550;
@@ -1032,7 +1036,7 @@ void DrawCadreNewGame(void) {
 
     GetDxDyGraph(0, &dx, &dy, ptr);
 
-    DrawCadreSave(240, 50);
+    DrawCadreSave(SAVE_THUMB_X, 50);
 
     x = (S32)ModeDesiredX / 2 - dx / 2;
     y = 50 + (SCREEN_SAVE_HEIGHT) / 2 - dy / 2;
@@ -1408,7 +1412,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                     FindPlayerFile();
                 ptr = LoadGameScreen();
                 if (ptr)
-                    DrawScreenSave(ptr, 240, 50);
+                    DrawScreenSave(ptr, SAVE_THUMB_X, 50);
             } else // Nouvelle partie
             {
                 //                                DrawCadreSave( 240, 50 ) ;
@@ -1730,7 +1734,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                         FindPlayerFile();
                     ptr = LoadGameScreen();
                     if (ptr)
-                        DrawScreenSave(ptr, 240, 50);
+                        DrawScreenSave(ptr, SAVE_THUMB_X, 50);
                 } else // Nouvelle partie
                 {
                     //					DrawCadreSave( 240, 50 ) ;
@@ -2729,7 +2733,7 @@ S32 DoGameMenu(U16 *ptrmenu) {
 
                 ptr = LoadGameScreen();
                 if (ptr)
-                    DrawScreenSave(ptr, 240, 10);
+                    DrawScreenSave(ptr, SAVE_THUMB_X, 10);
 
                 strcpy(GamePathname, memogamepathname);
                 strcpy(PlayerName, memoplayername);
@@ -3168,7 +3172,7 @@ S32 DeleteSavedGame(void) {
     DrawOneString((S32)ModeDesiredX / 2, 80, PlayerName, 2);
     ptr = LoadGameScreen();
     if (ptr)
-        DrawScreenSave(ptr, 240, 130);
+        DrawScreenSave(ptr, SAVE_THUMB_X, 130);
     BoxUpdate();
 
     SavedConfirmMenu[0] = 0;
@@ -3629,7 +3633,7 @@ S32 MainGameMenu(S32 load) {
 
                     BoxReset(); // pas de flip
 
-                    ZoomSavedGame(240, 10);
+                    ZoomSavedGame(SAVE_THUMB_X, 10);
 
                     HQ_ResumeSamples();
                     RestoreTimer();
@@ -3701,7 +3705,7 @@ S32 MainGameMenu(S32 load) {
 
                 BoxReset(); // pas de flip
 
-                ZoomSavedGame(240, 50);
+                ZoomSavedGame(SAVE_THUMB_X, 50);
 
                 HQ_ResumeSamples();
                 RestoreTimer();
@@ -3786,7 +3790,7 @@ S32 MainGameMenu(S32 load) {
 
                 BoxReset(); // pas de flip
 
-                ZoomSavedGame(240, 50);
+                ZoomSavedGame(SAVE_THUMB_X, 50);
 
                 HQ_ResumeSamples();
                 RestoreTimer();

--- a/SOURCES/GAMEMENU.H
+++ b/SOURCES/GAMEMENU.H
@@ -18,10 +18,15 @@ extern void InitMenuIncrustText(const char *text, S32 sprite, S32 time);
 /*--------------------------------------------------------------------------*/
 extern void DrawFireBar(S32 xmin, S32 ymin, S32 xmax, S32 ymax, S32 coul);
 /*--------------------------------------------------------------------------*/
-#define DrawFire(y, coul) DrawFireBar(320 - LargeurMenu / 2, \
-                                      y,                     \
-                                      320 + LargeurMenu / 2, \
-                                      y + HAUTEUR_STANDARD,  \
+/* Plasma/fire highlight bar on the active menu option. Sits horizontally
+   centred on the screen, LargeurMenu wide. The bar's x-range mirrors the
+   DrawOneString/DrawOneChoice box (x ± LargeurMenu/2) — those callers
+   already centre at ModeDesiredX/2 post-C2, so this macro tracks the same
+   anchor or the highlight slides off the menu items at wider widths. */
+#define DrawFire(y, coul) DrawFireBar((S32)ModeDesiredX / 2 - LargeurMenu / 2, \
+                                      y,                                       \
+                                      (S32)ModeDesiredX / 2 + LargeurMenu / 2, \
+                                      y + HAUTEUR_STANDARD,                    \
                                       coul)
 /*--------------------------------------------------------------------------*/
 extern int my_sort_function(const void *a, const void *b);

--- a/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
+++ b/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
@@ -271,6 +271,9 @@ purely the 2D UI layer.
 3814, 4032). At 768×480 these darken only the left 640 columns — the
 rightmost 128 columns stay un-shaded behind menus.
 
+**GAMEMENU sites resolved by C2 pass (PR #213 + follow-ups).** Other
+files (SAVEGAME, CONFIG, INVENT, MESSAGE, HOLOPLAN) still pending.
+
 ### B2. UI text centred at X=320
 
 87 occurrences of `320` as a text-anchor. The big consumers:
@@ -284,7 +287,11 @@ rightmost 128 columns stay un-shaded behind menus.
 | [`SOURCES/MESSAGE.CPP:298`](../SOURCES/MESSAGE.CPP) | `Font(320 - dx/2, …, "Please wait")` |
 | [`SOURCES/PERSO.CPP:2226-2229`](../SOURCES/PERSO.CPP) | system message at `320 - x, 236` |
 
-All need re-anchoring to `ModeDesiredX/2`.
+All need re-anchoring to `ModeDesiredX/2`. **GAMEMENU sites resolved by
+the C2 pass** (DrawOneString / DrawSingleString / ClearOneString /
+DrawOneChoice families + the (320, 240) "Saved" box). The CONFIG /
+SAVEGAME / MESSAGE / PERSO sites are still open as their own surface
+PRs.
 
 ### B3. Inventory / dialog layout
 
@@ -319,17 +326,21 @@ SetProjection(320, 240, 128, 200, 200);
 ```
 
 Game-over model rendered at hardcoded 4:3 centre. The model is a 3D
-prop; widening would centre it.
+prop; widening would centre it. **Resolved by the C2 GAMEMENU pass.**
 
 ### B6. Fade / venetian-blind transitions
 
 [`SOURCES/GAMEMENU.CPP:4633-4639`](../SOURCES/GAMEMENU.CPP) — fade-in
-animation that uses both 479 (row count) and 640 (row stride). Same
-class as A1: needs routing.
+animation that reads a 640×480 PCX into the framebuffer. The 640/479/639
+literals are PCX-image dimensions, not framebuffer ones. **Deferred** to
+the PCX-resampling pass; marked with a `TODO(pcx)` comment in-source.
+Until then the venetian fade paints only the leftmost 640 columns of the
+wider framebuffer.
 
 [`SOURCES/GAMEMENU.CPP:3220-3227`](../SOURCES/GAMEMENU.CPP) —
 `ScaleBox(0, 0, 639, 479, Screen, x0, y0, x1, y1, Log)` — save-load
-zoom animation, full-screen source rect hardcoded.
+zoom animation, full-screen source rect hardcoded. **Resolved by the
+C2 GAMEMENU pass** (source rect routed via `ModeDesiredX/Y - 1`).
 
 ### B7. AMBIANCE extended visibility
 


### PR DESCRIPTION
## Summary
- First PR of the Category B (C2) campaign per `docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md`.
- Re-anchors GAMEMENU.CPP's hardcoded 4:3 literals (320, 240, 639, 479) to `ModeDesiredX/Y`-derived expressions so menus, save-load screens, the "Saved" box, the game-over 3D model, and the save-zoom animation centre on the actual screen at any width.
- One file, ~50 site edits, +58/-50 LoC.

## Substitutions

| Site | 4:3 literal | C2 expression |
|---|---|---|
| `ShadeBoxBlk` full-screen darken (B1, 14 sites) | `(0, 0, 639, 479, …)` | `(0, 0, MDX-1, MDY-1, …)` |
| `DrawOneString`/`DrawSingleString` text centre (B2) | `(320, …)` | `(MDX/2, …)` |
| `ClearOneString`, `DrawOneChoice` centre | `(320, …)` | `(MDX/2, …)` |
| Player-name entry cursor + width bounds | `320` / `550` | `MDX/2`, `MDX/2 + 230` |
| Save-list panel half-width | `320 ± GM_MENU_HALF…` | `MDX/2 ± GM_MENU_HALF…` |
| "Saved" confirmation box | `(320 ± …, 240 ± 25)` | `(MDX/2 ± …, MDY/2 ± 25)` |
| Game-over model `SetProjection` (B5) | `(320, 240, …)` | `(MDX/2, MDY/2, …)` |
| Save-zoom `ScaleBox` source rect (B6 / partial) | `(0, 0, 639, 479, …)` | `(0, 0, MDX-1, MDY-1, …)` |
| Save-zoom `RegleTrois` targets | `639`, `479` | `MDX-1`, `MDY-1` |

(MDX = `ModeDesiredX`, MDY = `ModeDesiredY`)

## Deferred (TODO(pcx) in-source)
- **Venetian-blind fade-in at line 4633** — reads a 640×480 PCX into the framebuffer. The 640/479/639 literals are *PCX-image* dimensions, not framebuffer ones; left alone with a comment until the PCX-resampling pass lands.
- **`DrawScreenSave(240, …)`, `ZoomSavedGame(240, …)`, `DrawCadreSave(240, …)`** — PCX save-thumbnail positioning. Same scope.

## Test plan
- [x] **640 default frame byte-identical** to pre-PR baseline (`demo_attract` headless screenshot diff is `None`). Confirms zero behaviour change at the canonical 4:3 width.
- [x] `--resolution 768x480` and `--resolution 1024x768` demo runs complete without crash.
- [x] `make test`: 10/10 host tests pass.
- [x] `apply-format.sh` / clang-format clean.
- [x] **Interactive verification of menu screens** (no headless hook opens them automatically). Recommended: launch the wide build, open the in-game menu (Esc), confirm darkening covers the full screen and text labels centre on the actual middle. Try save-load too. The C2 substitutions are mechanical, but a visual confirmation across at least 768 and 1024 widths is the right gate before merge.

## Follow-ups (separate PRs)
Per the surface plan, next:
- SAVEGAME.CPP / save-load prompts
- CONFIG.CPP / options screens
- INVENT.CPP / inventory
- MESSAGE.CPP / dialog boxes
- HOLOPLAN.CPP / holomap
- Plus the PCX-resampling pass (later, separate roadmap) for the deferred sites flagged here and elsewhere.