### PR TITLE
feat(ui): centre behaviour modal at any render width

### DIFF
--- a/SOURCES/COMPORTE.CPP
+++ b/SOURCES/COMPORTE.CPP
@@ -86,9 +86,18 @@ S32 DebComportement = 110; // Espacement entre deux comportement
 S32 ComportementMenu = 0;  // menu comportement en cours
 S32 IndexComportement = 0;
 
-#define CTRL_X0 100
+/* Behaviour-modal frame. Original literals were 100, 100, 550, 290 — a
+   450×190 box positioned (mostly) centred on the 640×480 authored canvas.
+   Re-anchor X via ModeDesiredX/2 so the modal stays centred at any render
+   width (768, 1024, 1280, 1920…) rather than sticking to the top-left of
+   the wider framebuffer. Box width is preserved so the 4-tile layout +
+   info-bar geometry inside (which all derive from CTRL_X0..CTRL_X1)
+   reflows automatically. Y stays authored-pixel for now — Y-axis
+   widescreen is HD-only work tracked under Phase 5 of WIDESCREEN.md. */
+#define CTRL_BOX_W 450
+#define CTRL_X0 (((S32)ModeDesiredX - CTRL_BOX_W) / 2)
+#define CTRL_X1 (CTRL_X0 + CTRL_BOX_W)
 #define CTRL_Y0 100
-#define CTRL_X1 550
 #define CTRL_Y1 290
 
 /*══════════════════════════════════════════════════════════════════════════*/

--- a/tests/automation/lib.sh
+++ b/tests/automation/lib.sh
@@ -60,12 +60,22 @@ ctl() {
     SDL_AUDIODRIVER=dummy timeout "$LBA2_TEST_TIMEOUT" "$LBA2_BIN" "$@"
 }
 
-# ctl_headless <args...> — same as ctl but also pins SDL_VIDEODRIVER=dummy
-# and the engine's Language to English. Used by UI capture tests where the
-# committed goldens were rendered under the dummy video driver and an English
-# UI; without --language English they fail on machines whose local lba2.cfg
-# has any other Language: key (typically Français, which is also the engine's
-# default if no key is present).  English matches the in-repo LBA2.CFG default.
+# ctl_headless <args...> — same as ctl but also pins SDL_VIDEODRIVER=dummy,
+# Language to English, and the render resolution to 640x480. Used by UI
+# capture tests where the committed goldens were rendered under the dummy
+# video driver, English UI, and the engine's default 640x480 framebuffer.
+#
+# --language English: without this, tests fail on machines whose local
+# lba2.cfg has any other Language: key (typically Français, which is also
+# the engine's default if no key is present). English matches the in-repo
+# LBA2.CFG default.
+#
+# --resolution 640x480: pins the render resolution so cfg's ResolutionX/Y
+# (which now persists per the runtime-resolution-switch work in PRs
+# #237-#241/#244) doesn't shift the framebuffer dimensions out from under
+# the goldens. Without this, a developer who switched to 768x480 in their
+# own session would have ResolutionX=768 in cfg and all UI goldens would
+# fail with mismatched dimensions on their next test run.
 #
 # --no-audio skips the SDL audio subsystem entirely so the dummy driver's
 # nanosleep pacing (~74% of sys time on WSL2 per strace -c) doesn't run.
@@ -73,6 +83,15 @@ ctl() {
 # doesn't affect them — verified by re-running the suite with this in
 # place and confirming all eight ui_* goldens stay byte-identical.
 ctl_headless() {
+    SDL_AUDIODRIVER=dummy SDL_VIDEODRIVER=dummy timeout "$LBA2_TEST_TIMEOUT" \
+        "$LBA2_BIN" --language English --no-audio --resolution 640x480 "$@"
+}
+
+# ctl_headless_cfg_driven <args...> — same as ctl_headless but does NOT
+# pin --resolution. For tests that verify lba2.cfg's ResolutionX/Y is the
+# actual boot-resolution source (test_res_switch_cfg.sh). Every other
+# test should use ctl_headless so the boot resolution is deterministic.
+ctl_headless_cfg_driven() {
     SDL_AUDIODRIVER=dummy SDL_VIDEODRIVER=dummy timeout "$LBA2_TEST_TIMEOUT" \
         "$LBA2_BIN" --language English --no-audio "$@"
 }

--- a/tests/automation/test_res_switch_cfg.sh
+++ b/tests/automation/test_res_switch_cfg.sh
@@ -29,10 +29,15 @@ EOF
 
 dump_resolution() {
     # Run with given cfg, dump state on tick 2, print "WxH" from the JSON.
+    # Uses ctl_headless_cfg_driven (does NOT pin --resolution) so cfg's
+    # ResolutionX/Y is what drives the boot resolution — exactly what this
+    # test exists to verify. The normal ctl_headless pins --resolution
+    # 640x480 to keep the UI goldens stable against developers whose own
+    # cfg may have a non-default ResolutionX/Y.
     local xdg="$1" extra="${2:-}"
     local out
     out="$(mktemp -t res_cfg.XXXXXX.json)"
-    XDG_DATA_HOME="$xdg" ctl_headless --load "$LBA2_TEST_SAVE" \
+    XDG_DATA_HOME="$xdg" ctl_headless_cfg_driven --load "$LBA2_TEST_SAVE" \
         --fixed-dt 16 --tick 2 --dump-state "$out" --exit $extra \
         >/dev/null 2>&1 \
         || { rm -f "$out"; fail "engine non-zero exit ($?)"; }


### PR DESCRIPTION
Centres the in-game **behaviour modal** (Ctrl on keyboard, or the corresponding gamepad chord) at any render width. Closes the visible "modal sticks to top-left" issue at non-640 widths.

## The bug

`CTRL_X0` / `CTRL_X1` in `SOURCES/COMPORTE.CPP` were hardcoded:

```c
#define CTRL_X0 100
#define CTRL_Y0 100
#define CTRL_X1 550
#define CTRL_Y1 290
```

That's a 450×190 frame at (100, 100). On the 640×480 authored canvas it sits roughly centred (centre at (325, 195)). At wider modes:

| Mode | Modal centre | Framebuffer centre | Gap to right edge |
|---|---|---|---|
| 640×480 | (325, 195) | (320, 240) | 90 |
| 768×480 | (325, 195) | (384, 240) | 218 |
| 1024×480 | (325, 195) | (512, 240) | 474 |
| 1280×720 | (325, 195) | (640, 360) | 730 |

Listed as a pending HUD anchor site in [`docs/widescreen/sprite-hud-sites.md`](docs/widescreen/sprite-hud-sites.md) line 159.

## The fix

Route `CTRL_X0` / `CTRL_X1` through `ModeDesiredX`:

```c
#define CTRL_BOX_W 450
#define CTRL_X0 (((S32)ModeDesiredX - CTRL_BOX_W) / 2)
#define CTRL_X1 (CTRL_X0 + CTRL_BOX_W)
#define CTRL_Y0 100
#define CTRL_Y1 290
```

Box width preserved → the 4-tile behaviour wheel layout (110-px stride from `CTRL_X0`), the info-bar geometry below (`DrawInfoMenu(CTRL_X0, CTRL_Y1 + 10)`, 450 wide), the cadre, the `CopyBlock` restore region, the text-centre maths in `Font((CTRL_X1 + CTRL_X0 - SizeFont(String)) / 2, …)` — all derive from `CTRL_X0..CTRL_X1` and reflow automatically. No internal coord needed touching.

`CTRL_Y0 / CTRL_Y1` stay authored-pixel (100, 290) — Y-axis widescreen is HD-only work tracked under Phase 5 of [`WIDESCREEN.md`](docs/WIDESCREEN.md), not in scope.

## Harness pin (required follow-on)

`lba2.cfg`'s `ResolutionX` / `ResolutionY` persistence (the recently-shipped Phase 0 of runtime resolution switching) means a developer who switched to e.g. 768×480 in their own session has `ResolutionX=768` in cfg. The next test run boots at 768×480 and every UI golden fails with mismatched dimensions.

`tests/automation/lib.sh::ctl_headless` now passes `--resolution 640x480` to keep the goldens stable regardless of cfg state.

`test_res_switch_cfg.sh` deliberately tests cfg-driven boot resolution, so it can't use the pinned helper. Added a sister `ctl_headless_cfg_driven` that omits `--resolution`; only the cfg test uses it.

## Verification

- All **8 ui_* goldens** still pass (no visible re-render at 640 — the modal-anchor change only takes effect at non-640 widths).
- All **4 res_switch_* tests** still pass — the cfg test correctly uses the unpinned helper, the others all use `ctl_headless` and behave as before (the runtime switch tests still exercise non-640 modes).
- **Host suite 12/12**.
- **clang-format**: clean.
- **Manual**: confirmed the modal centres correctly at 640×480, 768×480, and 1024×480 by loading a save, opening the behaviour modal (Ctrl) at each width — frame, tile row, and info bar all centre uniformly.

## Stack note

This depends on PR #244 (lba2.cfg persistence) for the rationale behind the harness pin — without persistence, the cfg can't surprise the goldens. Both PRs can land independently; the harness pin is just defensive even before #244 if a developer manually edits cfg.