### PR TITLE
test(automation): bigger timeout + accurate failure message for projection_demo

### DIFF
--- a/tests/automation/lib.sh
+++ b/tests/automation/lib.sh
@@ -115,7 +115,7 @@ ui_compare() {
     # the verb takes the capture path as its last arg
     ctl_headless --load "$LBA2_TEST_SAVE" \
         --exec "ui $args $out" --fixed-dt 16 --tick 200 --exit >/dev/null 2>&1 \
-        || { rm -f "$out"; fail "verb 'ui $args' returned non-zero ($?)"; }
+        || { rc=$?; rm -f "$out"; fail "verb 'ui $args' returned non-zero ($rc)"; }
     [ -f "$out" ] || fail "no capture written for 'ui $args'"
     if [ "${LBA2_UI_REGEN:-}" = "1" ]; then
         mkdir -p "$(dirname "$golden")"

--- a/tests/automation/test_projection_demo.sh
+++ b/tests/automation/test_projection_demo.sh
@@ -11,6 +11,15 @@
 # Opt-in via PROJREC_RUN_DEMO=1 — even at 35s this is the slowest test in
 # the harness suite. Skip by default.
 #
+# The "~35 seconds wall-clock" figure is from a native-Linux Release build.
+# Slower setups (Debug builds, WSL2 — where SDL syscall overhead can be
+# ~50% of total CPU time) easily stretch into 2 minutes. Bump the default
+# timeout to 240s here so opt-in runs don't get SIGTERM'd mid-capture
+# before Projrec_EndCapture() flushes the hash to disk. The caller can
+# still override (LBA2_TEST_TIMEOUT=N bash tests/automation/test_projection_demo.sh).
+: "${LBA2_TEST_TIMEOUT:=240}"
+export LBA2_TEST_TIMEOUT
+#
 # Local-only (needs retail data). Regenerate with:
 #   LBA2_PROJECTION_REGEN=1 PROJREC_RUN_DEMO=1 bash tests/automation/test_projection_demo.sh
 # or:
@@ -32,7 +41,7 @@ ctl_headless --game-dir "$LBA2_GAME_DIR" \
              --demo --fixed-dt 16 --tick 30000 \
              --projection-hash "$OUT" --exit \
              >/dev/null 2>&1 \
-    || { rm -f "$OUT"; fail "demo harness returned non-zero ($?)"; }
+    || { rc=$?; rm -f "$OUT"; fail "demo harness returned non-zero ($rc)"; }
 
 # Strip any non-SCENE lines the harness may have emitted, then format the
 # fixture body (the committed file has the same header).


### PR DESCRIPTION
Two small fixes that surfaced while validating the post-#231 test suite on a WSL2 / Debug build setup.

## 1. `LBA2_TEST_TIMEOUT` default for `projection_demo` → 240s

The test's docstring claims `~35 seconds wall-clock`. That figure was measured on a native-Linux Release build. WSL2 + Debug stacks two slowdowns:

| Factor | Effect |
|---|---|
| Debug = no `-O` | 1.78M `Projrec_LongProjectPoint{3D,Iso}` events run through unoptimised math paths |
| WSL2 syscall overhead | `time(1)` on a Release run showed `user=56s sys=53s real=89s` — sys% ~58% of total CPU time |

Net effect: the test that's "the slowest test in the harness suite" per its own docstring runs ~2 min on this kind of setup. The default 90s timeout from `lib.sh` isn't enough — `projection_demo` gets SIGTERM'd before `Projrec_EndCapture()` flushes the FNV-1a hash to disk, leaving a 0-byte output file.

Setting `LBA2_TEST_TIMEOUT=240` as the test's local default gives 2–2.5× headroom over a real Release run on this kind of setup. The env var still wins if a caller explicitly overrides it.

## 2. Capture `$?` before `rm -f` in the `||` branch

The original pattern:
```bash
ctl_headless ... || { rm -f "$OUT"; fail "demo harness returned non-zero ($?)"; }
```

`$?` here is `rm`'s exit code (always 0 when `$OUT` exists), not `ctl_headless`'s. A SIGTERM'd run reported `"returned non-zero (0)"` — both contradictory and misleading. Fixed by capturing into a local first:

```bash
ctl_headless ... || { rc=$?; rm -f "$OUT"; fail "demo harness returned non-zero ($rc)"; }
```

Same bug pattern in `lib.sh`'s `ui_compare` helper — fixed there too. Now any future `ctl_headless` failure (timeout, crash, bad CLI) reports the actual code the user sees.

## Verification

- [x] Induced timeout test: `PROJREC_RUN_DEMO=1 LBA2_TEST_TIMEOUT=10 bash tests/automation/test_projection_demo.sh` reports `non-zero (124)` (timeout(1)'s own exit code) instead of the old `non-zero (0)`.
- [x] `make test` 12/12, all `ui_*` tests still pass.
- [x] `clang-format` clean (no C++ touched).

## Out of scope (worth a separate look)

`sys%` being ~58% of total CPU time on this hardware suggests a tight SDL polling loop somewhere — could be a 1-line throttle that lifts every harness test, not just the demo capture. Not investigated here; flagged as a future task.
