### PR TITLE
feat(control): add --no-audio CLI flag for harness fast-path

### DIFF
--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -82,6 +82,12 @@ static const char *kControlLanguageFull[CONTROL_LANG_COUNT] = {
 static const char *kControlLanguageShort[CONTROL_LANG_COUNT] = {
     "EN", "FR", "DE", "SP", "IT", "PO"};
 
+/* --no-audio: skip InitAIL() and InitSampleDriver() at engine boot. Pure boolean
+   override; the harness uses it to bypass the SDL dummy driver's nanosleep pacing
+   that dominates sys time under SDL_AUDIODRIVER=dummy. See INITADEL.C for the
+   gate. */
+static int s_no_audio = 0;
+
 /* --- Runtime ---------------------------------------------------------------- */
 static long s_hook_calls = 0;
 static int s_finalized = 0;
@@ -260,6 +266,17 @@ void Control_ParseArgs(int *argc, char *argv[]) {
             read += 2;
             continue;
         }
+        if (!strcmp(a, "--no-audio")) {
+            /* Boolean flag — skip InitAIL() and InitSampleDriver() at boot so
+               the SDL audio subsystem never opens a stream and the dummy
+               driver's nanosleep pacing (~58% of sys time on WSL2) never
+               runs. The engine's audio playback paths already gate on
+               Sample_Driver_Enabled / non-NULL stream — every call becomes a
+               silent no-op when this is set. */
+            s_no_audio = 1;
+            read += 1;
+            continue;
+        }
 
         argv[write++] = argv[read++];
     }
@@ -293,6 +310,10 @@ int Control_HasLanguage(void) {
 
 int Control_GetLanguage(void) {
     return s_language;
+}
+
+int Control_NoAudio(void) {
+    return s_no_audio;
 }
 
 /* --- Boot ------------------------------------------------------------------- */

--- a/SOURCES/CONTROL.H
+++ b/SOURCES/CONTROL.H
@@ -50,6 +50,16 @@ long Control_GetResolutionY(void);
 int Control_HasLanguage(void);
 int Control_GetLanguage(void);
 
+/* --no-audio: skip InitAIL() and InitSampleDriver() at boot. Returns 1 if the flag
+   was supplied, 0 otherwise. With audio init skipped, the SDL audio subsystem
+   never opens a stream and the dummy driver's nanosleep pacing (~74% of sys time
+   in projection_demo on a WSL2 setup) doesn't run. Every audio entry point in
+   LIB386/AIL/SDL/{SAMPLE,STREAM,VIDEO_AUDIO_SDL}.CPP already gates on
+   Sample_Driver_Enabled or a non-NULL stream, so playback calls become silent
+   no-ops. Harness-only intent; players who actually want audio shouldn't pass
+   this flag. */
+int Control_NoAudio(void);
+
 /* Set up the boot path and arm the tick hook. Call once, instead of MainGameMenu(),
    when active: applies --load (InitGame(-1) + ChangeCube while FlagLoadGame is set)
    or a fresh InitGame(1), then arms Control_TickHook. Returns 1 on success (caller

--- a/SOURCES/INITADEL.C
+++ b/SOURCES/INITADEL.C
@@ -151,7 +151,15 @@ void InitAdeline(S32 argc, char *argv[]) {
     // ··········································································
     //  AIL API init (for vmm_lock/timer)
 
-    InitAIL(); // TODO: Reorganize/reposition closer to sound subsystem
+    /* --no-audio (harness): skip the SDL audio subsystem entirely. Avoids the
+       SDL dummy driver's nanosleep pacing — ~58% of sys time in projection_demo
+       on a WSL2 setup. Player builds always init audio; this gate is only
+       reached when the harness explicitly opts out. The SDL audio call sites in
+       LIB386/AIL/SDL/* gate on Sample_Driver_Enabled / non-NULL stream, so
+       playback paths become silent no-ops when audio isn't up. */
+    if (!Control_NoAudio()) {
+        InitAIL(); // TODO: Reorganize/reposition closer to sound subsystem
+    }
 
     // --- VIDEO
     // -------------------------------------------------------------------
@@ -190,7 +198,7 @@ void InitAdeline(S32 argc, char *argv[]) {
 
     // ··········································································
     //  Sample device
-    {
+    if (!Control_NoAudio()) {
 #ifndef LIB_AIL
 #error ADELINE: you need to include AIL.H
 #endif

--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -28,6 +28,9 @@ lba2cc --load <slot>          restore a save before the loop starts
        --fixed-dt <ms>        advance the clock by a constant <ms> per tick (deterministic)
        --language <name>      override Language at boot (English | Français | Deutsch |
                               Español | Italiano | Portugues; or EN | FR | DE | SP | IT | PO)
+       --no-audio             skip InitAIL() and InitSampleDriver() at boot — bypasses
+                              the SDL dummy driver's nanosleep pacing on WSL2 setups
+                              (~58% of sys time in projection_demo without this)
        --demo                 attract/demo mode: scripts drive the scene, modals auto-advance
        --dump-state <path>    write a JSON snapshot of engine state
        --screenshot <path>    write a PNG of the rendered frame


### PR DESCRIPTION
Second of two PRs from the sys% investigation. Adds `--no-audio` so the harness can skip audio init entirely — bypassing the SDL `dummy` driver's `nanosleep` pacing that dominated sys time per `strace -c`.

Independent of #233 (graceful-fail audio init); the two compose cleanly in either merge order.

## What

| File | Change |
|---|---|
| `SOURCES/CONTROL.H` | `Control_NoAudio()` declaration |
| `SOURCES/CONTROL.CPP` | `s_no_audio` static, `--no-audio` parse (boolean, no value), accessor |
| `SOURCES/INITADEL.C` | Wraps `InitAIL()` + the `InitSampleDriver()` block in `!Control_NoAudio()` gates |
| `docs/CONTROL.md` | Adds `--no-audio` to usage block with rationale |

Same `Control_*` pattern as `--language` / `--resolution`. Pure boot-time override; doesn't touch cfg, doesn't touch user state.

## Why

`strace -c` on `projection_demo` showed `clock_nanosleep` was **74% of total syscall time** (2,226 calls × 7ms each in a 1000-tick run) — SDL's `dummy` audio driver pacing itself to simulate real-time playback. The audio frames go to /dev/null but the driver still sleeps for `buffer_duration_ms` between accepts.

With audio init skipped, the SDL audio subsystem never opens a stream and the pacing thread never starts.

## Verification

Same workload (`--demo --fixed-dt 16 --tick 1000` on Debug):

| Run | real | user | sys |
|---|---|---|---|
| Default (audio on) | 15.5s | 9.9s | 8.2s |
| `--no-audio` | **12.6s** | 7.9s | **6.7s** |

~20% wall, ~18% sys reduction. The remaining sys is unrelated stdout I/O — `LIB386_TRACE_CPP` scope leak via `LBA2_BUILD_TESTS=ON`. Separate PR #234 (sibling of this one) addresses that and is expected to take sys close to zero.

- [x] `make build` clean.
- [x] `make test`: 12/12.
- [x] All 8 `ui_*` tests pass — `ctl_headless` doesn't add `--no-audio` today (goldens were captured audio-on); this PR's path isn't exercised by existing tests, confirms zero regression.
- [x] **Determinism**: 3 consecutive `--no-audio --demo --fixed-dt 16 --tick 1000` runs produced identical SHA-256 outputs.
- [x] `clang-format` clean.

## Hash diverges from audio-on baseline (FYI for future)

The `projection_demo` golden was captured with audio on. With `--no-audio` the demo's Life scripts pace differently (no audio callbacks → no Life pulses on those events), so the projection event stream is different and the hash differs. Both hashes are reproducible; they just measure two different scene trajectories.

A future harness change that adds `--no-audio` to `projection_demo` would need a one-time `LBA2_PROJECTION_REGEN=1` regen. Not in scope here.

## Relationship to #233

This PR's gate sits *before* `InitSampleDriver()` is called, so the `exit(1)` softened by #233 isn't reached when `--no-audio` is set. The two PRs:

- **#233**: when audio init fails *organically* (missing device, invalid SDL driver), log + continue instead of crashing the game launch.
- **This PR**: explicit harness opt-out — never even try to init audio.

Different purposes, different code paths, no merge conflict.
