### PR TITLE
fix(audio): don't exit when sample driver init fails

### DIFF
--- a/SOURCES/INITADEL.C
+++ b/SOURCES/INITADEL.C
@@ -196,7 +196,17 @@ void InitAdeline(S32 argc, char *argv[]) {
 #endif
         LogPuts("\nInitialising Sample device. Please wait...\n");
         if (!InitSampleDriver(NULL)) {
-            exit(1); // TODO: Implement graceful exit
+            /* No usable audio output (host has no audio device, SDL_AUDIODRIVER
+               points at something invalid, the audio subsystem failed to come
+               up earlier). Previously this exit(1)'d the process; now we log
+               and continue with audio disabled. Every audio entry point in
+               LIB386/AIL/SDL/{SAMPLE,STREAM,VIDEO_AUDIO_SDL}.CPP already gates
+               on Sample_Driver_Enabled / a non-NULL stream, so playback calls
+               become silent no-ops rather than UB. The harness uses this to
+               bypass the SDL dummy driver's nanosleep pacing (~58% of sys time
+               in projection_demo); a player whose audio device fails just
+               loses sound instead of being unable to launch the game. */
+            LogPuts("\nWarning: no audio output — running silently.\n");
         }
     }
 


### PR DESCRIPTION
First of two PRs targeting the sys% hot loop investigation surfaced after #232. This one is the engine-side prerequisite; PR 2 will add a `--no-audio` CLI flag that consumes it.

## The bug

`INITADEL.C:198` was:

```c
if (!InitSampleDriver(NULL)) {
    exit(1); // TODO: Implement graceful exit
}
```

Any audio-init failure was **fatal**:

- A user whose audio device is unavailable couldn't launch the game.
- The harness couldn't bypass SDL's `dummy` audio driver (which paces itself with `nanosleep` — **74% of `sys` time in `projection_demo` on a WSL2 setup** per `strace -c`) by setting `SDL_AUDIODRIVER` to an invalid name.

The `// TODO: Implement graceful exit` comment was a known-gap marker.

## The fix

Soften the failure to log + continue. The audio backend in `LIB386/AIL/SDL/{SAMPLE,STREAM,VIDEO_AUDIO_SDL}.CPP` is **already defensively coded**:

- `SAMPLE.CPP` only sets `Sample_Driver_Enabled = TRUE` after `SDL_OpenAudioDeviceStream` succeeds. `PlaySample`, the lock helpers, and `PauseSamples` / `ResumeSamples` all gate on it or on `sampleStream != NULL`.
- `STREAM.CPP` (music) opens streams lazily per track and logs + skips on failure.
- `VIDEO_AUDIO_SDL.CPP` (cinematic audio) is also lazy and gated.

So with `InitSampleDriver` returning `FALSE`, every audio entry point silently no-ops instead of crashing. The engine runs the rest of the boot / main-loop path normally.

## Verification

| Scenario | Before | After |
|---|---|---|
| SDL audio comes up cleanly (`SDL_AUDIODRIVER=dummy` or unset) | works | **works, unchanged** |
| Audio device unavailable / invalid driver | `exit(1)` | logs warning, continues silently |

- [x] `make build` clean.
- [x] `make test`: 12/12.
- [x] All 8 `ui_*` tests pass (they use `SDL_AUDIODRIVER=dummy` so audio IS up; this PR's code path isn't exercised — verifies no regression to the working path).
- [x] `SDL_AUDIODRIVER=does_not_exist --demo --tick 1000 --projection-hash` produces a clean run (`OK.` + hash written + exit 0) instead of the old early exit.
- [x] `clang-format` clean.

## Player impact

A missing or broken audio device used to fail the game launch. With this PR, the player gets a silent game launch instead. Reasonable failure mode — better than "doesn't start at all."

## Harness impact (intentional)

On WSL2 the `dummy` driver's `nanosleep` pacing was ~58% of total CPU time in the `projection_demo` loop. With `SDL_AUDIODRIVER` set to an invalid name, that vanishes — a 1000-tick `--demo` ran ~20% faster on Debug. PR 2 in this sequence will add a `--no-audio` CLI flag so the harness can opt in without needing the env-var trick.

## Out of scope (worth a separate PR)

`LIB386/CMakeLists.txt:5` does:
```cmake
if(LBA2_BUILD_TESTS)
  add_definitions(-DENABLE_LIB386_DEBUG_TRACES)
endif()
```

`add_definitions` is directory-scoped, so it propagates to **every target** built in `LIB386/*` subdirs — including the shipping engine binary, which then writes ~22K `[CPP][...]` lines per tick to stdout. Should be `target_compile_definitions` scoped to the test targets only. Tracked separately; doesn't block this PR.
