### PR TITLE
docs(widescreen): drop X-axis campaign lessons into audit doc + WIDESCREEN.md

### DIFF
--- a/docs/WIDESCREEN.md
+++ b/docs/WIDESCREEN.md
@@ -91,6 +91,56 @@ The deferred, larger surface:
 - UI strategy — pick C1 or C2 (see [UI strategy](#ui-strategy-c1-vs-c2) below) and apply it so the 2D UI is correct in the wider frame.
 - HD-only concerns, if native high resolution is later pursued: filler precision (the `LIB386/pol_work/` fillers use 16-bit fixed-point step accumulation calibrated to 640-wide spans — the polyrec harness is the tool for measuring drift), bitmap fonts (`LIB386/SVGA/FONT.CPP` / `AFFSTR.CPP` blit 1:1), the 16-bit Z-buffer and `Fill_ZBuffer_Factor` (tuned for the 4:3 frustum), mouse-coordinate inversion against any UI scale, and a Smacker cutscene upscale policy.
 
+#### HD prerequisites — what the X-axis campaign settled
+
+The X-axis C2 campaign (PRs #213–#228) settled the structural prerequisites for HD. What's HD-ready vs what's still HD-only work:
+
+**HD-ready** (X-axis campaign cleared these):
+
+| Layer | Why it's ready |
+|---|---|
+| Memory pool | `Mem_ConfigureScreenBuffers(resX, resY)` sizes every framebuffer-dependent entry; `Mem_TeardownMainBuffer` (Phase 0 of runtime-res) will allow re-sizing at runtime. Z-buffer entry was the last "missing from the config sweep" bug (PR #220). |
+| Save format | `MAX_PLAYER` is keyed to literal `640×480` per [save-format invariant](#what-does-not-need-to-change); saves cross resolutions without migration. Verified across every routing PR in the campaign. |
+| Projection + isometric origin | Phase 2 routed all six call sites through `(S32)ModeDesiredX/Y/2`. `SetProjection` and `SetIsoProjection` are both width-correct at any resolution. |
+| Per-surface centring discipline | Image-edge vs framebuffer-edge is a documented decision per-surface (see [`WIDESCREEN_HARDCODED_DIMS_AUDIT.md`](WIDESCREEN_HARDCODED_DIMS_AUDIT.md) — the per-surface table is the reusable artifact). |
+| Audio panning + 2D distance | `GiveBalance` re-derived from `ModeDesiredX/Y`; pinned at the math layer by `test_ambiance_balance` (PR #228). |
+| Cinematic centring | Smacker writes directly into Log at the centred origin with proper stride (PR #226). |
+
+**Still HD-only work** (Y-axis + true high-resolution concerns):
+
+| Concern | Notes |
+|---|---|
+| Y-axis clamps | A4 (terrain horizon Y=479), A5 (holomap Z-buffer Y bounds). Same fix shape as the X-axis routing — substitute `(S32)ModeDesiredY - 1` for the literal — but exposes the next layer of bugs at Y > 480. Tracked under task #99. |
+| Holomap at Y > 480 | `ui holoplan` at `1024×768` times out (cinema-mode rendering bug independent of the planet bitmap centring). Needs the A4/A5 pass to unblock. Catch a `test_ui_holoplan_768x768.sh` once unblocked. |
+| Filler precision | `LIB386/pol_work/` step accumulators are 16-bit fixed-point calibrated to 640-wide spans. At 1920 the spans are 3× longer; accumulators may drift or overflow. **The polyrec harness is the diagnostic** — capture corpus + demo at the new width, compare per-draw-call deltas to 640. Drift points at specific fillers (texture vs gouraud vs flat). |
+| Bitmap fonts | `LIB386/SVGA/FONT.CPP` / `AFFSTR.CPP` blit at 1:1 pixel size. At 1920×1080 in-game text is tiny. Either pixel-scale the existing 8×N glyphs (cheap, blocky) or re-author a higher-DPI font set (slow, clean). |
+| Z-buffer precision | 16-bit Z + `Fill_ZBuffer_Factor` is tuned for the 4:3 frustum's depth range. May Z-fight at HD aspect ratios on distant geometry; the polyrec harness catches drift here too if you log Z values. |
+| Smacker upscale policy | Source is 320×200. At HD widths the existing centred-letterbox path (PR #226) preserves the cinematic feel with bigger sidebars. Alternative is to fill the frame (uglier, lossy); the current default is the right one. |
+| Mouse cursor inversion | Today mouse positions are framebuffer-pixel coords and SDL scales 1:1. Works at any framebuffer resolution. Only needs invert if we add a "render at 640, pixel-double in present" mode. |
+
+The handful of remaining open audit rows (B7 done; A4/A5 deferred; A10 PERSO cosmetic) are all in the second column.
+
+#### Testing posture, honestly
+
+What the campaign protected against, and what it didn't:
+
+**Protected** — every routing PR ships with a 640×480 byte-identical contract:
+
+- `host_quick` includes a unit test for every newly-extracted pure-math layer (`test_image_load` for the bitmap helpers, `test_ambiance_balance` for the pan/volume math). 12/12 host tests in CI.
+- The `ui_*` capture-based regressions (`ui_holomap`, `ui_holoplan`, `ui_inventory`, `ui_video`) each pin one UI surface byte-identical to its 640×480 golden. Run via `bash tests/automation/test_ui_*.sh` with `LBA2_GAME_DIR` set.
+- Per-PR visual A/B at 768 + 1024 lives in PR descriptions as embedded screenshots.
+
+**Not protected** — there is no automated regression coverage *at wider widths*:
+
+- The `ui_*` goldens are all at 640. A future PR that breaks rendering at 768 would not fail any test the CI runs.
+- The projrec harness has a `corpus_768x480.projrec.hash` baseline committed under `tests/projection/baselines/`, but it's not part of `make test` and was not exercised on any C2 routing PR in this campaign.
+- B5 (game-over `SetProjection`), B6 (venetian-blind reveal), and the menu stretch-BG path have zero automated coverage at any width — they were re-anchored without a capture verb.
+- "Verified at 768" in each PR description was an honor-system promise from the author. No machine confirms it after the fact.
+
+**The single most useful next step:** commit `_768.png` goldens alongside every existing `_640.png` golden, and run the `ui_*` suite at both widths. ~15 minutes per surface; closes the gap entirely.
+
+Until that lands, the rule of thumb is: a routing PR that *only* shows the 640 golden passing is incomplete. Visuals at 768 + 1024 belong in the PR body, and the next person on this branch should re-eyeball them before merging anything that touches the same surface.
+
 ### Phase 6 — regression
 
 Run the polyrec suite and the host tests. Confirm the default 640×480 build is byte-identical to before, and check the wide build across representative scenes — exterior terrain, brick interiors, cinema bars, the HUD — for centring and clipping. Lock the result in.

--- a/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
+++ b/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
@@ -75,6 +75,118 @@ like font-glyph byte patterns or angle constants.
 
 Total: **~110 distinct sites** across **15 source files**.
 
+## How the audit ages — patterns from the campaign
+
+The audit-doc-as-survey only stays useful if you remember a few things the
+campaign repeatedly demonstrated.
+
+### This doc is a survey, not a state machine
+
+Rows here capture what was true *when the row was written*, not what's true
+in the source today. Five rows in this file (A1, A2, A3, B5, the venetian-
+blind half of B6) were marked "open" in body text for months after the
+underlying code was already fixed — the fixes landed in Phase 3 Tier-1 /
+earlier C2 surfaces, and the doc just didn't get updated. PR #225 swept
+those into per-row "Resolved" annotations; the same drift will accumulate
+again unless the next sweep checks every cited file:line against current
+`main`.
+
+**Rule:** before recommending work for any row, grep the cited expression
+in the current source. If the literal is gone, the row is resolved — say
+so, propose a doc-cleanup PR if there's a batch worth bundling. Only act
+on rows that grep confirms are genuinely open.
+
+### Stride bugs come in waves of the same shape
+
+A1 (`BackupAngles` 640-stride pixel arithmetic), A9 (`Load_HQR(file, Log, id)`
+on the holomap planet image), A10 (`CopyBlock(0,0,640,480, dest, 0,0, Log)`
+on Smacker cinematic) all had the *identical* shape: a 640-wide source byte
+block consumed by a routine that read row pitch from `TabOffLine[1]` /
+`ModeDesiredX` and would shear / smear the source at any width > 640.
+
+Fix template — pick the one the surface allows:
+
+| Surface | Fix |
+|---|---|
+| Raw HQR bitmap, 640×480, destination is `Log` | Swap `Load_HQR` → `Image_LoadCentered`. Caller pre-clears `Log` if sidebars need to be black. |
+| Pre-rendered scratch buffer blitted via `CopyBlock` | Eliminate the scratch — write directly into `Log` at the centred origin with an explicit destination stride. `CopyBlock` itself reads pitch from `TabOffLine[1]` for both sides and can't be used to blit a 640-stride source into a wider `Log`. |
+| Pure pixel arithmetic on `Log` (e.g. `src[640]` for "one row down") | Replace the `640` row stride with `TabOffLine[1]` (or `(S32)ModeDesiredX`). |
+
+When you spot one stride bug, grep for sibling shapes immediately —
+`grep -rn "640 \*" SOURCES/ LIB386/` is a 30-second sweep that surfaces
+candidates. The bugs cluster in the same handful of files.
+
+### Type-B work surfaces Type-A bugs
+
+Several of the worst bugs found during this campaign were discovered
+*while testing a Type-B (UI re-anchor) PR*, not while doing dedicated
+Type-A auditing:
+
+- The Dark Monk holomap SIGSEGV (PR #220) surfaced while wiring up
+  `ui holomap` testing for the B4 HOLOPLAN routing PR — turned out
+  to be an unrelated Z-buffer init-order regression from PR #212.
+- A9 planet-image stride was spotted while capturing 768 visuals
+  for the B4 routing in PR #221 (planet rendered as a diagonal smear).
+- A10 PLAYACF `CopyBlock` stride bug only became visible after the
+  `ui video` capture verb was added for cinematic centring.
+
+**Implication:** budget time for the Type-A surface to grow during a
+Type-B sweep. Don't promise "B4 will be the last HOLOPLAN PR" — the
+testing pass for B4 is itself the discovery vector for the next
+HOLOPLAN bug. The pattern repeats.
+
+### Alignment-class sweep, in practice
+
+The "How to sweep" recipe above (the `for w in 640 768 800 1024 1280
+1366 1600 1920` loop) is the right shape, but the campaign hardened
+two practical points:
+
+- **Test widths that fall off `(MDX/2 - 32) % 24 == 0` alignment.** 768,
+  800, 1280, 1366 expose alignment-class bugs that 640, 1024, 1600
+  silently mask. A "looks fine at 1024" PR is not proof of correctness;
+  retest at 768.
+- **Visual screenshots are the diff target, not log lines.** The bugs
+  surfaced in this campaign were visible at-a-glance (diagonal smear,
+  off-centre globe, garbage sidebars), not in instrumentation output.
+  The `xdg-open /tmp/sweep_*.png` step in the recipe is the load-
+  bearing one.
+
+### Image-edge vs framebuffer-edge is a per-surface choice
+
+Centring decisions during C2 work split along a single axis: **does
+the surface have an underlying 640-wide piece of authored art?**
+
+| Surface | Anchor |
+|---|---|
+| HoloGlobe rotating planet (no underlying image) | Framebuffer centre (`MDX/2`) |
+| HoloPlan planet detail (centred 640×480 island map) | Image-edge (`xOff` / `xOff+639`) |
+| Inventory slate (centred 640×480 panel art) | Image-edge |
+| Centred PCX cinematic (CDROM splash, slideshow) | Image-edge (via `Dial_Letterbox` flag) |
+| Smacker cutscene (centred 640×480 buffer) | Image-edge (`cineX0`/`cineY0`) |
+| Full-screen menu BG / shade boxes | Framebuffer-edge |
+| Smacker cinematic dirty-box rect | Framebuffer-edge (sidebars must be painted) |
+
+The decision rule: anchor to the *frame the player perceives the
+content in*. For 4:3 authored art, that's the image. For UI that has
+no underlying art, that's the framebuffer.
+
+### Audit-row resolution requires both a grep and a behavioural check
+
+A row going from "open" to "Resolved" needs two things:
+
+1. **Grep confirms the literal is gone or routed.** Necessary, not
+   sufficient.
+2. **Behaviour verified at the canonical width + at least one wider
+   width.** A routed literal can still be wrong if the routing
+   produces the wrong destination (image-edge vs framebuffer-edge
+   choice was the recurring example).
+
+PR #221's HOLOPLAN routing satisfied (1) but not (2) for the bracket
+anchors — they were routed to `MDX-1, MDY-1` (framebuffer-edge) when
+the right answer for that surface was image-edge. PR #223 corrected
+the anchor target after the underlying image-stride fix (A9) made
+the right answer obvious.
+
 ## Category A — Critical: corrupts memory / breaks rendering at wider widths
 
 **True bugs under either C1 or C2.** These sites use `640` as a buffer


### PR DESCRIPTION
Retrospective on the X-axis C2 campaign (PRs #213–#228). Drops the patterns and decisions that recurred across ~10 routing PRs into durable form so the next contributor — or the next campaign — doesn't have to re-derive them.

Doc-only, no code changes.

## What goes where

### `WIDESCREEN_HARDCODED_DIMS_AUDIT.md` — new "How the audit ages" section

Sits between the existing "Method" section and "Category A". Captures the working notes that the audit's row-by-row format can't carry:

- **"This doc is a survey, not a state machine"** — five rows in this file (A1, A2, A3, B5, half of B6) were flagged "open" in body text for months after the underlying code had been fixed. Almost cost a wasted PR cycle in this campaign before the user pushed back. **Grep before recommending** is now codified.
- **Stride bugs come in waves of the same shape** — A1 / A9 / A10 all had the identical signature (640-wide source byte block consumed by a routine that reads `TabOffLine[1]` row pitch). Captures the fix template in a per-surface table.
- **Type-B work surfaces Type-A bugs** — three of the worst bugs in this campaign were discovered while testing a B-section PR. Documents this as a forcing-function pattern so the next sweep budgets for it.
- **Alignment-class sweep, in practice** — reinforces the existing "How to sweep" recipe with two practical points: test widths off `(MDX/2 - 32) % 24 == 0` alignment, screenshots are the diff target.
- **Image-edge vs framebuffer-edge per-surface table** — the centring decision that recurred across every C2 PR is now codified as a single table with seven worked examples (HoloGlobe → framebuffer-edge, HoloPlan → image-edge, etc.).
- **Resolution requires both a grep AND a behavioural check** — PR #221's brackets were technically routed but anchored to the wrong target. PR #223 corrected after A9 made the right answer obvious. Documents this failure mode.

### `WIDESCREEN.md` Phase 5 — two new subsections

- **"HD prerequisites — what the X-axis campaign settled"** — a two-column table that separates HD-ready layers (memory pool, save format, projection, audio panning, cinematic centring, per-surface discipline) from still-HD-only work (Y-axis clamps, filler precision, fonts, Z-buffer precision, Smacker upscale). This is the "what does the next campaign need to do" mapping that didn't exist anywhere before.

- **"Testing posture, honestly"** — admits the coverage gap. Every routing PR shipped with a 640×480 byte-identical contract; **no test in CI verifies wider-width behaviour**. `corpus_768x480.projrec.hash` exists but isn't in `make test`. B5/B6/menu-stretch have zero automated coverage. "Verified at 768" in PR descriptions was honor-system. Documents the single most useful next step (commit `_768.png` goldens, run ui_* at both widths) so the gap is visible, not invisible.

## Companion memory note (out of scope of this PR)

Added separately to my auto-memory at `feedback_audit_doc_lags_merges.md` — same content as the audit-doc lesson above, scoped to the personal-grep-reflex level. Not in this PR because it's `.claude/projects/.../memory/` which is per-developer not repo-tracked.

## Why this matters

The widescreen X-axis campaign is functionally done — every B-row in the audit is resolved (except the Y-axis A4/A5 deferred to HD pass). But "done" without writing down what we learned would have left the next person to re-derive:

- the stride-bug fix template,
- the image-edge vs framebuffer-edge decision rule,
- the alignment-class sweep recipe,
- the realisation that the audit doc itself drifts,
- the honest state of test coverage.

All of which we learned the hard way (one near-wasted PR, one PR that re-anchored to the wrong target, multiple surfaces that surfaced sibling Type-A bugs during Type-B testing). Better to write it down than to relearn it.

## Verification

This is doc-only. Sanity-checked by:

- [x] All file:line citations verified against current `main` (post-#228).
- [x] All PR numbers verified against the merged set.
- [x] Markdown renders correctly (preview pass).
- [x] No code changes — `make build` / `make test` not affected.
