### PR TITLE
refactor(perso): remove FollowCamTerrainFrame timer-compensation workaround

### DIFF
--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -55,15 +55,13 @@ S32 EscTimer;
 /* FollowCamera refreshes terrain with AFF_ALL_FLIP every movement frame.
  * AFF_ALL_FLIP runs the full AffScene preamble (MemoClipWindow / UnsetClipWindow
  * / ClearImpactRain) before the render, preventing black edges from active clip
- * regions.  The timer lock during render+vsync is compensated by the
- * SaveTimer/RestoreTimer + TimerSystemHR adjustment around AffScene below, so
- * game logic (hero, NPCs, rain) runs at correct wall-clock speed.
- * Vsync naturally caps terrain refreshes at the display rate (~60 Hz).
- * When the hero is idle, all work is skipped entirely. */
+ * regions. Wall-clock time during the render+vsync wait is correctly credited
+ * to TimerRefHR by ManageTime() after the LIB386/SYSTEM/TIMER.CPP generalised
+ * fix; see docs/TIMING.md. Vsync naturally caps terrain refreshes at the
+ * display rate (~60 Hz). When the hero is idle, all work is skipped entirely. */
 /* Default resting distance for the spring arm: midpoint of the two VueCamera
  * presets (DefVueDistance[0]=10500, DefVueDistance[1]=17000). */
 #define FOLLOW_CAM_INITIAL_DIST ((DefVueDistance[0] + DefVueDistance[1]) / 2)
-static S32 FollowCamTerrainFrame = FALSE;
 static S32 FollowCamPrevHeroX = 0;
 static S32 FollowCamPrevHeroY = 0;
 static S32 FollowCamPrevHeroZ = 0;
@@ -1650,12 +1648,6 @@ restartloop:
                 // AlphaCam (touches '+' et '-' *)
                 GereExtKeys(MyKey);
 
-                /* Any AFF_ALL_FLIP forced by GereExtKeys (e.g. elevation +/-)
-                 * while the follow camera is active needs timer compensation
-                 * so the vsync lock doesn't bleed into the game clock. */
-                if (FollowCamera AND CubeMode == CUBE_EXTERIEUR AND FirstTime == AFF_ALL_FLIP)
-                    FollowCamTerrainFrame = TRUE;
-
                 if (Input & I_CAMERA) {
                     SaveTimer();
                     AddBetaCam = (AddBetaCam + 1024) & 4095;
@@ -1811,7 +1803,6 @@ restartloop:
                         }
 
                         FirstTime = AFF_ALL_FLIP;
-                        FollowCamTerrainFrame = TRUE;
 
                         FollowCamPrevHeroX = ptr3d->X;
                         FollowCamPrevHeroY = ptr3d->Y;
@@ -1888,32 +1879,9 @@ restartloop:
         /*-------------------------------------------------------------------------*/
         /* affiche tout */
 
-        /* For FollowCamera AFF_ALL_FLIP frames: save the timer before the
-         * render+vsync and restore it after, then add back the real wall-clock
-         * time elapsed (TimerSystemHR is updated by ManageTime inside
-         * RestoreTimer).  This makes the full render+vsync transparent to the
-         * game clock so hero, NPCs, and rain run at correct speed. */
-        U32 FollowCamTimerBefore = 0;
-        if (FollowCamTerrainFrame) {
-            SaveTimer();
-            FollowCamTimerBefore = TimerSystemHR;
-        }
-
         Perftrace_PhaseBegin(PERFTRACE_PHASE_SCENE);
         AffScene(FirstTime);
         Perftrace_PhaseEnd(PERFTRACE_PHASE_SCENE);
-
-        if (FollowCamTerrainFrame) {
-            RestoreTimer();
-            // The re-add compensates real render+vsync wall-clock so the follow-cam frame
-            // doesn't stall the game clock. Under fixed-dt that wall-clock term is exactly
-            // the nondeterminism we are pinning out, so skip it: the clock advances by the
-            // fixed step alone. Default (non-fixed-dt) behaviour is unchanged.
-            if (!Timer_FixedDtActive()) {
-                TimerRefHR += TimerSystemHR - FollowCamTimerBefore;
-            }
-            FollowCamTerrainFrame = FALSE;
-        }
 
         if ((FirstLoop OR RestartMusic)
                 AND !PLAY_THE_END) {


### PR DESCRIPTION
## Summary

Removes the local `SaveTimer`/`RestoreTimer` + wall-clock re-add wrap around `AffScene` for `FollowCamTerrainFrame` frames in `SOURCES/PERSO.CPP`. PR #50 added it to work around the 1997 `ManageTime` bug. #252 generalised the fix in `ManageTime()` itself, so this local workaround is now mathematically redundant.

**Depends on #252** (`fix/timer-lock-window-leak`). This PR is based on that branch, not on `main`. Will rebase if #252 lands first.

## What changes

- `static S32 FollowCamTerrainFrame` and its two TRUE-set sites (`PERSO.CPP:1654` GereExtKeys path, `:1811` terrain-refresh path) — both existed only to drive the Save/Restore block.
- The 24-line `if (FollowCamTerrainFrame) { SaveTimer(); ... }` wrap around `AffScene` + the `!Timer_FixedDtActive()` re-credit math + `FollowCamTimerBefore` local.
- The multi-line header comment above `FOLLOW_CAM_INITIAL_DIST` that documented the workaround — replaced with a one-liner pointing at `docs/TIMING.md`.

Net: **-36 / +4 lines**, one file touched (`SOURCES/PERSO.CPP`).

## Why it's safe

Mathematical equivalence under wall-clock:

| Step | Pre-removal (with workaround) | Post-removal |
|---|---|---|
| Entry to MainLoop body | `TimerRefHR = T0` | `TimerRefHR = T0` |
| `SaveTimer()` | snapshot `MemoTimerRefHR = T0` | (no-op) |
| `AffScene` `LockTimer` | locked window starts | locked window starts |
| `AffScene` `UnlockTimer` | post-fix: `TimerRefHR += wall_dt` (= `T0 + Δ`) | post-fix: `TimerRefHR += wall_dt` (= `T0 + Δ`) |
| `RestoreTimer()` | `TimerRefHR = MemoTimerRefHR = T0` (discards Δ) | (no-op) |
| `TimerRefHR += TimerSystemHR - FollowCamTimerBefore` | adds Δ back: `TimerRefHR = T0 + Δ` | (no-op) |
| **Net** | `T0 + Δ` | `T0 + Δ` |

Same outcome either way. The workaround was undoing what the locked window now does correctly, then redoing it manually.

## Test plan

Run on the chore branch, with an identical binary built from the parent fix branch's `PERSO.CPP` as the pre-removal control.

- [x] `make test` — host_quick CTest, 13/13 pass (incl. `test_timer_lock_window` from #252)
- [x] `bash scripts/ci/check-format.sh` — rc=0
- [x] `make savegame-corpus` — 50 saves × {auto, 32}-abi init/decompress, 0 divergences
- [x] `tests/automation/test_projection_corpus.sh` — projection hash matches the golden #252 regenerated (50 saves × 5 ticks at `--fixed-dt 16`)
- [x] `tests/automation/test_demo.sh` — byte-identical reruns at `--fixed-dt 16` (cube 193 + cube 218 `LM_THE_END`)
- [x] **Exterior state-dump A/B** at `--fixed-dt 16`, byte-identical across:
  - `Desert Island.LBA` (cube 65), 1000 ticks
  - `Volcano Island.LBA`, 500 ticks
  - `Emerald Moon.LBA`, 500 ticks
  - `Mosquibees.LBA`, 500 ticks

## Caveat

The original workaround's re-credit was already gated on `!Timer_FixedDtActive()`, so the headless harness can only prove equivalence under fixed-dt. Wall-clock equivalence follows from the math above. Manual testing on a real display (FollowCam exterior gameplay at native resolution, hero walking with camera tracking) would close the last loop. Was confirmed across 3 platforms for #252; this PR only *removes* dead code paths, so wall-clock behavioural risk is low.