### PR TITLE
fix(demo): pin RNG seed so attract reel reproduces (#176)

### DIFF
--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -2,9 +2,10 @@
 
 #include "C_EXTERN.H" /* pulls DEFINES.H (T_OBJET) + game globals */
 #include "COMMON.H"
-#include "PERSO.H"  /* InitGame, MainLoop, TheEnd */
-#include "OBJECT.H" /* ChangeCube */
-#include "PATCH.H"  /* NbPatches */
+#include "PERSO.H"    /* InitGame, MainLoop, TheEnd */
+#include "OBJECT.H"   /* ChangeCube */
+#include "GAMEMENU.H" /* BeginDemoSlide */
+#include "PATCH.H"    /* NbPatches */
 #include "DIRECTORIES.H"
 #include "RES_SWITCH.H" /* Res_Switch for --res-switch-test */
 #include "CONSOLE/CONSOLE.H"
@@ -404,10 +405,14 @@ int Control_Begin(void) {
 
     /* Attract/demo mode: the scene's scripts drive the hero along authored tracks (a
        "canned playthrough"), and dialogues/choices auto-advance on the game clock instead
-       of waiting for input. Combined with --fixed-dt this is a deterministic scripted run.
-       Opt-in; default gameplay is unaffected. */
+       of waiting for input. BeginDemoSlide() also zeroes TimerRefHR so the srand seed at
+       ChangeCube (OBJECT.CPP:1171) is canonical and the demo reel reproduces — without it,
+       --demo without --fixed-dt would still seed RNG from boot-to-arming wall-clock and the
+       wandering creatures (the Desert Island bat being the most visible) would diverge per
+       run. The --fixed-dt path also resets the clock via Timer_EnableFixedDt() above; doing
+       it again here is idempotent. Opt-in; default gameplay is unaffected. See issue #176. */
     if (s_demo)
-        DemoSlide = TRUE;
+        BeginDemoSlide();
 
     /* Arm projection capture before any InitGame/ChangeCube path that may call
        SetProjection. The boot path's first SetProjection (EXTFUNC.CPP at scene init)

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -2553,7 +2553,7 @@ S32 DoGameMenu(U16 *ptrmenu) {
 
                 FlagShowEndDemo = TRUE;
 #else
-                DemoSlide = TRUE;
+                BeginDemoSlide();
 
                 InitGame(1);
                 NewCube = 193;
@@ -4353,6 +4353,20 @@ S32 SlideShow(void) {
     return ret;
 }
 
+// Enter "canned demo" mode (SHIFT+D from the main menu, the idle attract trigger, the
+// SlideDemo debug entry, and the harness --demo flag all funnel through here). Zeroing
+// TimerRefHR before the first ChangeCube pins the srand seed at OBJECT.CPP:1171 to a
+// canonical value, so every player's demo run reproduces the same RNG-driven wandering
+// (most visibly the bat-vs-Twinsen outcome on the Desert Island demo scene). Without
+// this, the seed is "ms between engine boot and demo trigger", which varies per run.
+// Safe outside the harness path: every site that calls this immediately goes through
+// InitGame(1) + ChangeCube, so the clock reset doesn't bleed into ordinary gameplay
+// timers. See issue #176.
+void BeginDemoSlide(void) {
+    TimerRefHR = 0;
+    DemoSlide = TRUE;
+}
+
 void SlideDemo(int argc, char *argv[]) {
     S32 aff = TRUE;
     U32 cubedeb = 5;
@@ -4365,7 +4379,7 @@ void SlideDemo(int argc, char *argv[]) {
     argv = argv;
 #endif
 
-    DemoSlide = TRUE;
+    BeginDemoSlide();
 
     FOREVER {
         if (!BumperLogo()) {

--- a/SOURCES/GAMEMENU.H
+++ b/SOURCES/GAMEMENU.H
@@ -101,6 +101,10 @@ extern void SlideShow_RequestCapture(const char *path);
 /*--------------------------------------------------------------------------*/
 extern void SlideDemo(int argc, char *argv[]);
 /*--------------------------------------------------------------------------*/
+/* Enter canned-demo mode: pin the RNG seed (zero TimerRefHR before the next
+   ChangeCube's srand call) and set DemoSlide = TRUE. See issue #176. */
+extern void BeginDemoSlide(void);
+/*--------------------------------------------------------------------------*/
 extern S32 AdelineLogo(void);
 /*--------------------------------------------------------------------------*/
 extern void DistribLogo(void);


### PR DESCRIPTION
Closes #176.

## Summary
- SHIFT+D, idle auto-attract, `SlideDemo`, and `--demo` all seed RNG (via `ChangeCube` → `srand(TimerRefHR)` at `SOURCES/OBJECT.CPP:1171`) with whatever ms elapsed between engine boot and demo trigger — so the bat-vs-Twinsen outcome on the Desert Island demo scene (and every other wandering creature in the reel) varies per player.
- PR #175 already zeroed `TimerRefHR` inside `Timer_EnableFixedDt()`, but only the harness `--fixed-dt` path went through that — SHIFT+D, the auto-attract, and `--demo` without `--fixed-dt` were unaffected.
- Factor a tiny `BeginDemoSlide()` helper that zeroes `TimerRefHR` and sets `DemoSlide = TRUE`, and route all three call sites through it (`SOURCES/CONTROL.CPP:415`, `SOURCES/GAMEMENU.CPP:2556`, `SOURCES/GAMEMENU.CPP:4382`). `ChangeCube`'s existing `srand(TimerRefHR)` does the actual reseed — no new RNG calls.

## Safety
Every caller immediately runs `InitGame(1)` + `ChangeCube`, so the clock reset doesn't bleed into ordinary gameplay timers. Loading a save overrides `TimerRefHR` from the save afterward; normal play never enters `DemoSlide`.

## Test plan
- [x] Release build clean (`cmake --build build-rel`)
- [x] Host tests pass (`ctest -j8` in `build-rel`)
- [x] `--demo --fixed-dt 16` (no `--exec`): 3 sequential 1500-tick runs produce byte-identical `--dump-state` JSON — the path that already worked under #175 is unchanged
- [ ] Interactive SHIFT+D / idle attract: verified locally by visual smoke — the demo reel runs to completion
- [ ] On a second machine / fresh boot, the bat-vs-Twinsen Desert Island scene should now play out the same way it does locally (canonical-seed reproduction)

The third bullet is the user-visible payoff and can't be auto-tested without two machines, but the mechanism is straightforward: same seed → same `MyRnd()` sequence → same wandering trajectories.