### PR TITLE
feat(control): add --language <name> CLI flag (engine override)

### DIFF
--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -69,6 +69,19 @@ static long s_res_y = 0;
 #define CONTROL_RES_MAX_X 1920
 #define CONTROL_RES_MAX_Y 1024
 
+/* --language <name>: override the engine's Language global at boot, bypassing
+   the cfg's Language key. Doesn't write anything to disk; the cfg is not touched.
+   Index matches MESSAGE.CPP's TabLanguage[] — 0=English, 1=Français, 2=Deutsch,
+   3=Español, 4=Italiano, 5=Portugues. Applied in PERSO.CPP after InitLanguage()
+   returns. */
+static int s_have_language = 0;
+static int s_language = 0;
+#define CONTROL_LANG_COUNT 6
+static const char *kControlLanguageFull[CONTROL_LANG_COUNT] = {
+    "English", "Français", "Deutsch", "Español", "Italiano", "Portugues"};
+static const char *kControlLanguageShort[CONTROL_LANG_COUNT] = {
+    "EN", "FR", "DE", "SP", "IT", "PO"};
+
 /* --- Runtime ---------------------------------------------------------------- */
 static long s_hook_calls = 0;
 static int s_finalized = 0;
@@ -219,6 +232,34 @@ void Control_ParseArgs(int *argc, char *argv[]) {
             read += 2;
             continue;
         }
+        if (!strcmp(a, "--language") && has_val) {
+            /* Accept either the full language name (English / Français / Deutsch /
+               Español / Italiano / Portugues) or the 2-character code (EN / FR /
+               DE / SP / IT / PO).  strcasecmp is byte-wise ASCII case-folding, so
+               the cedilla / tilde bytes in Français / Español compare exactly —
+               case-insensitive on the ASCII letters only, which is the same
+               behaviour InitLanguage() in MESSAGE.CPP gets from the cfg parse. */
+            const char *val = argv[read + 1];
+            int matched = -1;
+            for (int n = 0; n < CONTROL_LANG_COUNT; n++) {
+                if (!strcasecmp(val, kControlLanguageFull[n]) || !strcasecmp(val, kControlLanguageShort[n])) {
+                    matched = n;
+                    break;
+                }
+            }
+            if (matched >= 0) {
+                s_have_language = 1;
+                s_language = matched;
+            } else {
+                fprintf(stderr,
+                        "[control] --language: invalid '%s' (valid: "
+                        "English/Français/Deutsch/Español/Italiano/Portugues "
+                        "or EN/FR/DE/SP/IT/PO)\n",
+                        val);
+            }
+            read += 2;
+            continue;
+        }
 
         argv[write++] = argv[read++];
     }
@@ -244,6 +285,14 @@ long Control_GetResolutionX(void) {
 
 long Control_GetResolutionY(void) {
     return s_res_y;
+}
+
+int Control_HasLanguage(void) {
+    return s_have_language;
+}
+
+int Control_GetLanguage(void) {
+    return s_language;
 }
 
 /* --- Boot ------------------------------------------------------------------- */

--- a/SOURCES/CONTROL.H
+++ b/SOURCES/CONTROL.H
@@ -40,6 +40,16 @@ int Control_HasResolution(void);
 long Control_GetResolutionX(void);
 long Control_GetResolutionY(void);
 
+/* Language override via --language <name>. Returns 1 if the flag was supplied (use
+   Control_GetLanguage as a 0..5 index into MESSAGE.CPP's TabLanguage[]), 0 otherwise
+   (the engine reads the cfg's Language key as normal). Accepts full names
+   (English / Français / Deutsch / Español / Italiano / Portugues, case-insensitive on
+   ASCII letters) and 2-character codes (EN / FR / DE / SP / IT / PO). Parsed in
+   Control_ParseArgs; applied in PERSO.CPP after InitLanguage() returns. Doesn't
+   touch the cfg file. */
+int Control_HasLanguage(void);
+int Control_GetLanguage(void);
+
 /* Set up the boot path and arm the tick hook. Call once, instead of MainGameMenu(),
    when active: applies --load (InitGame(-1) + ChangeCube while FlagLoadGame is set)
    or a fresh InitGame(1), then arms Control_TickHook. Returns 1 on success (caller

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2389,6 +2389,16 @@ int main(int argc, char *argv[]) {
     //-------------------
 
     InitLanguage(); // multilangue
+    /* --language <name> override: bypass the cfg's Language key for this run.
+       Used by the test harness to pin a deterministic language regardless of
+       whatever the local cfg says, and useful for any dev wanting to spot-
+       check a language without editing their cfg. */
+    if (Control_HasLanguage()) {
+        Language = Control_GetLanguage();
+        if (Control_IsVerbose())
+            fprintf(stderr, "[control] --language: %s (index %d)\n",
+                    GetLanguageName(Language), (int)Language);
+    }
 
     BufText = (U8 *)SmartMalloc(BIG_FILE_DIA);
     if (!BufText)

--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -26,6 +26,8 @@ lba2cc --load <slot>          restore a save before the loop starts
        --exec "<cmd>;<cmd>"   run console commands (';'-separated) on the first tick
        --tick <N>             advance N simulation ticks
        --fixed-dt <ms>        advance the clock by a constant <ms> per tick (deterministic)
+       --language <name>      override Language at boot (English | Français | Deutsch |
+                              Español | Italiano | Portugues; or EN | FR | DE | SP | IT | PO)
        --demo                 attract/demo mode: scripts drive the scene, modals auto-advance
        --dump-state <path>    write a JSON snapshot of engine state
        --screenshot <path>    write a PNG of the rendered frame
@@ -54,6 +56,11 @@ lba2cc --exec "cube 100" --tick 5 --screenshot shot.png --exit
 
 # Batch several commands.
 lba2cc --load mysave --exec "cube 100; give clover 3" --tick 5 --dump-state s.json --exit
+
+# Force a language for the run (bypasses the cfg's Language key — useful for
+# regression captures that should be reproducible regardless of the developer's
+# local lba2.cfg).
+lba2cc --language Français --load Anon1 --exec "ui dialog 1 /tmp/fr.png" --fixed-dt 16 --tick 200 --exit
 ```
 
 `--load` resolves its argument as a direct file path first, then as a save name in the


### PR DESCRIPTION
Adds `--language <name>` to the harness flag set. Pins the engine's `Language` global at boot, **bypassing the cfg's `Language` key** — pure runtime override, doesn't read or write `lba2.cfg`.

## Why

Three of the four `ui_*` tests we'd been seeing fail were pure language drift, not widescreen regressions. Goldens at PR #185 were captured under Français; on any machine with `Language: English` in cfg (the in-repo default) those tests fail with French-vs-English text diffs. The harness has no language normalisation today, so test goldens are non-portable across developers.

A CLI override is the right fix at the engine level — it composes with the existing `--resolution` flag (same `Control_ParseArgs` path), is discoverable via `docs/CONTROL.md`, doesn't mutate user state, and is useful beyond testing (any dev wanting to spot-check a language can run `--language Français` without editing cfg).

## What

| Flag form | Behaviour |
|---|---|
| `--language English` (or `Français`, `Deutsch`, `Español`, `Italiano`, `Portugues`) | Pin to that language |
| `--language EN` (or `FR`, `DE`, `SP`, `IT`, `PO`) | Same, 2-character code |
| `--language english` (any case on the ASCII letters) | Case-insensitive — same as `InitLanguage`'s cfg parsing |
| `--language Klingon` | stderr warning, falls through to cfg |
| omitted | engine reads `Language` from cfg (current behaviour) |

## Implementation

- `SOURCES/CONTROL.H` — `Control_HasLanguage()` / `Control_GetLanguage()` declarations.
- `SOURCES/CONTROL.CPP` — `s_have_language` / `s_language` statics, `--language` case in `Control_ParseArgs`, accessors.
- `SOURCES/PERSO.CPP` — after `InitLanguage()` returns, overrides the `Language` extern from `MESSAGE.CPP` if `Control_HasLanguage()`. Logs the chosen language under `--verbose`.
- `docs/CONTROL.md` — usage block + one example showing `--language Français` driving a deterministic capture.

## Verification

- [x] `--language Français` + `ui dialog 1` → **byte-identical** to the committed Français golden (`dialog_Anon1_t1.png`).
- [x] `--language English` / `--language EN` / `--language français` (case-insensitive) — all parsed correctly, override applied.
- [x] `--language Klingon` → stderr warning, cfg's Language used.
- [x] `--resolution 768x480 --language Français` — both flags apply; verbose log shows each one's `[control]` line.
- [x] `make build`, `make test` (12/12), `clang-format` clean.
- [x] `test_ui_holomap` / `holoplan` / `inventory` / `video` PASS — no regression to the goldens already in English (these don't render Language-dependent text in the captured area).

## What this doesn't fix (PR B's job)

Doesn't fix the four stale `ui_*` test failures on its own. Those need a harness change to add `--language English` to `ctl_headless` and regen the goldens in English. For `ui_menu_main` specifically, there's a second environmental dep — the small thumbnail at the top of the main menu comes from the user's local `~/.local/share/Twinsen/LBA2/save/current.lba`, not the corpus save. Both fixes belong in a follow-up harness PR.

What this PR delivers: the engine-side knob the harness PR needs.
