### PR TITLE
feat(widescreen): Dial_Letterbox — keep PCX cinematic dialog inside the picture

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -357,16 +357,35 @@ static void cmd_ui(int argc, const char *argv[]) {
            pcx-idx is an absolute PCR_ value (PCR_LOGO=0, PCR_CDROM=60,
            PCR_ACTIVISION=72, ...). EffectPcxMess internally doubles its arg
            to skip interleaved palettes, so we halve here before passing. */
+        /* Optional 5th arg `mode` overrides the WinDial selection via the
+           harness-only Dial_ForceFlag: "big" → DIAL_BIG (multi-line big
+           message box, end-game style), "full" → DIAL_FUL, "normal" →
+           DIAL_DEF. Anything else (or omitted) → leave as the text-id's
+           encoded mode. */
         S32 pcx_idx = (S32)atoi(argv[2]);
         S32 text_id = (S32)atoi(argv[3]);
-        const char *path = (argc >= 5) ? argv[4] : NULL;
+        const char *path = (argc >= 5 && argv[4][0] && strcmp(argv[4], "-") != 0)
+                               ? argv[4]
+                               : NULL;
+        const char *mode = (argc >= 6) ? argv[5] : "";
+        S32 forced = 0;
+        if (!strcmp(mode, "big"))
+            forced = DIAL_BIG;
+        else if (!strcmp(mode, "full"))
+            forced = DIAL_FUL;
+        else if (!strcmp(mode, "normal"))
+            forced = DIAL_DEF;
         if (path && path[0])
             Dial_RequestCapture(path);
+        Dial_ForceFlag = forced;
         EffectPcxMess((U8)(pcx_idx / 2), (U8 *)Screen, PCX_FADE, text_id);
+        Dial_ForceFlag = 0;
         if (path && path[0])
             Dial_RequestCapture(NULL);
-        Console_Print("ui pcx-message pcx=%d text=%d -> %s",
-                      (int)pcx_idx, (int)text_id, path ? path : "(no path)");
+        Console_Print("ui pcx-message pcx=%d text=%d mode=%s -> %s",
+                      (int)pcx_idx, (int)text_id,
+                      mode[0] ? mode : "(default)",
+                      path ? path : "(no path)");
         return;
     }
     if (argc >= 3 && !strcmp(argv[1], "config")) {
@@ -398,7 +417,7 @@ static void cmd_ui(int argc, const char *argv[]) {
     Console_Print("       ui menu-main <path>");
     Console_Print("       ui config <path>");
     Console_Print("       ui slideshow <path>");
-    Console_Print("       ui pcx-message <pcx-idx> <text-id> [<path>]");
+    Console_Print("       ui pcx-message <pcx-idx> <text-id> [<path>] [big|full|normal]");
     Console_Print("       ui found-object <numvar> <path>");
 }
 
@@ -1096,7 +1115,7 @@ void Console_RegisterAll(void) {
     Console_RegisterCommandEx("screenshot", cmd_screenshot, "Save next frame as PNG (no console)", "(no args)",
                               "PNG under shoot/; console closes first.");
     Console_RegisterCommandEx("ui", cmd_ui, "Open a UI modal and capture a screenshot",
-                              "ui {inventory|holomap|menu-options|menu-main|config|slideshow} <path> | ui {dialog|found-object} <id> <path> | ui pcx-message <pcx-idx> <text-id> [<path>]",
+                              "ui {inventory|holomap|menu-options|menu-main|config|slideshow} <path> | ui {dialog|found-object} <id> <path> | ui pcx-message <pcx-idx> <text-id> [<path>] [big|full|normal]",
                               "Composite verb for UI regression fixtures: opens a UI modal "
                               "with a deterministic auto-exit, writes the settled frame to <path> "
                               "via SavePNG, then closes.  Compose with --load / --exec to drive "

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -332,6 +332,43 @@ static void cmd_ui(int argc, const char *argv[]) {
         Console_Print("ui menu-main -> %s", argv[2]);
         return;
     }
+    if (argc >= 3 && !strcmp(argv[1], "slideshow")) {
+        /* End-of-island / end-game still-image montage. SlideShow loads
+           pre-rendered screenshots from scrshot.hqr, each shown with a story
+           caption via Dial. SlideShow_RequestCapture arms a one-shot SavePNG
+           inside the first frame's Dial typewriter loop, exits the slideshow
+           loop cleanly after the capture fires. Centred PCX + letterboxed
+           dialog flow — useful for verifying the Dial_Letterbox path.
+           NOTE: requires scrshot.hqr in the game data (typically Demo only);
+           returns silently if absent. Use `ui pcx-message` below for a path
+           that works on standard retail data. */
+        SlideShow_RequestCapture(argv[2]);
+        SlideShow();
+        SlideShow_RequestCapture(NULL); /* disarm if SlideShow exited some other way */
+        Console_Print("ui slideshow -> %s", argv[2]);
+        return;
+    }
+    if (argc >= 4 && !strcmp(argv[1], "pcx-message")) {
+        /* EffectPcxMess(pcx, screen, PCX_FADE, mess) — load a screen.hqr PCX
+           centred via Pcx_LoadCentered, then overlay the given dialog text-id
+           from the currently-loaded dialog bank. Same Dial_Letterbox path as
+           SlideShow / scripted LM_PCX_MESS_OBJ scenes; usable on standard
+           retail data (screen.hqr is present everywhere).
+           pcx-idx is an absolute PCR_ value (PCR_LOGO=0, PCR_CDROM=60,
+           PCR_ACTIVISION=72, ...). EffectPcxMess internally doubles its arg
+           to skip interleaved palettes, so we halve here before passing. */
+        S32 pcx_idx = (S32)atoi(argv[2]);
+        S32 text_id = (S32)atoi(argv[3]);
+        const char *path = (argc >= 5) ? argv[4] : NULL;
+        if (path && path[0])
+            Dial_RequestCapture(path);
+        EffectPcxMess((U8)(pcx_idx / 2), (U8 *)Screen, PCX_FADE, text_id);
+        if (path && path[0])
+            Dial_RequestCapture(NULL);
+        Console_Print("ui pcx-message pcx=%d text=%d -> %s",
+                      (int)pcx_idx, (int)text_id, path ? path : "(no path)");
+        return;
+    }
     if (argc >= 3 && !strcmp(argv[1], "config")) {
         /* Controls-remapping screen (keyboard). Config_MainCapture loads the
            menu PCX into Screen (the background MenuConfig normally inherits
@@ -360,6 +397,8 @@ static void cmd_ui(int argc, const char *argv[]) {
     Console_Print("       ui menu-options <path>");
     Console_Print("       ui menu-main <path>");
     Console_Print("       ui config <path>");
+    Console_Print("       ui slideshow <path>");
+    Console_Print("       ui pcx-message <pcx-idx> <text-id> [<path>]");
     Console_Print("       ui found-object <numvar> <path>");
 }
 
@@ -1057,7 +1096,7 @@ void Console_RegisterAll(void) {
     Console_RegisterCommandEx("screenshot", cmd_screenshot, "Save next frame as PNG (no console)", "(no args)",
                               "PNG under shoot/; console closes first.");
     Console_RegisterCommandEx("ui", cmd_ui, "Open a UI modal and capture a screenshot",
-                              "ui {inventory|holomap|menu-options|menu-main|config} <path> | ui {dialog|found-object} <id> <path>",
+                              "ui {inventory|holomap|menu-options|menu-main|config|slideshow} <path> | ui {dialog|found-object} <id> <path> | ui pcx-message <pcx-idx> <text-id> [<path>]",
                               "Composite verb for UI regression fixtures: opens a UI modal "
                               "with a deterministic auto-exit, writes the settled frame to <path> "
                               "via SavePNG, then closes.  Compose with --load / --exec to drive "

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -4160,6 +4160,25 @@ void Credits(S32 mode) {
 
 /*──────────────────────────────────────────────────────────────────────────*/
 
+/* Harness capture state — see SlideShow_RequestCapture() in GAMEMENU.H. When
+   armed, SlideShow's main loop breaks out after the first frame's Dial returns
+   (Dial itself does the SavePNG via Dial_RequestCapture, which we arm
+   alongside this flag). Same compose pattern as Menu_*Capture / Inv_*Capture. */
+static int s_slideshow_capture_active = 0;
+
+void SlideShow_RequestCapture(const char *path) {
+    if (!path || !path[0]) {
+        s_slideshow_capture_active = 0;
+        Dial_RequestCapture(NULL);
+        return;
+    }
+    s_slideshow_capture_active = 1;
+    /* The actual SavePNG happens inside Dial's typewriter loop — same hook
+       used by `ui dialog`. We just need to break out of the slideshow loop
+       after that fires so the harness doesn't iterate the remaining shots. */
+    Dial_RequestCapture(path);
+}
+
 // SlideShow de screenshots
 S32 SlideShow(void) {
     U8 pal[768 + RECOVER_AREA];
@@ -4222,6 +4241,15 @@ S32 SlideShow(void) {
         //		AffGraph( 0, 639-105, 3, HQR_Get(HQRPtrSprite,11) ) ;
 
         Dial(START_SLIDESHOW_TEXT + n, FALSE);
+
+        /* Harness: SlideShow_RequestCapture arms a one-shot SavePNG in Dial
+           above. After it fires, exit cleanly without iterating remaining
+           shots so the harness's --exit can finish promptly. */
+        if (s_slideshow_capture_active) {
+            s_slideshow_capture_active = 0;
+            ret = FALSE;
+            break;
+        }
 
         // charge palette
         Load_HQR(tmpScrshotFilePath, pal, (n * 2) + 1);

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -5,6 +5,7 @@
 #include "JOYSTICK.H"
 #include "SAVENAME_VALIDATION.H"
 #include "CONSOLE/CONSOLE.H"
+#include "MESSAGE.H"
 #include "PCX_LOAD.H"
 
 #include <FILEIO/SAVEPNG.H>
@@ -4189,6 +4190,12 @@ S32 SlideShow(void) {
     Console_SetSlideShowActive(1);
     Bulle = FALSE;
 
+    /* The slideshow renders centred 4:3 PCX stills with story text on top.
+       Setting Dial_Letterbox keeps the dialog box inside the picture's 4:3
+       region instead of stretching into the black sidebars at wider widths. */
+    S32 memoDialLetterbox = Dial_Letterbox;
+    Dial_Letterbox = 1;
+
 #ifdef DEMO
     FlagSlideShow = TRUE; // pour les tempos des messages
 #endif
@@ -4266,6 +4273,7 @@ S32 SlideShow(void) {
 
     /* Restore normal console availability once slideshow exits. */
     Console_SetSlideShowActive(0);
+    Dial_Letterbox = memoDialLetterbox;
     return ret;
 }
 
@@ -4606,6 +4614,14 @@ void DemoBumper(void) {
 void EffectPcx(U8 numpcx, U8 *screen, U8 effect, U8 flagbcl) {
     char tmpFilePath[ADELINE_MAX_PATH];
 
+    /* PCX cinematic: any dialog drawn over the centred PCX should letterbox to
+       stay inside the picture's 4:3 region. The flag is scoped to this call —
+       AffScene at the end (in the flagbcl branch) re-renders the gameplay
+       scene, and subsequent Dial calls during normal play will see the
+       restored original value. */
+    S32 memoDialLetterbox = Dial_Letterbox;
+    Dial_Letterbox = 1;
+
     SaveTimer();
 
     numpcx *= 2; // car il y a les palettes intercalées
@@ -4670,6 +4686,8 @@ void EffectPcx(U8 numpcx, U8 *screen, U8 effect, U8 flagbcl) {
         FlagFade = TRUE;
     } else
         RestoreTimer();
+
+    Dial_Letterbox = memoDialLetterbox;
 }
 
 /*──────────────────────────────────────────────────────────────────────────*/
@@ -4677,6 +4695,15 @@ void EffectPcxMess(U8 numpcx, U8 *screen, U8 effect, S32 mess) {
 #ifdef CDROM
     S32 memoflagdisplaytext;
 #endif
+
+    /* PCX cinematic with a dialog message overlay (scripted scene-message
+       opcodes, end-of-island stills, etc.). Letterbox the dialog so it stays
+       inside the centred PCX picture instead of bleeding into the black
+       sidebars at wider framebuffers. Encompasses EffectPcx + Dial; AffScene
+       at the end clears the cinematic and the restore returns to gameplay
+       dialog framing. */
+    S32 memoDialLetterbox = Dial_Letterbox;
+    Dial_Letterbox = 1;
 
     SaveTimer();
 
@@ -4705,6 +4732,8 @@ void EffectPcxMess(U8 numpcx, U8 *screen, U8 effect, S32 mess) {
     FlagFade = FALSE;
     AffScene(AFF_ALL_FLIP);
     FlagFade = TRUE;
+
+    Dial_Letterbox = memoDialLetterbox;
 }
 
 /*══════════════════════════════════════════════════════════════════════════*

--- a/SOURCES/GAMEMENU.H
+++ b/SOURCES/GAMEMENU.H
@@ -94,6 +94,11 @@ extern void Credits(S32 mode);
 /*--------------------------------------------------------------------------*/
 extern S32 SlideShow(void);
 /*--------------------------------------------------------------------------*/
+/* Arm a one-shot SavePNG inside SlideShow's first frame and exit cleanly
+   after capturing. Mirrors Inv_RequestCapture / Menu_RequestCapture /
+   Dial_RequestCapture etc. Wire into the harness via `ui slideshow <path>`. */
+extern void SlideShow_RequestCapture(const char *path);
+/*--------------------------------------------------------------------------*/
 extern void SlideDemo(int argc, char *argv[]);
 /*--------------------------------------------------------------------------*/
 extern S32 AdelineLogo(void);

--- a/SOURCES/MESSAGE.CPP
+++ b/SOURCES/MESSAGE.CPP
@@ -108,6 +108,10 @@ U8 *PalOrg;
 /*-------------------------------------------------------------------------*/
 S32 Dial_X0 = 16;
 S32 Dial_Y0 = 334;
+/* File-scope defaults match the historical 4:3 layout (W=640, H=480); they are
+   only used transiently before NormalWinDial / BigWinDial / etc. reset them
+   from ClipWindowYMax + width-aware bounds (see the Dial_X1 = ModeDesiredX - 1
+   - N substitutions in those functions below). */
 S32 Dial_X1 = 639 - 16;
 S32 Dial_Y1 = 479 - 16;
 static S32 DialMaxSize = ((623 - 8) - (16 + 8));
@@ -296,7 +300,7 @@ void TimeBar(U32 max, U32 val) {
 
     ColorFont(LBAWHITE);
     dx = SizeFont(PleaseWait);
-    Font(320 - dx / 2, BAR_Y0, PleaseWait);
+    Font((S32)ModeDesiredX / 2 - dx / 2, BAR_Y0, PleaseWait);
 
     BoxMovingAdd(BAR_X0, BAR_Y0, BAR_X1, BAR_Y1);
     BoxUpdate();
@@ -845,7 +849,7 @@ void PlaySpeakVoc(S32 fd) {
                         ListObjet[NumObjSpeak].Obj.Z);
 
         if (CubeMode == CUBE_INTERIEUR)
-            distance = Distance2D(320, 240, Xp, Yp);
+            distance = Distance2D((S32)ModeDesiredX / 2, (S32)ModeDesiredY / 2, Xp, Yp);
         else {
             distance = Distance3D(ListObjet[NumObjSpeak].Obj.X,
                                   ListObjet[NumObjSpeak].Obj.Y,
@@ -1225,7 +1229,7 @@ void TestCoulDial(S32 coul) {
 void NormalWinDial() {
     Dial_X0 = 8;
     Dial_Y0 = ClipWindowYMax - 137; // 334 lorsque ClipWindowYMax==479
-    Dial_X1 = 639 - 8;
+    Dial_X1 = (S32)ModeDesiredX - 1 - 8;
     Dial_Y1 = ClipWindowYMax - 8;
 
     MaxLineDial = 3;
@@ -1234,8 +1238,8 @@ void NormalWinDial() {
 /*-------------------------------------------------------------------------*/
 void DemoWinDial() {
     Dial_X0 = -6;
-    Dial_Y0 = 340; // 334 lorsque ClipWindowYMax==479
-    Dial_X1 = 639 + 6;
+    Dial_Y0 = 340;                       // 334 lorsque ClipWindowYMax==479
+    Dial_X1 = (S32)ModeDesiredX - 1 + 6; // demo dialog bleeds 6 px past each edge
     Dial_Y1 = 8;
 
     MaxLineDial = 3;
@@ -1245,7 +1249,7 @@ void DemoWinDial() {
 void BigWinDial() {
     Dial_X0 = 8;
     Dial_Y0 = ClipWindowYMin + 8;
-    Dial_X1 = 639 - 8;
+    Dial_X1 = (S32)ModeDesiredX - 1 - 8;
     Dial_Y1 = ClipWindowYMax - 8;
 
     MaxLineDial = (Dial_Y1 - Dial_Y0) / 42;
@@ -1255,7 +1259,7 @@ void BigWinDial() {
 void HoloWinDial() {
     Dial_X0 = 8;
     Dial_Y0 = 425;
-    Dial_X1 = 631;
+    Dial_X1 = (S32)ModeDesiredX - 1 - 8;
     Dial_Y1 = 477;
 
     MaxLineDial = 1;

--- a/SOURCES/MESSAGE.CPP
+++ b/SOURCES/MESSAGE.CPP
@@ -122,6 +122,9 @@ static S32 DialMaxSize = ((623 - 8) - (16 + 8));
    black sidebars. Zero during normal gameplay → dialog uses the full width. */
 S32 Dial_Letterbox = 0;
 
+/* See MESSAGE.H. Test-only override for GereFlagDial. */
+S32 Dial_ForceFlag = 0;
+
 /* Horizontal inset to apply when Dial_Letterbox is set: half the gap between
    the framebuffer's width and the authored 640 px PCX width. Zero at 640. */
 static S32 DialLetterboxInset(void) {
@@ -1315,6 +1318,14 @@ void ExplainWinDial() {
 /*-------------------------------------------------------------------------*/
 S32 GereFlagDial(S32 text) {
     S32 ret = FALSE;
+
+    /* Harness override: when Dial_ForceFlag is non-zero, replace the FlagDial
+       byte read from the text bank so the test can force a specific WinDial
+       mode (BigWinDial, NormalWinDial, …) without needing a text-id that's
+       authored with that mode. No-op for production callers. */
+    if (Dial_ForceFlag) {
+        FlagDial = Dial_ForceFlag;
+    }
 
     FlagMessageShade = TRUE;
 

--- a/SOURCES/MESSAGE.CPP
+++ b/SOURCES/MESSAGE.CPP
@@ -116,6 +116,18 @@ S32 Dial_X1 = 639 - 16;
 S32 Dial_Y1 = 479 - 16;
 static S32 DialMaxSize = ((623 - 8) - (16 + 8));
 
+/* See MESSAGE.H. Set by SlideShow / EffectPcx for the duration of a
+   centred-PCX cinematic so the *WinDial configurators inset the dialog box
+   to stay inside the picture's 4:3 region instead of stretching into the
+   black sidebars. Zero during normal gameplay → dialog uses the full width. */
+S32 Dial_Letterbox = 0;
+
+/* Horizontal inset to apply when Dial_Letterbox is set: half the gap between
+   the framebuffer's width and the authored 640 px PCX width. Zero at 640. */
+static S32 DialLetterboxInset(void) {
+    return Dial_Letterbox ? (((S32)ModeDesiredX - 640) / 2) : 0;
+}
+
 static char BufLine[256];
 static char *PtLine;
 static S32 SizeLine;
@@ -1227,9 +1239,10 @@ void TestCoulDial(S32 coul) {
 }
 /*-------------------------------------------------------------------------*/
 void NormalWinDial() {
-    Dial_X0 = 8;
+    S32 inset = DialLetterboxInset();
+    Dial_X0 = inset + 8;
     Dial_Y0 = ClipWindowYMax - 137; // 334 lorsque ClipWindowYMax==479
-    Dial_X1 = (S32)ModeDesiredX - 1 - 8;
+    Dial_X1 = (S32)ModeDesiredX - 1 - inset - 8;
     Dial_Y1 = ClipWindowYMax - 8;
 
     MaxLineDial = 3;
@@ -1237,9 +1250,10 @@ void NormalWinDial() {
 }
 /*-------------------------------------------------------------------------*/
 void DemoWinDial() {
-    Dial_X0 = -6;
-    Dial_Y0 = 340;                       // 334 lorsque ClipWindowYMax==479
-    Dial_X1 = (S32)ModeDesiredX - 1 + 6; // demo dialog bleeds 6 px past each edge
+    S32 inset = DialLetterboxInset();
+    Dial_X0 = inset - 6; // demo dialog bleeds 6 px past each edge of the active region
+    Dial_Y0 = 340;       // 334 lorsque ClipWindowYMax==479
+    Dial_X1 = (S32)ModeDesiredX - 1 - inset + 6;
     Dial_Y1 = 8;
 
     MaxLineDial = 3;
@@ -1247,9 +1261,10 @@ void DemoWinDial() {
 }
 /*-------------------------------------------------------------------------*/
 void BigWinDial() {
-    Dial_X0 = 8;
+    S32 inset = DialLetterboxInset();
+    Dial_X0 = inset + 8;
     Dial_Y0 = ClipWindowYMin + 8;
-    Dial_X1 = (S32)ModeDesiredX - 1 - 8;
+    Dial_X1 = (S32)ModeDesiredX - 1 - inset - 8;
     Dial_Y1 = ClipWindowYMax - 8;
 
     MaxLineDial = (Dial_Y1 - Dial_Y0) / 42;
@@ -1257,9 +1272,10 @@ void BigWinDial() {
 }
 /*-------------------------------------------------------------------------*/
 void HoloWinDial() {
-    Dial_X0 = 8;
+    S32 inset = DialLetterboxInset();
+    Dial_X0 = inset + 8;
     Dial_Y0 = 425;
-    Dial_X1 = (S32)ModeDesiredX - 1 - 8;
+    Dial_X1 = (S32)ModeDesiredX - 1 - inset - 8;
     Dial_Y1 = 477;
 
     MaxLineDial = 1;

--- a/SOURCES/MESSAGE.H
+++ b/SOURCES/MESSAGE.H
@@ -17,6 +17,13 @@ extern S32 Dial_Y1;
    caller's responsibility. */
 extern S32 Dial_Letterbox;
 
+/* Test-only override for GereFlagDial. When non-zero, replaces the FlagDial
+   the dialog text encodes (its first byte) so the harness can force a
+   specific WinDial mode (BigWinDial, NormalWinDial, …) without needing to
+   find a text-id that's authored with that mode. Set to 0 to disable.
+   Production callers should leave at 0. */
+extern S32 Dial_ForceFlag;
+
 extern S32 FlagAnimWhoSpeak;
 
 extern S32 Language; // English

--- a/SOURCES/MESSAGE.H
+++ b/SOURCES/MESSAGE.H
@@ -9,6 +9,14 @@ extern S32 Dial_Y0;
 extern S32 Dial_X1;
 extern S32 Dial_Y1;
 
+/* When non-zero, the four *WinDial configurators clamp Dial_X0/X1 to a centred
+   4:3 region so the dialog box stays inside the centred-PCX picture instead of
+   bleeding into the black sidebars at wider framebuffers. Set/cleared by the
+   PCX-cinematic call sites (SlideShow, EffectPcx); regular gameplay dialog
+   keeps it 0 and renders full-width. Save/restore around nested sets is the
+   caller's responsibility. */
+extern S32 Dial_Letterbox;
+
 extern S32 FlagAnimWhoSpeak;
 
 extern S32 Language; // English

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2224,10 +2224,10 @@ void Message(const char *mess, S32 flag) {
     x = (strlen(mess) * 8) / 2;
     MemoClip();
 
-    GraphPrintf(FALSE, 320 - x, 236, "%s", mess);
-    Rect(320 - x - 4, 234, 320 + x + 4, 248, LBAWHITE);
+    GraphPrintf(FALSE, (S32)ModeDesiredX / 2 - x, 236, "%s", mess);
+    Rect((S32)ModeDesiredX / 2 - x - 4, 234, (S32)ModeDesiredX / 2 + x + 4, 248, LBAWHITE);
 
-    BoxStaticAdd(320 - x - 4, 234, 320 + x + 4, 248);
+    BoxStaticAdd((S32)ModeDesiredX / 2 - x - 4, 234, (S32)ModeDesiredX / 2 + x + 4, 248);
 
     if (flag) {
         BoxUpdate();

--- a/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
+++ b/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
@@ -284,8 +284,8 @@ files (SAVEGAME, CONFIG, INVENT, MESSAGE, HOLOPLAN) still pending.
 | [`SOURCES/CONFIG.CPP`](../SOURCES/CONFIG.CPP) | 7 — config-screen text centred at 320 *(resolved by C2 CONFIG.CPP pass)* |
 | [`SOURCES/SAVEGAME.CPP:544-547`](../SOURCES/SAVEGAME.CPP) | save-prompt text box centred at (320, 240) |
 | [`SOURCES/GAMEMENU.CPP:4521-4524`](../SOURCES/GAMEMENU.CPP) | "Saved" message box at (320 ± X, 240 ± 25) |
-| [`SOURCES/MESSAGE.CPP:298`](../SOURCES/MESSAGE.CPP) | `Font(320 - dx/2, …, "Please wait")` |
-| [`SOURCES/PERSO.CPP:2226-2229`](../SOURCES/PERSO.CPP) | system message at `320 - x, 236` |
+| [`SOURCES/MESSAGE.CPP:298`](../SOURCES/MESSAGE.CPP) | `Font(320 - dx/2, …, "Please wait")` *(resolved by C2 MESSAGE.CPP pass)* |
+| [`SOURCES/PERSO.CPP:2226-2229`](../SOURCES/PERSO.CPP) | system message at `320 - x, 236` *(resolved by C2 MESSAGE.CPP pass — PERSO sites swapped at the same time)* |
 
 All need re-anchoring to `ModeDesiredX/2`. **GAMEMENU sites resolved by
 the C2 pass** (DrawOneString / DrawSingleString / ClearOneString /
@@ -303,7 +303,7 @@ surface PRs.
 | [`SOURCES/INVENT.CPP:1871`](../SOURCES/INVENT.CPP) | `#define PLAN_X1 (PLAN_X0 + 479)` | Slate panel right edge — slate art is 480 wide, OK as-is. *(Resolved: `PLAN_X0` now carries `INV_LEFT_OFFSET` so the slate stays inside the centred inventory region; the deferred `PCR_ARDOISE` PCX is loaded via `Pcx_LoadCentered`.)* |
 | [`SOURCES/INVENT.H:23,41`](../SOURCES/INVENT.H) | `INV_DELTA_X = 639 - INV_START_X*2`, `INV_NAME_X1 = 639 - INV_START_X` | Inventory panel width tied to 639. *(Resolved: centred-4:3 design — `INV_DELTA_X` is fixed 623, `INV_START_X` carries `INV_LEFT_OFFSET = (ModeDesiredX-640)/2`. Icons stay fixed-size; the rectangle slides as a unit.)* |
 | [`SOURCES/INVENT.H:34,36`](../SOURCES/INVENT.H) | `INV_ZOOM_X0 = 317 - 120`, `INV_ZOOM_X1 = 317 + 120` | Zoom box at iso projection X (`317 = 320 - 3`). *(Resolved: `(S32)ModeDesiredX / 2 - 3 ± 120`.)* |
-| [`SOURCES/MESSAGE.CPP:110, 111, 1227, 1237, 1247, 1258, 1969, 1970`](../SOURCES/MESSAGE.CPP) | `Dial_X1 = 639 - 16`, `Dial_Y1 = 479 - 16` and variants | Dialog box right/bottom margins |
+| [`SOURCES/MESSAGE.CPP:110, 111, 1227, 1237, 1247, 1258`](../SOURCES/MESSAGE.CPP) | `Dial_X1 = 639 - 16`, `Dial_Y1 = 479 - 16` and variants | Dialog box right/bottom margins *(resolved by C2 MESSAGE.CPP pass — NormalWinDial / DemoWinDial / BigWinDial / HoloWinDial all route Dial_X1 through `(S32)ModeDesiredX - 1 - N`; file-scope defaults left as 4:3 literals since the WinDial functions overwrite them before use)* |
 
 ### B4. Holomap UI
 


### PR DESCRIPTION
## Summary
Follow-up to #218 (MESSAGE.CPP C2). The end-game slideshow (`SlideShow()`) and the scripted PCX-message opcodes (`EffectPcxMess()`) display a centred 4:3 PCX with story text overlaid on top. Before this PR, the dialog box from #218's full-width default extended past the 640 picture into the black sidebars at any wider framebuffer — visually disjointed.

This PR introduces a `Dial_Letterbox` flag that the cinematic call sites set for the duration of the cinematic. When the flag is on, the four `*WinDial` configurators inset `Dial_X0/X1` by `(ModeDesiredX - 640) / 2` so the dialog box stays inside the centred 4:3 picture. Off during normal gameplay → dialog uses the full width, no regression.

## What changed

| File | Change |
|---|---|
| `MESSAGE.H` | Extern declaration for `Dial_Letterbox`. |
| `MESSAGE.CPP` | New `S32 Dial_Letterbox = 0;` + `static S32 DialLetterboxInset(void)`. The four `WinDial` configurators (`NormalWinDial`, `DemoWinDial`, `BigWinDial`, `HoloWinDial`) compute `inset = DialLetterboxInset()` and apply it to both `Dial_X0` and `Dial_X1`. |
| `GAMEMENU.CPP` | `SlideShow()`, `EffectPcx()`, `EffectPcxMess()` each save / set / restore `Dial_Letterbox` around their bodies. Save/restore (not unconditional set/clear) so nested cinematics compose cleanly. |

## Verification
- [x] 640 `ui menu-main` (excl plasma), `ui inventory`, `ui dialog 0` all byte-identical pre vs post — proves the letterbox path is a complete no-op when `Dial_Letterbox = 0`.
- [x] At 640 with `Dial_Letterbox = 0`, `inset = 0` → every `WinDial` resolves to the same `Dial_X0/X1` as in #218.
- [x] At any width with `Dial_Letterbox = 1`, `inset = (ModeDesiredX - 640) / 2` → dialog box spans `inset + 8 .. ModeDesiredX - 1 - inset - 8` (e.g. 72..695 at 768; 192..831 at 1024) — centred inside the 640-px PCX region.
- [x] `make test` 10/10 pass.
- [x] `apply-format.sh` / clang-format clean.

**No `ui slideshow` / `ui pcx-message` console commands exist** to capture the cinematic surfaces headlessly. Interactive verification: play to an end-of-island slideshow or trigger a scripted `LM_PCX_MESS_OBJ` scene at 768 / 1024 — dialog should sit within the centred picture rather than overflowing past it.

## Depends on
This PR sits on top of #218 (currently mergeable / not yet merged). When #218 merges, this PR rebases cleanly onto main with no expected conflicts (only adds new code; doesn't re-touch the WinDial bodies in a way that would conflict).