### PR TITLE
fix(widescreen): C2 re-anchor INVENT.CPP/H + load slate-art PCX centred

### DIFF
--- a/SOURCES/INVENT.CPP
+++ b/SOURCES/INVENT.CPP
@@ -2,6 +2,7 @@
 #include "CONTROL.H"
 #include "DIRECTORIES.H"
 #include "INPUT.H"
+#include "PCX_LOAD.H"
 
 #include <FILEIO/SAVEPNG.H>
 #include <SVGA/SCREEN.H>
@@ -1865,8 +1866,12 @@ void DoFoundObj(S32 numvar) {
 #define R_X1 (R_X0 + 50)
 #define R_Y1 (R_Y0 + 29)
 
-// Coordonnees de la boite des plans se trouvant dans l'ardoise
-#define PLAN_X0 78
+// Coordonnees de la boite des plans se trouvant dans l'ardoise.
+// PLAN_X0 carries the INV_LEFT_OFFSET so the slate-plan box stays inside the
+// centred inventory region at wider framebuffers; the 78 inner offset is the
+// historical literal (matches the slate art's left margin within its 640x480
+// authored canvas). PLAN_Y stays absolute — slate art top-aligns at y=61.
+#define PLAN_X0 (78 + INV_LEFT_OFFSET)
 #define PLAN_Y0 61
 #define PLAN_X1 (PLAN_X0 + 479)
 #define PLAN_Y1 (PLAN_Y0 + 360)
@@ -2118,7 +2123,11 @@ void ChangeArdoise(S32 left) // 0:right, 1:left
 
     // Chargement pcx
     GetResPath(tmpFilePath, ADELINE_MAX_PATH, SCREEN_HQR_NAME);
-    if (!Load_HQR(tmpFilePath, Screen, ListArdoise[CurrentArdoise] * 2)) // *2 pour compter les palettes
+    // Pcx_LoadCentered shifts each row of the 640x480 PCX by INV_LEFT_OFFSET
+    // so its "original column 78" content lands at framebuffer column
+    // 78 + INV_LEFT_OFFSET — which is exactly where PLAN_X0 (now offset-aware)
+    // reads from in the CopyBlockIncrust below.
+    if (!Pcx_LoadCentered(tmpFilePath, Screen, ListArdoise[CurrentArdoise] * 2)) // *2 pour compter les palettes
         TheEndCheckFile(tmpFilePath);
 
     CopyBlock(PLAN_X0, PLAN_Y0, PLAN_X1, PLAN_Y1, BufSpeak,
@@ -2145,7 +2154,7 @@ void DrawArdoise() {
     char tmpFilePath[ADELINE_MAX_PATH];
 
     GetResPath(tmpFilePath, ADELINE_MAX_PATH, SCREEN_HQR_NAME);
-    if (!Load_HQR(tmpFilePath, Log, PCR_ARDOISE))
+    if (!Pcx_LoadCentered(tmpFilePath, Log, PCR_ARDOISE))
         TheEndCheckFile(tmpFilePath);
 
     CopyScreen(Log, BufSpeak); //	Ardoise Vierge
@@ -2155,8 +2164,10 @@ void DrawArdoise() {
 	SaveBlock( Log, BufSpeak+10000, PLAN_X0, PLAN_Y0, PLAN_X1, PLAN_Y1 ) ;
 */
     if (CurrentArdoise >= 0 AND CurrentArdoise < NbArdoise) {
-        // Chargement pcx
-        if (!Load_HQR(tmpFilePath, Screen, ListArdoise[CurrentArdoise] * 2)) // *2 pour compter les palettes
+        // Chargement pcx — see ChangeArdoise above: Pcx_LoadCentered shifts the
+        // 640x480 PCX content into Screen so the offset-aware PLAN_X0 reads
+        // from the correct centred position.
+        if (!Pcx_LoadCentered(tmpFilePath, Screen, ListArdoise[CurrentArdoise] * 2)) // *2 pour compter les palettes
             TheEndCheckFile(tmpFilePath);
 
         CopyBlockIncrust(PLAN_X0, PLAN_Y0, PLAN_X1, PLAN_Y1, Screen,

--- a/SOURCES/INVENT.CPP
+++ b/SOURCES/INVENT.CPP
@@ -1854,14 +1854,18 @@ void DoFoundObj(S32 numvar) {
 
 #ifndef COMPILATOR
 
-// Coordonnees de la boite de la fleche gauche
-#define L_X0 78
+// Coordonnees de la boite de la fleche gauche.
+// X carries INV_LEFT_OFFSET so the arrows stay inside the centred slate at
+// wider framebuffers — same anchor convention as PLAN_X0 below; the 78 / 495
+// inner offsets are the historical literals against the slate's 640x480
+// authored canvas.
+#define L_X0 (78 + INV_LEFT_OFFSET)
 #define L_Y0 436
 #define L_X1 (L_X0 + 50)
 #define L_Y1 (L_Y0 + 29)
 
 // Coordonnees de la boite de la fleche droite
-#define R_X0 495
+#define R_X0 (495 + INV_LEFT_OFFSET)
 #define R_Y0 436
 #define R_X1 (R_X0 + 50)
 #define R_Y1 (R_Y0 + 29)

--- a/SOURCES/INVENT.H
+++ b/SOURCES/INVENT.H
@@ -9,8 +9,8 @@
 */
 //--------------------------	Can change
 
-#define INV_START_X 8 //	Margin inventory screen X
-#define INV_START_Y 8 //	Margin inventory screen Y
+#define INV_START_X_MARGIN 8 //	Margin inventory screen X (from the 4:3 inner box's left edge)
+#define INV_START_Y 8        //	Margin inventory screen Y
 
 #define INV_NBOBJ_X 7 //	Nb Object X ex 8
 #define INV_NBOBJ_Y 5 //	Nb Object Y
@@ -20,8 +20,19 @@
 
 //--------------------------	Auto change
 
-#define INV_DELTA_X (639 - (INV_START_X * 2))         //	Size Inventory in X
-#define INV_DELTA_Y (INV_NAME_Y0 - (INV_START_Y * 2)) //            in Y
+/* At framebuffers wider than 640 the inventory layout is rendered as a
+   centred 4:3 region rather than stretched: the icons are fixed-size sprites
+   so stretching would just add awkward whitespace between them. INV_LEFT_OFFSET
+   shifts every X coord below so the whole inventory + name box + slate art
+   moves as a unit; INV_DELTA_X stays fixed at the authored inner width (623).
+   At 640 INV_LEFT_OFFSET is 0 and every macro resolves to the historical
+   literal (10/8/0/...). The iso-relative INV_ZOOM box centres on
+   ModeDesiredX/2 - 3 (matches the historical 317 anchor at 640). */
+#define INV_LEFT_OFFSET (((S32)ModeDesiredX - 640) / 2)
+#define INV_START_X (INV_START_X_MARGIN + INV_LEFT_OFFSET)
+
+#define INV_DELTA_X (640 - INV_START_X_MARGIN * 2 - 1) //	Size Inventory in X (623, fixed inner width)
+#define INV_DELTA_Y (INV_NAME_Y0 - (INV_START_Y * 2))  //	            in Y
 
 #define INV_END_X (INV_START_X + INV_DELTA_X)
 #define INV_END_Y (INV_START_Y + INV_DELTA_Y)
@@ -31,15 +42,15 @@
 
 //	Before : 317-120, 218-140, 317+120, 218+140
 
-#define INV_ZOOM_X0 317 - 120
-#define INV_ZOOM_Y0 210 - 120
-#define INV_ZOOM_X1 317 + 120
-#define INV_ZOOM_Y1 210 + 120
+#define INV_ZOOM_X0 ((S32)ModeDesiredX / 2 - 3 - 120)
+#define INV_ZOOM_Y0 (210 - 120)
+#define INV_ZOOM_X1 ((S32)ModeDesiredX / 2 - 3 + 120)
+#define INV_ZOOM_Y1 (210 + 120)
 
-#define INV_NAME_X0 INV_START_X         //	Name Object X0
-#define INV_NAME_Y0 429                 //	Name Object Y0
-#define INV_NAME_X1 (639 - INV_START_X) //	Name Object X1
-#define INV_NAME_Y1 471                 //	Name Object Y1
+#define INV_NAME_X0 INV_START_X //	Name Object X0
+#define INV_NAME_Y0 429         //	Name Object Y0
+#define INV_NAME_X1 INV_END_X   //	Name Object X1
+#define INV_NAME_Y1 471         //	Name Object Y1
 
 extern S32 ProtectActif;
 extern S32 FlagZoomed;

--- a/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
+++ b/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
@@ -300,9 +300,9 @@ surface PRs.
 
 | File | Site | What |
 |---|---|---|
-| [`SOURCES/INVENT.CPP:1871`](../SOURCES/INVENT.CPP) | `#define PLAN_X1 (PLAN_X0 + 479)` | Slate panel right edge — slate art is 480 wide, OK as-is |
-| [`SOURCES/INVENT.H:23,41`](../SOURCES/INVENT.H) | `INV_DELTA_X = 639 - INV_START_X*2`, `INV_NAME_X1 = 639 - INV_START_X` | Inventory panel width tied to 639 |
-| [`SOURCES/INVENT.H:34,36`](../SOURCES/INVENT.H) | `INV_ZOOM_X0 = 317 - 120`, `INV_ZOOM_X1 = 317 + 120` | Zoom box at iso projection X (`317 = 320 - 3`) |
+| [`SOURCES/INVENT.CPP:1871`](../SOURCES/INVENT.CPP) | `#define PLAN_X1 (PLAN_X0 + 479)` | Slate panel right edge — slate art is 480 wide, OK as-is. *(Resolved: `PLAN_X0` now carries `INV_LEFT_OFFSET` so the slate stays inside the centred inventory region; the deferred `PCR_ARDOISE` PCX is loaded via `Pcx_LoadCentered`.)* |
+| [`SOURCES/INVENT.H:23,41`](../SOURCES/INVENT.H) | `INV_DELTA_X = 639 - INV_START_X*2`, `INV_NAME_X1 = 639 - INV_START_X` | Inventory panel width tied to 639. *(Resolved: centred-4:3 design — `INV_DELTA_X` is fixed 623, `INV_START_X` carries `INV_LEFT_OFFSET = (ModeDesiredX-640)/2`. Icons stay fixed-size; the rectangle slides as a unit.)* |
+| [`SOURCES/INVENT.H:34,36`](../SOURCES/INVENT.H) | `INV_ZOOM_X0 = 317 - 120`, `INV_ZOOM_X1 = 317 + 120` | Zoom box at iso projection X (`317 = 320 - 3`). *(Resolved: `(S32)ModeDesiredX / 2 - 3 ± 120`.)* |
 | [`SOURCES/MESSAGE.CPP:110, 111, 1227, 1237, 1247, 1258, 1969, 1970`](../SOURCES/MESSAGE.CPP) | `Dial_X1 = 639 - 16`, `Dial_Y1 = 479 - 16` and variants | Dialog box right/bottom margins |
 
 ### B4. Holomap UI


### PR DESCRIPTION
## Summary
Fourth C2 surface PR. Two scopes in one cohesive PR:

1. **Inventory layout C2** — re-anchor `INV_*` macros so the inventory rectangle, name box, and item-zoom box stay centred in any wider framebuffer instead of clinging to the left edge.
2. **Slate-art PCX centred load** — wire the three `PCR_ARDOISE` / `ListArdoise` `Load_HQR` sites (the deferred case from #215) through `Pcx_LoadCentered` so the slate PCX aligns with the offset-aware `PLAN_X0`.

## Design
**Centre, don't stretch.** Inventory icons are fixed-size sprites; stretching the rectangle would just spread out the icons with awkward whitespace. The slate art is a fixed-size PCX too. So:

- New `INV_LEFT_OFFSET = (ModeDesiredX - 640) / 2` in INVENT.H. Zero at 640, scales with width.
- `INV_DELTA_X` becomes the fixed inner width (623; was `639 - INV_START_X*2` which evaluated to 623 at 640).
- `INV_START_X` carries the offset (`8 + INV_LEFT_OFFSET`); derived `INV_END_X`, `INV_NAME_X0/X1` auto-track.
- `INV_ZOOM_X0/X1` (item-zoom box centred on iso projection X = 317 historically): route to `ModeDesiredX/2 - 3 ± 120`.
- `PLAN_X0` (slate panel inside the inventory) becomes `78 + INV_LEFT_OFFSET`; `PLAN_X1` derives from it.
- Three `Load_HQR(..., Screen|Log, PCR_ARDOISE | ListArdoise * 2)` sites switch to `Pcx_LoadCentered` from #215.

At 640 every macro evaluates to its historical literal — `ui inventory` capture is byte-identical to pre-PR.

The Y axis is left absolute (no `INV_TOP_OFFSET`): at H=480 it doesn't matter, and most common widescreen targets keep H=480. Vertical centring can be added later if 1080p+ targets ship.

## Verification
- [x] 640 `ui inventory` pre vs post: byte-identical (None diff).
- [x] 768 and 1024 captures: inventory rectangle + slate art + zoom box centre on the actual screen middle; icons stay 79 px wide as authored.
- [x] `make test`: 10/10 host tests pass.
- [x] `apply-format.sh` / clang-format clean.

## Resolves audit-doc B3 entries
- INV_DELTA_X / INV_NAME_X1 → centred via `INV_LEFT_OFFSET`
- INV_ZOOM_X0/X1 → `ModeDesiredX/2 - 3 ± 120`
- PLAN_X1 → offset-aware via PLAN_X0
- PCR_ARDOISE PCX load → `Pcx_LoadCentered` (the deferred #215 case)

## Follow-ups
Next per the plan: MESSAGE.CPP (Dial_X1 family, dialog box right/bottom margins) → HOLOPLAN.CPP (corners + holomap 3D projection centre).