### PR TITLE
chore(INITADEL): silence -Wcomment in no-audio block comment

### DIFF
--- a/SOURCES/INITADEL.C
+++ b/SOURCES/INITADEL.C
@@ -154,8 +154,8 @@ void InitAdeline(S32 argc, char *argv[]) {
     /* --no-audio (harness): skip the SDL audio subsystem entirely. Avoids the
        SDL dummy driver's nanosleep pacing — ~58% of sys time in projection_demo
        on a WSL2 setup. Player builds always init audio; this gate is only
-       reached when the harness explicitly opts out. The SDL audio call sites in
-       LIB386/AIL/SDL gate on Sample_Driver_Enabled / non-NULL stream, so
+       reached when the harness explicitly opts out. Call sites under
+       LIB386/AIL/SDL/ gate on Sample_Driver_Enabled / non-NULL stream, so
        playback paths become silent no-ops when audio isn't up. */
     if (!Control_NoAudio()) {
         InitAIL(); // TODO: Reorganize/reposition closer to sound subsystem

--- a/SOURCES/INITADEL.C
+++ b/SOURCES/INITADEL.C
@@ -155,7 +155,7 @@ void InitAdeline(S32 argc, char *argv[]) {
        SDL dummy driver's nanosleep pacing — ~58% of sys time in projection_demo
        on a WSL2 setup. Player builds always init audio; this gate is only
        reached when the harness explicitly opts out. The SDL audio call sites in
-       LIB386/AIL/SDL/* gate on Sample_Driver_Enabled / non-NULL stream, so
+       LIB386/AIL/SDL gate on Sample_Driver_Enabled / non-NULL stream, so
        playback paths become silent no-ops when audio isn't up. */
     if (!Control_NoAudio()) {
         InitAIL(); // TODO: Reorganize/reposition closer to sound subsystem


### PR DESCRIPTION
## Summary

- Fixes Clang `-Wcomment` (`'/*' within block comment`) when building `INITADEL.C` — the `LIB386/AIL/SDL/*` path inside a `/* … */` block comment was parsed as a nested comment opener.
- Drops the glob `*` from the comment text; meaning is unchanged.

## Test plan

- [x] `cmake --build build` (macOS) — no `-Wcomment` on `INITADEL.C`
- [x] `make test` — 12/12 `host_quick` tests passed