### PR TITLE
feat(reso): cmd_resolution console verb on top of Res_Switch

### DIFF
--- a/LIB386/H/SYSTEM/WINDOW.H
+++ b/LIB386/H/SYSTEM/WINDOW.H
@@ -25,6 +25,12 @@ void DestroyWindowSurface();
  *  focus, multi-monitor placement, and (in fullscreen) the fullscreen state
  *  without a destroy/recreate round-trip. Returns true on success. */
 bool ResizeWindowSurface(U32 newW, U32 newH);
+
+/** Query the current display's logical dimensions (the desktop the SDL
+ *  window is on, via SDL_GetCurrentDisplayMode). Writes both outputs and
+ *  returns true on success. Returns false if SDL hasn't initialised a
+ *  window yet; *outW and *outH are untouched in that case. */
+bool Window_GetDisplayDimensions(U32 *outW, U32 *outH);
 void PresentRendererFrame(const void *pixels, U32 pitch);
 bool LockRendererTexture(void **pixels, int *pitch);
 void UnlockAndPresentRendererTexture();

--- a/LIB386/SYSTEM/WINDOW.CPP
+++ b/LIB386/SYSTEM/WINDOW.CPP
@@ -183,6 +183,23 @@ bool CreateWindowSurface(U32 resX, U32 resY) {
     return true;
 }
 
+bool Window_GetDisplayDimensions(U32 *outW, U32 *outH) {
+    if (outW == NULL || outH == NULL || sdlWindow == NULL) {
+        return false;
+    }
+    SDL_DisplayID display = SDL_GetDisplayForWindow(sdlWindow);
+    if (display == 0) {
+        return false;
+    }
+    const SDL_DisplayMode *mode = SDL_GetCurrentDisplayMode(display);
+    if (mode == NULL || mode->w <= 0 || mode->h <= 0) {
+        return false;
+    }
+    *outW = (U32)mode->w;
+    *outH = (U32)mode->h;
+    return true;
+}
+
 bool ResizeWindowSurface(U32 newW, U32 newH) {
     /* No-op if the surface was never created.  Caller should fall through to
        CreateWindowSurface in that case (boot path), not Resize. */

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -15,8 +15,10 @@
 #include "../INPUT.H"
 /* HOLO.H lacks include guards and is pulled in transitively by DEFINES.H. */
 #include "../INVENT.H"
+#include "../RES_SWITCH.H"
 #include <SYSTEM/FILES.H>
 #include <SYSTEM/STRING.H>
+#include <SYSTEM/WINDOW.H>
 #include <SVGA/SCREEN.H>
 #include <SVGA/DIRTYBOX.H>
 #include <dirent.h>
@@ -1101,6 +1103,273 @@ static void cmd_listbugs(int argc, const char *argv[]) {
 }
 
 /*──────────────────────────────────────────────────────────────────────────*/
+/* resolution — runtime render-resolution switch (see docs/RUNTIME_RESOLUTION.md) */
+/*──────────────────────────────────────────────────────────────────────────*/
+
+/* Same numeric guardrails as --resolution / Res_Switch. Duplicated here so
+   the verb's parser doesn't pull in CONTROL.CPP's private constants. */
+#define RES_VERB_MIN_W 320
+#define RES_VERB_MAX_W 1920
+#define RES_VERB_MIN_H 200
+#define RES_VERB_MAX_H 1024
+
+typedef struct {
+    U32 w, h;
+    const char *tag;
+} ResEntry;
+
+/* Always-present recommended modes, ordered. The console filters by display
+   ≤ at presentation time; entries that don't fit are dropped. 640x480 is
+   pinned at index 1 unconditionally. */
+static const ResEntry kRecommended[] = {
+    {640, 480, "classic"},        /* 4:3 — the authentic-mode anchor */
+    {768, 480, "recommended"},    /* 16:10 */
+    {1024, 480, "recommended"},   /* ~21:10 */
+    {1280, 720, "experimental"},  /* 16:9 — Y>480, holomap may glitch */
+    {1920, 1080, "experimental"}, /* 16:9 — same caveat */
+};
+#define kRecommendedCount ((int)(sizeof(kRecommended) / sizeof(kRecommended[0])))
+
+/* Curated "advanced" list shown behind --all. Reasonable common modes only
+   — full multiples-of-8 enumeration would emit hundreds of entries. */
+static const ResEntry kAdvanced[] = {
+    {320, 200, "advanced"},
+    {320, 240, "advanced"},
+    {400, 300, "advanced"},
+    {512, 384, "advanced"},
+    {800, 600, "advanced"},
+    {856, 480, "advanced"},
+    {960, 540, "advanced"},
+    {1024, 600, "advanced"},
+    {1024, 768, "advanced"},
+    {1152, 648, "advanced"},
+    {1280, 800, "advanced"},
+    {1280, 960, "advanced"},
+    {1280, 1024, "advanced"},
+    {1366, 768, "advanced"},
+    {1440, 900, "advanced"},
+    {1600, 900, "advanced"},
+    {1600, 1024, "advanced"},
+    {1680, 1024, "advanced"},
+};
+#define kAdvancedCount ((int)(sizeof(kAdvanced) / sizeof(kAdvanced[0])))
+
+/* GCD-reduce W,H to its aspect (e.g. 1280,720 -> 16,9). */
+static void res_aspect(U32 w, U32 h, U32 *outA, U32 *outB) {
+    U32 a = w, b = h;
+    while (b) {
+        U32 t = b;
+        b = a % b;
+        a = t;
+    }
+    if (a == 0)
+        a = 1;
+    *outA = w / a;
+    *outB = h / a;
+}
+
+static bool res_validate(U32 w, U32 h) {
+    return (w >= RES_VERB_MIN_W && w <= RES_VERB_MAX_W && h >= RES_VERB_MIN_H &&
+            h <= RES_VERB_MAX_H && (w & 7) == 0);
+}
+
+/* Snap a display width down to the nearest multiple of 8 inside the
+   supported range, so "native" works on any monitor (e.g. 1366 -> 1360).
+   Returns 0 if the result falls below the minimum width. */
+static U32 res_snap_native_w(U32 dispW) {
+    if (dispW > RES_VERB_MAX_W)
+        dispW = RES_VERB_MAX_W;
+    dispW &= ~(U32)7;
+    if (dispW < RES_VERB_MIN_W)
+        return 0;
+    return dispW;
+}
+
+static U32 res_snap_native_h(U32 dispH) {
+    if (dispH > RES_VERB_MAX_H)
+        dispH = RES_VERB_MAX_H;
+    if (dispH < RES_VERB_MIN_H)
+        return 0;
+    return dispH;
+}
+
+/* Compose the visible list (recommended ± advanced) into `out`, filtering
+   to entries ≤ display. Appends a synthetic "native" entry at the end of
+   the recommended portion. Returns count. */
+static int res_build_list(ResEntry *out, int cap, bool includeAdvanced) {
+    U32 dispW = 0, dispH = 0;
+    const bool hasDisplay = Window_GetDisplayDimensions(&dispW, &dispH);
+    int n = 0;
+
+    /* Recommended */
+    for (int i = 0; i < kRecommendedCount && n < cap; i++) {
+        if (i == 0) { /* 640x480 always present */
+            out[n++] = kRecommended[i];
+            continue;
+        }
+        if (hasDisplay && (kRecommended[i].w > dispW || kRecommended[i].h > dispH))
+            continue;
+        out[n++] = kRecommended[i];
+    }
+
+    /* Native (synthesised from current display). Only if the snapped value
+       isn't already in the list. */
+    if (hasDisplay && n < cap) {
+        U32 nw = res_snap_native_w(dispW), nh = res_snap_native_h(dispH);
+        if (nw && nh) {
+            bool dup = false;
+            for (int i = 0; i < n; i++)
+                if (out[i].w == nw && out[i].h == nh) {
+                    dup = true;
+                    break;
+                }
+            if (!dup) {
+                out[n].w = nw;
+                out[n].h = nh;
+                out[n].tag = "native";
+                n++;
+            }
+        }
+    }
+
+    if (!includeAdvanced)
+        return n;
+
+    /* Advanced — dedupe against what's already in the list. */
+    for (int i = 0; i < kAdvancedCount && n < cap; i++) {
+        if (hasDisplay && (kAdvanced[i].w > dispW || kAdvanced[i].h > dispH))
+            continue;
+        bool dup = false;
+        for (int k = 0; k < n; k++)
+            if (out[k].w == kAdvanced[i].w && out[k].h == kAdvanced[i].h) {
+                dup = true;
+                break;
+            }
+        if (dup)
+            continue;
+        out[n++] = kAdvanced[i];
+    }
+
+    return n;
+}
+
+static void res_print_list(const ResEntry *list, int count, U32 curW, U32 curH) {
+    for (int i = 0; i < count; i++) {
+        U32 a, b;
+        res_aspect(list[i].w, list[i].h, &a, &b);
+        const bool isCurrent = (list[i].w == curW && list[i].h == curH);
+        Console_Print("  %2d: %4ux%-4u  (%2u:%-2u, %-12s)%s", i + 1, list[i].w, list[i].h,
+                      a, b, list[i].tag, isCurrent ? "  <- current" : "");
+    }
+}
+
+/* Parses "WxH" / "WXH" into a validated (w, h). Returns true on success. */
+static bool res_parse_wxh(const char *s, U32 *outW, U32 *outH) {
+    const char *xp = strchr(s, 'x');
+    if (xp == NULL)
+        xp = strchr(s, 'X');
+    if (xp == NULL || xp == s || xp[1] == '\0')
+        return false;
+    char *end_w = NULL, *end_h = NULL;
+    long w = strtol(s, &end_w, 10);
+    long h = strtol(xp + 1, &end_h, 10);
+    if (end_w != xp || end_h == NULL || *end_h != '\0')
+        return false;
+    if (w <= 0 || h <= 0)
+        return false;
+    if (!res_validate((U32)w, (U32)h))
+        return false;
+    *outW = (U32)w;
+    *outH = (U32)h;
+    return true;
+}
+
+static void cmd_resolution(int argc, const char *argv[]) {
+    /* Cap intentionally generous so cap-overflow can't silently truncate the
+       advanced list as it grows over time. */
+    ResEntry list[64];
+
+    /* No-args: print the recommended-only list and current resolution. */
+    if (argc < 2) {
+        const int count = res_build_list(list, (int)(sizeof(list) / sizeof(list[0])), false);
+        Console_Print("Current: %ux%u", ModeDesiredX, ModeDesiredY);
+        Console_Print("Available:");
+        res_print_list(list, count, ModeDesiredX, ModeDesiredY);
+        Console_Print("Usage: resolution <n> | resolution WxH | resolution native | resolution --all");
+        return;
+    }
+
+    const char *arg = argv[1];
+
+    /* --all: expand to the advanced list. */
+    if (!strcmp(arg, "--all")) {
+        const int count = res_build_list(list, (int)(sizeof(list) / sizeof(list[0])), true);
+        Console_Print("Current: %ux%u", ModeDesiredX, ModeDesiredY);
+        Console_Print("Available (advanced):");
+        res_print_list(list, count, ModeDesiredX, ModeDesiredY);
+        return;
+    }
+
+    /* native: snap the current display dims to the nearest valid WxH. */
+    if (!strcmp(arg, "native")) {
+        U32 dispW = 0, dispH = 0;
+        if (!Window_GetDisplayDimensions(&dispW, &dispH)) {
+            Console_Print("resolution native: display dimensions unavailable.");
+            return;
+        }
+        U32 nw = res_snap_native_w(dispW), nh = res_snap_native_h(dispH);
+        if (!nw || !nh) {
+            Console_Print("resolution native: %ux%u out of supported range (%dx%d - %dx%d).",
+                          dispW, dispH, RES_VERB_MIN_W, RES_VERB_MIN_H,
+                          RES_VERB_MAX_W, RES_VERB_MAX_H);
+            return;
+        }
+        if (!Res_Switch(nw, nh)) {
+            Console_Print("resolution native: Res_Switch to %ux%u failed (see log).", nw, nh);
+            return;
+        }
+        Console_Print("Resolution: %ux%u", nw, nh);
+        return;
+    }
+
+    /* Numeric: pick from the recommended (no --all) list. */
+    {
+        char *end = NULL;
+        long n = strtol(arg, &end, 10);
+        if (end && *end == '\0') {
+            const int count = res_build_list(list, (int)(sizeof(list) / sizeof(list[0])), false);
+            if (n < 1 || n > count) {
+                Console_Print("resolution: index %ld out of range (1..%d). Run 'resolution' to list.",
+                              n, count);
+                return;
+            }
+            const ResEntry *e = &list[n - 1];
+            if (!Res_Switch(e->w, e->h)) {
+                Console_Print("resolution: switch to %ux%u failed (see log).", e->w, e->h);
+                return;
+            }
+            Console_Print("Resolution: %ux%u", e->w, e->h);
+            return;
+        }
+    }
+
+    /* WxH explicit. */
+    {
+        U32 w = 0, h = 0;
+        if (!res_parse_wxh(arg, &w, &h)) {
+            Console_Print("resolution: bad target '%s' (need WxH; W%%8==0; range %dx%d - %dx%d).",
+                          arg, RES_VERB_MIN_W, RES_VERB_MIN_H, RES_VERB_MAX_W, RES_VERB_MAX_H);
+            return;
+        }
+        if (!Res_Switch(w, h)) {
+            Console_Print("resolution: switch to %ux%u failed (see log).", w, h);
+            return;
+        }
+        Console_Print("Resolution: %ux%u", w, h);
+    }
+}
+
+/*──────────────────────────────────────────────────────────────────────────*/
 /* Registration */
 /*──────────────────────────────────────────────────────────────────────────*/
 
@@ -1156,6 +1425,12 @@ void Console_RegisterAll(void) {
                               "headless captures of UI state.");
     Console_RegisterCommandEx("savebug", cmd_savebug, "Save current game to bugs dir (optional name)", "savebug [name]",
                               "Requires in-game loaded cube (not during video); writes bugs/<name>.lba.");
+    Console_RegisterCommandEx("resolution", cmd_resolution,
+                              "Switch render resolution at runtime (no args = list)",
+                              "resolution [<n> | WxH | native | --all]",
+                              "No args lists recommended modes; <n> picks by index; WxH is arbitrary "
+                              "(W%8==0, range 320x200..1920x1024); native snaps to the current display; "
+                              "--all expands the list with advanced modes. See docs/RUNTIME_RESOLUTION.md.");
 
     Console_RegisterCvar("fps", &DebugFps, CONSOLE_CVAR_BOOL, "Frame rate display");
     Console_RegisterCvar("horizon", (void *)&FlagDrawHorizon, CONSOLE_CVAR_BOOL_U8, "Draw horizon/cubes around");

--- a/tests/automation/test_res_switch_console.sh
+++ b/tests/automation/test_res_switch_console.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Console verb `resolution`: drive Res_Switch through the user-facing path.
+#
+# Mirrors what a player would type at the console:
+#   resolution              — list + current (no switch)
+#   resolution <n>          — switch by recommended-list index
+#   resolution WxH          — explicit, validated against W%8==0 and range
+#   resolution native       — snap to display dims
+#   resolution --all        — extended catalog including advanced modes
+#
+# Asserts the engine survives each switch, the right [control] echoes come
+# out for both success and error paths, and the recommended list always
+# contains the 640x480 classic anchor.
+TESTNAME=res_switch_console
+. "$(dirname "$0")/lib.sh"
+precheck
+need_save
+
+out="$(mktemp)"
+trap 'rm -f "$out"' EXIT
+
+run_with() {
+    local exec_arg="$1"
+    local extra="${2:-}"
+    # shellcheck disable=SC2086
+    ctl_headless --load "$LBA2_TEST_SAVE" --exec "$exec_arg" \
+        --fixed-dt 16 --tick 80 --exit $extra >"$out" 2>&1
+}
+
+# 1. No-args: list + current, no switch.
+run_with "resolution" || fail "no-args returned non-zero ($?)"
+grep -q "^\[control\] Current: 640x480"   "$out" || fail "no-args: missing 'Current:' line"
+grep -q "640x480"                          "$out" || fail "no-args: 640x480 must always be listed"
+grep -q "Usage:"                           "$out" || fail "no-args: missing Usage hint"
+
+# 2. Numeric: switch to entry 2 in recommended list (768x480 on a >=768 display).
+run_with "resolution 2" || fail "numeric returned non-zero ($?)"
+grep -q "Res_Switch: 640x480 -> 768x480 OK" "$out" \
+    || fail "numeric: orchestrator log missing (got: $(grep -m1 Res_Switch "$out"))"
+grep -q "^\[control\] Resolution: 768x480" "$out" \
+    || fail "numeric: missing success echo"
+
+# 3. WxH explicit: 800x480 (not in recommended list).
+run_with "resolution 800x480" || fail "WxH returned non-zero ($?)"
+grep -q "Res_Switch: 640x480 -> 800x480 OK" "$out" || fail "WxH: orchestrator did not fire"
+
+# 4. Invalid WxH (not W%8==0): rejected, no switch.
+run_with "resolution 645x480" || fail "invalid WxH returned non-zero ($?)"
+grep -q "bad target '645x480'"      "$out" || fail "invalid WxH: missing rejection echo"
+grep -qv "Res_Switch: .* -> 645x480" "$out" || fail "invalid WxH: switch ran but shouldn't"
+
+# 5. Out-of-range index.
+run_with "resolution 12345" || fail "bad index returned non-zero ($?)"
+grep -q "out of range"     "$out" || fail "bad index: missing rejection echo"
+
+# 6. --all expands the list (must include 640x480 and at least one advanced).
+run_with "resolution --all" || fail "--all returned non-zero ($?)"
+grep -q "Available (advanced):" "$out" || fail "--all: missing advanced banner"
+grep -q "advanced"              "$out" || fail "--all: no advanced entries shown"
+
+pass "list / numeric / WxH / invalid / --all all behave correctly"


### PR DESCRIPTION
**Stacked on [#238](https://github.com/LBALab/lba2-classic-community/pull/238) (which is stacked on #237).** Rebase the base to `main` once those land.

Third slice of the runtime resolution-switch plan from [`docs/RUNTIME_RESOLUTION.md`](docs/RUNTIME_RESOLUTION.md) — the user-facing console verb on top of the `Res_Switch` orchestrator.

## `resolution` — four forms

```
resolution               list recommended modes + current; no switch
resolution <n>           pick by 1-based index from the recommended list
resolution WxH           explicit, validated against --resolution's range
                         (W%8==0, 320x200..1920x1024)
resolution native        snap to SDL display dims (W rounded down to %8)
resolution --all         expand the catalog with ~18 advanced modes
                         (320x200 .. 1680x1024), filtered to ≤ display
```

Example session (here the display is 1024x768, so 1280x720+ are filtered out):

```
> resolution
Current: 640x480
Available:
   1:  640x480   ( 4:3 , classic     )  <- current
   2:  768x480   ( 8:5 , recommended )
   3: 1024x480   (32:15, recommended )
   4: 1024x768   ( 4:3 , native      )
Usage: resolution <n> | resolution WxH | resolution native | resolution --all
> resolution 2
Resolution: 768x480
```

## Catalog tiers

| Tag | What | Example |
|---|---|---|
| `classic` | 640x480, always present, pinned at index 1 | `640x480` |
| `recommended` | Common widescreen modes <= display | `768x480`, `1024x480` |
| `experimental` | 16:9 modes with Y>480 (may hit known holomap glitches per [WIDESCREEN_HARDCODED_DIMS_AUDIT.md A5](docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md#a5-holomap-z-buffer-y-bounds)) | `1280x720`, `1920x1080` |
| `native` | Synthesised entry — current display dims snapped | varies |
| `advanced` | Curated multiples-of-8 sweep, only behind `--all` | `800x600`, `1280x1024` |

`Window_GetDisplayDimensions()` (new in `LIB386/SYSTEM/WINDOW.H`) wraps `SDL_GetCurrentDisplayMode` so the console TU doesn't pull in SDL directly.

## Test coverage — `tests/automation/test_res_switch_console.sh`

Six cases, all asserting against the `[control]` echo lines and the orchestrator's own `Res_Switch:` log:

| # | Input | Asserted behaviour |
|---|---|---|
| 1 | `resolution` | Lists; 640x480 always present; usage hint printed; no switch fires |
| 2 | `resolution 2` | Numeric: switches to recommended[2]; success echo "Resolution: 768x480" |
| 3 | `resolution 800x480` | WxH explicit: orchestrator fires 640->800x480 |
| 4 | `resolution 645x480` | Invalid W%8: "bad target" echo; orchestrator does NOT fire |
| 5 | `resolution 12345` | Out-of-range index: "out of range" echo; no switch |
| 6 | `resolution --all` | Expanded list; "Available (advanced):" banner; advanced entries shown |

## Verification

- [x] `make test`: 12/12.
- [x] All 8 `ui_*` tests + `test_res_switch` + `test_res_switch_console` pass.
- [x] `clang-format`: clean.
- [x] Manual: live-typed each form into the console under `--no-audio`, observed correct list rendering, correct switch behaviour, correct error messages.

## Stacking

| PR | Status | What |
|---|---|---|
| [#237](https://github.com/LBALab/lba2-classic-community/pull/237) | draft | Teardown primitives |
| [#238](https://github.com/LBALab/lba2-classic-community/pull/238) | draft | `Res_Switch` orchestrator + harness flag |
| **This** | draft | `cmd_resolution` console verb |
| Next | not started | Safety gates + preview/revert dialog |