### PR TITLE
feat(reso): polish revert dialog — panel + plasma buttons + flicker fix

### DIFF
--- a/LIB386/SYSTEM/WINDOW.CPP
+++ b/LIB386/SYSTEM/WINDOW.CPP
@@ -54,17 +54,31 @@ static void ComputePresentationRect(SDL_FRect *dstRect) {
     const double surfaceAspect = (double)windowSurfaceResX / (double)windowSurfaceResY;
     const double outputAspect = (double)outputW / (double)outputH;
 
+    /* Compute as ints then promote to float. SDL_FRect + NEAREST sample mode
+       can shift the rasterised output by 1 px frame-to-frame if the dst
+       coordinates carry sub-pixel components and the window size jitters
+       slightly (Wayland compositors do this during resize settle, even
+       when the framebuffer is steady). Rounding to whole pixels here pins
+       the present rect so a still framebuffer presents identically every
+       frame — fixes a visible flicker on the runtime-resolution-switch
+       modal at non-native (non-1:1) display modes. The tiny aspect drift
+       this introduces (< 1 px in one dimension) is invisible. */
+    int dstW, dstH, dstX, dstY;
     if (outputAspect > surfaceAspect) {
-        dstRect->h = (float)outputH;
-        dstRect->w = (float)(dstRect->h * surfaceAspect);
-        dstRect->x = ((float)outputW - dstRect->w) * 0.5f;
-        dstRect->y = 0.0f;
+        dstH = outputH;
+        dstW = (int)(dstH * surfaceAspect + 0.5);
+        dstX = (outputW - dstW) / 2;
+        dstY = 0;
     } else {
-        dstRect->w = (float)outputW;
-        dstRect->h = (float)(dstRect->w / surfaceAspect);
-        dstRect->x = 0.0f;
-        dstRect->y = ((float)outputH - dstRect->h) * 0.5f;
+        dstW = outputW;
+        dstH = (int)(dstW / surfaceAspect + 0.5);
+        dstX = 0;
+        dstY = (outputH - dstH) / 2;
     }
+    dstRect->x = (float)dstX;
+    dstRect->y = (float)dstY;
+    dstRect->w = (float)dstW;
+    dstRect->h = (float)dstH;
 }
 
 static void PresentCurrentTexture() {

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -296,8 +296,8 @@ enum MenuLocalizedLabel {
     MENU_LABEL_RES_TITLE,
     MENU_LABEL_RES_NOW_AT,
     MENU_LABEL_RES_KEEP_Q,
-    MENU_LABEL_RES_KEEP_REVERT,
-    MENU_LABEL_RES_REVERT_IN,
+    MENU_LABEL_RES_BTN_KEEP,
+    MENU_LABEL_RES_BTN_REVERT_FMT,
     MENU_LABEL_COUNT,
 };
 
@@ -318,8 +318,8 @@ static const char *LocalizedMenuLabels[6][MENU_LABEL_COUNT] = {
         "Resolution changed",
         "Now running at %ux%u.",
         "Keep this resolution?",
-        "[Y] Keep      [N] Revert",
-        "Reverts automatically in %ds...",
+        "Keep",
+        "Revert (%d)",
     },
     {
         "Choix de la langue",
@@ -337,8 +337,8 @@ static const char *LocalizedMenuLabels[6][MENU_LABEL_COUNT] = {
         "Résolution modifiée",
         "Affichage en %ux%u.",
         "Conserver cette résolution ?",
-        "[O] Conserver   [N] Annuler",
-        "Annulation automatique dans %ds...",
+        "Conserver",
+        "Annuler (%d)",
     },
     {
         "Sprachauswahl",
@@ -356,8 +356,8 @@ static const char *LocalizedMenuLabels[6][MENU_LABEL_COUNT] = {
         "Auflösung geändert",
         "Läuft jetzt mit %ux%u.",
         "Diese Auflösung beibehalten?",
-        "[J] Beibehalten   [N] Zurück",
-        "Automatischer Wechsel zurück in %ds...",
+        "Beibehalten",
+        "Zurück (%d)",
     },
     {
         "Elegir idioma",
@@ -375,8 +375,8 @@ static const char *LocalizedMenuLabels[6][MENU_LABEL_COUNT] = {
         "Resolución cambiada",
         "Funcionando a %ux%u.",
         "¿Mantener esta resolución?",
-        "[S] Mantener   [N] Revertir",
-        "Se revertirá automáticamente en %ds...",
+        "Mantener",
+        "Revertir (%d)",
     },
     {
         "Scegli lingua",
@@ -394,8 +394,8 @@ static const char *LocalizedMenuLabels[6][MENU_LABEL_COUNT] = {
         "Risoluzione modificata",
         "In esecuzione a %ux%u.",
         "Mantenere questa risoluzione?",
-        "[S] Mantieni   [N] Annulla",
-        "Annullamento automatico tra %ds...",
+        "Mantieni",
+        "Annulla (%d)",
     },
     {
         "Escolha do idioma",
@@ -413,8 +413,8 @@ static const char *LocalizedMenuLabels[6][MENU_LABEL_COUNT] = {
         "Resolução alterada",
         "Em execução a %ux%u.",
         "Manter esta resolução?",
-        "[S] Manter   [N] Reverter",
-        "Reversão automática em %ds...",
+        "Manter",
+        "Reverter (%d)",
     },
 };
 
@@ -441,8 +441,8 @@ const char *GetLocalizedResDialogLabel(int which) {
         MENU_LABEL_RES_TITLE,
         MENU_LABEL_RES_NOW_AT,
         MENU_LABEL_RES_KEEP_Q,
-        MENU_LABEL_RES_KEEP_REVERT,
-        MENU_LABEL_RES_REVERT_IN,
+        MENU_LABEL_RES_BTN_KEEP,
+        MENU_LABEL_RES_BTN_REVERT_FMT,
     };
     if (which < 0 || which >= (int)RES_DIALOG_LABEL_COUNT)
         return "";

--- a/SOURCES/GAMEMENU.H
+++ b/SOURCES/GAMEMENU.H
@@ -128,11 +128,11 @@ extern void Introduction(void);
    GAMEMENU's other UI text uses; format-string entries have %u/%d args
    that the caller fills in via snprintf. */
 enum ResDialogLabel {
-    RES_DIALOG_TITLE = 0,   /* "Resolution changed" */
-    RES_DIALOG_NOW_AT,      /* "Now running at %ux%u." */
-    RES_DIALOG_KEEP_Q,      /* "Keep this resolution?" */
-    RES_DIALOG_KEEP_REVERT, /* "[Y] Keep      [N] Revert" */
-    RES_DIALOG_REVERT_IN,   /* "Reverts automatically in %ds..." */
+    RES_DIALOG_TITLE = 0,      /* "Resolution changed" */
+    RES_DIALOG_NOW_AT,         /* "Now running at %ux%u." */
+    RES_DIALOG_KEEP_Q,         /* "Keep this resolution?" */
+    RES_DIALOG_BTN_KEEP,       /* "Keep" — right button label (no countdown) */
+    RES_DIALOG_BTN_REVERT_FMT, /* "Revert (%d)" — left button label, %d = seconds left */
     RES_DIALOG_LABEL_COUNT
 };
 extern const char *GetLocalizedResDialogLabel(int which);

--- a/SOURCES/RES_SWITCH.CPP
+++ b/SOURCES/RES_SWITCH.CPP
@@ -341,8 +341,12 @@ static void RevertDialog_Draw(ResDialogBtn focused, U32 secondsLeft) {
         RevertDialog_ButtonRect((ResDialogBtn)b, &bx0, &by0, &bx1, &by1);
 
         if (focused == (ResDialogBtn)b) {
-            /* Inset 2px so the cadre border stays clean over the fire. */
-            DrawFireBar(bx0 + 2, by0 + 2, bx1 - 2, by1 - 2, FIRE_SELECT_MENU);
+            /* Full-rect plasma, no inset — matches DrawOneString in
+               GAMEMENU.CPP which paints DrawFire over the entire menu-item
+               rect and lets the cadre draw on top. Insetting the plasma
+               leaves a gap between the fire and the cadre that visually
+               misaligns (the "doesn't perfectly line up" observation). */
+            DrawFireBar(bx0, by0, bx1, by1, FIRE_SELECT_MENU);
         }
         DrawCadre(bx0, by0, bx1, by1, ALL_ANGLES);
 
@@ -355,14 +359,15 @@ static void RevertDialog_Draw(ResDialogBtn focused, U32 secondsLeft) {
                      GetLocalizedResDialogLabel(RES_DIALOG_BTN_KEEP));
         }
         CopyUtf8ToCp850(cp850, sizeof cp850, buf);
-        /* DrawSingleString draws Font(..., y - 18, ...) — its y argument is
-           calibrated for HAUTEUR_STANDARD (50) menu items, where the text
-           sits in the upper portion of the box. For our shorter (42 px)
-           button, the glyph centre at the button centre needs the call's
-           y to be button_center + 10 (so Font's y - 18 lands the glyph
-           top 8 px above the button's vertical centre, which centres a
-           ~16 px-tall glyph). */
-        DrawSingleString((bx0 + bx1) / 2, (by0 + by1) / 2 + 10, cp850);
+        /* Pass the button vertical centre directly to DrawSingleString.
+           Its internal Font(..., y - 18, ...) is calibrated for the
+           engine's HAUTEUR_STANDARD=50 menu items, but the *visible*
+           glyph centre lands very close to the y arg in practice (as
+           ShowSaveConfirmation relies on when it passes the screen
+           centre for the "Game saved" splash). Earlier attempts at -8
+           and +10 were both wrong (text above / below) — passing the
+           plain centre is what looks right. */
+        DrawSingleString((bx0 + bx1) / 2, (by0 + by1) / 2, cp850);
     }
 
     /* Mark only the panel rect dirty — the screen-wide darken + scene

--- a/SOURCES/RES_SWITCH.CPP
+++ b/SOURCES/RES_SWITCH.CPP
@@ -355,9 +355,14 @@ static void RevertDialog_Draw(ResDialogBtn focused, U32 secondsLeft) {
                      GetLocalizedResDialogLabel(RES_DIALOG_BTN_KEEP));
         }
         CopyUtf8ToCp850(cp850, sizeof cp850, buf);
-        /* Glyph centre at button centre; DrawSingleString uses y as the
-           top of the text raster, so -8 lifts it onto the centre line. */
-        DrawSingleString((bx0 + bx1) / 2, (by0 + by1) / 2 - 8, cp850);
+        /* DrawSingleString draws Font(..., y - 18, ...) — its y argument is
+           calibrated for HAUTEUR_STANDARD (50) menu items, where the text
+           sits in the upper portion of the box. For our shorter (42 px)
+           button, the glyph centre at the button centre needs the call's
+           y to be button_center + 10 (so Font's y - 18 lands the glyph
+           top 8 px above the button's vertical centre, which centres a
+           ~16 px-tall glyph). */
+        DrawSingleString((bx0 + bx1) / 2, (by0 + by1) / 2 + 10, cp850);
     }
 
     /* Mark only the panel rect dirty — the screen-wide darken + scene
@@ -470,9 +475,13 @@ ResRevertChoice Res_RunRevertDialogIfPending(void) {
         const U32 secondsLeft = (remainingMs + 999u) / 1000u;
 
         /* Per-frame redraw so the plasma animates smoothly. DoTextureAnimation
-           advances the fire texture state; CopyScreen restores the captured
-           background before we paint the panel over it. */
-        CopyScreen(Log, Screen);
+           advances the fire texture state; CopyScreen restores Log from the
+           Screen backup so the modal paints over a clean copy of the
+           captured scene (instead of compounding the per-frame ShadeBoxBlk
+           darken on top of the previous frame's already-darkened pixels —
+           which manifested as a flickering / progressively-black panel
+           before this fix). CopyScreen(src, dst) — direction matters. */
+        CopyScreen(Screen, Log);
         DoTextureAnimation();
         RevertDialog_Draw(focused, secondsLeft);
     }

--- a/SOURCES/RES_SWITCH.CPP
+++ b/SOURCES/RES_SWITCH.CPP
@@ -265,10 +265,12 @@ void Res_CancelPendingRevert(void) {
 }
 
 /* Panel geometry — fixed physical size, vertically stacked buttons.
-   580x240 fits the LargeurMenu (550) wide DrawOneString buttons with
-   margin, plus 3 text lines above. */
+   580×252 fits the LargeurMenu (550) wide DrawOneString buttons with
+   matching top/bottom padding (~17 px each — the top padding is
+   determined by Font's y-18 offset, the bottom is panel height minus
+   the second button's bottom edge). */
 #define RES_DIALOG_PANEL_W 580
-#define RES_DIALOG_PANEL_H 240
+#define RES_DIALOG_PANEL_H 252
 
 typedef enum {
     RES_BTN_REVERT = 0, /* top — default focus, carries the countdown */

--- a/SOURCES/RES_SWITCH.CPP
+++ b/SOURCES/RES_SWITCH.CPP
@@ -341,12 +341,16 @@ static void RevertDialog_Draw(ResDialogBtn focused, U32 secondsLeft) {
         RevertDialog_ButtonRect((ResDialogBtn)b, &bx0, &by0, &bx1, &by1);
 
         if (focused == (ResDialogBtn)b) {
-            /* Full-rect plasma, no inset — matches DrawOneString in
-               GAMEMENU.CPP which paints DrawFire over the entire menu-item
-               rect and lets the cadre draw on top. Insetting the plasma
-               leaves a gap between the fire and the cadre that visually
-               misaligns (the "doesn't perfectly line up" observation). */
-            DrawFireBar(bx0, by0, bx1, by1, FIRE_SELECT_MENU);
+            /* DrawCadre(ALL_ANGLES) chamfers each corner with a 5-pixel
+               diagonal (see DrawAngles in INVENT.CPP). A full-rect
+               DrawFireBar leaves the chamfered corner triangles filled
+               with plasma OUTSIDE the visible cadre line — barely
+               noticeable on the engine's 550x50 menu items but very
+               visible on our 170x42 buttons. Inset by 4 (just inside
+               the chamfer) so the plasma matches the cadre's visible
+               interior. The remaining 1-px halo is invisible at all
+               supported scales. */
+            DrawFireBar(bx0 + 4, by0 + 4, bx1 - 4, by1 - 4, FIRE_SELECT_MENU);
         }
         DrawCadre(bx0, by0, bx1, by1, ALL_ANGLES);
 

--- a/SOURCES/RES_SWITCH.CPP
+++ b/SOURCES/RES_SWITCH.CPP
@@ -264,18 +264,15 @@ void Res_CancelPendingRevert(void) {
     s_revertPending = false;
 }
 
-/* Panel + button geometry — fixed physical size, centred for any resolution.
-   The 520x220 panel comfortably fits 3 text lines + 2 buttons at the engine's
-   ~16px font height with breathing room. */
-#define RES_DIALOG_PANEL_W 520
-#define RES_DIALOG_PANEL_H 220
-#define RES_DIALOG_BTN_W 170
-#define RES_DIALOG_BTN_H 42
-#define RES_DIALOG_BTN_GAP 30
+/* Panel geometry — fixed physical size, vertically stacked buttons.
+   580x240 fits the LargeurMenu (550) wide DrawOneString buttons with
+   margin, plus 3 text lines above. */
+#define RES_DIALOG_PANEL_W 580
+#define RES_DIALOG_PANEL_H 240
 
 typedef enum {
-    RES_BTN_REVERT = 0, /* left, default focus (matches Windows/macOS/Steam) */
-    RES_BTN_KEEP = 1    /* right */
+    RES_BTN_REVERT = 0, /* top — default focus, carries the countdown */
+    RES_BTN_KEEP = 1    /* bottom */
 } ResDialogBtn;
 
 static void RevertDialog_PanelRect(S32 *x0, S32 *y0, S32 *x1, S32 *y1) {
@@ -287,25 +284,28 @@ static void RevertDialog_PanelRect(S32 *x0, S32 *y0, S32 *x1, S32 *y1) {
     *y1 = *y0 + RES_DIALOG_PANEL_H - 1;
 }
 
-static void RevertDialog_ButtonRect(ResDialogBtn b, S32 *bx0, S32 *by0, S32 *bx1, S32 *by1) {
-    const S32 cx = (S32)ModeDesiredX / 2;
-    S32 px0, py0, px1, py1;
-    RevertDialog_PanelRect(&px0, &py0, &px1, &py1);
-    const S32 by_top = py1 - 33 - RES_DIALOG_BTN_H + 1; /* 33px bottom margin */
-    if (b == RES_BTN_REVERT) {
-        *bx0 = cx - RES_DIALOG_BTN_GAP / 2 - RES_DIALOG_BTN_W;
-    } else {
-        *bx0 = cx + RES_DIALOG_BTN_GAP / 2;
-    }
-    *bx1 = *bx0 + RES_DIALOG_BTN_W - 1;
-    *by0 = by_top;
-    *by1 = by_top + RES_DIALOG_BTN_H - 1;
+/* Draws a horizontally-centred string at the engine's standard text-in-
+   menu-item offset. Mirrors DrawSingleString's drop-shadow + colour, but
+   omits the BoxUpdate present — caller batches via BoxStaticFullflip so
+   the modal doesn't trigger multiple presents per redraw. */
+static void RevertDialog_DrawCenteredText(S32 cx, S32 y, const char *utf8) {
+    char cp850[128];
+    CopyUtf8ToCp850(cp850, sizeof cp850, utf8);
+    S32 sf = SizeFont(cp850);
+    /* Drop shadow + main text — same colours and (+4, +4) shadow offset as
+       DrawSingleString. Using LBAWHITE directly instead of CoulTextMenu
+       (which isn't declared extern in GAMEMENU.H) — LBAWHITE is the default
+       menu text colour, only swapped to "disabled" grey in places we're not
+       touching. */
+    ColorFont(BLACK);
+    Font(cx - sf / 2 + 4, y - 18 + 4, cp850);
+    ColorFont(LBAWHITE);
+    Font(cx - sf / 2, y - 18, cp850);
 }
 
-/* Renders the whole modal — panel + 3 text lines + 2 buttons + plasma on the
-   focused button — into Log.  Caller is responsible for first restoring the
-   background (CopyScreen Log<-Screen) and presenting (BoxStaticFullflip)
-   after this returns. */
+/* Renders the whole modal into Log. Caller restores the background
+   (CopyScreen Screen->Log) before this runs and presents after via
+   BoxStaticFullflip. */
 static void RevertDialog_Draw(ResDialogBtn focused, U32 secondsLeft) {
     /* Whole-screen darken so the panel reads on any underlying scene. */
     ShadeBoxBlk(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, SCREEN_SHADE_LVL);
@@ -320,63 +320,45 @@ static void RevertDialog_Draw(ResDialogBtn focused, U32 secondsLeft) {
 
     const S32 cx = (S32)ModeDesiredX / 2;
     char buf[128];
-    char cp850[128];
 
-    /* Three text lines, top-aligned within the panel. */
-    CopyUtf8ToCp850(cp850, sizeof cp850, GetLocalizedResDialogLabel(RES_DIALOG_TITLE));
-    DrawSingleString(cx, py0 + 30, cp850);
+    /* Three text lines using direct Font calls (no per-call BoxUpdate). */
+    RevertDialog_DrawCenteredText(cx, py0 + 35,
+                                  GetLocalizedResDialogLabel(RES_DIALOG_TITLE));
 
     snprintf(buf, sizeof buf, GetLocalizedResDialogLabel(RES_DIALOG_NOW_AT),
              (unsigned)s_revertNewW, (unsigned)s_revertNewH);
-    CopyUtf8ToCp850(cp850, sizeof cp850, buf);
-    DrawSingleString(cx, py0 + 65, cp850);
+    RevertDialog_DrawCenteredText(cx, py0 + 68, buf);
 
-    CopyUtf8ToCp850(cp850, sizeof cp850, GetLocalizedResDialogLabel(RES_DIALOG_KEEP_Q));
-    DrawSingleString(cx, py0 + 105, cp850);
+    RevertDialog_DrawCenteredText(cx, py0 + 100,
+                                  GetLocalizedResDialogLabel(RES_DIALOG_KEEP_Q));
 
-    /* Two buttons side-by-side. Plasma highlight on the focused one
-       (drawn first so the cadre border sits on top of the fire). */
-    for (int b = 0; b < 2; b++) {
-        S32 bx0, by0, bx1, by1;
-        RevertDialog_ButtonRect((ResDialogBtn)b, &bx0, &by0, &bx1, &by1);
+    /* Two buttons stacked vertically via DrawOneString — the engine's
+       standard menu-item painter (same one MainGameMenu / OptionsMenu
+       use). Handles cadre, shading, optional plasma (draw == 1), and
+       text at the engine's calibrated y-18 offset, all matching the
+       rest of the game pixel-for-pixel. LargeurMenu (550) wide ×
+       HAUTEUR_STANDARD (50) tall, centred horizontally at cx. */
+    char cp850_revert[64], cp850_keep[64];
+    snprintf(buf, sizeof buf,
+             GetLocalizedResDialogLabel(RES_DIALOG_BTN_REVERT_FMT),
+             (int)secondsLeft);
+    CopyUtf8ToCp850(cp850_revert, sizeof cp850_revert, buf);
+    snprintf(buf, sizeof buf, "%s",
+             GetLocalizedResDialogLabel(RES_DIALOG_BTN_KEEP));
+    CopyUtf8ToCp850(cp850_keep, sizeof cp850_keep, buf);
 
-        if (focused == (ResDialogBtn)b) {
-            /* DrawCadre(ALL_ANGLES) chamfers each corner with a 5-pixel
-               diagonal (see DrawAngles in INVENT.CPP). A full-rect
-               DrawFireBar leaves the chamfered corner triangles filled
-               with plasma OUTSIDE the visible cadre line — barely
-               noticeable on the engine's 550x50 menu items but very
-               visible on our 170x42 buttons. Inset by 4 (just inside
-               the chamfer) so the plasma matches the cadre's visible
-               interior. The remaining 1-px halo is invisible at all
-               supported scales. */
-            DrawFireBar(bx0 + 4, by0 + 4, bx1 - 4, by1 - 4, FIRE_SELECT_MENU);
-        }
-        DrawCadre(bx0, by0, bx1, by1, ALL_ANGLES);
+    const S32 btn_revert_y = py0 + 150;
+    const S32 btn_keep_y = py0 + 210;
 
-        if (b == RES_BTN_REVERT) {
-            snprintf(buf, sizeof buf,
-                     GetLocalizedResDialogLabel(RES_DIALOG_BTN_REVERT_FMT),
-                     (int)secondsLeft);
-        } else {
-            snprintf(buf, sizeof buf, "%s",
-                     GetLocalizedResDialogLabel(RES_DIALOG_BTN_KEEP));
-        }
-        CopyUtf8ToCp850(cp850, sizeof cp850, buf);
-        /* Pass the button vertical centre directly to DrawSingleString.
-           Its internal Font(..., y - 18, ...) is calibrated for the
-           engine's HAUTEUR_STANDARD=50 menu items, but the *visible*
-           glyph centre lands very close to the y arg in practice (as
-           ShowSaveConfirmation relies on when it passes the screen
-           centre for the "Game saved" splash). Earlier attempts at -8
-           and +10 were both wrong (text above / below) — passing the
-           plain centre is what looks right. */
-        DrawSingleString((bx0 + bx1) / 2, (by0 + by1) / 2, cp850);
-    }
+    DrawOneString(cx, btn_revert_y, cp850_revert,
+                  focused == RES_BTN_REVERT ? 1 : 0);
+    DrawOneString(cx, btn_keep_y, cp850_keep,
+                  focused == RES_BTN_KEEP ? 1 : 0);
 
-    /* Mark only the panel rect dirty — the screen-wide darken + scene
-       backup behind it are static for the modal's lifetime, so per-frame
-       redraw doesn't have to walk the whole framebuffer. */
+    /* DrawOneString accumulates dirty rects via BoxStaticAdd but doesn't
+       present. Mark the panel + small margin too (for the cadre border
+       and text drop-shadow that extend slightly outside the buttons)
+       and flip once for the whole modal. */
     BoxStaticAdd(px0 - 1, py0 - 1, px1 + 1, py1 + 1);
     BoxStaticFullflip();
 }
@@ -438,7 +420,7 @@ ResRevertChoice Res_RunRevertDialogIfPending(void) {
     /* Drain stale input so a key still held from before doesn't immediately
        pick a side or toggle focus. */
     InitWaitNoKey();
-    InitWaitNoInput(I_FIRE | I_ACTION | I_MENUS | I_LEFT | I_RIGHT);
+    InitWaitNoInput(I_FIRE | I_ACTION | I_MENUS | I_UP | I_DOWN);
 
     while (TimerRefHR < endMs) {
         /* Under --fixed-dt the harness pins time to the per-tick advance done
@@ -452,12 +434,13 @@ ResRevertChoice Res_RunRevertDialogIfPending(void) {
         ManageTime();
         MyGetInput();
 
-        /* Directional input (D-pad on gamepad, arrow keys on keyboard, or
-           the steering keys via the engine's input remap) toggles focus
-           between the two buttons. */
-        if (Input & I_LEFT)
+        /* Directional input toggles focus between the two stacked buttons.
+           UP / DOWN matches the rest of the engine's menus (NPC choice
+           menus, options menu, save list — all vertical stacks navigated
+           with the same keys, on both keyboard and gamepad). */
+        if (Input & I_UP)
             focused = RES_BTN_REVERT;
-        if (Input & I_RIGHT)
+        if (Input & I_DOWN)
             focused = RES_BTN_KEEP;
 
         /* Confirm selected. I_FIRE covers the action / inventory / return /

--- a/SOURCES/RES_SWITCH.CPP
+++ b/SOURCES/RES_SWITCH.CPP
@@ -5,11 +5,12 @@
 
 #include "RES_SWITCH.H"
 
+#include "ANIMTEX.H" /* InitPlasmaMenu, DoTextureAnimation (plasma fire bar) */
 #include "C_EXTERN.H"
 #include "FLOW.H"
 #include "GAMEMENU.H"
 #include "INTEXT.H" /* CameraCenter, SaveCamera / RestoreCamera */
-#include "INVENT.H" /* BackupScreen / RestoreScreen */
+#include "INVENT.H" /* BackupScreen / RestoreScreen / DrawCadre / ALL_ANGLES */
 #include "PTRFUNC.H"
 
 #include <3D/CAMERA.H>
@@ -263,47 +264,106 @@ void Res_CancelPendingRevert(void) {
     s_revertPending = false;
 }
 
-static void RevertDialog_Draw(U32 secondsLeft) {
-    /* Full-screen darken so the message reads cleanly against the just-
-       rendered scene without needing its own panel art. Same SCREEN_SHADE_LVL
-       (8) ShowSaveConfirmation uses for the in-game "Saved" box. */
+/* Panel + button geometry — fixed physical size, centred for any resolution.
+   The 520x220 panel comfortably fits 3 text lines + 2 buttons at the engine's
+   ~16px font height with breathing room. */
+#define RES_DIALOG_PANEL_W 520
+#define RES_DIALOG_PANEL_H 220
+#define RES_DIALOG_BTN_W 170
+#define RES_DIALOG_BTN_H 42
+#define RES_DIALOG_BTN_GAP 30
+
+typedef enum {
+    RES_BTN_REVERT = 0, /* left, default focus (matches Windows/macOS/Steam) */
+    RES_BTN_KEEP = 1    /* right */
+} ResDialogBtn;
+
+static void RevertDialog_PanelRect(S32 *x0, S32 *y0, S32 *x1, S32 *y1) {
+    const S32 cx = (S32)ModeDesiredX / 2;
+    const S32 cy = (S32)ModeDesiredY / 2;
+    *x0 = cx - RES_DIALOG_PANEL_W / 2;
+    *y0 = cy - RES_DIALOG_PANEL_H / 2;
+    *x1 = *x0 + RES_DIALOG_PANEL_W - 1;
+    *y1 = *y0 + RES_DIALOG_PANEL_H - 1;
+}
+
+static void RevertDialog_ButtonRect(ResDialogBtn b, S32 *bx0, S32 *by0, S32 *bx1, S32 *by1) {
+    const S32 cx = (S32)ModeDesiredX / 2;
+    S32 px0, py0, px1, py1;
+    RevertDialog_PanelRect(&px0, &py0, &px1, &py1);
+    const S32 by_top = py1 - 33 - RES_DIALOG_BTN_H + 1; /* 33px bottom margin */
+    if (b == RES_BTN_REVERT) {
+        *bx0 = cx - RES_DIALOG_BTN_GAP / 2 - RES_DIALOG_BTN_W;
+    } else {
+        *bx0 = cx + RES_DIALOG_BTN_GAP / 2;
+    }
+    *bx1 = *bx0 + RES_DIALOG_BTN_W - 1;
+    *by0 = by_top;
+    *by1 = by_top + RES_DIALOG_BTN_H - 1;
+}
+
+/* Renders the whole modal — panel + 3 text lines + 2 buttons + plasma on the
+   focused button — into Log.  Caller is responsible for first restoring the
+   background (CopyScreen Log<-Screen) and presenting (BoxStaticFullflip)
+   after this returns. */
+static void RevertDialog_Draw(ResDialogBtn focused, U32 secondsLeft) {
+    /* Whole-screen darken so the panel reads on any underlying scene. */
     ShadeBoxBlk(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1, SCREEN_SHADE_LVL);
 
-    const S32 cx = (S32)ModeDesiredX / 2;
-    /* Five text lines, evenly spaced around the vertical centre. Spacing is
-       picked to match DrawSingleString's ~20px line height across the modes
-       we ship at. */
-    const S32 lineH = 28;
-    const S32 baseY = (S32)ModeDesiredY / 2 - 2 * lineH;
+    /* Panel: a second shade level for extra contrast against the scene,
+       then the rounded-corner cadre border. Same DrawCadre that
+       DrawCadreConfirm uses for in-game confirmation dialogs. */
+    S32 px0, py0, px1, py1;
+    RevertDialog_PanelRect(&px0, &py0, &px1, &py1);
+    ShadeBoxBlk(px0, py0, px1, py1, SCREEN_SHADE_LVL);
+    DrawCadre(px0, py0, px1, py1, ALL_ANGLES);
 
+    const S32 cx = (S32)ModeDesiredX / 2;
     char buf[128];
     char cp850[128];
 
-    /* "Resolution changed" */
+    /* Three text lines, top-aligned within the panel. */
     CopyUtf8ToCp850(cp850, sizeof cp850, GetLocalizedResDialogLabel(RES_DIALOG_TITLE));
-    DrawSingleString(cx, baseY + 0 * lineH, cp850);
+    DrawSingleString(cx, py0 + 30, cp850);
 
-    /* "Now running at WxH." */
     snprintf(buf, sizeof buf, GetLocalizedResDialogLabel(RES_DIALOG_NOW_AT),
              (unsigned)s_revertNewW, (unsigned)s_revertNewH);
     CopyUtf8ToCp850(cp850, sizeof cp850, buf);
-    DrawSingleString(cx, baseY + 1 * lineH, cp850);
+    DrawSingleString(cx, py0 + 65, cp850);
 
-    /* "Keep this resolution?" */
     CopyUtf8ToCp850(cp850, sizeof cp850, GetLocalizedResDialogLabel(RES_DIALOG_KEEP_Q));
-    DrawSingleString(cx, baseY + 2 * lineH, cp850);
+    DrawSingleString(cx, py0 + 105, cp850);
 
-    /* "[Y] Keep      [N] Revert" */
-    CopyUtf8ToCp850(cp850, sizeof cp850, GetLocalizedResDialogLabel(RES_DIALOG_KEEP_REVERT));
-    DrawSingleString(cx, baseY + 3 * lineH, cp850);
+    /* Two buttons side-by-side. Plasma highlight on the focused one
+       (drawn first so the cadre border sits on top of the fire). */
+    for (int b = 0; b < 2; b++) {
+        S32 bx0, by0, bx1, by1;
+        RevertDialog_ButtonRect((ResDialogBtn)b, &bx0, &by0, &bx1, &by1);
 
-    /* "Reverts automatically in Ns..." */
-    snprintf(buf, sizeof buf, GetLocalizedResDialogLabel(RES_DIALOG_REVERT_IN),
-             (int)secondsLeft);
-    CopyUtf8ToCp850(cp850, sizeof cp850, buf);
-    DrawSingleString(cx, baseY + 4 * lineH, cp850);
+        if (focused == (ResDialogBtn)b) {
+            /* Inset 2px so the cadre border stays clean over the fire. */
+            DrawFireBar(bx0 + 2, by0 + 2, bx1 - 2, by1 - 2, FIRE_SELECT_MENU);
+        }
+        DrawCadre(bx0, by0, bx1, by1, ALL_ANGLES);
 
-    BoxStaticAdd(0, 0, (S32)ModeDesiredX - 1, (S32)ModeDesiredY - 1);
+        if (b == RES_BTN_REVERT) {
+            snprintf(buf, sizeof buf,
+                     GetLocalizedResDialogLabel(RES_DIALOG_BTN_REVERT_FMT),
+                     (int)secondsLeft);
+        } else {
+            snprintf(buf, sizeof buf, "%s",
+                     GetLocalizedResDialogLabel(RES_DIALOG_BTN_KEEP));
+        }
+        CopyUtf8ToCp850(cp850, sizeof cp850, buf);
+        /* Glyph centre at button centre; DrawSingleString uses y as the
+           top of the text raster, so -8 lifts it onto the centre line. */
+        DrawSingleString((bx0 + bx1) / 2, (by0 + by1) / 2 - 8, cp850);
+    }
+
+    /* Mark only the panel rect dirty — the screen-wide darken + scene
+       backup behind it are static for the modal's lifetime, so per-frame
+       redraw doesn't have to walk the whole framebuffer. */
+    BoxStaticAdd(px0 - 1, py0 - 1, px1 + 1, py1 + 1);
     BoxStaticFullflip();
 }
 
@@ -349,15 +409,22 @@ ResRevertChoice Res_RunRevertDialogIfPending(void) {
 
     BackupScreen(TRUE); /* Screen → ScreenAux, then Log → Screen */
 
+    /* Initialise the plasma/fire-bar texture (writes to SkySeaTexture). Without
+       this the DrawFireBar call below renders whatever bytes were in that
+       texture region. Same call MainGameMenu / OptionsMenu make before
+       showing a plasma-highlighted menu. */
+    InitPlasmaMenu();
+
     ManageTime();
     const U32 startMs = TimerRefHR;
     const U32 endMs = startMs + RES_REVERT_TIMEOUT_MS;
     ResRevertChoice choice = RES_REVERT_REVERT; /* default if we time out */
-    U32 lastSecondsDrawn = (U32)-1;
+    ResDialogBtn focused = RES_BTN_REVERT;      /* default focus: the safe one */
 
     /* Drain stale input so a key still held from before doesn't immediately
-       pick a side. */
+       pick a side or toggle focus. */
     InitWaitNoKey();
+    InitWaitNoInput(I_FIRE | I_ACTION | I_MENUS | I_LEFT | I_RIGHT);
 
     while (TimerRefHR < endMs) {
         /* Under --fixed-dt the harness pins time to the per-tick advance done
@@ -371,26 +438,43 @@ ResRevertChoice Res_RunRevertDialogIfPending(void) {
         ManageTime();
         MyGetInput();
 
-        if (MyKey == K_Y || MyKey == K_O || MyKey == K_J || MyKey == K_S ||
-            MyKey == K_ENTER || MyKey == K_SPACE) {
-            choice = RES_REVERT_KEEP;
+        /* Directional input (D-pad on gamepad, arrow keys on keyboard, or
+           the steering keys via the engine's input remap) toggles focus
+           between the two buttons. */
+        if (Input & I_LEFT)
+            focused = RES_BTN_REVERT;
+        if (Input & I_RIGHT)
+            focused = RES_BTN_KEEP;
+
+        /* Confirm selected. I_FIRE covers the action / inventory / return /
+           comportement bindings (so the gamepad's A button works regardless
+           of which keyboard mapping the player uses); Enter and Space are
+           explicit keyboard shortcuts. */
+        if ((Input & I_FIRE) || MyKey == K_ENTER || MyKey == K_SPACE) {
+            choice = (focused == RES_BTN_KEEP) ? RES_REVERT_KEEP : RES_REVERT_REVERT;
             break;
         }
-        if (MyKey == K_N || MyKey == K_ESC) {
+
+        /* Direct shortcuts (regardless of focus). Esc / B-button / N → Revert.
+           Y/O (oui)/J (ja)/S (sí/sì/sim) → Keep. */
+        if ((Input & I_MENUS) || MyKey == K_ESC || MyKey == K_N) {
             choice = RES_REVERT_REVERT;
+            break;
+        }
+        if (MyKey == K_Y || MyKey == K_O || MyKey == K_J || MyKey == K_S) {
+            choice = RES_REVERT_KEEP;
             break;
         }
 
         const U32 remainingMs = endMs - TimerRefHR;
         const U32 secondsLeft = (remainingMs + 999u) / 1000u;
-        if (secondsLeft != lastSecondsDrawn) {
-            /* Re-fill Log from the Screen backup so the previous countdown
-               digit doesn't leave ghost pixels and the scene stays visible
-               under the darken. */
-            CopyScreen(Log, Screen);
-            RevertDialog_Draw(secondsLeft);
-            lastSecondsDrawn = secondsLeft;
-        }
+
+        /* Per-frame redraw so the plasma animates smoothly. DoTextureAnimation
+           advances the fire texture state; CopyScreen restores the captured
+           background before we paint the panel over it. */
+        CopyScreen(Log, Screen);
+        DoTextureAnimation();
+        RevertDialog_Draw(focused, secondsLeft);
     }
 
     LogPrintf("Res_Switch: revert dialog -> %s (target was %ux%u)\n",


### PR DESCRIPTION
**Stacked on [#240](https://github.com/LBALab/lba2-classic-community/pull/240) (which is stacked on #239 → #238 → #237).** Rebase the base to `main` once those land.

Final polish slice of the Phase 0 runtime resolution-switch work. Takes the bare-text revert modal from #240 and turns it into a proper engine-styled dialog: framed panel, two stacked menu-item buttons, animated plasma highlight on the focused button, and a few backed-out experiments along the way.

## Final look

```
                ┌──────────────────────────────────────────┐
                │            Resolution changed            │
                │         Now running at 1280×720          │
                │           Keep this resolution?          │
                │                                          │
                │     ┌──────── Revert (15) ────────┐      │  ← plasma, focus
                │     └─────────────────────────────┘      │
                │     ┌──────────── Keep ───────────┐      │
                │     └─────────────────────────────┘      │
                └──────────────────────────────────────────┘
```

- Panel `580 × 252`, centred for any render resolution.
- Buttons drawn by `DrawOneString` — the engine's canonical menu-item painter, same one used by `MainGameMenu` / `OptionsMenu` / NPC choice menus. Buttons are pixel-identical to the rest of the game's menus.
- Default focus on **Revert** (the safe choice — if the player can't read the screen, doing nothing reverts). Plasma + countdown on Revert; clean Keep.

## Input

| Input | Action |
|---|---|
| **D-pad/Arrow UP** | focus Revert |
| **D-pad/Arrow DOWN** | focus Keep |
| **A button / Enter / Space (`I_FIRE`)** | confirm focused button |
| **B button / Esc (`I_MENUS`) / N** | shortcut → Revert |
| **Y / O / J / S** | shortcut → Keep |
| **Wait 15 s** | auto-revert |

UP/DOWN matches every other vertical menu the engine ships.

## Design path (what's in the commit history)

The commits walk through the iteration, in case it helps a future polish pass:

1. **`feat(reso): polish revert dialog — panel, plasma buttons, gamepad input`** — first cut with side-by-side buttons.
2. **`fix(reso): flicker and button text alignment`** — surfaced two bugs immediately (CopyScreen arg order destroying the backup → progressive blackening; text alignment off by 18 px).
3. **`fix(reso): button text + plasma alignment`** — second attempt at vertical centring.
4. **`fix(reso, window): plasma corner inset + integer present-rect to fix flicker`** — chamfer corner inset on plasma, and `ComputePresentationRect` now rounds to integer pixels (was the actual cause of the non-native-resolution flicker — Wayland compositors serve slightly-different window sizes frame-to-frame during settle, and `SDL_FRect` + nearest-neighbour sampling would shift the output by 1 px).
5. **`refactor(reso): vertical-stacked buttons via DrawOneString`** — pivoted to the engine pattern; deleted ~85 lines of custom button geometry, text positioning, and plasma inset math. The engine's `DrawOneString` knows how to draw a menu item.
6. **`ui(reso): match bottom padding to top`** — final 5-px tweak so the visual breathing room above the title matches what's below the bottom button.

The "step back and use the engine's pattern" move (#5) was the right call — same visual quality with substantially less code, and the side-by-side button pattern simply doesn't exist anywhere else in the game so we'd have been carrying a unique widget forever.

## Verification

- [x] `make test`: 12/12.
- [x] `test_res_switch` + `test_res_switch_console` + `test_res_switch_dialog`: all pass.
- [x] `clang-format`: clean.
- [x] Manually verified: dialog appears at the new resolution with the correct palette and centred camera, buttons stack vertically, UP/DOWN toggles focus with plasma swap, A/Enter confirms, timeout reverts, Y/N shortcuts work, no flicker at non-native modes (1024×768 ↔ 768×480 / 1280×720), padding balanced top to bottom.

## Stacking

| PR | Status | What |
|---|---|---|
| [#237](https://github.com/LBALab/lba2-classic-community/pull/237) | draft | Teardown primitives |
| [#238](https://github.com/LBALab/lba2-classic-community/pull/238) | draft | `Res_Switch` orchestrator |
| [#239](https://github.com/LBALab/lba2-classic-community/pull/239) | draft | `cmd_resolution` console verb |
| [#240](https://github.com/LBALab/lba2-classic-community/pull/240) | draft | Safety gate + revert dialog v1 |
| **This** | draft | Modal polish: vertical buttons, plasma, integer present rect |

After this, Phase 0 is feature-complete. Phase 1 (boot-path consolidation), Phase 2 (Display options submenu), Phase 3 (music continuity, cfg persistence) are doc-tracked follow-ups.