### PR TITLE
feat(mem,svga): teardown primitives for runtime resolution switch

### DIFF
--- a/LIB386/H/SVGA/VIDEO.H
+++ b/LIB386/H/SVGA/VIDEO.H
@@ -20,6 +20,12 @@ void EndVideo();
 
 // --- Interface ---------------------------------------------------------------
 bool CreateVideoSurface(U32 resX, U32 resY);
+
+/** Free the Phys buffer and the SDL palette without taking the SDL_INIT_VIDEO
+ *  subsystem down — paired with CreateVideoSurface for the runtime resolution
+ *  switcher (docs/RUNTIME_RESOLUTION.md). EndVideo() is still the lifetime
+ *  teardown called from EndAdeline. */
+void DestroyVideoSurface();
 U32 VideoSurfacePitch();
 void LockVideoSurface();
 void UnlockVideoSurface();

--- a/LIB386/SVGA/SDL.CPP
+++ b/LIB386/SVGA/SDL.CPP
@@ -57,6 +57,14 @@ bool InitVideo() {
 }
 
 void EndVideo() {
+    DestroyVideoSurface();
+}
+
+void DestroyVideoSurface() {
+    if (Phys) {
+        free(Phys);
+        Phys = NULL;
+    }
     if (sdlPalette) {
         SDL_DestroyPalette(sdlPalette);
         sdlPalette = NULL;

--- a/SOURCES/MEM.CPP
+++ b/SOURCES/MEM.CPP
@@ -211,6 +211,27 @@ void InitMainBuffer(void) {
 }
 
 //▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+void Mem_TeardownMainBuffer(void) {
+    if (MainBuffer) {
+        Free(MainBuffer);
+        MainBuffer = NULL;
+    }
+    SizeOfMemAllocated = 0;
+
+    /* Null every published pointer so a stale read after teardown traps fast
+       instead of silently reading freed memory. */
+    for (S32 t = 0; t < NB_MEM_ELTS; t++) {
+        if (ListMem[t].AdrPtr) {
+            *ListMem[t].AdrPtr = NULL;
+        }
+    }
+
+    /* The two convenience aliases set up at the end of InitMainBuffer. */
+    BufCube = NULL;
+    BufferBrick = NULL;
+}
+
+//▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
 void InitMemory(void) {
     // Alloue Memoire DOS si possible
     SkySeaTexture = (U8 *)SmartMalloc(256 * 256L + RECOVER_AREA);

--- a/SOURCES/MEM.H
+++ b/SOURCES/MEM.H
@@ -34,3 +34,9 @@ extern void AdjustLba2Mem(void);
 extern void InitMainBuffer(void);
 extern void InitMemory(void);
 extern void Mem_ConfigureScreenBuffers(U32 resX, U32 resY);
+
+/* Frees the single-shot MainBuffer and nulls every ListMem AdrPtr so a fresh
+   InitMainBuffer() can run at a different resolution. Intended for the runtime
+   resolution switcher (docs/RUNTIME_RESOLUTION.md). Safe to call when
+   MainBuffer is already NULL. */
+extern void Mem_TeardownMainBuffer(void);


### PR DESCRIPTION
First slice of the runtime resolution-switch plan from [`docs/RUNTIME_RESOLUTION.md`](docs/RUNTIME_RESOLUTION.md). The doc lists `Mem_TeardownMainBuffer()` as a missing prerequisite for `Res_Switch`, and the existing `EndVideo()` only freed the SDL palette — `Phys` leaks at shutdown.

Two pure-additive teardown entry points. Both are safe to call repeatedly and against a null state.

## What lands

- **`Mem_TeardownMainBuffer()`** (`SOURCES/MEM.CPP`)
  Frees the single-shot `MainBuffer`, zeros `SizeOfMemAllocated`, nulls every `*ListMem[i].AdrPtr` and the two convenience aliases (`BufCube`, `BufferBrick`). Stale reads after teardown trap fast instead of silently reading freed memory.
- **`DestroyVideoSurface()`** (`LIB386/SVGA/SDL.CPP`)
  Paired with `CreateVideoSurface`. Frees `Phys` (previously leaked by `EndVideo`) and the SDL palette. `EndVideo` now delegates, closing the leak for the lifetime-teardown path too.

## Why no caller yet

Splitting the orchestrator into its own PR — the scene-reload step (`LoadScene` + `PtrInitGrille`, carved out of `ChangeCube` to skip RNG reseed / position re-snap / FlagReinit side effects) needs its own focused review. Bundling primitives + orchestrator + harness test + console verb + revert dialog in one PR would be 350+ lines across six files; reviewers asked for tight scopes in earlier campaigns.

These two primitives compile clean, format clean, host tests 12/12.

## Stacking plan

| PR | Scope |
|---|---|
| **This** | Teardown primitives only |
| Next | `Res_Switch(W, H)` orchestrator + carved-out `Grille_Reload` + temp CLI flag (`--res-switch-test`) for harness validation |
| Then | `cmd_resolution` console verb (catalog / select-by-number / WxH / native / --all) + safety gates |
| Then | Preview/revert dialog (text mode for V1, menu modal in Phase 2) |

## Verification

- [x] `cmake --build build`: clean.
- [x] `make test`: 12/12.
- [x] `check-format`: clean.