### PR TITLE
fix(widescreen): re-anchor SAVEGAME.CPP screen-thumbnail capture

### DIFF
--- a/SOURCES/SAVEGAME.CPP
+++ b/SOURCES/SAVEGAME.CPP
@@ -532,8 +532,12 @@ void SaveGame(S32 flagmess) {
     //	char string[30] ;
     //	S32	x0, y0, x1, y1 ;
 
-    // Image 160x120
-    ScaleBox(0, 0, 639, 479, Log, 0, 0, 159, 119, BufSpeak + 50000L); // old Screen
+    // Image 160x120: capture the whole framebuffer (whatever its width) into the
+    // 160x120 save thumbnail. ScaleBox handles non-square scaling — at wider
+    // widths the captured frame is squeezed horizontally into the same 4:3
+    // thumbnail box; the result is still recognisable in the save-load list and
+    // matches the dimensions DrawScreenSave expects.
+    ScaleBox(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, Log, 0, 0, 159, 119, BufSpeak + 50000L);
     SaveBlock(BufSpeak + 50000L, BufSpeak + 150000L, 0, 0, 159, 119);
     RemapPicture(BufSpeak + 150000L, 160 * 120);
 


### PR DESCRIPTION
## Summary
- Second PR of the Category B (C2) campaign per `docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md`.
- Routes the save-thumbnail capture's source rect from `(0, 0, 639, 479)` to `(0, 0, ModeDesiredX-1, ModeDesiredY-1)` so the whole framebuffer is captured into the thumbnail at any width.
- Tiny PR — one site, +6/-2 LoC.

## What was broken
`SAVEGAME.CPP:536` calls `ScaleBox(0, 0, 639, 479, Log, …)` to scale the current frame down to a 160x120 thumbnail. At any width above 640 it captured only the leftmost 640 columns, dropping the right sidebar from the save-list preview.

## What didn't need changing
The (320, 240) text-box + `ShadeBoxBlk(0,0,639,479)` block referenced in the audit doc's B2 entry at lines 541–555 is inside a `/* … */` comment and is dead code. Left alone.

## Out of scope
A6 in the audit doc (`DefFileBufferInit(..., BufSpeak, 640 * 480)` at lines 457 and 502) is a DOS-legacy file-buffer sizing concern — different class (Tier 1 memory rather than Category B UI). Will be addressed separately.

## Verification
- [x] ScaleBox source rect at 640 evaluates to `(0, 0, 639, 479)` — identical to the historical literal, so no behaviour change at the canonical 4:3 width.
- [x] 640 attract runs cleanly.
- [x] 768x480 attract runs without crash.
- [x] `make test`: 10/10 host tests pass.
- [x] clang-format clean.

The save-thumbnail capture only fires when the user actually saves a slot, which the headless attract doesn't reach. Reviewers can confirm interactively: save at a wide build, reload the save-list, see the thumbnail reflect the full frame (squeezed into 4:3) instead of just the leftmost 640 columns.

## Follow-ups (separate PRs)
Per the surface plan: CONFIG.CPP → INVENT.CPP → MESSAGE.CPP → HOLOPLAN.CPP. Plus the PCX-resampling pass (separate roadmap) for the deferred sites flagged in previous PRs.