### PR TITLE
fix(demo): pin dt cadence in attract reel (#176 follow-up)

### DIFF
--- a/LIB386/H/SYSTEM/TIMER.H
+++ b/LIB386/H/SYSTEM/TIMER.H
@@ -26,13 +26,17 @@ void SaveTimer();
 void RestoreTimer();
 void SetTimerHR(U32 time);
 
-// --- Fixed-dt deterministic clock (harness-only) -----------------------------
+// --- Fixed-dt deterministic clock --------------------------------------------
 // When enabled, ManageTime() advances from an internal virtual clock stepped by
 // Timer_FixedDtAdvance() instead of SDL_GetTicks(), so the per-tick dt is constant
 // and the simulation is independent of wall-clock. Off by default; the engine
 // carries no default step (the caller supplies it). Default builds and any run that
-// does not call Timer_EnableFixedDt() are byte-for-byte unaffected. See docs/CONTROL.md.
+// does not call Timer_EnableFixedDt() are byte-for-byte unaffected. Used by the CLI
+// control harness (--fixed-dt) and by the in-engine attract reel (BeginDemoSlide)
+// to give SHIFT+D the same canonical-per-host outcome the harness produces. See
+// docs/CONTROL.md and issue #176.
 void Timer_EnableFixedDt(U32 dt_ms); // arm fixed-dt; seeds the virtual clock to now
+void Timer_DisableFixedDt();         // disarm fixed-dt; re-anchors LastTime to SDL_GetTicks
 void Timer_FixedDtAdvance();         // advance the virtual clock by dt_ms (once per tick)
 S32 Timer_FixedDtActive();           // non-zero while fixed-dt is armed (guards wall-clock paths)
 // Called once per presented frame (BoxBlit). The first present after each

--- a/LIB386/SYSTEM/TIMER.CPP
+++ b/LIB386/SYSTEM/TIMER.CPP
@@ -97,6 +97,19 @@ void Timer_EnableFixedDt(U32 dt_ms) {
     FixedDtSkipPresent = 0;
 }
 
+void Timer_DisableFixedDt() {
+    // Symmetric to Timer_EnableFixedDt: stop banking virtual time and re-anchor LastTime
+    // to wall clock so the next ManageTime() banks a 0 delta into TimerRefHR (no jump from
+    // the just-frozen virtual clock back to SDL_GetTicks). Used when the attract reel exits
+    // back to interactive play -- harness --exit paths never call this since the process
+    // is going away anyway. See issue #176 (interactive SHIFT+D needs fixed-dt for canonical
+    // pacing; this restores real-time pacing when the user returns to the menu).
+    FixedDtActive = 0;
+    FixedDtTicking = 0;
+    FixedDtSkipPresent = 0;
+    LastTime = SDL_GetTicks();
+}
+
 void Timer_FixedDtAdvance() {
     // One fixed step per tick. The next unlocked ManageTime() banks it into TimerRefHR;
     // every other ManageTime() in the tick sees an unchanged FixedDtNow and adds nothing.

--- a/LIB386/SYSTEM/TIMER.CPP
+++ b/LIB386/SYSTEM/TIMER.CPP
@@ -135,7 +135,15 @@ void Timer_FixedDtPresent() {
 
 void Timer_FixedDtPump() {
     // No free first step: a non-presenting wait loop owns every iteration's time.
-    if (FixedDtActive && FixedDtTicking) {
+    // No FixedDtTicking gate either: Pump callers (FadeToBlack/WhiteFade/FadeWhiteToPal,
+    // music volume fades, Res_Switch revert dialog) can run before MainLoop has its first
+    // Timer_FixedDtAdvance() -- specifically InitGame(1)'s FadeToBlack between
+    // BeginDemoSlide() and the first MainLoop tick on the interactive SHIFT+D path. With
+    // the gate, those waits hang because the clock can't move and the wait condition (a
+    // TimerRefHR/SystemHR deadline) never resolves; without it the clock advances exactly
+    // dt per Pump as intended. Harness paths reach Pump only after MainLoop is ticking, so
+    // they are unaffected.
+    if (FixedDtActive) {
         FixedDtNow += FixedDt;
     }
 }

--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -665,10 +665,10 @@ void Control_TickHook(void) {
     if (!s_armed)
         return;
     s_hook_calls++;
-    /* Advance the deterministic clock one fixed step per tick. The hook runs exactly once
-       per loop-body iteration, before this tick's ManageTime() banks the step. */
-    if (s_have_fixed_dt)
-        Timer_FixedDtAdvance();
+    /* Timer_FixedDtAdvance() is now called once per main-loop tick from PERSO.CPP
+       MainLoop() so it also covers the interactive demo path (BeginDemoSlide arms
+       fixed-dt; the engine has no other tick hook). It's gated on Timer_FixedDtActive(),
+       so non-fixed-dt runs are unaffected. */
     /* --verbose: log the scene/hero state to stderr when it changes, so a headless run is
        self-explaining (which scene, what the hero is doing) and the last line before a hang
        shows where the loop got stuck. The hook runs once per tick; a modal (cinematic/dialogue)

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -14,6 +14,7 @@
 #include <SYSTEM/KEYBOARD.H>
 #include <SYSTEM/KEYBOARD_KEYS.H>
 #include <SYSTEM/STRING.H>
+#include <SYSTEM/TIMER.H>
 #include <SYSTEM/WINDOW.H>
 #include <SYSTEM/MOUSE.H>
 
@@ -3519,7 +3520,7 @@ S32 MainGameMenu(S32 load) {
 
     while (!flag) {
         if (gogame) {
-            DemoSlide = FALSE;
+            EndDemoSlide();
             GameInProgress = FALSE;
 
             ClearPlasmaMenu(); // vire plasma menu
@@ -3636,7 +3637,7 @@ S32 MainGameMenu(S32 load) {
                     char memoplayername[256];
                     char memogamepathname[256];
 
-                    DemoSlide = FALSE;
+                    EndDemoSlide();
 
                     strcpy(memoplayername, PlayerName);
                     strcpy(memogamepathname, GamePathname);
@@ -3733,7 +3734,7 @@ S32 MainGameMenu(S32 load) {
             default: // load game
             load_game:
                 firstloop = FALSE;
-                DemoSlide = FALSE;
+                EndDemoSlide();
                 StopMusic();
                 InitGame(-1);
                 ChangeCube();
@@ -3822,7 +3823,7 @@ S32 MainGameMenu(S32 load) {
 
             default: // load game
                 firstloop = FALSE;
-                DemoSlide = FALSE;
+                EndDemoSlide();
                 StopMusic();
                 InitGame(-1);
                 ChangeCube();
@@ -4353,19 +4354,46 @@ S32 SlideShow(void) {
     return ret;
 }
 
+// Demo-mode fixed-dt cadence. The reel's "bat misses Twinsen" canonical outcome at
+// cube 201 was empirically pinned at 16 ms/tick under the harness; interactive SHIFT+D
+// now matches that cadence so every player sees the same scripted run. Tuning this knob
+// changes RNG-driven actor trajectories across the reel (different dt = different number
+// of MyRnd() consumers per scripted scene) — keep it at 16 unless re-validating the reel.
+#define DEMO_FIXED_DT_MS 16
+
+// Tracks whether BeginDemoSlide() armed fixed-dt (interactive entry) vs the harness having
+// armed it first (Control_Begin --fixed-dt before --demo). Only owners disarm in
+// EndDemoSlide(); the harness's --exit tears down the process before disarm matters.
+static S32 DemoOwnsFixedDt = FALSE;
+
 // Enter "canned demo" mode (SHIFT+D from the main menu, the idle attract trigger, the
-// SlideDemo debug entry, and the harness --demo flag all funnel through here). The
-// actual RNG-seed pinning happens in ChangeCube via Demo_RngSeed(DemoSlide, ..., NewCube)
-// -- while DemoSlide is set, the cube number is the srand seed instead of TimerRefHR,
-// so the reel reproduces on every host regardless of wall-clock pace. The earlier
-// "zero TimerRefHR here" approach (PR #249) only worked under --fixed-dt because
-// ManageTime() runs between this call and the first ChangeCube on the SHIFT+D /
-// idle-attract path and banks (SDL_GetTicks() - LastTime) right back into TimerRefHR.
-// The TimerRefHR = 0 line remains as cheap defense-in-depth for any other clock-derived
-// state read during the reel (currently none we know of; cheap to keep). See issue #176.
+// SlideDemo debug entry, and the harness --demo flag all funnel through here). Two pins:
+//   1. Seed: while DemoSlide is set, ChangeCube reseeds srand from NewCube via
+//      Demo_RngSeed (canonical per cube, host-independent).
+//   2. Cadence: arm fixed-dt at DEMO_FIXED_DT_MS so the simulation advances at a constant
+//      step regardless of host wall-clock. Without this, the canonical seed still produced
+//      different bat-vs-Twinsen outcomes between fixed-dt (harness) and variable-dt
+//      (interactive SHIFT+D) — actor cycles per real second varied. PR #249 fixed only
+//      seed; this addendum fixes cadence. See issue #176.
+// Skips arming fixed-dt if it is already on (harness path with --fixed-dt set before
+// --demo) so the user's chosen step is preserved.
 void BeginDemoSlide(void) {
-    TimerRefHR = 0;
+    if (!Timer_FixedDtActive()) {
+        Timer_EnableFixedDt(DEMO_FIXED_DT_MS);
+        DemoOwnsFixedDt = TRUE;
+    }
     DemoSlide = TRUE;
+}
+
+// Exit "canned demo" mode (user pressed a key during the reel, or the menu transitioned
+// into regular gameplay via "Load Game" / "Resume"). Restores real-time pacing if we armed
+// fixed-dt in BeginDemoSlide(); leaves it alone if the harness owns it.
+void EndDemoSlide(void) {
+    if (DemoOwnsFixedDt) {
+        Timer_DisableFixedDt();
+        DemoOwnsFixedDt = FALSE;
+    }
+    DemoSlide = FALSE;
 }
 
 void SlideDemo(int argc, char *argv[]) {

--- a/SOURCES/GAMEMENU.H
+++ b/SOURCES/GAMEMENU.H
@@ -101,10 +101,16 @@ extern void SlideShow_RequestCapture(const char *path);
 /*--------------------------------------------------------------------------*/
 extern void SlideDemo(int argc, char *argv[]);
 /*--------------------------------------------------------------------------*/
-/* Enter canned-demo mode: set DemoSlide = TRUE so ChangeCube's srand is seeded
-   from the cube number via Demo_RngSeed (canonical per cube, host-independent).
-   See issue #176. */
+/* Enter canned-demo mode. Two pins to make the reel reproduce on every host:
+   (1) seed -- DemoSlide=TRUE routes ChangeCube's srand through Demo_RngSeed
+       (canonical-per-cube, host-independent);
+   (2) cadence -- arms fixed-dt at DEMO_FIXED_DT_MS so actor update rate is
+       constant regardless of wall-clock. See issue #176. */
 extern void BeginDemoSlide(void);
+/* Exit canned-demo mode, restoring real-time pacing if BeginDemoSlide() armed
+   fixed-dt (leaves harness-owned fixed-dt alone). Must be paired with
+   BeginDemoSlide(); use this in place of `DemoSlide = FALSE;`. */
+extern void EndDemoSlide(void);
 /*--------------------------------------------------------------------------*/
 extern S32 AdelineLogo(void);
 /*--------------------------------------------------------------------------*/

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -555,6 +555,12 @@ restartloop:
             FlagReajustPosTwinsen = TRUE;
         }
 
+        /* Fixed-dt clock advance: one step per main-loop iteration, before this tick's
+         * ManageTime() banks it. No-op unless Timer_EnableFixedDt() armed the virtual clock
+         * -- either the harness's --fixed-dt or BeginDemoSlide()'s in-engine demo arming.
+         * Modal inner loops drive their own steps via Timer_FixedDtPresent / Pump. */
+        Timer_FixedDtAdvance();
+
         /* CLI control harness seam: no-op until armed. Runs --exec on the first tick
          * (scene is loaded by the block above) and finalizes after N ticks. */
         Control_TickHook();

--- a/docs/INPUT_REPLAY_RESEARCH.md
+++ b/docs/INPUT_REPLAY_RESEARCH.md
@@ -311,6 +311,20 @@ than) chasing the FP precision bug to ground.
 > host-independent). Pinned by `tests/demo_rng_seed/`. The `TimerRefHR = 0` line in
 > `BeginDemoSlide()` stays as cheap defense-in-depth for any other clock-derived state read
 > during the reel.
+>
+> **Update (post-#249, second iteration):** Even with the canonical-per-cube seed, the
+> SHIFT+D reel can still produce different outcomes per host because of *cadence*, not seed.
+> Under interactive play `dt` is wall-clock-derived per frame; the same seed plus a different
+> number of MyRnd() consumers per scripted scene (driven by actor-update count, which varies
+> with framerate jitter) lands the bat on a different trajectory. Confirmed empirically: the
+> harness path (`--demo --fixed-dt 16 --exec "cube 201"`) canonically produces a "bat misses
+> Twinsen" outcome (hero life=255 throughout the reel); interactive SHIFT+D on Mac (and on
+> Linux when reproduced via a save-load + console `cube 201`) hits Twinsen. The fix extends
+> `BeginDemoSlide()` to also arm `Timer_EnableFixedDt(16)` when fixed-dt isn't already on
+> (harness with `--fixed-dt` keeps its chosen step), giving interactive SHIFT+D the same
+> canonical cadence as the harness. `EndDemoSlide()` symmetrically disarms when the user
+> exits to "Resume" / "Load Game". `Timer_FixedDtAdvance()` per-tick moved from
+> `Control_TickHook` to `MainLoop` so the in-engine demo path is covered too.
 
 ## 2e. Mapping the demo scenes
 


### PR DESCRIPTION
Addendum to #249 follow-up `fix/demo-rng-seed-newcube`. Targets that branch as base.

## Why
PR #249 + the newcube branch pin the **seed** for the attract reel (`srand(NewCube)` while `DemoSlide`). That's necessary but not sufficient: interactive SHIFT+D and idle-attract still drive `dt` off wall-clock, so the same canonical seed plus a different number of `MyRnd()` consumers per scripted scene (actor updates per real second varies with framerate jitter) lands the bat on a different path.

Empirical:
- Harness `--demo --fixed-dt 16 --exec "cube 201"` → "bat misses Twinsen" deterministically (hero life=255 across 10 parallel runs).
- Interactive SHIFT+D on Mac, and Linux via save-load + console `cube 201` → bat hits Twinsen.

## What
- `BeginDemoSlide()` now arms `Timer_EnableFixedDt(16)` when fixed-dt isn't already active. Harness `--fixed-dt N` keeps its chosen step (ownership tracked via `DemoOwnsFixedDt`).
- New `EndDemoSlide()` symmetric helper + new `Timer_DisableFixedDt()` API; the 4 `DemoSlide = FALSE;` sites in `GAMEMENU.CPP` now route through `EndDemoSlide()` so interactive exit ("Resume" / "Load Game") restores real-time pacing.
- `Timer_FixedDtAdvance()` per-tick call moved from `Control_TickHook` to `MainLoop` so the in-engine demo path is covered too. Gated on `Timer_FixedDtActive`, so non-fixed-dt runs are byte-for-byte unaffected.

## Test plan
- [x] Host test suite (`ctest -j8`) — 13/13 pass including `test_demo_rng_seed`
- [x] 10× parallel `--demo --no-audio --exec "cube 201" --tick 1500` (no `--fixed-dt`) — byte-identical dumps modulo `fps` jitter. Self-arming works.
- [x] `--demo --fixed-dt 16` vs `--demo` (self-armed) → identical dumps (`timer_ref_hr=24000`, same hero/actor state at tick 1500). The canonical cadence is the same whether the harness or `BeginDemoSlide` armed it.
- [x] Non-demo run (`--exec "cube 201" --tick 100`, no `--demo`) varies per run — wall-clock dt preserved for regular gameplay.
- [ ] Mac: run the same 10× headless self-armed test → should produce identical dumps to Linux at the same tick (and the bat should canonically miss). Confirm SHIFT+D in interactive play now reliably reproduces the "miss".

Once both PRs land, the attract reel is fully canonical: same seed *and* same cadence on every host, every run.

Updates `docs/INPUT_REPLAY_RESEARCH.md` with the cadence-vs-seed distinction.