### PR TITLE
feat(widescreen): re-anchor HoloGlobe to ModeDesiredX/2 (C2)

### DIFF
--- a/SOURCES/HOLOGLOB.CPP
+++ b/SOURCES/HOLOGLOB.CPP
@@ -259,7 +259,7 @@ void AffHoloMess() {
             NextDialWindow();
 
             dx = SizeFont(PtDial);
-            X_Dial = CENTERX - dx / 2; //	Center
+            X_Dial = (S32)ModeDesiredX / 2 - dx / 2; //	Center
 
             DialStatHolo = 1;
         } else
@@ -339,7 +339,7 @@ void ComputeObjectifPlanet(S32 arrow) {
     LongWorldRotatePoint(x, y, z);
     LongProjectPoint(X0, Y0, Z0);
 
-    dist = Distance2D(Xp, Yp, CENTERX, CENTERY);
+    dist = Distance2D(Xp, Yp, (S32)ModeDesiredX / 2, CENTERY);
 
     if (dist < DistObjectif) {
         DistObjectif = dist;
@@ -834,7 +834,7 @@ void InitHoloGlobe(S32 planet) {
 
     //-----
 
-    SetProjection(CENTERX, CENTERY, 128, 1024, 1024);
+    SetProjection((S32)ModeDesiredX / 2, CENTERY, 128, 1024, 1024);
     //	SetProjection( CENTERX, CENTERY, 128,700,700 ) ;
     SetLightVector(0, 0, 0);
 
@@ -921,7 +921,7 @@ void FindAngleIsland(S32 island) {
 
             LongProjectPoint(X0, Y0, Z0);
 
-            dist = Distance2D(Xp, Yp, CENTERX, CENTERY);
+            dist = Distance2D(Xp, Yp, (S32)ModeDesiredX / 2, CENTERY);
             if (dist < min) {
                 min = dist;
                 DestAlpha = halpha;


### PR DESCRIPTION
Routes the four `CENTERX` uses in HOLOGLOB.CPP through `(S32)ModeDesiredX / 2`. The rotating-planet view ("the world map screen") renders against a black background — there's no underlying 4:3 image to align with, so we anchor to true framebuffer centre instead of the 4:3-relative `CENTERX = 320`.

## Before / after at 768×480

| Before | After |
|---|---|
| Globe drawn at X=320 (left of centre on a 768-wide framebuffer) | Globe drawn at X=384 (true framebuffer centre) |

The dialog box itself already spanned the framebuffer via the existing `MESSAGE.CPP` C2 routing (PR #218); this PR centres the **globe + reticule + text** *within* that box.

## What changed

| Site | Before | After |
|---|---|---|
| `HOLOGLOB.CPP:262` | `X_Dial = CENTERX - dx / 2;` | `X_Dial = (S32)ModeDesiredX / 2 - dx / 2;` |
| `HOLOGLOB.CPP:342` (`ComputeObjectifPlanet`) | `Distance2D(Xp, Yp, CENTERX, CENTERY)` | `Distance2D(Xp, Yp, (S32)ModeDesiredX / 2, CENTERY)` |
| `HOLOGLOB.CPP:837` (globe `SetProjection`) | `SetProjection(CENTERX, CENTERY, 128, 1024, 1024)` | `SetProjection((S32)ModeDesiredX / 2, CENTERY, 128, 1024, 1024)` |
| `HOLOGLOB.CPP:924` (`FindAngleIsland`) | `Distance2D(Xp, Yp, CENTERX, CENTERY)` | `Distance2D(Xp, Yp, (S32)ModeDesiredX / 2, CENTERY)` |

`CENTERY` (220) is left as the literal — it's image-Y-independent and keeps the globe at the same height above the dialog window at any `MDY ≥ 480`. Y > 480 stays under the HD pass (audit A4/A5).

## Why keep CENTERX defined in HOLO.H?

After PR #223 (A9), HOLOPLAN's zoom-in animation uses `CENTERX` as the *image-relative* reticule X (offset by `anim_imageX0 = (MDX-640)/2` at runtime). That's a distinct semantic from HoloGlobe's screen-centre use — the planet detail view sits inside a centred 640-wide image, so its reticule lives at image-coordinate 320. Keeping the literal `320` as that image-internal coordinate is correct; only the HoloGlobe call sites needed routing.

## No behaviour change at 640×480

`CENTERX == (S32)ModeDesiredX / 2 == 320` at 640. Every edit reduces back to the prior value. `test_ui_holomap.sh` byte-identical to the committed golden.

## Verification

- [x] `make build` clean.
- [x] `make test` — 11/11 host tests pass (incl. `test_image_load` from #222).
- [x] `test_ui_holomap.sh` — golden unchanged at 640×480.
- [x] `test_ui_holoplan.sh` — golden unchanged at 640×480.
- [x] Manual `ui holomap` capture at 768×480 — globe correctly centred (64-px shift right vs main).
- [x] Manual `ui holomap` capture at 1024×480 — same, 192-px shift right.
- [x] `clang-format` clean.

## What's left in the campaign

After this merges, the X-axis C2 routing for the holomap subsystem is **done end-to-end** (HoloGlobe + HoloPlan). The remaining widescreen audit items are:

- `A3` HoloGlobe Z-buffer clear stride — already shipped (#205).
- `A4`/`A5` Y-axis clamps — HD-only (task #99).
- `A6` save-thumbnail buffer — separate surface.
- `A10` misc full-framebuffer allocations — separate surface.
- `B5` game-over `SetProjection` — separate surface.
