### PR TITLE
fix(widescreen): re-anchor CONFIG.CPP + add ui config harness command

### DIFF
--- a/SOURCES/CONFIG.CPP
+++ b/SOURCES/CONFIG.CPP
@@ -15,9 +15,12 @@
 */
 
 #include "C_EXTERN.H"
+#include "CONFIG.H"
 #include "PCX_LOAD.H"
 #include "DIRECTORIES.H"
 #include "INPUT.H"
+
+#include <FILEIO/SAVEPNG.H>
 
 #include <stdio.h>
 
@@ -55,23 +58,29 @@
 S32 SelectConfig = 0;
 S32 SelectKey = 0;
 
-#define CFG_X0 10
+/* The config screen is a fixed 620-px-wide three-column layout (margins of
+   10 each side in the 4:3 layout). At wider framebuffers, centre the 620-px
+   region rather than letting it cling to the left edge — keeps the
+   ACTION/KEY1/KEY2 columns visually balanced and matches the rest of the
+   centred UI (menus, save-load, config text). At 640, both edges resolve to
+   the original 10 / 630 literals. */
+#define CFG_X0 ((S32)ModeDesiredX / 2 - 310)
 #define CFG_Y0 10
-#define CFG_X1 630
+#define CFG_X1 ((S32)ModeDesiredX / 2 + 310)
 #define CFG_Y1 (CFG_Y0 + MAX_INPUT * 10 + 35)
 
 #define ACTION_X (CFG_X0 + 20)
 #define KEY1_X (CFG_X0 + 371)
 #define KEY2_X (CFG_X0 + 501)
 
-#define CFG_MENU_X0 10
+#define CFG_MENU_X0 CFG_X0
 #define CFG_MENU_Y0 (CFG_Y1 + 5)
-#define CFG_MENU_X1 630
+#define CFG_MENU_X1 CFG_X1
 #define CFG_MENU_Y1 (CFG_MENU_Y0 + 10 + 3 * 10)
 
-#define CFG_TXT_X0 10
+#define CFG_TXT_X0 CFG_X0
 #define CFG_TXT_Y0 (CFG_MENU_Y1 + 5)
-#define CFG_TXT_X1 630
+#define CFG_TXT_X1 CFG_X1
 #define CFG_TXT_Y1_NORMAL (CFG_TXT_Y0 + 20)
 
 // Set while drawing / using the gamepad remap screen (footer text differs;
@@ -455,9 +464,9 @@ void DrawOneConfigMenu(S32 n) {
 
     GetMultiText(START_MENUS_TXT + CFG_TXT_DEFAUT + n, txt);
 
-    x0 = 320 - (strlen(txt) * SizeChar) / 2 - 10;
+    x0 = (S32)ModeDesiredX / 2 - (strlen(txt) * SizeChar) / 2 - 10;
     y0 = y - 2;
-    x1 = 320 + (strlen(txt) * SizeChar) / 2 + 10;
+    x1 = (S32)ModeDesiredX / 2 + (strlen(txt) * SizeChar) / 2 + 10;
     y1 = y + 8;
 
     CopyBlock(x0, y0, x1, y1, Screen, x0, y0, Log);
@@ -477,7 +486,7 @@ void DrawOneConfigMenu(S32 n) {
         CoulText(COUL_MENU, -1);
     }
 
-    GraphPrintf(FALSE, 320 - (strlen(txt) * SizeChar) / 2, y, txt);
+    GraphPrintf(FALSE, (S32)ModeDesiredX / 2 - (strlen(txt) * SizeChar) / 2, y, txt);
 
     BoxStaticAdd(x0, y0, x1, y1);
 }
@@ -552,7 +561,7 @@ void DrawStatusConfig(S32 num) {
             strcpy(kClr, "---");
 
         FormatUtf8ToCp850(lineBuf, sizeof(lineBuf), footerOneLine[lang], kExit, kSel, kClr);
-        GraphPrintf(FALSE, 320 - (strlen(lineBuf) * SizeChar) / 2, CFG_TXT_Y0 + 6, lineBuf);
+        GraphPrintf(FALSE, (S32)ModeDesiredX / 2 - (strlen(lineBuf) * SizeChar) / 2, CFG_TXT_Y0 + 6, lineBuf);
         return;
     }
 
@@ -566,7 +575,7 @@ void DrawStatusConfig(S32 num) {
         CoulText(COUL_STATUS, -1);
     }
 
-    GraphPrintf(FALSE, 320 - (strlen(txt) * SizeChar) / 2, CFG_TXT_Y0 + 7, txt);
+    GraphPrintf(FALSE, (S32)ModeDesiredX / 2 - (strlen(txt) * SizeChar) / 2, CFG_TXT_Y0 + 7, txt);
 }
 
 //▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
@@ -635,6 +644,44 @@ S32 CheckKeyConfig(S32 key) {
 #define REPEATDELAY 400
 #define REPEATRATE 40
 
+/* Harness capture state — see Config_RequestCapture() in CONFIG.H. When the
+   path is non-empty, MenuConfig's modal loop counts down per iteration; on
+   reaching zero it SavePNGs the rendered config screen and sets `ok = TRUE`
+   so the loop exits cleanly without modifying the saved key bindings.
+   Mirror of Menu_RequestCapture (GAMEMENU.CPP) / Inv_RequestCapture etc. */
+static char s_config_capture_path[ADELINE_MAX_PATH] = "";
+static int s_config_capture_countdown = 0;
+
+void Config_RequestCapture(const char *path) {
+    if (!path || !path[0]) {
+        s_config_capture_path[0] = '\0';
+        s_config_capture_countdown = 0;
+        return;
+    }
+    strncpy(s_config_capture_path, path, ADELINE_MAX_PATH - 1);
+    s_config_capture_path[ADELINE_MAX_PATH - 1] = '\0';
+    s_config_capture_countdown = 60; /* ~1 s at fixed-dt 16 — past fade-in
+                                        + initial DrawScreenConfig settle */
+}
+
+/* Full harness entry: set up the screen background MenuConfig expects from
+   its in-game invocation chain (Main Menu → Options → Controls loads the
+   menu PCX into Screen), arm the capture, and call MenuConfig. Mirror of
+   GAMEMENU.CPP's Menu_MainCapture. */
+void Config_MainCapture(const char *path) {
+    char tmpFilePathScreen[ADELINE_MAX_PATH];
+
+    GetResPath(tmpFilePathScreen, ADELINE_MAX_PATH, SCREEN_HQR_NAME);
+    Pcx_LoadStretched(tmpFilePathScreen, Screen, PCR_MENU);
+    CopyScreen(Screen, Log);
+    PtrPal = PtrPalNormal;
+    PaletteSync(PtrPalNormal);
+
+    Config_RequestCapture(path);
+    MenuConfig();
+    Config_RequestCapture(NULL); /* disarm if MenuConfig exited some other way */
+}
+
 //▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
 void MenuConfig(void) {
     S32 oldselect;
@@ -675,6 +722,14 @@ void MenuConfig(void) {
         DrawOneConfigMenu(SelectConfig);
 
         BoxUpdate();
+
+        if (s_config_capture_path[0] && --s_config_capture_countdown <= 0) {
+            SavePNG(s_config_capture_path, Log, (S32)ModeDesiredX,
+                    (S32)ModeDesiredY, PtrPal);
+            s_config_capture_path[0] = '\0';
+            ok = TRUE; /* exit cleanly without restoring MemoDefKeys */
+            break;
+        }
 
         oldkey = MyKey;
         DetectJoys();
@@ -1307,8 +1362,8 @@ void DrawCadreConfirm(S32 x0, S32 y0, S32 x1, S32 y1) {
 void DrawConfirmChoice(S32 xlen, S32 y0, char *txt, S32 select) {
     S32 x0, x1, y1, coul = COUL_MENU;
 
-    x0 = 320 - xlen;
-    x1 = 320 + xlen;
+    x0 = (S32)ModeDesiredX / 2 - xlen;
+    x1 = (S32)ModeDesiredX / 2 + xlen;
     y1 = y0 + SizeChar + 3;
     y0--;
 
@@ -1322,7 +1377,7 @@ void DrawConfirmChoice(S32 xlen, S32 y0, char *txt, S32 select) {
         RestoreAngles(x0, y0, x1, y1);
     }
 
-    DetourGraphPrintf(FALSE, coul, 320 - (strlen(txt) * SizeChar) / 2, y0 + 3, txt);
+    DetourGraphPrintf(FALSE, coul, (S32)ModeDesiredX / 2 - (strlen(txt) * SizeChar) / 2, y0 + 3, txt);
     BoxStaticAdd(x0, y0, x1, y1);
 }
 
@@ -1338,10 +1393,10 @@ S32 ConfirmMenu(char *ask, char *ok, char *cancel) {
     S32 oldselect = 1;
     S32 flag = -1;
 
-    x0 = 320 - larg / 2;
-    x1 = 320 + larg / 2;
-    y0 = 240 - haut / 2;
-    y1 = 240 + haut / 2;
+    x0 = (S32)ModeDesiredX / 2 - larg / 2;
+    x1 = (S32)ModeDesiredX / 2 + larg / 2;
+    y0 = (S32)ModeDesiredY / 2 - haut / 2;
+    y1 = (S32)ModeDesiredY / 2 + haut / 2;
 
     by0 = y1 + 2;
     by1 = by0 + 4 * SizeChar;

--- a/SOURCES/CONFIG.H
+++ b/SOURCES/CONFIG.H
@@ -6,6 +6,19 @@ extern void DrawConfigFire(S32 xmin, S32 ymin, S32 xmax, S32 ymax, S32 coul);
 //▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
 extern void MenuConfig(void);
 //▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+/* Arm a one-shot SavePNG inside MenuConfig's modal loop. After the loop
+   settles past initial draw, SavePNGs to <path> and exits cleanly (no key
+   bindings changed). Pass NULL to disarm. Mirror of Menu_RequestCapture /
+   Inv_RequestCapture / Holo_RequestCapture (see GAMEMENU.H, INVENT.H, HOLO.H). */
+extern void Config_RequestCapture(const char *path);
+
+//▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+/* Like Config_RequestCapture, but also performs the screen-background setup
+   (menu PCX into Screen) that MenuConfig expects from its normal in-game
+   invocation path (Main Menu → Options → Controls). Use from the harness
+   when MenuConfig is invoked directly without the surrounding menu chain. */
+extern void Config_MainCapture(const char *path);
+//▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
 extern void MenuGamepadConfig(void);
 //▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
 extern S32 AskForCD(void);

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -5,6 +5,7 @@
 #include "../COMMON.H"
 #include "../DIRECTORIES.H"
 #include "../PLAYACF.H"
+#include "../CONFIG.H"
 #include "../GAMEMENU.H"
 #include "../MUSIC.H"
 #include "../AMBIANCE.H"
@@ -331,6 +332,15 @@ static void cmd_ui(int argc, const char *argv[]) {
         Console_Print("ui menu-main -> %s", argv[2]);
         return;
     }
+    if (argc >= 3 && !strcmp(argv[1], "config")) {
+        /* Controls-remapping screen (keyboard). Config_MainCapture loads the
+           menu PCX into Screen (the background MenuConfig normally inherits
+           from its Main Menu → Options → Controls invocation chain), arms a
+           one-shot SavePNG, and calls MenuConfig directly. */
+        Config_MainCapture(argv[2]);
+        Console_Print("ui config -> %s", argv[2]);
+        return;
+    }
     if (argc >= 4 && !strcmp(argv[1], "found-object")) {
         /* DoFoundObj(numvar) opens the found-object cinematic: 3D rotation
            of the discovered item alongside a typewriter dialogue.  numvar
@@ -349,6 +359,7 @@ static void cmd_ui(int argc, const char *argv[]) {
     Console_Print("       ui dialog <text-id> <path>");
     Console_Print("       ui menu-options <path>");
     Console_Print("       ui menu-main <path>");
+    Console_Print("       ui config <path>");
     Console_Print("       ui found-object <numvar> <path>");
 }
 
@@ -1046,7 +1057,7 @@ void Console_RegisterAll(void) {
     Console_RegisterCommandEx("screenshot", cmd_screenshot, "Save next frame as PNG (no console)", "(no args)",
                               "PNG under shoot/; console closes first.");
     Console_RegisterCommandEx("ui", cmd_ui, "Open a UI modal and capture a screenshot",
-                              "ui {inventory|holomap|menu-options|menu-main} <path> | ui {dialog|found-object} <id> <path>",
+                              "ui {inventory|holomap|menu-options|menu-main|config} <path> | ui {dialog|found-object} <id> <path>",
                               "Composite verb for UI regression fixtures: opens a UI modal "
                               "with a deterministic auto-exit, writes the settled frame to <path> "
                               "via SavePNG, then closes.  Compose with --load / --exec to drive "

--- a/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
+++ b/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
@@ -281,7 +281,7 @@ files (SAVEGAME, CONFIG, INVENT, MESSAGE, HOLOPLAN) still pending.
 | File | Sites |
 |---|---|
 | [`SOURCES/GAMEMENU.CPP`](../SOURCES/GAMEMENU.CPP) | ~30 — `DrawOneString(320, …)`, `DrawSingleString(320, 240, …)`, etc. |
-| [`SOURCES/CONFIG.CPP`](../SOURCES/CONFIG.CPP) | 7 — config-screen text centred at 320 |
+| [`SOURCES/CONFIG.CPP`](../SOURCES/CONFIG.CPP) | 7 — config-screen text centred at 320 *(resolved by C2 CONFIG.CPP pass)* |
 | [`SOURCES/SAVEGAME.CPP:544-547`](../SOURCES/SAVEGAME.CPP) | save-prompt text box centred at (320, 240) |
 | [`SOURCES/GAMEMENU.CPP:4521-4524`](../SOURCES/GAMEMENU.CPP) | "Saved" message box at (320 ± X, 240 ± 25) |
 | [`SOURCES/MESSAGE.CPP:298`](../SOURCES/MESSAGE.CPP) | `Font(320 - dx/2, …, "Please wait")` |
@@ -289,9 +289,12 @@ files (SAVEGAME, CONFIG, INVENT, MESSAGE, HOLOPLAN) still pending.
 
 All need re-anchoring to `ModeDesiredX/2`. **GAMEMENU sites resolved by
 the C2 pass** (DrawOneString / DrawSingleString / ClearOneString /
-DrawOneChoice families + the (320, 240) "Saved" box). The CONFIG /
-SAVEGAME / MESSAGE / PERSO sites are still open as their own surface
-PRs.
+DrawOneChoice families + the (320, 240) "Saved" box). **CONFIG.CPP
+resolved** (text anchors via `ModeDesiredX/2`, the 3-column `CFG_X0/X1`
+layout box re-centred via `ModeDesiredX/2 ± 310`, plus a new
+`Config_MainCapture` + `ui config` console command for headless A/B).
+The SAVEGAME / MESSAGE / PERSO sites are still open as their own
+surface PRs.
 
 ### B3. Inventory / dialog layout
 


### PR DESCRIPTION
## Summary
Third C2 surface PR. The controls-remapping screen (`MenuConfig`) had its 3-column layout (Action / Key1 / Key2) plus all centred text anchored to 4:3 literals; at any framebuffer wider than 640 the entire layout clung to the left edge.

Two scopes in one PR:

1. **C2 substitutions in `CONFIG.CPP`** (11 centring sites + 3 layout-macro pairs).
2. **Headless capture support** — new `ui config <path>` console command, mirroring `ui menu-main` / `ui menu-options` / `ui inventory` / `ui holomap`. Enables the same A/B verification workflow for this and future config-related PRs.

## What changed

### C2 substitutions in CONFIG.CPP
| Site | 4:3 literal | C2 expression |
|---|---|---|
| `DrawOneConfigMenu` row bbox | `x0 = 320 ± (strlen * SizeChar) / 2 ± N` | `(S32)ModeDesiredX / 2 ± …` |
| `GraphPrintf(FALSE, 320 - …, …)` text anchors (5×) | `320` | `(S32)ModeDesiredX / 2` |
| `DrawConfirmChoice` button bbox | `x0 = 320 ± xlen` | `(S32)ModeDesiredX / 2 ± xlen` |
| `DetourGraphPrintf` button text | `320 - (strlen * SizeChar) / 2` | `(S32)ModeDesiredX / 2 - …` |
| `ConfirmMenu` centred dialog box | `(320 ± larg/2, 240 ± haut/2)` | `(MDX/2 ± larg/2, MDY/2 ± haut/2)` |
| `CFG_X0/X1`, `CFG_MENU_X0/X1`, `CFG_TXT_X0/X1` macros | `10` / `630` (margin-aware 4:3) | `MDX/2 ± 310` (620-px-wide centred region) |

`ACTION_X`, `KEY1_X`, `KEY2_X` defined as `CFG_X0 + N` auto-track via cascading. At 640 every macro resolves to the original literals → byte-identical at the canonical width.

### `ui config` harness command
New `Config_RequestCapture(path)` + `Config_MainCapture(path)` in `CONFIG.{H,CPP}`, mirroring `Menu_RequestCapture` / `Menu_MainCapture` in GAMEMENU.CPP:
- `Config_RequestCapture` arms a one-shot SavePNG inside `MenuConfig`'s modal loop. Fires after a ~60-iteration settle, exits with `ok = TRUE` so the loop exits cleanly **without modifying the saved key bindings**.
- `Config_MainCapture` does the screen-background setup MenuConfig inherits from its in-game invocation chain: loads `PCR_MENU` into `Screen` (stretched per `#215`), copies to `Log`, syncs the palette, then arms + calls MenuConfig.
- Wired into `cmd_ui` as `ui config <path>`.

## Verification
- [x] 640 main-menu pre vs post excluding the (non-deterministic) plasma strip — byte-identical.
- [x] `ui config` at 640 / 768 / 1024 captures the config screen with the 3-column layout centred in the framebuffer at any width.
- [x] `make test` 10/10 pass.
- [x] `apply-format.sh` / clang-format clean.

The `ui config` capture shows leftover dialog text on the left side at all widths — that's pre-existing harness state (the engine init populates Log with various stuff before the console command fires), not a C2 regression. It happens identically at 640 and 768.

## Follow-ups
Next surfaces per the C2 plan: INVENT.CPP (medium; would unblock the deferred `PCR_ARDOISE` slate art from `#215`), MESSAGE.CPP (dialog `Dial_X1` family), HOLOPLAN.CPP (corners + holomap projection centre).