### PR TITLE
build(lib386): scope ENABLE_LIB386_DEBUG_TRACES to test targets only

### DIFF
--- a/LIB386/CMakeLists.txt
+++ b/LIB386/CMakeLists.txt
@@ -1,9 +1,21 @@
 include_directories(H)
 
-# Enable debug traces for ASM-vs-CPP comparison when building tests
-if(LBA2_BUILD_TESTS)
-  add_definitions(-DENABLE_LIB386_DEBUG_TRACES)
-endif()
+# LIB386 debug traces are an ASM-vs-CPP equivalence check tool — every shim in
+# LIB386_TRACE_CPP / LIB386_TRACE_ASM prints "[CPP][Func][N] ..." lines that the
+# ASM equivalence tests diff against the matching "[ASM]" lines. The macros are
+# defined inline as ((void)0) when ENABLE_LIB386_DEBUG_TRACES isn't set.
+#
+# This define was previously applied at directory scope (add_definitions when
+# LBA2_BUILD_TESTS was on), which leaked into every target built in the LIB386
+# subdirs — including the static libraries linked into the shipping engine
+# binary. The engine then wrote ~22K [CPP] lines per tick to stdout on any
+# build configured with -DLBA2_BUILD_TESTS=ON (e.g. the default `make build`
+# after a CI-style configure). Scope of the leak: ~58% of sys time in
+# projection_demo on a WSL2 setup.
+#
+# The fix: only the test executables that need the traces opt in, via
+# target_compile_definitions(<test> PRIVATE ENABLE_LIB386_DEBUG_TRACES) inside
+# the add_asm_cpp_test() helper. Engine targets stay clean.
 
 add_subdirectory(3D)
 add_subdirectory(AIL)

--- a/tests/cmake/asm_test_helpers.cmake
+++ b/tests/cmake/asm_test_helpers.cmake
@@ -48,8 +48,14 @@ function(add_asm_cpp_test)
     target_link_libraries(${ARG_NAME} PRIVATE ${ARG_LIBS})
     target_link_libraries(${ARG_NAME} PRIVATE m)  # math lib
     # Pass source root so test_harness.h can strip it from __FILE__ paths.
+    # Enable LIB386_TRACE_CPP / LIB386_TRACE_ASM so the equivalence test can
+    # diff [CPP] vs [ASM] trace lines — scoped to this test target only so
+    # the shipping engine binary doesn't get the same define (previously the
+    # define leaked into all LIB386 targets via LIB386/CMakeLists.txt's
+    # add_definitions, polluting stdout with ~22K lines per tick).
     target_compile_definitions(${ARG_NAME} PRIVATE
         "TEST_SOURCE_ROOT=\"${CMAKE_SOURCE_DIR}/\""
+        ENABLE_LIB386_DEBUG_TRACES
     )
     add_test(NAME ${ARG_NAME} COMMAND ${ARG_NAME})
 


### PR DESCRIPTION
Third of three PRs from the sys% investigation. Sibling of #233 (graceful-fail audio init) and #234 (`--no-audio`). All three are independent and compose; merge in any order.

This one is the biggest local win on my measurement box: **~2× speedup, sys drops from 8.2s to 0.08s** on a 1000-tick `projection_demo` Debug run.

## The bug

[`LIB386/CMakeLists.txt:4-6`](https://github.com/LBALab/lba2-classic-community/blob/main/LIB386/CMakeLists.txt) set the trace define at directory scope:

```cmake
if(LBA2_BUILD_TESTS)
  add_definitions(-DENABLE_LIB386_DEBUG_TRACES)
endif()
```

`add_definitions()` applies to **every target built in the directory and its subdirectories**, including the static libraries (`libsys`, `lib3d`, `libobj`, `libpoly`, `libsvg`, `libail`, `libfio`, `libsnapshot`, etc.) that the shipping engine binary links against.

`LBA2_BUILD_TESTS=ON` is the default for the canonical `make build` target. So the default engine binary was being built with `-DENABLE_LIB386_DEBUG_TRACES`, and every `LIB386_TRACE_CPP` call site was writing to stdout. ~22K `[CPP][...]` lines per simulation tick on the projection_demo run, ~91% of sys time after the audio-pacing fix. The test's "~35 seconds" estimate (native-Linux, traces off) bloated to ~2 min on a default Debug build with traces on.

## The fix

The trace define is only needed by ASM-equivalence test executables — they compile their own copy of LIB386 `.cpp` files via `target_sources` and diff `[CPP]` vs `[ASM]` trace lines to verify behavioural equivalence between the original Watcom ASM and our C++ ports.

Move the define from `add_definitions` to `target_compile_definitions` inside `add_asm_cpp_test()` — same place that already sets `TEST_SOURCE_ROOT`. The engine + all LIB386 library targets compile without the define; the ASM-equivalence test executables compile with it.

| File | Change |
|---|---|
| `LIB386/CMakeLists.txt` | Remove `add_definitions(-DENABLE_LIB386_DEBUG_TRACES)`. Add an explanatory comment about why. |
| `tests/cmake/asm_test_helpers.cmake` | Add `ENABLE_LIB386_DEBUG_TRACES` to the `target_compile_definitions` list in `add_asm_cpp_test()` |

## Verification

Same 1000-tick `projection_demo` Debug run:

| Run | real | user | sys | stdout lines |
|---|---|---|---|---|
| Before | 15.5s | 9.9s | 8.2s | ~22,000 per tick |
| **After** | **7.6s** | **7.2s** | **0.08s** | **37 total** |

- [x] `make build` clean.
- [x] `make test`: 12/12 host tests pass.
- [x] `test_ui_*` 8/8 — goldens captured under the previous build are bit-identical to the new build's captures. Removing the trace define is purely observability; it doesn't affect rendered pixels or simulation state.
- [x] `clang-format` clean (no C/C++ touched).

## ASM-equivalence tests untouched

The ASM-equivalence tests are gated behind `LBA2_BUILD_ASM_EQUIV_TESTS` (off by default, opt-in via `run_tests_docker.sh`). They still get the trace define via the new per-target `target_compile_definitions` in `add_asm_cpp_test`. Their test-source compilation and any `target_sources` additions (e.g. `SOURCES/GRILLE.CPP` added to `test_grille`) all inherit the test target's `PRIVATE` definitions.

## Relationship to #233 / #234

Three independent fixes for the same investigation:

- **#233**: audio-init failure → log + continue (player-facing fix)
- **#234**: `--no-audio` CLI flag — explicit harness opt-out (~20% speedup on top of audio dummy)
- **This PR**: trace-define scope leak (~2× speedup on default Debug build)

The wins stack. With #232 / #233 / #234 / this PR all merged, default `make build && projection_demo` should fit comfortably under 90s wall on most hardware — and `--no-audio` on top should push it to maybe ~2× faster again on WSL2.

Worth noting: the projection_demo test's golden was captured before this PR. With this PR merged, the golden is **byte-identical** because the trace define only affected stdout logging — the projection events the harness hashes are unchanged.
