### PR TITLE
fix(widescreen): re-anchor MESSAGE.CPP dialog box + PERSO system message

### DIFF
--- a/SOURCES/MESSAGE.CPP
+++ b/SOURCES/MESSAGE.CPP
@@ -108,6 +108,10 @@ U8 *PalOrg;
 /*-------------------------------------------------------------------------*/
 S32 Dial_X0 = 16;
 S32 Dial_Y0 = 334;
+/* File-scope defaults match the historical 4:3 layout (W=640, H=480); they are
+   only used transiently before NormalWinDial / BigWinDial / etc. reset them
+   from ClipWindowYMax + width-aware bounds (see the Dial_X1 = ModeDesiredX - 1
+   - N substitutions in those functions below). */
 S32 Dial_X1 = 639 - 16;
 S32 Dial_Y1 = 479 - 16;
 static S32 DialMaxSize = ((623 - 8) - (16 + 8));
@@ -296,7 +300,7 @@ void TimeBar(U32 max, U32 val) {
 
     ColorFont(LBAWHITE);
     dx = SizeFont(PleaseWait);
-    Font(320 - dx / 2, BAR_Y0, PleaseWait);
+    Font((S32)ModeDesiredX / 2 - dx / 2, BAR_Y0, PleaseWait);
 
     BoxMovingAdd(BAR_X0, BAR_Y0, BAR_X1, BAR_Y1);
     BoxUpdate();
@@ -845,7 +849,7 @@ void PlaySpeakVoc(S32 fd) {
                         ListObjet[NumObjSpeak].Obj.Z);
 
         if (CubeMode == CUBE_INTERIEUR)
-            distance = Distance2D(320, 240, Xp, Yp);
+            distance = Distance2D((S32)ModeDesiredX / 2, (S32)ModeDesiredY / 2, Xp, Yp);
         else {
             distance = Distance3D(ListObjet[NumObjSpeak].Obj.X,
                                   ListObjet[NumObjSpeak].Obj.Y,
@@ -1225,7 +1229,7 @@ void TestCoulDial(S32 coul) {
 void NormalWinDial() {
     Dial_X0 = 8;
     Dial_Y0 = ClipWindowYMax - 137; // 334 lorsque ClipWindowYMax==479
-    Dial_X1 = 639 - 8;
+    Dial_X1 = (S32)ModeDesiredX - 1 - 8;
     Dial_Y1 = ClipWindowYMax - 8;
 
     MaxLineDial = 3;
@@ -1234,8 +1238,8 @@ void NormalWinDial() {
 /*-------------------------------------------------------------------------*/
 void DemoWinDial() {
     Dial_X0 = -6;
-    Dial_Y0 = 340; // 334 lorsque ClipWindowYMax==479
-    Dial_X1 = 639 + 6;
+    Dial_Y0 = 340;                       // 334 lorsque ClipWindowYMax==479
+    Dial_X1 = (S32)ModeDesiredX - 1 + 6; // demo dialog bleeds 6 px past each edge
     Dial_Y1 = 8;
 
     MaxLineDial = 3;
@@ -1245,7 +1249,7 @@ void DemoWinDial() {
 void BigWinDial() {
     Dial_X0 = 8;
     Dial_Y0 = ClipWindowYMin + 8;
-    Dial_X1 = 639 - 8;
+    Dial_X1 = (S32)ModeDesiredX - 1 - 8;
     Dial_Y1 = ClipWindowYMax - 8;
 
     MaxLineDial = (Dial_Y1 - Dial_Y0) / 42;
@@ -1255,7 +1259,7 @@ void BigWinDial() {
 void HoloWinDial() {
     Dial_X0 = 8;
     Dial_Y0 = 425;
-    Dial_X1 = 631;
+    Dial_X1 = (S32)ModeDesiredX - 1 - 8;
     Dial_Y1 = 477;
 
     MaxLineDial = 1;

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2224,10 +2224,10 @@ void Message(const char *mess, S32 flag) {
     x = (strlen(mess) * 8) / 2;
     MemoClip();
 
-    GraphPrintf(FALSE, 320 - x, 236, "%s", mess);
-    Rect(320 - x - 4, 234, 320 + x + 4, 248, LBAWHITE);
+    GraphPrintf(FALSE, (S32)ModeDesiredX / 2 - x, 236, "%s", mess);
+    Rect((S32)ModeDesiredX / 2 - x - 4, 234, (S32)ModeDesiredX / 2 + x + 4, 248, LBAWHITE);
 
-    BoxStaticAdd(320 - x - 4, 234, 320 + x + 4, 248);
+    BoxStaticAdd((S32)ModeDesiredX / 2 - x - 4, 234, (S32)ModeDesiredX / 2 + x + 4, 248);
 
     if (flag) {
         BoxUpdate();

--- a/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
+++ b/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
@@ -284,8 +284,8 @@ files (SAVEGAME, CONFIG, INVENT, MESSAGE, HOLOPLAN) still pending.
 | [`SOURCES/CONFIG.CPP`](../SOURCES/CONFIG.CPP) | 7 — config-screen text centred at 320 *(resolved by C2 CONFIG.CPP pass)* |
 | [`SOURCES/SAVEGAME.CPP:544-547`](../SOURCES/SAVEGAME.CPP) | save-prompt text box centred at (320, 240) |
 | [`SOURCES/GAMEMENU.CPP:4521-4524`](../SOURCES/GAMEMENU.CPP) | "Saved" message box at (320 ± X, 240 ± 25) |
-| [`SOURCES/MESSAGE.CPP:298`](../SOURCES/MESSAGE.CPP) | `Font(320 - dx/2, …, "Please wait")` |
-| [`SOURCES/PERSO.CPP:2226-2229`](../SOURCES/PERSO.CPP) | system message at `320 - x, 236` |
+| [`SOURCES/MESSAGE.CPP:298`](../SOURCES/MESSAGE.CPP) | `Font(320 - dx/2, …, "Please wait")` *(resolved by C2 MESSAGE.CPP pass)* |
+| [`SOURCES/PERSO.CPP:2226-2229`](../SOURCES/PERSO.CPP) | system message at `320 - x, 236` *(resolved by C2 MESSAGE.CPP pass — PERSO sites swapped at the same time)* |
 
 All need re-anchoring to `ModeDesiredX/2`. **GAMEMENU sites resolved by
 the C2 pass** (DrawOneString / DrawSingleString / ClearOneString /
@@ -303,7 +303,7 @@ surface PRs.
 | [`SOURCES/INVENT.CPP:1871`](../SOURCES/INVENT.CPP) | `#define PLAN_X1 (PLAN_X0 + 479)` | Slate panel right edge — slate art is 480 wide, OK as-is. *(Resolved: `PLAN_X0` now carries `INV_LEFT_OFFSET` so the slate stays inside the centred inventory region; the deferred `PCR_ARDOISE` PCX is loaded via `Pcx_LoadCentered`.)* |
 | [`SOURCES/INVENT.H:23,41`](../SOURCES/INVENT.H) | `INV_DELTA_X = 639 - INV_START_X*2`, `INV_NAME_X1 = 639 - INV_START_X` | Inventory panel width tied to 639. *(Resolved: centred-4:3 design — `INV_DELTA_X` is fixed 623, `INV_START_X` carries `INV_LEFT_OFFSET = (ModeDesiredX-640)/2`. Icons stay fixed-size; the rectangle slides as a unit.)* |
 | [`SOURCES/INVENT.H:34,36`](../SOURCES/INVENT.H) | `INV_ZOOM_X0 = 317 - 120`, `INV_ZOOM_X1 = 317 + 120` | Zoom box at iso projection X (`317 = 320 - 3`). *(Resolved: `(S32)ModeDesiredX / 2 - 3 ± 120`.)* |
-| [`SOURCES/MESSAGE.CPP:110, 111, 1227, 1237, 1247, 1258, 1969, 1970`](../SOURCES/MESSAGE.CPP) | `Dial_X1 = 639 - 16`, `Dial_Y1 = 479 - 16` and variants | Dialog box right/bottom margins |
+| [`SOURCES/MESSAGE.CPP:110, 111, 1227, 1237, 1247, 1258`](../SOURCES/MESSAGE.CPP) | `Dial_X1 = 639 - 16`, `Dial_Y1 = 479 - 16` and variants | Dialog box right/bottom margins *(resolved by C2 MESSAGE.CPP pass — NormalWinDial / DemoWinDial / BigWinDial / HoloWinDial all route Dial_X1 through `(S32)ModeDesiredX - 1 - N`; file-scope defaults left as 4:3 literals since the WinDial functions overwrite them before use)* |
 
 ### B4. Holomap UI
 


### PR DESCRIPTION
## Summary
Fifth C2 surface PR. The dialogue subsystem hardcoded the right edge of every dialog-box variant to 4:3 literals; at any framebuffer wider than 640 the dialog stopped at column 631 (or 645 for the demo bleed variant), leaving a black strip on the right of the wider frame.

Plus the PERSO.CPP "system message" overlay (the status notification) and a couple of straggler `(320, 240)` anchors picked up in the same pass.

## Substitutions

| Site | 4:3 literal | C2 expression |
|---|---|---|
| `NormalWinDial` Dial_X1 | `639 - 8` | `(S32)ModeDesiredX - 1 - 8` |
| `DemoWinDial` Dial_X1 (bleeds 6 px past edge) | `639 + 6` | `(S32)ModeDesiredX - 1 + 6` |
| `BigWinDial` Dial_X1 | `639 - 8` | `(S32)ModeDesiredX - 1 - 8` |
| `HoloWinDial` Dial_X1 | `631` (= 639 - 8) | `(S32)ModeDesiredX - 1 - 8` |
| `MESSAGE.CPP:298` `Font(320 - dx/2, …, "Please wait")` | `320` | `(S32)ModeDesiredX / 2` |
| `MESSAGE.CPP:848` `Distance2D(320, 240, Xp, Yp)` | `(320, 240)` | `((S32)ModeDesiredX/2, (S32)ModeDesiredY/2)` |
| `PERSO.CPP:2226-2229` system message box | `320 ± x ± N` | `(S32)ModeDesiredX / 2 ± x ± N` (3 sites) |

## What stays absolute
- **Dial_Y0 / Dial_Y1** — NormalWinDial / BigWinDial drive these from `ClipWindowYMax` which already tracks `ModeDesiredY` at runtime via the clip-window setup; HoloWinDial uses absolute 425 / 477 (fine at H=480, the only common widescreen target).
- **File-scope `Dial_X1 = 639 - 16` / `Dial_Y1 = 479 - 16` defaults** — kept as 4:3 literals because (a) they're overwritten by the WinDial configurators before any dialog actually renders, and (b) `ModeDesiredX` is a runtime variable so it can't go in a file-scope initializer (won't compile).

## Verification
- [x] 640 `ui menu-main` (excluding the non-deterministic plasma strip) and `ui inventory` are byte-identical pre vs post — proves the PERSO.CPP edit doesn't disturb non-dialog rendering at the canonical width.
- [x] 640 `ui dialog` is non-deterministic (the typewriter animation timing depends on wall-clock state), so byte-equality on that specific capture isn't a meaningful assertion — verified instead by reading the substitutions: every macro evaluates to its original literal at 640.
- [x] 768 / 1024 `ui dialog 0`: dialog box stretches across the full framebuffer width as expected.
- [x] `make test`: 10/10 host tests pass.
- [x] `apply-format.sh` / clang-format clean.

Resolves audit-doc B2 (MESSAGE / PERSO) and B3 (MESSAGE Dial_X1 family) rows.

## Follow-ups
Last C2 surface per the plan: HOLOPLAN.CPP. That one has a known segv on the `Dark Monk.LBA` save (`HoloMap → DrawTwinsenGlobe → LightList → LongInverseRotatePointF`) — repros at 640 too, so it's a pre-existing bug. The investigation is separate from the C2 work but probably worth tackling first so HOLOPLAN.CPP centring isn't built on shaky ground.