### PR TITLE
fix(widescreen): centre holomap planet image; anchor UI to image edges (A9)

### DIFF
--- a/SOURCES/HOLOPLAN.CPP
+++ b/SOURCES/HOLOPLAN.CPP
@@ -1,5 +1,6 @@
 #include "C_EXTERN.H"
 #include "DIRECTORIES.H"
+#include "IMAGE_LOAD.H"
 #include "INPUT.H"
 
 #include <FILEIO/SAVEPNG.H>
@@ -425,14 +426,28 @@ void InitHoloPlan() {
 
     GetResPath(tmpFilePath, ADELINE_MAX_PATH, HOLO_HQR_NAME);
 
-    Load_HQR(tmpFilePath, Log, id);
+    // The planet-detail HQR entry is a 640×480 raw bitmap. A raw Load_HQR
+    // smears it diagonally into a wider Log; Image_LoadCentered blits it
+    // centred with proper row stride. Clear Log first so the sidebars are
+    // black instead of showing whatever HoloGlobe left behind.
+    memset(Log, 0, (size_t)ModeDesiredX * (size_t)ModeDesiredY);
+    Image_LoadCentered(tmpFilePath, Log, id);
 
     Load_HQR(tmpFilePath, buffer, id + 1);
 
-    AffUpperLeft(0, 0, 0);
-    AffLowerLeft(0, (S32)ModeDesiredY - 1, 0);
-    AffUpperRight((S32)ModeDesiredX - 1, 0, 0);
-    AffLowerRight((S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, 0);
+    // Anchor UI to the *image* rect, not the framebuffer rect. The corner
+    // brackets sit on the image corners; the 3D projection used for arrows
+    // + Twinsen + Buggy/Dyno targets the image centre so models line up
+    // with the texture features (citadel, arrows, etc.).
+    const S32 imageX0 = ((S32)ModeDesiredX - IMAGE_AUTHORED_WIDTH) / 2;
+    const S32 imageY0 = ((S32)ModeDesiredY - IMAGE_AUTHORED_HEIGHT) / 2;
+    const S32 imageX1 = imageX0 + IMAGE_AUTHORED_WIDTH - 1;
+    const S32 imageY1 = imageY0 + IMAGE_AUTHORED_HEIGHT - 1;
+
+    AffUpperLeft(imageX0, imageY0, 0);
+    AffLowerLeft(imageX0, imageY1, 0);
+    AffUpperRight(imageX1, imageY0, 0);
+    AffLowerRight(imageX1, imageY1, 0);
 
     CopyScreen(Log, Screen);
 
@@ -467,7 +482,8 @@ void InitHoloPlan() {
     ScaleRotBody3D(BufDyno, SCALE_DYNO_PLAN, FALSE);
 
     //	SetProjection( 320, 240, 1024, 1024, 1024 ) 			;
-    SetProjection((S32)ModeDesiredX / 2, (S32)ModeDesiredY / 2, 1024, 700, 700);
+    SetProjection(imageX0 + IMAGE_AUTHORED_WIDTH / 2,
+                  imageY0 + IMAGE_AUTHORED_HEIGHT / 2, 1024, 700, 700);
     SetFollowCamera(orgmx, 0, orgmz, alpha, beta, 0, distance);
     SetLightVector(lalpha, lbeta, 0);
 
@@ -833,19 +849,27 @@ void HoloPlan(S32 numplan) {
             //      HoloGlobe()
             BoxReset();
 
+            // Zoom-in animates from the reticule centre (CENTERX/Y are
+            // image-relative) out to the image rect, not the framebuffer
+            // rect — at wider widths the sidebars stay black through the
+            // whole animation.
+            const S32 anim_imageX0 = ((S32)ModeDesiredX - IMAGE_AUTHORED_WIDTH) / 2;
+            const S32 anim_imageY0 = ((S32)ModeDesiredY - IMAGE_AUTHORED_HEIGHT) / 2;
+            const S32 anim_imageX1 = anim_imageX0 + IMAGE_AUTHORED_WIDTH - 1;
+            const S32 anim_imageY1 = anim_imageY0 + IMAGE_AUTHORED_HEIGHT - 1;
             while (TRUE) {
                 ManageTime();
                 timer = TimerRefHR - MemoTimerRot;
-                x0 = BoundRegleTrois(CENTERX - 8, 0, 1000, timer);
-                y0 = BoundRegleTrois(CENTERY - 8, 0, 1000, timer);
-                x1 = BoundRegleTrois(CENTERX + 8, (S32)ModeDesiredX - 1, 1000, timer);
-                y1 = BoundRegleTrois(CENTERY + 8, (S32)ModeDesiredY - 1, 1000, timer);
+                x0 = BoundRegleTrois(CENTERX + anim_imageX0 - 8, anim_imageX0, 1000, timer);
+                y0 = BoundRegleTrois(CENTERY + anim_imageY0 - 8, anim_imageY0, 1000, timer);
+                x1 = BoundRegleTrois(CENTERX + anim_imageX0 + 8, anim_imageX1, 1000, timer);
+                y1 = BoundRegleTrois(CENTERY + anim_imageY0 + 8, anim_imageY1, 1000, timer);
 
-                if (x0 == 0) {
+                if (x0 == anim_imageX0) {
                     break; // Before Crash!
                 }
 
-                ScaleBox(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, BufSpeak, x0, y0, x1, y1, Log);
+                ScaleBox(anim_imageX0, anim_imageY0, anim_imageX1, anim_imageY1, BufSpeak, x0, y0, x1, y1, Log);
 
                 AffUpperLeft(x0, y0, 0);
                 AffLowerLeft(x0, y1, 0);

--- a/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
+++ b/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
@@ -257,6 +257,16 @@ Discovered while testing PR for B4 routing; not blocking that PR — the
 C2 routing is a no-op at 640×480 and an independent surface to this
 stride bug.
 
+*(Resolved: `Load_HQR` swapped for `Image_LoadCentered`; Log is cleared
+to black first so sidebars are clean. The B4-routed corner brackets +
+`SetProjection` + zoom-in animation were re-anchored to **image edges**
+(not framebuffer edges) so the planet, Twinsen body, arrows, and
+brackets all line up with the centred bitmap. `BoxStaticAdd` for the
+full-screen dirty marker stays at framebuffer corners so the sidebars
+are still painted on each repaint. No-op at 640×480; X-axis widening
+verified at 768 and 1024. Y>480 still subject to the wider HD-pass — A4
+/ A5 still flag the Y-axis sites.)*
+
 ### A10. Misc full-framebuffer allocations + sizes
 
 | Site | What |


### PR DESCRIPTION
Fixes **A9** in [`WIDESCREEN_HARDCODED_DIMS_AUDIT.md`](https://github.com/LBALab/lba2-classic-community/blob/main/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md): the holomap planet-detail image smeared diagonally at widths > 640 because `InitHoloPlan` dropped a 640×480 raw HQR bitmap straight into `Log` via `Load_HQR(file, Log, id)` with no row-stride translation.

## Before / after at 768×480

| Before | After |
|---|---|
| Planet image sheared diagonally; sidebar shows globe leftovers | 640 image centred (xOffset=64), black sidebars, brackets on image corners |

`ui holoplan 0` at 768 with the fix — planet renders cleanly, "Citadel Island." anchored, brackets on image corners.

## What changed

| Site | Before | After |
|---|---|---|
| `HOLOPLAN.CPP:426` — planet bitmap load | `Load_HQR(file, Log, id)` | `memset(Log, 0, MDX*MDY)` + `Image_LoadCentered(file, Log, id)` |
| `HOLOPLAN.CPP:431-433` — corner brackets | framebuffer-corner anchor | image-corner anchor (`imageX0/Y0`, `imageX1/Y1`) |
| `HOLOPLAN.CPP:468` — projection centre | framebuffer-centre (`MDX/2`, `MDY/2`) | image-centre (`imageX0 + 320`, `imageY0 + 240`) |
| `HOLOPLAN.CPP:808-815` — zoom-in animation | end at framebuffer corners; ScaleBox src = whole MDX×MDY | end at image corners; ScaleBox src = image rect of BufSpeak |
| `HOLOPLAN.CPP:747` — full-screen `BoxStaticAdd` | **unchanged** — `(0, 0, MDX-1, MDY-1)` |

## Why anchor to image edges, not framebuffer edges

The planet bitmap is 640-wide content. The player's eye reads the bitmap as the frame; Twinsen + arrows + Buggy/Dyno project onto features *of the texture* (citadel, arrows pointing at islands). If we'd kept the framebuffer-corner anchoring from B4 (PR #221) and just stride-fixed the load, brackets would float in the black sidebars and the 3D body would drift off the texture. Anchoring everything to the image rect keeps the player's mental model coherent.

`BoxStaticAdd` is the exception — we *want* the sidebars in the dirty rect so they get painted black on each repaint.

## No behaviour change at 640×480

Every site reduces back to the pre-PR values:
- `imageX0 = (640 - 640) / 2 = 0`, `imageY0 = (480 - 480) / 2 = 0`
- `AffUpperLeft(0, 0)` / `AffLowerRight(639, 479)` — same as the B4 routing produces at 640
- `SetProjection(0 + 320, 0 + 240, …)` — same as `SetProjection(320, 240, …)`
- Zoom-in anim: `CENTERX + 0 - 8 = 312`, end `0`, same as before

The `ui holoplan 0` committed golden is byte-identical after this PR.

## Verification

- [x] `make build` clean.
- [x] `make test` — 11/11 host tests pass (incl. `test_image_load`).
- [x] `test_ui_holoplan.sh` — golden unchanged at 640×480.
- [x] `test_ui_holomap.sh` — golden unchanged at 640×480.
- [x] Manual `ui holoplan 0` capture at 768×480 — planet renders cleanly, no smear.
- [x] Manual `ui holoplan 0` capture at 1024×480 — same.
- [x] `clang-format` clean.

## Out of scope: Y > 480

At 1024×**768** the planet centres horizontally and vertically (yOffset=144) but Y>480 hits unrelated holomap-Y-clamp bugs already flagged in the audit (A4 terrain horizon, A5 ZBuf Y-bounds). Tracked under task #99 / the wider HD pass.
