### PR TITLE
fix(timer): hold LastTime across TimerLock window so render+vsync isn't lost

### DIFF
--- a/LIB386/SYSTEM/TIMER.CPP
+++ b/LIB386/SYSTEM/TIMER.CPP
@@ -136,9 +136,16 @@ void ManageTime() {
 
     if (!TimerLock) {
         TimerRefHR += TimerSystemHR - LastTime;
+        // Only advance LastTime while unlocked. Previously LastTime advanced
+        // unconditionally, so any ManageTime() call inside a Lock/Save window
+        // (input, audio, animation -- ~100 call sites) would update LastTime
+        // to the current wall clock while skipping the TimerRefHR increment.
+        // On the next unlocked call, TimerSystemHR - LastTime was near zero
+        // and the entire locked interval was discarded from the game clock.
+        // PR #50 patched this for the FollowCamTerrainFrame path (PERSO.CPP);
+        // this generalises the fix to every Lock/Save call site.
+        LastTime = TimerSystemHR;
     }
-
-    LastTime = TimerSystemHR;
 
     // FPS Calculation
     S32 time = TimerSystemHR - LastEvaluate;

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Index of documentation in this repository.
 | [CONFIG.md](CONFIG.md) | lba2.cfg lifecycle, keys, and what each does (original vs community). |
 | [SAVEGAME.md](SAVEGAME.md) | .lba save format: lifecycle, binary layout, version compatibility, save editors, LBALab tools. |
 | [CAMERA.md](CAMERA.md) | Camera system: interior (iso) vs exterior (perspective), CameraCenter, Auto camera (`FollowCamera`, community addition). |
+| [TIMING.md](TIMING.md) | Engine timing: TimerSystemHR vs TimerRefHR, LockTimer vs SaveTimer semantics, ManageTime call sites, fixed-dt overlay, and the 1997 `ManageTime` bug history. |
 | [SPRITES.md](SPRITES.md) | Sprite system: UI / world-extra / 3D-anim lanes, `ScaleSprite` vs `ScaleSpriteTransp`, perspective scale (`CalculeScaleFactorSprite`), sort-tree integration. Magic-ball case study. |
 | [LBA_EDITOR.md](LBA_EDITOR.md) | What `LBA_EDITOR`/`PERSO` paths still do: editor capabilities, runtime hooks, and likely missing pieces. |
 

--- a/docs/TIMING.md
+++ b/docs/TIMING.md
@@ -1,0 +1,202 @@
+# Engine timing
+
+Clocks, locks, and the game-clock vs wall-clock distinction. Read this before touching
+`LIB386/SYSTEM/TIMER.CPP` or adding a `LockTimer`/`SaveTimer` call site. Companion to
+[LIFECYCLES.md](LIFECYCLES.md) (which gives the main-loop call order) and
+[FIXED_DT_PLAN.md](FIXED_DT_PLAN.md) (which is the harness-only deterministic overlay).
+
+Truth hierarchy: code > this document > external sources.
+
+## The two clocks
+
+The engine maintains two parallel `U32` millisecond clocks (`LIB386/SYSTEM/TIMER.CPP`):
+
+| Variable | Meaning | Who reads it |
+|---|---|---|
+| `TimerSystemHR` | Wall clock. Snapshot of `SDL_GetTicks()` taken inside `ManageTime()`. | FPS calc, present pacing, anywhere "how long has the host been running" matters. |
+| `TimerRefHR` | Game clock. Advances by wall-clock delta only when *unlocked*. | Animation interpolation (`Obj.Time`), `DoTrack` script delays, music fades, zone timers, RNG seeding at `ChangeCube`. |
+
+The distinction matters: any pause/render/modal subloop that should freeze game time pauses
+`TimerRefHR` but lets `TimerSystemHR` keep ticking. The fixed-dt deterministic mode
+([FIXED_DT_PLAN.md](FIXED_DT_PLAN.md)) replaces `SDL_GetTicks()` with a virtual clock that
+only advances on explicit tick events, so both `TimerSystemHR` and `TimerRefHR` become
+reproducible byte-for-byte.
+
+## Internal state
+
+| Variable | Role |
+|---|---|
+| `LastTime` | The most recent `TimerSystemHR` an *unlocked* `ManageTime()` saw. The next unlocked call computes `TimerRefHR += TimerSystemHR - LastTime`, then updates `LastTime` to the new `TimerSystemHR`. While locked, both `TimerRefHR` and `LastTime` are held frozen. |
+| `MemoTimerRefHR` | Snapshot of `TimerRefHR` taken by the outermost `SaveTimer()`. The outermost `RestoreTimer()` *assigns* `TimerRefHR` back to this snapshot (see below). |
+| `TimerLock` | Lock depth counter. Incremented by `LockTimer()`, decremented by `UnlockTimer()`. `ManageTime()` skips the `TimerRefHR`/`LastTime` updates while `TimerLock > 0`. |
+| `CmptMemoTimerRef` | `SaveTimer/RestoreTimer` nesting counter. Only the outermost pair runs the snapshot/restore. |
+| `LastEvaluate` | Per-second window anchor used by the FPS calc inside `ManageTime`. Independent of `LastTime`. |
+
+`FixedDt*` state (off by default; see [FIXED_DT_PLAN.md](FIXED_DT_PLAN.md)) overlays a
+virtual clock source on `TimerSystemHR` for harness determinism.
+
+## Lock vs Save — they are *not* the same
+
+This is the most-common rake to step on. Both look like "pause and resume," only one is.
+
+| Pattern | Outermost-entry behaviour | Outermost-exit behaviour | Net effect on game clock |
+|---|---|---|---|
+| `LockTimer` / `UnlockTimer` | Snapshot `LastTime`. | Resume `LastTime` from where it was. Next `ManageTime` credits the full elapsed wall time to `TimerRefHR`. | **Transparent**: the locked interval is invisible to game logic but the game clock catches up afterwards. |
+| `SaveTimer` / `RestoreTimer` | Snapshot `TimerRefHR` into `MemoTimerRefHR`. | `TimerRefHR = MemoTimerRefHR`. Elapsed wall time is **discarded**. | **Rewind**: the locked interval is invisible *and* the game clock acts as if it never happened. |
+
+Choose by intent:
+
+- **Wrapping a synchronous render or a brief CPU window where game time should pause and
+  then resume correctly**: `LockTimer/UnlockTimer`. Example: the `AffScene` full-redraw
+  path at `SOURCES/OBJECT.CPP:5400`.
+- **Wrapping a modal subloop (menu, dialogue, paused message) that should leave the game
+  clock exactly where it found it**: `SaveTimer/RestoreTimer`. Example:
+  `SOURCES/PERSO.CPP:354` around the pause/clover dialog.
+
+`SaveTimer/RestoreTimer` discarding time is intentional, not a bug. `LockTimer/UnlockTimer`
+*used* to discard time too — see the history section below.
+
+## `ManageTime` and the call-site population
+
+`ManageTime()` is the only function that mutates `TimerSystemHR`, `TimerRefHR`, and
+`LastTime`. The body is short (`LIB386/SYSTEM/TIMER.CPP:134`):
+
+```c
+void ManageTime() {
+    TimerSystemHR = FixedDtActive ? FixedDtNow : SDL_GetTicks();
+
+    if (!TimerLock) {
+        TimerRefHR += TimerSystemHR - LastTime;
+        LastTime = TimerSystemHR;
+    }
+
+    // FPS calc against LastEvaluate ...
+}
+```
+
+There are ~100 `ManageTime()` call sites across the engine. Most are inside modal/wait
+loops that pump the clock manually because the main loop's `ManageSystem()` macro
+(`LIB386/H/SYSTEM/TIMER.H:57`) isn't reached during a modal. Examples:
+
+| File | Use case |
+|---|---|
+| `SOURCES/PERSO.CPP` (`MainLoop`) | Once per tick via `ManageSystem()` at the top of the loop body. |
+| `SOURCES/AMBIANCE.CPP`, `SOURCES/MESSAGE.CPP`, `SOURCES/INVENT.CPP` | Modal subloops pump the clock while waiting for input or for an animation to finish. |
+| `SOURCES/MUSIC.CPP` | Music fade-out loops; under fixed-dt these use `Timer_FixedDtPump` to step the virtual clock without a present. |
+| `LIB386/SVGA/SDL.CPP`, `LIB386/SYSTEM/TIMER.CPP` | Internal callers from `LockTimer`/`SaveTimer`/`SetTimerHR`. |
+
+If you add a new modal/wait loop, pump `ManageTime` (and call `Timer_FixedDtPump` if you
+also want the loop to terminate under fixed-dt) — see `SOURCES/MUSIC.CPP:312` for the
+canonical fade pattern.
+
+## Fixed-dt mode (harness only)
+
+Inert in default builds. When `Timer_EnableFixedDt(dt_ms)` is called (from
+`Control_Begin` when the harness sees `--fixed-dt`):
+
+- `TimerSystemHR` reads `FixedDtNow` instead of `SDL_GetTicks()`.
+- `Timer_FixedDtAdvance()` is called once per main-loop tick from the control hook,
+  incrementing `FixedDtNow` by `dt`.
+- `Timer_FixedDtPresent()` is called from `BoxBlit`; the first present after each
+  `Timer_FixedDtAdvance()` is "free" (the main-loop render already paid for it). Every
+  additional present in the same tick advances `FixedDtNow` by `dt` — that's how modal
+  subloops avoid deadlocking on a `TimerRefHR` deadline.
+- `Timer_FixedDtPump()` advances `FixedDtNow` without a present, for non-presenting
+  busy-waits.
+
+Result: `--dump-state` is byte-identical across repeated harness runs. The host wall
+clock has zero influence. See [FIXED_DT_PLAN.md](FIXED_DT_PLAN.md) for the design rationale
+and [CONTROL.md](CONTROL.md) for the CLI surface.
+
+## History — the 1997 `ManageTime` bug
+
+A latent bug lived in `ManageTime` from the 1997 retail release until 2026-05.
+
+The original Adeline source (`LIB386/SYSTEM/TIMERWIN.CPP` in the initial public
+commit `333929ab`, 2021-10-27) updated `LastTime` *unconditionally* — outside the
+`if (!TimerLock)` guard:
+
+```c
+if (!TimerLock) {
+    TimerRefHR += TimerSystemHR - LastTime;
+}
+LastTime = TimerSystemHR;  // unconditional
+```
+
+Effect: any `ManageTime()` call inside a Lock or Save window (audio, input, animation,
+modal pumps — ~100 sites) bumped `LastTime` to the current wall clock while skipping the
+`TimerRefHR` increment. When the lock released, the next `ManageTime()` saw
+`TimerSystemHR - LastTime ≈ 0` and the whole locked interval was discarded from `TimerRefHR`.
+
+**Why retail never noticed.** On bare-metal DOS at 640×480, the `LockTimer` window at
+`OBJECT.CPP:5400` (around the `AffScene` full-redraw path) contained sub-millisecond CPU
+work between the lock and the direct-to-VGA blit. The amount of wall time "lost" per frame
+was rounding noise.
+
+**Why the SDL port resurrected it.** The SDL port (PR #3, commit `e29b9bd7`, 2023-01-24)
+created `LIB386/SYSTEM/TIMER.CPP` as a byte-for-byte clone of the original logic, with
+`timeGetTime()` replaced by `SDL_GetTicks()`. The same window now contained
+`BoxBlit` → `UnlockVideoSurface` → `SDL_RenderPresent`, which under SDL3 + GL backbuffer
+blocks on vsync for a full refresh period (~16.67 ms at 60 Hz). At native resolution where
+vsync becomes the dominant per-frame cost, ~16-17 ms of game-clock advance was discarded
+*every frame*. Animations and sim ran at 25-50% real speed; held movement keys felt
+unresponsive.
+
+**Local patch first.** PR #50 (`8af40faa7`, 2026-04-08) noticed the symptom on
+`FollowCamTerrainFrame` exterior frames and patched it locally
+(`SOURCES/PERSO.CPP:1916`) with a `SaveTimer`/`RestoreTimer` + wall-clock re-add. The
+comment there names the mechanism exactly:
+
+> "save the timer before the render+vsync and restore it after, then add back the real
+> wall-clock time elapsed ... This makes the full render+vsync transparent to the game
+> clock so hero, NPCs, and rain run at correct speed."
+
+The patch fixed the FollowCam exterior path. Every other Lock/Save site in the engine
+still discarded its window's wall time.
+
+**General fix in 2026-05.** Diagnosis with a `perftrace`-style ring-buffer instrumentation
+narrowed the leak to one source line (`OBJECT.CPP:5400` `LockTimer()`, called every frame
+in the user-facing scene). The fix is one line moved: `LastTime = TimerSystemHR;` moves
+*inside* the `if (!TimerLock)` block, so `LastTime` is held frozen across the locked
+window and the next unlocked `ManageTime` correctly credits the full wall-clock delta to
+`TimerRefHR`. The `FollowCamTerrainFrame` workaround in `PERSO.CPP:1916` becomes
+redundant; left in place for now, removable in a follow-up.
+
+Self-determinism (`test_demo` at `--fixed-dt 16`, byte-identical reruns) is preserved.
+The 5-tick projection-corpus replay drifts on 12/50 saves with active animations in the
+window — the drift is the fix working, since animation interpolation now lands at the
+correct game-clock time. The corpus golden was regenerated alongside the fix.
+
+## Practical guidance
+
+When adding code that touches the timer, in rough order of how often you'll need each:
+
+1. **Don't wrap rendering in `SaveTimer`.** Use `LockTimer/UnlockTimer`. `Save/Restore`
+   *rewinds* the game clock; you almost never want that.
+2. **Wrapping a modal subloop (menu, dialogue, paused message)?** Use
+   `SaveTimer/RestoreTimer` — the rewind is the point.
+3. **Adding `ManageTime()` inside a Lock/Save window** (e.g. you have a busy-wait that
+   pumps animation): pre-2026-05 fix, this silently discarded the wall time. Post-fix it
+   doesn't, but the standing rule is the same — only pump `ManageTime` inside loops that
+   need the game clock to actually move, and call `Timer_FixedDtPump`/`Timer_FixedDtPresent`
+   alongside if the loop should also terminate under fixed-dt.
+4. **Adding a new modal/wait loop?** Mirror `SOURCES/MUSIC.CPP:312` (`PauseMusic`,
+   fade-out): `SaveTimer()`, loop with `ManageTime()` + `Timer_FixedDtPump()`,
+   `RestoreTimer()`.
+5. **Touching `ManageTime` itself?** Re-run the projection-corpus regression after any
+   change to `TimerRefHR`/`LastTime` semantics — the 5-tick golden catches one-frame
+   timing drift across 50 diverse saves and is the strongest fixed-dt invariant the
+   suite carries today.
+
+## Related
+
+- [LIFECYCLES.md](LIFECYCLES.md) — main loop step order; where `ManageTime` lives in the
+  per-tick sequence.
+- [CONTROL.md](CONTROL.md) — the CLI control harness; `--fixed-dt`, `--tick`,
+  `--dump-state`.
+- [FIXED_DT_PLAN.md](FIXED_DT_PLAN.md) — the deterministic-clock design that overlays the
+  virtual time source on `TimerSystemHR`.
+- [FIXED_DT_RESEARCH.md](FIXED_DT_RESEARCH.md) — Phase 1 research mapping loop classes
+  and inventorying every site that reads `TimerRefHR`/`TimerSystemHR`.
+- `LIB386/SYSTEM/TIMER.CPP`, `LIB386/H/SYSTEM/TIMER.H` — source of truth for
+  everything above.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_subdirectory(savegame)
 add_subdirectory(deffile)
 add_subdirectory(image_load)
 add_subdirectory(ambiance_balance)
+add_subdirectory(timer)
 
 if(LBA2_BUILD_ASM_EQUIV_TESTS)
 include(cmake/asm_test_helpers.cmake)

--- a/tests/projection/baselines/corpus_640x480.projrec.hash
+++ b/tests/projection/baselines/corpus_640x480.projrec.hash
@@ -1,13 +1,14 @@
 # projrec-corpus-hash v1
-# 5-tick deterministic replay (--fixed-dt 16 --tick 5) per committed save.
+# 5-tick deterministic replay (--fixed-dt 16 --tick 5) per committed save,
+# at render width 640 (the binary's compiled RESOLUTION_X).
 # Regenerate with: scripts/dev/regen_projrec_baselines.sh
-Anon1.LBA                        events=8395      fnv1a=62b2914e34007dca
+Anon1.LBA                        events=8393      fnv1a=9fb78f8411423be9
 Anon2.LBA                        events=5635      fnv1a=b5294cf263085096
-Ball of Sendell.LBA              events=4508      fnv1a=2c3c0b163ad59434
+Ball of Sendell.LBA              events=4507      fnv1a=feda539a76962e85
 Bu.LBA                           events=8189      fnv1a=10565f09dbf3b576
 DOS2.LBA                         events=5819      fnv1a=3df31cb6092a48b9
 DT Otringal.LBA                  events=1048      fnv1a=4f01aabdb5e3589a
-Dark Monk.LBA                    events=3246      fnv1a=e505a891b70d659a
+Dark Monk.LBA                    events=3278      fnv1a=e415a7fb974bb151
 Desert Island.LBA                events=23071     fnv1a=99fc0857f37161bd
 Desperado.LBA                    events=4399      fnv1a=756cf92bf33d65f2
 Dissidents.LBA                   events=1308      fnv1a=f87a9f9ae4b49e08
@@ -16,10 +17,10 @@ EM2.LBA                          events=4959      fnv1a=7e333ca23839947c
 Emerald Moon.LBA                 events=1393      fnv1a=dc3b591af7fe24c7
 Emperor Palace.LBA               events=941       fnv1a=0bed617382956826
 End game.LBA                     events=4666      fnv1a=fb8a5dc6f24bbdbf
-Esmer Secret Base.LBA            events=8958      fnv1a=f92403f525c6bf9b
+Esmer Secret Base.LBA            events=8957      fnv1a=27c968c737a82b8c
 Franco Elevator.LBA              events=5206      fnv1a=32233c44bbd06b7f
 Francos.LBA                      events=1953      fnv1a=c5fee0bd776758e9
-Fully loaded horn.LBA            events=11243     fnv1a=823b16dd6273d3a1
+Fully loaded horn.LBA            events=11242     fnv1a=4d5c7d43ee1b9be2
 Gazogem.LBA                      events=2836      fnv1a=af2715529cba796e
 Hacienda.LBA                     events=15941     fnv1a=b60a3fdc5fb12070
 ICX.LBA                          events=4407      fnv1a=bda4fce2f3a53796
@@ -27,8 +28,8 @@ In the school.LBA                events=3567      fnv1a=03d50eecc58d5255
 Island CX 4 Real.LBA             events=5393      fnv1a=aca005a7b22374b7
 Island CX.LBA                    events=18114     fnv1a=c02675a16693ec4f
 Kidnapped!.LBA                   events=1861      fnv1a=bd23c9db284c58c2
-Lazer Crystal.LBA                events=4863      fnv1a=cfbea23590aea438
-Lightning Spell.LBA              events=4642      fnv1a=0b21ca9fcdb44262
+Lazer Crystal.LBA                events=4867      fnv1a=8e3a1c31c0a16fee
+Lightning Spell.LBA              events=4648      fnv1a=db42df5f66e4e8bf
 Lucky jump.LBA                   events=11639     fnv1a=b338257b0ca25206
 Mos attack.LBA                   events=5494      fnv1a=8f91a6794da14e4a
 Mosquibees.LBA                   events=2048      fnv1a=cc4ca7f778d4b4a1
@@ -36,11 +37,11 @@ Oasis.LBA                        events=14048     fnv1a=92425e5735b4430c
 Off to be a Wizard.LBA           events=3627      fnv1a=64ff96c4a5e0ee83
 Otringal .LBA                    events=4716      fnv1a=75d9d3383e2d5299
 Pearl.LBA                        events=2122      fnv1a=b19f96806b592800
-Protection Spell.LBA             events=4943      fnv1a=46f66c4d6f79b31d
-Race.LBA                         events=15201     fnv1a=391f57fb058fa4fb
+Protection Spell.LBA             events=4941      fnv1a=998053b27ad89e4b
+Race.LBA                         events=15199     fnv1a=08a8163b5b449ee4
 Save the Queen.LBA               events=4040      fnv1a=07da4b25a81c4a05
 School of Magic.LBA              events=15187     fnv1a=ac85db5b19ef272d
-Spaceship.LBA                    events=1478      fnv1a=9ed80ac9c6089c52
+Spaceship.LBA                    events=1477      fnv1a=41be4e584a581e00
 Sword.LBA                        events=2219      fnv1a=bd3c5dea9eb8ad66
 The End almost.LBA               events=3109      fnv1a=b79ffdafd9e0c431
 Undergas.LBA                     events=4599      fnv1a=6b2bee844cf663e1
@@ -49,5 +50,5 @@ Volcano Island.LBA               events=11082     fnv1a=86bdd83cd5377d94
 Wannies fragment.LBA             events=5201      fnv1a=8ebebda95217728d
 Wizard outfit.LBA                events=22183     fnv1a=29e45fef8c7bf23b
 Zeelich.LBA                      events=13918     fnv1a=04a383311ee44637
-autosave.lba                     events=12445     fnv1a=f873b71e94c15c4a
-current.lba                      events=9897      fnv1a=cd233219324050e5
+autosave.lba                     events=12445     fnv1a=d070ab2f401109ea
+current.lba                      events=9898      fnv1a=090d9c3114c1e057

--- a/tests/timer/CMakeLists.txt
+++ b/tests/timer/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_executable(test_timer_lock_window test_timer_lock_window.cpp
+    ${CMAKE_SOURCE_DIR}/LIB386/SYSTEM/TIMER.CPP)
+
+target_include_directories(test_timer_lock_window PRIVATE
+    ${CMAKE_SOURCE_DIR}/LIB386/H
+)
+
+target_link_libraries(test_timer_lock_window PRIVATE SDL3::SDL3)
+
+set_target_properties(test_timer_lock_window PROPERTIES CXX_STANDARD 11)
+
+add_test(NAME test_timer_lock_window COMMAND test_timer_lock_window)
+
+register_host_test(test_timer_lock_window)

--- a/tests/timer/test_timer_lock_window.cpp
+++ b/tests/timer/test_timer_lock_window.cpp
@@ -1,0 +1,121 @@
+/* Host-only regression test for the TIMER.CPP LastTime-outside-lock bug
+ * (PR #252 / commit ed0e7a64): ManageTime() must NOT advance LastTime
+ * while TimerLock is held.
+ *
+ * The original 1997 source (and the SDL port through 2026-05) advanced
+ * LastTime unconditionally, which silently discarded wall-clock elapsed
+ * during any Lock window from TimerRefHR. Sub-millisecond on bare-metal
+ * DOS where the locked window was synchronous CPU work; catastrophic under
+ * SDL3 where the locked window holds a full vsync wait (~16.67 ms at 60 Hz)
+ * inside the AffScene full-redraw path.
+ *
+ * If this test fails, the LastTime semantic has regressed. See
+ * docs/TIMING.md for the full history and `LIB386/SYSTEM/TIMER.CPP`
+ * ManageTime() for the fix.
+ *
+ * Test strategy: drive the timer in fixed-dt mode (Timer_EnableFixedDt)
+ * so the wall clock is virtual and fully under our control. No SDL ticks,
+ * no sleeps, deterministic across hosts.
+ */
+
+#include <SYSTEM/TIMER.H>
+
+#include <cassert>
+#include <cstdio>
+
+/* Stub for WINDOW.H AppActive (referenced by TIMER.CPP::HandleEventsTimer).
+ * This test never calls HandleEventsTimer, but the symbol must resolve for
+ * link. */
+bool AppActive = true;
+
+static int fails = 0;
+
+static void check_eq(U32 got, U32 want, const char *label) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL: %s: TimerRefHR=%u (want %u)\n", label, got, want);
+        fails++;
+    }
+}
+
+int main() {
+    /* (1) Lock window must be transparent to TimerRefHR.
+     *
+     * Advance the (virtual) clock outside the lock, then inside the lock --
+     * every wall-clock ms elapsed must be credited to TimerRefHR by the
+     * first unlocked ManageTime() after UnlockTimer() releases. This is the
+     * direct regression test for the original bug. */
+    {
+        Timer_EnableFixedDt(16);
+        ManageTime(); /* bootstrap LastTime to FixedDtNow=0 */
+        check_eq(TimerRefHR, 0, "(1) post-init");
+
+        Timer_FixedDtAdvance(); /* FixedDtNow -> 16 */
+        ManageTime();           /* unlocked: credits +16 */
+        check_eq(TimerRefHR, 16, "(1) one tick before lock");
+
+        LockTimer(); /* calls ManageTime then ++TimerLock */
+
+        Timer_FixedDtAdvance(); /* FixedDtNow -> 32 */
+        ManageTime();           /* locked: must NOT bump LastTime */
+        Timer_FixedDtAdvance(); /* FixedDtNow -> 48 */
+        ManageTime();           /* locked: must NOT bump LastTime */
+
+        UnlockTimer(); /* calls ManageTime (still locked), then --TimerLock */
+        ManageTime();  /* unlocked: credits the whole locked window */
+
+        /* Pre-fix: bug discarded the 32 ms locked window. TimerRefHR stuck
+         * at 16. Post-fix: full wall-clock advance credited. TimerRefHR=48. */
+        check_eq(TimerRefHR, 48, "(1) post-unlock (the regression-pin assertion)");
+    }
+
+    /* (2) SaveTimer/RestoreTimer DOES discard elapsed time -- documented
+     * semantic difference from LockTimer (docs/TIMING.md "Lock vs Save").
+     * This pins the intentional rewind so a future contributor cleaning up
+     * Save/Restore doesn't accidentally turn it into a transparent pause. */
+    {
+        Timer_EnableFixedDt(16);
+        ManageTime();
+        Timer_FixedDtAdvance();
+        ManageTime();
+        check_eq(TimerRefHR, 16, "(2) one tick before save");
+
+        SaveTimer(); /* snapshots TimerRefHR=16 */
+        Timer_FixedDtAdvance();
+        ManageTime(); /* SaveTimer doesn't hold TimerLock, so this credits */
+        Timer_FixedDtAdvance();
+        ManageTime();
+        RestoreTimer(); /* TimerRefHR = snapshot, discards 32 ms */
+        ManageTime();
+
+        /* Post-restore: snapshot restored, two ticks of game time gone. */
+        check_eq(TimerRefHR, 16, "(2) post-restore (rewind semantic)");
+    }
+
+    /* (3) Nested LockTimer balances correctly: the locked window covers
+     * all nested calls and TimerRefHR catches up on the outermost release. */
+    {
+        Timer_EnableFixedDt(16);
+        ManageTime();
+        Timer_FixedDtAdvance();
+        ManageTime();
+        check_eq(TimerRefHR, 16, "(3) one tick before nested lock");
+
+        LockTimer(); /* depth 0 -> 1 */
+        Timer_FixedDtAdvance();
+        LockTimer(); /* nested: depth 1 -> 2 */
+        Timer_FixedDtAdvance();
+        ManageTime();  /* still locked */
+        UnlockTimer(); /* depth 2 -> 1 (still locked) */
+        Timer_FixedDtAdvance();
+        ManageTime();  /* still locked */
+        UnlockTimer(); /* depth 1 -> 0 */
+        ManageTime();  /* unlocked: credits the whole window */
+
+        /* 3 advances * 16ms = 48 ms of locked wall clock, all credited. */
+        check_eq(TimerRefHR, 64, "(3) post-nested-unlock");
+    }
+
+    assert(fails == 0);
+    std::printf("test_timer_lock_window: ok\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

`ManageTime()` advanced `LastTime` unconditionally, including while `TimerLock` was held. Any `ManageTime()` call inside a Lock/Save window (audio, input, animation — ~100 call sites) bumped `LastTime` to the current wall clock but skipped the `TimerRefHR` increment. When the lock released, the next `ManageTime()` saw a near-zero delta and the whole locked interval was discarded from the game clock.

The bug is in the original Adeline 1997 source (`LIB386/SYSTEM/TIMERWIN.CPP`) and was copied byte-for-byte into `TIMER.CPP` during the SDL port in 2023 (#3, `e29b9bd7`). Dormant on bare-metal DOS where lock windows were sub-ms; catastrophic under SDL3 because `BoxBlit → UnlockVideoSurface → SDL_RenderPresent` holds the lock across a full vsync wait (~16.67 ms at 60 Hz). At native resolution where vsync becomes the dominant per-frame cost, ~16–17 ms of game-clock advance was lost every frame. Animations and sim ran at 25-50% real speed; holding a movement key felt unresponsive.

PR #50 (`8af40faa7`, 2026-04-08) already patched this for `FollowCamTerrainFrame` exterior frames with a local `SaveTimer/RestoreTimer + wall-clock re-add` (`SOURCES/PERSO.CPP:1916`). The comment there names the mechanism exactly. That patch addressed one path; this PR generalises the fix to every Lock/Save call site by changing the underlying `ManageTime()` semantic.

**Fix** (one line moved): only advance `LastTime` when `TimerLock` is 0. The locked window's wall time is then correctly credited to `TimerRefHR` by the first unlocked `ManageTime` after the lock releases. The `PERSO.CPP:1916` workaround becomes redundant; left in place for now, removable in a follow-up.

## Commits

- `ed0e7a64` — the fix itself (`LIB386/SYSTEM/TIMER.CPP`, +9 / -2)
- `f0db0206` — regenerated `tests/projection/baselines/corpus_640x480.projrec.hash` (12/50 saves drift; the drift is the fix working, since animation interpolation now lands at the correct game-clock time under `--fixed-dt 16`)
- `7fabe64c` — `docs/TIMING.md` capturing clocks/locks semantics + 1997 bug archaeology, indexed in `docs/README.md`

## How this was found

A `perftrace`-style in-engine ring-buffer instrumentation (separate PR, kept local for now) measured per-frame `TimerSystemHR` and `TimerRefHR` deltas + per-call-site `LockTimer` hit counts using `dladdr`. The deltas showed `TimerRefHR` advancing at 18-50% of wall-clock during normal iso gameplay at native resolution, and the call-site table pinpointed `OBJECT.CPP:5400` `LockTimer()` as the single source of every per-frame leak.

## Test plan

- [x] `make test` — host_quick CTest (12/12 pass)
- [x] `bash scripts/ci/check-format.sh` — clang-format CI (rc=0)
- [x] `make savegame-corpus` — 50 saves × {auto, 32}-abi init/decompress (0 divergences)
- [x] `tests/automation/test_demo.sh` — 500-tick `--demo --fixed-dt 16` byte-identical reruns (PASS; the deterministic regression net, biggest invariant)
- [x] `tests/automation/test_projection_corpus.sh` — 5-tick `--fixed-dt 16` × 50 saves against the regenerated golden (PASS)
- [x] `tests/automation/test_load.sh`, `test_dump.sh`, `test_exec.sh`, `test_negative.sh` (PASS)
- [x] Manual testing across 3 platforms (no regression observed)

## Notes for review

- **The projection-corpus drift is intentional.** Under `--fixed-dt`, `Timer_FixedDtPresent` advances `FixedDtNow` on every non-first present per tick. Pre-fix, those advances inside the AffScene Lock window had their `LastTime` bump silently absorb the time. Post-fix the advance is correctly credited to `TimerRefHR` on lock release, so the next animation frame lands one fixed-dt step later than the (buggy) baseline. Drift is small: 12/50 saves changed, range -2..+32 events per save, sum |delta|=53. The 38 saves without active animations are unchanged.
- **The `PERSO.CPP:1916` `FollowCamTerrainFrame` workaround is now redundant.** Left in place to keep this PR focused; removable in a follow-up after a separate manual pass on exterior follow-cam scenes.
- **TIMERWIN.CPP** (the original 1997 file with the same bug) is not in any current `CMakeLists.txt` — pure history, no second copy to fix.

## Follow-ups (not in this PR)

- Remove the redundant `FollowCamTerrainFrame` Save/Restore block in `SOURCES/PERSO.CPP:1916` after dedicated exterior testing.
- Land the `perftrace` diagnostic module as its own PR (ring buffer + console verb + `PresentTimingFn`/`ManageTimeHook*` callback APIs, minus the one-shot `dladdr` bug-hunt scaffolding).
- Optional: add a host-only unit test that exercises `LockTimer/ManageTime/UnlockTimer/ManageTime` sequences with a controllable clock source, as a regression-guard for future `ManageTime` semantic changes (the projection-corpus catches it indirectly today).

## Related docs

- New: [`docs/TIMING.md`](https://github.com/LBALab/lba2-classic-community/blob/fix/timer-lock-window-leak/docs/TIMING.md)
- Cross-refs: `docs/LIFECYCLES.md`, `docs/CONTROL.md`, `docs/FIXED_DT_PLAN.md`