### PR TITLE
feat(camera): scale iso snap margins with clip window

### DIFF
--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -1832,8 +1832,15 @@ restartloop:
 
                 /* FollowCamera (exterior): the follow camera tracks the hero
                  * every frame — the classic off-screen snap (CameraCenter(0))
-                 * would fight it and cause jarring resets near trees / decors. */
-                if ((Xp < 80 OR Xp > 539 OR Yp<(80 + ClipWindowYMin) OR Yp>(ClipWindowYMax - 50) /*429*/)
+                 * would fight it and cause jarring resets near trees / decors.
+                 *
+                 * X margins track ClipWindowX* (the Y side already did) so the
+                 * snap follows the actual visible region. No-op at 640x480
+                 * (80/539 preserved); at wider widths it stops firing while
+                 * the hero is still well inside the right half of the screen,
+                 * which is most visible in iso scenes (iso centre shifts with
+                 * ModeDesiredX, so hero screen-X tracked the static 539). */
+                if ((Xp<(ClipWindowXMin + 80) OR Xp>(ClipWindowXMax - 100) OR Yp<(80 + ClipWindowYMin) OR Yp>(ClipWindowYMax - 50))
                         AND !(FollowCamera AND CubeMode == CUBE_EXTERIEUR)) {
                     SaveTimer();
 


### PR DESCRIPTION
## Summary

- The off-screen recenter trigger in `PERSO.CPP` hardcoded `Xp < 80 / Xp > 539`, which assumes a 640-wide screen. Y side already tracks `ClipWindowY*`; lift X to the same pattern.
- Most visible in iso scenes: iso projection centre = `ModeDesiredX/2 - 9` shifts right with the framebuffer, so the hero's screen-X tracks the right half and used to hit the static `539` long before approaching any visible edge. Camera snapped to recentre far too eagerly.
- Perspective (exterior) recentres the hero via `XCentre = ModeDesiredX/2` so the projected hero stays near screen centre — `539` rarely fires there, so the visible behaviour change here is iso-only.

## Behaviour

Mathematically a no-op at 640x480 (`0+80=80`, `639-100=539`). Margins at wider widths:

| Width | Left | Right |
| --- | --- | --- |
| 640  | 80 | 539  |
| 768  | 80 | 667  |
| 1024 | 80 | 923  |
| 1280 | 80 | 1179 |

Same physical right-edge buffer (100 px), visible zone scales.

## Test plan

- [x] `make test` host-only suite passes
- [x] UI golden suite (`test_ui_*`) all green — harness already pins `--resolution 640x480`, so the change is provably a no-op at the goldens' resolution
- [x] `test_load`, `test_res_switch*` green
- [x] `scripts/ci/check-format.sh` clean
- [x] In-game test at higher resolution: iso camera no longer snaps eagerly mid-screen