### PR TITLE
fix(reso): update dirty-box clip on Res_Switch — fix trailing right strip

### DIFF
--- a/SOURCES/RES_SWITCH.CPP
+++ b/SOURCES/RES_SWITCH.CPP
@@ -90,6 +90,18 @@ static bool ResizeSdlSurfaces(U32 w, U32 h) {
        subsequent draw is clipped to the previous resolution's width. */
     SetClipWindow(0, 0, (S32)w - 1, (S32)h - 1);
     SetClip(0, 0, (S32)w - 1, (S32)h - 1);
+    /* Dirty-box clip is a parallel system to the SVGA clip — BoxStaticFullflip
+       (which `FirstTime = AFF_ALL_FLIP` ultimately triggers a full-frame
+       redraw through) bounds its full-screen invalidation to BoxClipX/Y,
+       not ClipWindowX/Y.  Without this call after a 640->768 switch the
+       dirty-box clip stays at the old 640, the right strip [640..768) never
+       gets marked dirty + blitted + presented, and shows whatever leftover
+       pixels the SDL surface had after ResizeVideoSurface — visible as
+       trailing / smearing along the new-width strip until a relaunch.
+       The TRUE clean flag also makes the next BoxBlit zero the physical
+       surface outside the clip, closing the gap on shrinks too. Mirrors
+       the BoxInit call at DIRTYBOX.CPP:572. */
+    BoxChangeClip(0, 0, (S32)w - 1, (S32)h - 1, TRUE);
     return true;
 }
 


### PR DESCRIPTION
## Summary

The engine has two parallel clip systems: the SVGA clip (`ClipWindowX/Y`, updated by `SetClipWindow`) and the dirty-box clip (`BoxClipX/Y`, updated by `BoxChangeClip`). `Res_Switch` was updating only the former.

`BoxStaticFullflip` — the engine's "redraw everything" path that `FirstTime = AFF_ALL_FLIP` ultimately triggers — bounds its full-screen invalidation to `BoxClipXMax`. After a 640→768 switch the dirty-box clip stays at the old 640, so the right strip `[640..768)` never gets marked dirty, blitted, or presented. It shows whatever leftover pixels the SDL surface had after `ResizeVideoSurface`, until a relaunch starts `BoxClipXMax` at 768 cleanly via `BoxInit` (`DIRTYBOX.CPP:572`). Visible as trailing / smearing along the new-width strip on every res-switch from narrower to wider, matches the user-reported "dirty render" symptom.

Add the matching `BoxChangeClip` call to `ResizeSdlSurfaces`, next to `SetClipWindow`. The `TRUE` clean flag also makes the next `BoxBlit` zero the physical surface outside the new clip, which covers shrink switches (768→640) where the old right strip would otherwise linger as un-cleared physical-surface pixels.

This is one specific case of a broader pattern: `Res_Switch` has accreted seven "also re-init this" lines (palette, projection, CameraCenter, InitPartFlow, FirstTime, …) each added when a specific bug surfaced. A systematic audit of boot-only init points vs `Res_Switch` replay belongs as a follow-up, separate from this fix.

## Test plan

- [x] All 4 `test_res_switch*.sh` automation tests pass.
- [x] All 8 `test_ui_*.sh` automation tests still pass byte-identical.
- [x] Eyeball at a real display: launch at 640×480, switch to 768×480 in-game via the console verb or the Display dialog, walk around an exterior scene — the right strip should redraw cleanly with no trailing.
- [ ] Same flow for the shrink direction (768→640) — confirm no lingering pixels in the now-cropped area.