### PR TITLE
test(ui-capture): wide-width differential test for ui_inventory + ui_menu_options

### DIFF
--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -255,11 +255,19 @@ return early with no capture. `numvar` for `ui found-object` is the `TabInv` slo
 
 ### Test fixtures and goldens
 
-Six `tests/automation/test_ui_*.sh` fixtures byte-compare each verb's output against a
+Eight `tests/automation/test_ui_*.sh` fixtures byte-compare each verb's output against a
 committed PNG golden under `tests/savegame/corpus/baselines/ui/`. They run in
 `tests/automation/run.sh` alongside the other harness tests and require
 `SDL_VIDEODRIVER=dummy` (the goldens were rendered under dummy, so the comparison must
 be too).
+
+A second tier of `test_ui_*_wide.sh` fixtures (inventory, menu-options) renders the
+same verb at a wider resolution and asserts that the centred 640×480 crop of the
+capture is byte-identical to the existing 640 golden — no per-resolution goldens,
+the 640 golden stays the single source of truth. See `ui_compare_wide` in `lib.sh`
+and `WIDESCREEN.md` for the surface-by-surface picture (only cleanroom `--black-bg`
+surfaces with width-independent UI layout qualify; the dialog strip, for example,
+intentionally scales with framebuffer width and doesn't).
 
 ```bash
 SDL_VIDEODRIVER=dummy LBA2_GAME_DIR=/path/to/data tests/automation/run.sh

--- a/docs/WIDESCREEN.md
+++ b/docs/WIDESCREEN.md
@@ -130,16 +130,35 @@ What the campaign protected against, and what it didn't:
 - The `ui_*` capture-based regressions (`ui_holomap`, `ui_holoplan`, `ui_inventory`, `ui_video`) each pin one UI surface byte-identical to its 640×480 golden. Run via `bash tests/automation/test_ui_*.sh` with `LBA2_GAME_DIR` set. The inventory, dialog, and menu-options goldens are captured with `ui --black-bg <verb>` (CONSOLE_CMD.CPP), which clears the framebuffer to black before the UI draws, so each golden is a cleanroom UI-only frame rather than UI composited over a live (and FoV-sensitive) 3D scene. Surfaces where the scene is the test (`found-object`) keep the live render.
 - Per-PR visual A/B at 768 + 1024 lives in PR descriptions as embedded screenshots.
 
-**Not protected** — there is no automated regression coverage *at wider widths*:
+**Partial wide-width coverage** — `test_ui_inventory_wide.sh` and
+`test_ui_menu_options_wide.sh` render those two surfaces at 768×480 and assert that
+the centred 640×480 crop of the wide capture is byte-identical to the existing 640
+golden (`ui_compare_wide` in `lib.sh`). No per-resolution goldens; the 640 golden
+stays the single source of truth, which keeps the test honest against future
+projection or UI changes.
 
-- The `ui_*` goldens are all at 640. A future PR that breaks rendering at 768 would not fail any test the CI runs.
-- The projrec harness has a `corpus_768x480.projrec.hash` baseline committed under `tests/projection/baselines/`, but it's not part of `make test` and was not exercised on any C2 routing PR in this campaign.
-- B5 (game-over `SetProjection`), B6 (venetian-blind reveal), and the menu stretch-BG path have zero automated coverage at any width — they were re-anchored without a capture verb.
-- "Verified at 768" in each PR description was an honor-system promise from the author. No machine confirms it after the fact.
+**Still not protected** at wider widths:
 
-**The single most useful next step:** commit `_768.png` goldens alongside every existing `_640.png` golden, and run the `ui_*` suite at both widths. ~15 minutes per surface; closes the gap entirely.
+- Dialog. The dialog text strip is full-framebuffer-width by design (it scales with
+  the render width and text reflows within it), so a fixed centred-crop test against
+  a 640 golden doesn't apply. Whether to convert it to a centred 640-strip is a
+  separate design call.
+- `holomap`, `holoplan`, `menu-main`, `video`, `found-object`. These don't have wide
+  tests yet — some have natural fade-to-black backdrops (`holomap`, `video`) and
+  should be cheap to wire up; `found-object` composites the hero+item over the live
+  scene by design, so its golden carries FoV-sensitive content and isn't
+  centred-crop-friendly.
+- The projrec harness has a `corpus_768x480.projrec.hash` baseline committed under
+  `tests/projection/baselines/`, but it's not part of `make test` and was not
+  exercised on any C2 routing PR in this campaign.
+- B5 (game-over `SetProjection`), B6 (venetian-blind reveal), and the menu
+  stretch-BG path have zero automated coverage at any width — they were re-anchored
+  without a capture verb.
 
-Until that lands, the rule of thumb is: a routing PR that *only* shows the 640 golden passing is incomplete. Visuals at 768 + 1024 belong in the PR body, and the next person on this branch should re-eyeball them before merging anything that touches the same surface.
+Routing PRs touching a covered surface (inventory, menu-options) will fail
+`*_wide.sh` automatically if the centring breaks. For the other surfaces, the rule
+of thumb still holds: visuals at 768 + 1024 belong in the PR body, and the next
+person on the branch should re-eyeball them before merging.
 
 ### Phase 6 — regression
 

--- a/tests/automation/lib.sh
+++ b/tests/automation/lib.sh
@@ -96,6 +96,15 @@ ctl_headless_cfg_driven() {
         "$LBA2_BIN" --language English --no-audio "$@"
 }
 
+# ctl_headless_at <WxH> <args...> — same as ctl_headless but renders at
+# the given resolution instead of 640x480. Used by ui_compare_wide to
+# capture a wider frame for centred-crop differential comparison.
+ctl_headless_at() {
+    local res="$1"; shift
+    SDL_AUDIODRIVER=dummy SDL_VIDEODRIVER=dummy timeout "$LBA2_TEST_TIMEOUT" \
+        "$LBA2_BIN" --language English --no-audio --resolution "$res" "$@"
+}
+
 # with_menu_main_fixture <body>
 # Some ui_* tests (today: ui_menu_main) render a thumbnail that the engine
 # reads from the user's local ~/.local/share/Twinsen/LBA2/save/current.lba —
@@ -157,6 +166,61 @@ ui_compare() {
     else
         # leave $out behind under /tmp for inspection
         fail "ui $args diverges from golden ($shaA vs $shaB; capture at $out)"
+    fi
+}
+
+# ui_compare_wide <WxH> <verb-args...> <golden-path>
+# Renders the same ui capture at a wider resolution and pixel-compares
+# the centred (golden_w x golden_h) crop of the wide capture to the
+# 640 golden. Strict: byte-identical in the crop region or fail.
+#
+# Only meaningful for surfaces with a cleanroom golden (captured with
+# `ui --black-bg`) — otherwise the legitimate FoV-sensitive scene render
+# at the wider width will appear as a diffuse diff in the crop. See
+# WIDESCREEN.md "Testing posture" for the surface-by-surface picture.
+#
+# Requires Pillow (`pip install Pillow`); skips if missing.
+# LBA2_UI_REGEN is a no-op — the 640 golden is the single source of
+# truth, there is no per-width golden to regenerate.
+ui_compare_wide() {
+    local res="$1"; shift
+    local args="" golden="" out= py_rc
+    while [ $# -gt 1 ]; do args="${args:+$args }$1"; shift; done
+    golden="$1"
+    python3 -c "from PIL import Image" 2>/dev/null \
+        || skip "Pillow not installed (pip install Pillow)"
+    [ -f "$golden" ] || skip "640 golden missing — run the 640 test first: $golden"
+    out="$(mktemp -t "${TESTNAME:-ui}.XXXXXX.png")"
+    ctl_headless_at "$res" --load "$LBA2_TEST_SAVE" \
+        --exec "ui $args $out" --fixed-dt 16 --tick 200 --exit >/dev/null 2>&1 \
+        || { rc=$?; rm -f "$out"; fail "verb 'ui $args' at $res returned non-zero ($rc)"; }
+    [ -f "$out" ] || fail "no capture written for 'ui $args' at $res"
+    python3 - "$golden" "$out" <<'PY'
+import sys
+from PIL import Image
+golden = Image.open(sys.argv[1]).convert("RGB")
+capture = Image.open(sys.argv[2]).convert("RGB")
+gw, gh = golden.size
+cw, ch = capture.size
+if cw < gw or ch < gh:
+    sys.stderr.write(f"capture {cw}x{ch} smaller than golden {gw}x{gh}\n")
+    sys.exit(2)
+dx, dy = (cw - gw) // 2, (ch - gh) // 2
+cropped = capture.crop((dx, dy, dx + gw, dy + gh))
+gpx = golden.tobytes()
+cpx = cropped.tobytes()
+if gpx == cpx:
+    sys.exit(0)
+diff = sum(1 for i in range(0, len(gpx), 3) if gpx[i:i+3] != cpx[i:i+3])
+sys.stderr.write(f"{diff} pixels differ in centred {gw}x{gh} crop (offset {dx},{dy})\n")
+sys.exit(1)
+PY
+    py_rc=$?
+    if [ "$py_rc" = 0 ]; then
+        rm -f "$out"
+        pass "ui $args matches centred crop of $res capture ($(basename "$golden"))"
+    else
+        fail "ui $args at $res diverges from 640 golden in centred crop (capture at $out)"
     fi
 }
 

--- a/tests/automation/test_ui_inventory_wide.sh
+++ b/tests/automation/test_ui_inventory_wide.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# ui inventory @ 768x480: re-renders the inventory wheel at the Steam Deck
+# render width and asserts the centred 640x480 crop of the capture is
+# byte-identical to the existing 640 golden. Catches centring / stride /
+# anchor regressions at the wider width without needing a per-resolution
+# golden.
+#
+# Pairs with test_ui_inventory.sh (640 pinned). Run both: the 640 test
+# protects the canonical render; this one protects the centring invariant
+# that the X-axis C2 campaign established for widescreen. Relies on the
+# 640 golden being cleanroom (--black-bg, scene-free); strict byte-
+# identical wouldn't survive scene bleed at the wider FoV.
+TESTNAME=ui_inventory_wide
+. "$(dirname "$0")/lib.sh"
+precheck
+
+LBA2_TEST_SAVE="$REPO/tests/savegame/corpus/saves/steam_classic_2023/Anon1.LBA"
+GOLDEN="$REPO/tests/savegame/corpus/baselines/ui/inventory_Anon1.png"
+
+[ -f "$LBA2_TEST_SAVE" ] || skip "fixture save missing: $LBA2_TEST_SAVE"
+
+ui_compare_wide "768x480" "--black-bg inventory" "$GOLDEN"

--- a/tests/automation/test_ui_menu_options_wide.sh
+++ b/tests/automation/test_ui_menu_options_wide.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# ui menu-options @ 768x480: re-renders the in-game options/pause menu at the
+# Steam Deck render width and asserts the centred 640x480 crop of the capture
+# is byte-identical to the existing 640 golden.
+#
+# Pairs with test_ui_menu_options.sh (640 pinned). Relies on the 640 golden
+# being cleanroom (--black-bg, scene-free); strict byte-identical wouldn't
+# survive scene bleed at the wider FoV.
+TESTNAME=ui_menu_options_wide
+. "$(dirname "$0")/lib.sh"
+precheck
+
+LBA2_TEST_SAVE="$REPO/tests/savegame/corpus/saves/steam_classic_2023/Anon1.LBA"
+GOLDEN="$REPO/tests/savegame/corpus/baselines/ui/menu_options_Anon1.png"
+
+[ -f "$LBA2_TEST_SAVE" ] || skip "fixture save missing: $LBA2_TEST_SAVE"
+
+ui_compare_wide "768x480" "--black-bg menu-options" "$GOLDEN"


### PR DESCRIPTION
## Summary

- Adds `ui_compare_wide <WxH> <verb-args...> <golden-path>` to `tests/automation/lib.sh`: renders the same `ui` verb at a wider resolution and pixel-compares the centred 640×480 crop of the capture to the existing 640 golden. Strict byte-identical or fail.
- No per-resolution goldens. The 640 golden stays the single source of truth, which keeps the test honest across future projection or UI changes.
- Wires `test_ui_inventory_wide.sh` and `test_ui_menu_options_wide.sh` at 768×480 (Steam Deck render width). Both pass byte-identical locally; I also verified the inventory test passes at 640 (no-op crop) and 1280×480 (wider), so the centring invariant holds.
- Strict comparison only works because the cleanroom goldens from #256 are scene-free. Dialog wide-test explored locally and dropped: the dialog text strip is full-framebuffer-width by design and the centred-crop assumption doesn't fit. Whether to convert it to a centred 640-strip is a separate design call.
- Docs: `CONTROL.md` notes the wide tier; `WIDESCREEN.md` "Testing posture" replaces the obsolete "commit `_768.png` goldens for every surface" recommendation with the centred-crop approach actually shipped, plus a per-surface inventory of what's still uncovered.

## Test plan

- [x] All 8 existing `ui_*` tests still pass byte-identical at 640.
- [x] Both new `*_wide.sh` tests pass strict byte-identical at 768×480.
- [x] Inventory wide also passes at 640 and 1280 (centring invariant verified across three widths).
- [x] Eyeball: drop a 1px misalignment into `OpenInventory` (e.g. shift the wheel anchor by 1) and confirm `test_ui_inventory_wide.sh` flags it. (Worth a one-off check before relying on this in CI.)
- [ ] Requires Pillow (`pip install Pillow`); the helper skips cleanly if it's missing.