### PR TITLE
feat(reso): safety gate + keep/revert dialog for runtime res switch

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -1284,6 +1284,28 @@ static bool res_parse_wxh(const char *s, U32 *outW, U32 *outH) {
     return true;
 }
 
+/* Shared "fire the orchestrator, then arm the keep/revert dialog" path. Pulls
+   the safety gate, captures the previous (W, H), closes the console so the
+   modal isn't occluded by it, then schedules the dialog on the next tick. */
+static void res_do_switch(U32 newW, U32 newH) {
+    const char *why = Res_SwitchAllowedReason();
+    if (why) {
+        Console_Print("%s", why);
+        return;
+    }
+    const U32 prevW = ModeDesiredX;
+    const U32 prevH = ModeDesiredY;
+    if (!Res_Switch(newW, newH)) {
+        Console_Print("resolution: switch to %ux%u failed (see log).", newW, newH);
+        return;
+    }
+    if (prevW != newW || prevH != newH) {
+        Res_BeginRevertCountdown(prevW, prevH);
+        Console_Close();
+    }
+    Console_Print("Resolution: %ux%u", newW, newH);
+}
+
 static void cmd_resolution(int argc, const char *argv[]) {
     /* Cap intentionally generous so cap-overflow can't silently truncate the
        advanced list as it grows over time. */
@@ -1324,11 +1346,7 @@ static void cmd_resolution(int argc, const char *argv[]) {
                           RES_VERB_MAX_W, RES_VERB_MAX_H);
             return;
         }
-        if (!Res_Switch(nw, nh)) {
-            Console_Print("resolution native: Res_Switch to %ux%u failed (see log).", nw, nh);
-            return;
-        }
-        Console_Print("Resolution: %ux%u", nw, nh);
+        res_do_switch(nw, nh);
         return;
     }
 
@@ -1344,11 +1362,7 @@ static void cmd_resolution(int argc, const char *argv[]) {
                 return;
             }
             const ResEntry *e = &list[n - 1];
-            if (!Res_Switch(e->w, e->h)) {
-                Console_Print("resolution: switch to %ux%u failed (see log).", e->w, e->h);
-                return;
-            }
-            Console_Print("Resolution: %ux%u", e->w, e->h);
+            res_do_switch(e->w, e->h);
             return;
         }
     }
@@ -1361,11 +1375,7 @@ static void cmd_resolution(int argc, const char *argv[]) {
                           arg, RES_VERB_MIN_W, RES_VERB_MIN_H, RES_VERB_MAX_W, RES_VERB_MAX_H);
             return;
         }
-        if (!Res_Switch(w, h)) {
-            Console_Print("resolution: switch to %ux%u failed (see log).", w, h);
-            return;
-        }
-        Console_Print("Resolution: %ux%u", w, h);
+        res_do_switch(w, h);
     }
 }
 

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -293,6 +293,11 @@ enum MenuLocalizedLabel {
     MENU_LABEL_GAME_CONTROLLER,
     MENU_LABEL_GAME_SAVED,
     MENU_LABEL_BUG_SAVED,
+    MENU_LABEL_RES_TITLE,
+    MENU_LABEL_RES_NOW_AT,
+    MENU_LABEL_RES_KEEP_Q,
+    MENU_LABEL_RES_KEEP_REVERT,
+    MENU_LABEL_RES_REVERT_IN,
     MENU_LABEL_COUNT,
 };
 
@@ -310,6 +315,11 @@ static const char *LocalizedMenuLabels[6][MENU_LABEL_COUNT] = {
         "Configure gamepad",
         "Game saved",
         "Bug saved",
+        "Resolution changed",
+        "Now running at %ux%u.",
+        "Keep this resolution?",
+        "[Y] Keep      [N] Revert",
+        "Reverts automatically in %ds...",
     },
     {
         "Choix de la langue",
@@ -324,6 +334,11 @@ static const char *LocalizedMenuLabels[6][MENU_LABEL_COUNT] = {
         "Configuration manette",
         "Partie sauvegardée",
         "Bug sauvegardé",
+        "Résolution modifiée",
+        "Affichage en %ux%u.",
+        "Conserver cette résolution ?",
+        "[O] Conserver   [N] Annuler",
+        "Annulation automatique dans %ds...",
     },
     {
         "Sprachauswahl",
@@ -338,6 +353,11 @@ static const char *LocalizedMenuLabels[6][MENU_LABEL_COUNT] = {
         "Gamepad konfigurieren",
         "Spiel gespeichert",
         "Fehler gespeichert",
+        "Auflösung geändert",
+        "Läuft jetzt mit %ux%u.",
+        "Diese Auflösung beibehalten?",
+        "[J] Beibehalten   [N] Zurück",
+        "Automatischer Wechsel zurück in %ds...",
     },
     {
         "Elegir idioma",
@@ -352,6 +372,11 @@ static const char *LocalizedMenuLabels[6][MENU_LABEL_COUNT] = {
         "Configurar mando",
         "Partida guardada",
         "Error guardado",
+        "Resolución cambiada",
+        "Funcionando a %ux%u.",
+        "¿Mantener esta resolución?",
+        "[S] Mantener   [N] Revertir",
+        "Se revertirá automáticamente en %ds...",
     },
     {
         "Scegli lingua",
@@ -366,6 +391,11 @@ static const char *LocalizedMenuLabels[6][MENU_LABEL_COUNT] = {
         "Configura gamepad",
         "Partita salvata",
         "Bug salvato",
+        "Risoluzione modificata",
+        "In esecuzione a %ux%u.",
+        "Mantenere questa risoluzione?",
+        "[S] Mantieni   [N] Annulla",
+        "Annullamento automatico tra %ds...",
     },
     {
         "Escolha do idioma",
@@ -380,6 +410,11 @@ static const char *LocalizedMenuLabels[6][MENU_LABEL_COUNT] = {
         "Configurar gamepad",
         "Jogo salvo",
         "Erro salvo",
+        "Resolução alterada",
+        "Em execução a %ux%u.",
+        "Manter esta resolução?",
+        "[S] Manter   [N] Reverter",
+        "Reversão automática em %ds...",
     },
 };
 
@@ -399,6 +434,19 @@ static S32 GetMenuLanguageIndex(void) {
 
 static const char *GetLocalizedMenuLabel(enum MenuLocalizedLabel label) {
     return LocalizedMenuLabels[GetMenuLanguageIndex()][label];
+}
+
+const char *GetLocalizedResDialogLabel(int which) {
+    static const enum MenuLocalizedLabel kMap[RES_DIALOG_LABEL_COUNT] = {
+        MENU_LABEL_RES_TITLE,
+        MENU_LABEL_RES_NOW_AT,
+        MENU_LABEL_RES_KEEP_Q,
+        MENU_LABEL_RES_KEEP_REVERT,
+        MENU_LABEL_RES_REVERT_IN,
+    };
+    if (which < 0 || which >= (int)RES_DIALOG_LABEL_COUNT)
+        return "";
+    return GetLocalizedMenuLabel(kMap[which]);
 }
 
 static void BuildCustomMenuText(S32 num, char *string) {

--- a/SOURCES/GAMEMENU.H
+++ b/SOURCES/GAMEMENU.H
@@ -122,4 +122,19 @@ extern void EffectPcxMess(U8 numpcx, U8 *screen, U8 effect, S32 mess);
 extern void Introduction(void);
 /*--------------------------------------------------------------------------*/
 
+/* Localized labels for the runtime-resolution revert dialog (RES_SWITCH.CPP).
+   Kept as a numeric index so RES_SWITCH doesn't need to see the menu's full
+   label enum. The strings are sourced from the same 6-language table that
+   GAMEMENU's other UI text uses; format-string entries have %u/%d args
+   that the caller fills in via snprintf. */
+enum ResDialogLabel {
+    RES_DIALOG_TITLE = 0,   /* "Resolution changed" */
+    RES_DIALOG_NOW_AT,      /* "Now running at %ux%u." */
+    RES_DIALOG_KEEP_Q,      /* "Keep this resolution?" */
+    RES_DIALOG_KEEP_REVERT, /* "[Y] Keep      [N] Revert" */
+    RES_DIALOG_REVERT_IN,   /* "Reverts automatically in %ds..." */
+    RES_DIALOG_LABEL_COUNT
+};
+extern const char *GetLocalizedResDialogLabel(int which);
+
 #endif // GAMEMENU_H

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -8,6 +8,7 @@
 #include "RES_PICKER.H"
 #include "INPUT.H"
 #include "CONTROL.H"
+#include "RES_SWITCH.H"
 #include "CONSOLE/CONSOLE.H"
 #include <SYSTEM/EVENTS.H>
 #include <SVGA/VIDEO.H>
@@ -470,6 +471,13 @@ restartloop:
 
     while (TRUE) {
     startloop:
+
+        /* Runtime resolution-switch keep/revert dialog. Pending whenever
+           cmd_resolution (or a future menu path) fires a switch; runs once
+           per pending arming, then clears itself. Drives its own modal tick
+           loop, so by the time control returns the user has chosen Keep or
+           Revert (or the 15 s timeout fired). No-op when nothing is pending. */
+        Res_RunRevertDialogIfPending();
 
         /*#ifdef  THOMAS
 		if( DefKeys[0].Key1==0 )

--- a/SOURCES/RES_SWITCH.CPP
+++ b/SOURCES/RES_SWITCH.CPP
@@ -8,7 +8,8 @@
 #include "C_EXTERN.H"
 #include "FLOW.H"
 #include "GAMEMENU.H"
-#include "INTEXT.H" /* CameraCenter */
+#include "INTEXT.H" /* CameraCenter, SaveCamera / RestoreCamera */
+#include "INVENT.H" /* BackupScreen / RestoreScreen */
 #include "PTRFUNC.H"
 
 #include <3D/CAMERA.H>
@@ -309,10 +310,44 @@ static void RevertDialog_Draw(U32 secondsLeft) {
 ResRevertChoice Res_RunRevertDialogIfPending(void) {
     if (!s_revertPending)
         return RES_REVERT_NONE;
+    s_revertPending = false; /* claim the pending state up front so a recursive
+                                Res_Switch on revert doesn't re-trigger us */
 
-    /* Stash + restore Log so we don't permanently corrupt the post-dialog
-       frame with overlay pixels. Same shape as ShowSaveConfirmation. */
-    CopyScreen(Screen, Log);
+    /* Modal pattern lifted from MenuComportement (SOURCES/COMPORTE.CPP).
+       That's the in-game behaviour-change menu and it handles palette,
+       camera state, dirty-box invalidation, and full-screen repaint
+       correctly across both 3D and iso scenes.
+
+       Outline:
+         entry: SaveTimer / SaveCamera / UnsetClip / Palette(PtrPal)
+                paint a fresh AffScene into Log (post-switch Log is empty)
+                BackupScreen(TRUE) snapshots that frame
+         loop:  each redraw restores the background from Screen, then
+                draws darken + 5 text lines on top
+         exit:  RestoreScreen() drives a full-screen AffScene repaint,
+                so dirty-box rendering picks up cleanly on the next tick
+                RestoreCamera / RestoreTimer
+                if Revert: Res_Switch back to (prev) */
+
+    SaveTimer();
+    SaveCamera();
+    UnsetClip();
+    /* PtrPal was already pushed to SDL by Res_Switch, but Palette() also
+       triggers RebuildPaletteLUT which is cheap; belt + braces matches
+       MenuComportement's "au cas ou l'on soit appelé pendant un eclair". */
+    Palette(PtrPal);
+
+    /* Drive a full repaint into Log before BackupScreen. The post-switch
+       Log was just allocated and is zero — without this, the snapshot the
+       dialog uses as its background would be blank.  BoxStaticAdd over
+       the full frame plus AffScene(AFF_ALL_FLIP) is what MainLoop runs
+       at restartloop entry, and it's the same shape the engine uses when
+       it needs "definitely repaint everything". */
+    BoxReset();
+    BoxStaticAdd(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1);
+    AffScene(AFF_ALL_FLIP);
+
+    BackupScreen(TRUE); /* Screen → ScreenAux, then Log → Screen */
 
     ManageTime();
     const U32 startMs = TimerRefHR;
@@ -349,22 +384,28 @@ ResRevertChoice Res_RunRevertDialogIfPending(void) {
         const U32 remainingMs = endMs - TimerRefHR;
         const U32 secondsLeft = (remainingMs + 999u) / 1000u;
         if (secondsLeft != lastSecondsDrawn) {
-            /* Re-fill background each redraw so the previous countdown
-               digit doesn't leave ghost pixels. */
+            /* Re-fill Log from the Screen backup so the previous countdown
+               digit doesn't leave ghost pixels and the scene stays visible
+               under the darken. */
             CopyScreen(Log, Screen);
             RevertDialog_Draw(secondsLeft);
             lastSecondsDrawn = secondsLeft;
         }
     }
 
-    s_revertPending = false;
-
     LogPrintf("Res_Switch: revert dialog -> %s (target was %ux%u)\n",
               choice == RES_REVERT_KEEP ? "KEEP" : "REVERT",
               (unsigned)s_revertNewW, (unsigned)s_revertNewH);
 
+    /* Restore engine state regardless of choice. RestoreScreen drives a
+       full-screen AffScene(AFF_OBJETS_NO_FLIP) + BoxBlit so dirty-box
+       rendering picks up from a known-good frame on the next tick. */
+    RestoreScreen();
+    RestoreCamera();
+    RestoreTimer();
+
     if (choice == RES_REVERT_REVERT) {
-        /* Restoring to (prev) — recursive call into Res_Switch. The orchestrator
+        /* Recursive Res_Switch to the previous (W, H). The orchestrator
            handles the no-op case (already at prev W,H) cleanly. */
         Res_Switch(s_revertPrevW, s_revertPrevH);
     }

--- a/SOURCES/RES_SWITCH.CPP
+++ b/SOURCES/RES_SWITCH.CPP
@@ -7,17 +7,25 @@
 
 #include "C_EXTERN.H"
 #include "FLOW.H"
+#include "GAMEMENU.H"
 #include "INTEXT.H" /* CameraCenter */
 #include "PTRFUNC.H"
 
 #include <3D/CAMERA.H>
 #include <SVGA/CLIP.H>
+#include <SVGA/DIRTYBOX.H>
 #include <SVGA/SCREEN.H>
 #include <SVGA/VIDEO.H>
 #include <SYSTEM/LOGPRINT.H>
+#include <SYSTEM/STRING.H>
+#include <SYSTEM/TIMER.H>
 #include <SYSTEM/WINDOW.H>
+#include <SYSTEM/KEYBOARD_KEYS.H>
+
+#include "INPUT.H"
 
 #include <stdio.h>
+#include <string.h>
 
 /* Same validator the --resolution CLI uses (see CONTROL.CPP).  Kept local for
    now to avoid yet another shared header; if a third caller appears (the menu)
@@ -197,4 +205,169 @@ bool Res_Switch(U32 newW, U32 newH) {
                 (int)wasFullscreen, (int)isFullscreen);
     }
     return true;
+}
+
+/*══════════════════════════════════════════════════════════════════════════*
+ *   Safety gate                                                             *
+ *══════════════════════════════════════════════════════════════════════════*/
+
+const char *Res_SwitchAllowedReason(void) {
+    /* Refuse mid-cinematic: the Smacker decoder owns the framebuffer and
+       partial state would be lost. */
+    if (FlagPlayAcf)
+        return "Not now: a cinematic is playing — wait for it to finish.";
+    /* Refuse before the first scene loads. PtrInitGrille has nothing to
+       reload, and the engine isn't in a steady main-loop state yet. */
+    if (PtrScene == NULL || NumCube < 0)
+        return "Not now: no scene loaded yet.";
+    /* Holomap is *not* gated here despite the design doc listing it as a
+       safety gate — HoloMap() owns its own modal frame loop while open, so
+       MainLoop (and therefore Res_RunRevertDialogIfPending) doesn't tick
+       until the player closes it. Gating on HoloMode would be wrong: that's
+       0=Globe / 1=Plan, not an "open" sentinel. The genuine
+       holomap-is-active flag would need to be added in HOLOGLOB.CPP first;
+       deferred to the menu UX work in Phase 2. */
+    return NULL;
+}
+
+/*══════════════════════════════════════════════════════════════════════════*
+ *   Revert dialog                                                           *
+ *══════════════════════════════════════════════════════════════════════════*/
+
+/* The 15 s figure mirrors what modern OSes use for display-mode preview
+   ("revert if not confirmed"). Long enough to let the player realise the
+   new mode is unreadable; short enough that an unattended PC reverts soon. */
+#define RES_REVERT_TIMEOUT_MS 15000u
+#define RES_REVERT_TICK_MS 100u /* poll cadence inside the modal */
+
+static bool s_revertPending = false;
+static U32 s_revertPrevW = 0;
+static U32 s_revertPrevH = 0;
+static U32 s_revertNewW = 0; /* what the user picked (for the "now at" line) */
+static U32 s_revertNewH = 0;
+
+void Res_BeginRevertCountdown(U32 prevW, U32 prevH) {
+    s_revertPending = true;
+    s_revertPrevW = prevW;
+    s_revertPrevH = prevH;
+    s_revertNewW = ModeDesiredX;
+    s_revertNewH = ModeDesiredY;
+}
+
+bool Res_HasPendingRevert(void) {
+    return s_revertPending;
+}
+
+void Res_CancelPendingRevert(void) {
+    s_revertPending = false;
+}
+
+static void RevertDialog_Draw(U32 secondsLeft) {
+    /* Full-screen darken so the message reads cleanly against the just-
+       rendered scene without needing its own panel art. Same SCREEN_SHADE_LVL
+       (8) ShowSaveConfirmation uses for the in-game "Saved" box. */
+    ShadeBoxBlk(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, SCREEN_SHADE_LVL);
+
+    const S32 cx = (S32)ModeDesiredX / 2;
+    /* Five text lines, evenly spaced around the vertical centre. Spacing is
+       picked to match DrawSingleString's ~20px line height across the modes
+       we ship at. */
+    const S32 lineH = 28;
+    const S32 baseY = (S32)ModeDesiredY / 2 - 2 * lineH;
+
+    char buf[128];
+    char cp850[128];
+
+    /* "Resolution changed" */
+    CopyUtf8ToCp850(cp850, sizeof cp850, GetLocalizedResDialogLabel(RES_DIALOG_TITLE));
+    DrawSingleString(cx, baseY + 0 * lineH, cp850);
+
+    /* "Now running at WxH." */
+    snprintf(buf, sizeof buf, GetLocalizedResDialogLabel(RES_DIALOG_NOW_AT),
+             (unsigned)s_revertNewW, (unsigned)s_revertNewH);
+    CopyUtf8ToCp850(cp850, sizeof cp850, buf);
+    DrawSingleString(cx, baseY + 1 * lineH, cp850);
+
+    /* "Keep this resolution?" */
+    CopyUtf8ToCp850(cp850, sizeof cp850, GetLocalizedResDialogLabel(RES_DIALOG_KEEP_Q));
+    DrawSingleString(cx, baseY + 2 * lineH, cp850);
+
+    /* "[Y] Keep      [N] Revert" */
+    CopyUtf8ToCp850(cp850, sizeof cp850, GetLocalizedResDialogLabel(RES_DIALOG_KEEP_REVERT));
+    DrawSingleString(cx, baseY + 3 * lineH, cp850);
+
+    /* "Reverts automatically in Ns..." */
+    snprintf(buf, sizeof buf, GetLocalizedResDialogLabel(RES_DIALOG_REVERT_IN),
+             (int)secondsLeft);
+    CopyUtf8ToCp850(cp850, sizeof cp850, buf);
+    DrawSingleString(cx, baseY + 4 * lineH, cp850);
+
+    BoxStaticAdd(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1);
+    BoxStaticFullflip();
+}
+
+ResRevertChoice Res_RunRevertDialogIfPending(void) {
+    if (!s_revertPending)
+        return RES_REVERT_NONE;
+
+    /* Stash + restore Log so we don't permanently corrupt the post-dialog
+       frame with overlay pixels. Same shape as ShowSaveConfirmation. */
+    CopyScreen(Screen, Log);
+
+    ManageTime();
+    const U32 startMs = TimerRefHR;
+    const U32 endMs = startMs + RES_REVERT_TIMEOUT_MS;
+    ResRevertChoice choice = RES_REVERT_REVERT; /* default if we time out */
+    U32 lastSecondsDrawn = (U32)-1;
+
+    /* Drain stale input so a key still held from before doesn't immediately
+       pick a side. */
+    InitWaitNoKey();
+
+    while (TimerRefHR < endMs) {
+        /* Under --fixed-dt the harness pins time to the per-tick advance done
+           in Control_TickHook; ManageTime() called from a modal inner loop
+           would see the same virtual time forever and the dialog would never
+           time out. Timer_FixedDtPump() is the documented "non-presenting
+           wait loop owns every iteration's time" helper; it's a no-op in
+           normal (wall-clock) play, where ManageTime() already advances
+           TimerRefHR via SDL_GetTicks(). */
+        Timer_FixedDtPump();
+        ManageTime();
+        MyGetInput();
+
+        if (MyKey == K_Y || MyKey == K_O || MyKey == K_J || MyKey == K_S ||
+            MyKey == K_ENTER || MyKey == K_SPACE) {
+            choice = RES_REVERT_KEEP;
+            break;
+        }
+        if (MyKey == K_N || MyKey == K_ESC) {
+            choice = RES_REVERT_REVERT;
+            break;
+        }
+
+        const U32 remainingMs = endMs - TimerRefHR;
+        const U32 secondsLeft = (remainingMs + 999u) / 1000u;
+        if (secondsLeft != lastSecondsDrawn) {
+            /* Re-fill background each redraw so the previous countdown
+               digit doesn't leave ghost pixels. */
+            CopyScreen(Log, Screen);
+            RevertDialog_Draw(secondsLeft);
+            lastSecondsDrawn = secondsLeft;
+        }
+    }
+
+    s_revertPending = false;
+
+    LogPrintf("Res_Switch: revert dialog -> %s (target was %ux%u)\n",
+              choice == RES_REVERT_KEEP ? "KEEP" : "REVERT",
+              (unsigned)s_revertNewW, (unsigned)s_revertNewH);
+
+    if (choice == RES_REVERT_REVERT) {
+        /* Restoring to (prev) — recursive call into Res_Switch. The orchestrator
+           handles the no-op case (already at prev W,H) cleanly. */
+        Res_Switch(s_revertPrevW, s_revertPrevH);
+    }
+
+    return choice;
 }

--- a/SOURCES/RES_SWITCH.H
+++ b/SOURCES/RES_SWITCH.H
@@ -24,6 +24,39 @@ extern "C" {
    and the previous resolution had to be restored. */
 bool Res_Switch(U32 newW, U32 newH);
 
+/* Safety gate. Returns NULL if it's safe to call Res_Switch right now, else
+   a short user-facing reason string. Refuses while a cinematic is playing
+   (FlagPlayAcf), no scene is loaded, or the holomap is open (HoloMode). The
+   string is a static literal — do not free. */
+const char *Res_SwitchAllowedReason(void);
+
+/* Begin the keep-or-revert countdown after a successful Res_Switch. The
+   modal pops up on the next MainLoop tick via Res_RunRevertDialogIfPending().
+   Caller is responsible for closing the console (or any other layer) that
+   would otherwise occlude the modal. (prevW, prevH) is what gets restored
+   on Revert or timeout. */
+void Res_BeginRevertCountdown(U32 prevW, U32 prevH);
+
+/* Returns true if a revert dialog is pending (caller about to draw should
+   defer to the modal). */
+bool Res_HasPendingRevert(void);
+
+/* Run the revert modal if one is pending; otherwise no-op. Called from the
+   top of MainLoop. Drives its own tick loop (ManageTime + MyGetInput) until
+   the user picks Keep/Revert or the timeout expires; on Revert calls
+   Res_Switch back to (prevW, prevH). Returns the choice the user made
+   (RES_REVERT_NONE if no dialog was pending). */
+typedef enum {
+    RES_REVERT_NONE = 0,
+    RES_REVERT_KEEP,
+    RES_REVERT_REVERT
+} ResRevertChoice;
+ResRevertChoice Res_RunRevertDialogIfPending(void);
+
+/* Cancel any pending revert (e.g. on game state change that would make the
+   dialog stale). Idempotent; no-op when nothing is pending. */
+void Res_CancelPendingRevert(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/automation/test_res_switch_dialog.sh
+++ b/tests/automation/test_res_switch_dialog.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Revert dialog: the keep/revert modal that appears after every successful
+# `resolution` console verb (per docs/RUNTIME_RESOLUTION.md). Verifies the
+# 15 s timeout path — without any Y/N input the dialog must time out and
+# fire the orchestrator a second time to restore the previous resolution.
+#
+# Under --fixed-dt the dialog's TimerRefHR-based countdown is pumped by
+# Timer_FixedDtPump() once per modal iteration, so the 15 s timeout maps
+# to ~938 modal iterations rather than 15 wall-clock seconds.
+TESTNAME=res_switch_dialog
+. "$(dirname "$0")/lib.sh"
+precheck
+need_save
+
+out="$(mktemp)"
+trap 'rm -f "$out"' EXIT
+
+# Switch to 768x480 via console; no input means the dialog times out and
+# reverts to 640x480. Both the forward switch and the auto-revert must log.
+ctl_headless --load "$LBA2_TEST_SAVE" \
+    --exec "resolution 768x480" \
+    --fixed-dt 16 --tick 1500 --exit >"$out" 2>&1 \
+    || fail "exit code $? from forward+revert run (engine hung or crashed)"
+
+# Forward switch.
+grep -q "Res_Switch: 640x480 -> 768x480 OK" "$out" \
+    || fail "forward switch did not fire (no 'Res_Switch: 640x480 -> 768x480 OK')"
+
+# Dialog returned REVERT after the timeout.
+grep -q "Res_Switch: revert dialog -> REVERT" "$out" \
+    || fail "revert dialog did not time out (no 'revert dialog -> REVERT')"
+
+# Auto-revert orchestrator fire restoring the previous mode.
+grep -q "Res_Switch: 768x480 -> 640x480 OK" "$out" \
+    || fail "auto-revert switch did not fire (no 'Res_Switch: 768x480 -> 640x480 OK')"
+
+# Console verb still echoes success ("Resolution: ...") before the dialog
+# fires — confirms cmd_resolution ran cleanly.
+grep -q "^\[control\] Resolution: 768x480" "$out" \
+    || fail "missing 'Resolution: 768x480' console echo"
+
+pass "forward switch -> 15s timeout -> auto-revert chain works end-to-end"


### PR DESCRIPTION
**Stacked on [#239](https://github.com/LBALab/lba2-classic-community/pull/239) (which is stacked on #238 → #237).** Last slice of Phase 0 from [`docs/RUNTIME_RESOLUTION.md`](docs/RUNTIME_RESOLUTION.md).

Adds the safety gate predicate and the deferred-modal keep/revert dialog the doc's UX mockup describes:

```
┌── Resolution changed ──────────────┐
│ Now running at 1280x720.           │
│ Keep this resolution?              │
│ [Y] Keep      [N] Revert           │
│ Reverts automatically in 12s...    │
└────────────────────────────────────┘
```

## Approach: reuse existing modal building blocks

After surveying the engine, the closest existing pattern was `ShowSaveConfirmation()` in `GAMEMENU.CPP` — a `ShadeBoxBlk` darken + `DrawSingleString` + timer-driven poll loop. The dialog here reuses:

- `ShadeBoxBlk(0, 0, ModeDesiredX-1, ModeDesiredY-1, SCREEN_SHADE_LVL)` — full-screen darken
- `DrawSingleString(cx, y, msg)` — centred text, called 5 times for the 5 dialog lines
- `BoxStaticAdd / BoxStaticFullflip` — dirty-box present
- `LocalizedMenuLabels[6][MENU_LABEL_COUNT]` — the in-source 6-language UI string table (added 5 new `MENU_LABEL_RES_*` entries for EN/FR/DE/SP/IT/PO)
- `CopyUtf8ToCp850` + `GetLocalizedMenuLabel` — same path the rest of GAMEMENU uses
- `ManageTime` + `MyGetInput` + `MyKey` + `TimerRefHR` — the engine's standard modal-loop primitives

A tight-scope helper `GetLocalizedResDialogLabel()` exposes the 5 labels to RES_SWITCH without leaking the full menu label enum publicly.

## Architecture: deferred modal flag

`cmd_resolution` doesn't run the dialog inline — that'd fight with console state. Instead:

```
cmd_resolution -> res_do_switch()
    ├─> Res_SwitchAllowedReason()  // refuse with reason if non-NULL
    ├─> Res_Switch(newW, newH)
    └─> Res_BeginRevertCountdown(prevW, prevH) + Console_Close()

PERSO.CPP MainLoop (top of each tick)
    └─> Res_RunRevertDialogIfPending()
            ├─> ShadeBoxBlk + DrawSingleString x5 (countdown updates each second)
            ├─> ManageTime + MyGetInput
            └─> on REVERT or timeout: Res_Switch(prevW, prevH)
```

The flag also unlocks a future menu-driven path — same `Res_BeginRevertCountdown` call from `GAMEMENU.CPP`, same modal runs.

## Safety gate

`Res_SwitchAllowedReason()` refuses with a user-facing string when:

- `FlagPlayAcf` → "Not now: a cinematic is playing — wait for it to finish."
- `!PtrScene || NumCube < 0` → "Not now: no scene loaded yet."

The holomap case the design doc lists is **not** gated here. `HoloMap()` owns its own modal frame loop while open, so `MainLoop` doesn't tick until the player closes it. And `HoloMode` is `0=Globe / 1=Plan` — not an "open" sentinel; gating on it would always fire. A proper flag would need to be added in `HOLOGLOB.CPP` first; deferred to Phase 2.

## Keys

- **Keep**: Y, O (oui), J (ja), S (sí/sì/sim), Enter, Space
- **Revert**: N, Esc
- **Timeout** (15 s no input): Revert

## --fixed-dt interaction

The 15 s countdown uses `TimerRefHR`, which under `--fixed-dt` doesn't advance from a modal inner loop unless something pumps the virtual clock. `Timer_FixedDtPump()` is the engine's documented helper for "non-presenting wait loop owns every iteration's time" — calling it once per modal iter advances time as fast as the loop runs (so the harness test runs ~1 s of wall time, not 15). No-op under normal wall-clock play.

## Test coverage

`tests/automation/test_res_switch_dialog.sh` asserts the forward-switch → timeout → auto-revert chain end-to-end:

```
[control] Resolution: 768x480
Res_Switch: 640x480 -> 768x480 OK (fullscreen 0 -> 0)
Res_Switch: revert dialog -> REVERT (target was 768x480)
Res_Switch: 768x480 -> 640x480 OK (fullscreen 0 -> 0)
```

All three previous tests in the stack still pass — `test_res_switch`, `test_res_switch_console`, plus the existing 8 `ui_*` goldens and the 12/12 host suite.

Y/N/Esc key handling is verified manually (the harness has no programmatic way to inject a keypress mid-modal); a future PR could add a `--res-revert-choice {keep|revert}` flag if we want to automate it.

## Manual verification

Live-typed `resolution 768x480` in console:
- Dialog appears with full text in English (also tried `--language Français` — French strings render correctly)
- Y / Enter / Space / O / J / S → Keep
- N / Esc → Revert (immediate switch back)
- No input for 15 s → timeout → Revert
- Fullscreen toggle survives across switch + revert

## Stacking

| PR | Status | What |
|---|---|---|
| [#237](https://github.com/LBALab/lba2-classic-community/pull/237) | draft | Teardown primitives |
| [#238](https://github.com/LBALab/lba2-classic-community/pull/238) | draft | `Res_Switch` orchestrator + resize-not-recreate |
| [#239](https://github.com/LBALab/lba2-classic-community/pull/239) | draft | `cmd_resolution` console verb |
| **This** | draft | Safety gate + keep/revert dialog (Phase 0 done) |

Phase 1 (boot-path consolidation), Phase 2 (Display options submenu), and Phase 3 (music continuity / cfg persistence) are the doc's follow-ups — separate PRs.