### PR TITLE
feat(ui): centre found-object animation at any render width

### DIFF
--- a/SOURCES/INVENT.CPP
+++ b/SOURCES/INVENT.CPP
@@ -1395,11 +1395,25 @@ void MenuInventory(U32 tempo) {
  *══════════════════════════════════════════════════════════════════════════*/
 /*──────────────────────────────────────────────────────────────────────────*/
 /*──────────────────────────────────────────────────────────────────────────*/
-#define FOUND_X0 256
+/* Found-object animation box. Original literals were 256/48/384/178 — a
+   128×130 box at screen centre (320, 113) on the 640×480 authored canvas.
+   The cinematic plays "from the centre of the screen, then flies to the
+   inventory icon at the top-left". At wider widths the box stuck in the
+   left half (centre at 320, not ModeDesiredX/2), so the object cinema
+   appeared off-centre.
+   Re-anchor X via ModeDesiredX/2; box width 128 is preserved. The fly-
+   to destination at lines 1677-1680 (top-left "16") stays literal — that
+   is the actual position of the inventory HUD icon on screen-left and is
+   not anchored to the framebuffer centre. Y stays authored-pixel (HD work
+   tracked under Phase 5 / task #99). At ModeDesiredX==640 the math
+   collapses to the original (256, 320, 384) so the existing
+   ui_found_object golden still matches. */
+#define FOUND_BOX_W 128
+#define FOUND_X0 (((S32)ModeDesiredX - FOUND_BOX_W) / 2)
 #define FOUND_Y0 48
-#define FOUND_X1 384
+#define FOUND_X1 (FOUND_X0 + FOUND_BOX_W)
 #define FOUND_Y1 178
-#define FOUND_XO ((256 + 384) / 2)
+#define FOUND_XO (FOUND_X0 + FOUND_BOX_W / 2)
 #define FOUND_YO ((48 + 178) / 2)
 
 extern S32 Dial_Y0;


### PR DESCRIPTION
Centres the **found-object animation** (the cinematic that plays when Twinsen picks up an item — clover, magic ball, scroll, etc.) at any render width.

## The bug

`FOUND_X0 / X1 / XO` in `DoFoundObj` (`SOURCES/INVENT.CPP`) were hardcoded:

```c
#define FOUND_X0 256
#define FOUND_X1 384
#define FOUND_XO ((256 + 384) / 2)  // = 320
```

128-wide animation box centred at X=320, i.e. screen centre on the 640×480 authored canvas. The cinematic plays "from the centre of the screen, then flies to the inventory icon at the top-left". At wider widths the centre stuck at 320:

| Mode | Object centre | Framebuffer centre |
|---|---|---|
| 640×480 | (320, 113) | (320, 240) ✓ |
| 768×480 | (320, 113) | (384, 240) — 64 px left |
| 1024×480 | (320, 113) | (512, 240) — 192 px left |
| 1280×720 | (320, 113) | (640, 360) — 320 px left |

## The fix

Route X coords through `ModeDesiredX/2`. Box width preserved:

```c
#define FOUND_BOX_W 128
#define FOUND_X0 (((S32)ModeDesiredX - FOUND_BOX_W) / 2)
#define FOUND_X1 (FOUND_X0 + FOUND_BOX_W)
#define FOUND_XO (FOUND_X0 + FOUND_BOX_W / 2)
```

At `ModeDesiredX == 640` the formulas collapse to (256, 384, 320) — the existing `ui_found_object` golden passes byte-identical, no regen needed.

## What stays literal

The fly-to destination at `INVENT.CPP:1677-1680`:

```c
x0 = BoundRegleTrois(FOUND_X0, 16, 15 * 20, step);
// ...
```

The "16" is the actual screen-left position of the inventory HUD icon (which is left-anchored, not centred). Routing it through `ModeDesiredX` would put the destination at the wrong place. Left as-is intentionally.

`FOUND_Y0 / Y1 / YO` also stay authored-pixel — Y-axis widescreen is Phase 5 / HD-only work tracked in [`WIDESCREEN.md`](docs/WIDESCREEN.md) and task #99.

## Verification

- All **8 ui_* goldens** pass (the new formulas collapse to the historical literals at 640).
- All **4 res_switch_* tests** pass.
- **Host suite 12/12**.
- **clang-format**: clean.
- **Manual**: confirmed the animation centres correctly at 640×480, 768×480, 1024×480 by triggering it via `give clover 1` in-game at each width (verb spawns the found-object cinematic for the test item) — frame centres uniformly.

Same shape as the behaviour-modal re-anchor in [#246](https://github.com/LBALab/lba2-classic-community/pull/246).