### PR TITLE
fix(widescreen): sample-edge sidebars for Adeline bumper + logo

### DIFF
--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -4674,7 +4674,12 @@ S32 AdelineLogo(void) {
     //      S32     volume ;
 
     GetResPath(tmpFilePath, ADELINE_MAX_PATH, SCREEN_HQR_NAME);
-    if (!Image_LoadCentered(tmpFilePath, Log, PCR_LOGO))
+    // FillFromEdge: the Adeline logo PCX has a white background that
+    // should extend across the framebuffer at widescreen, not be
+    // black-cropped to the centred 640. Sampling the PCX's top-left
+    // pixel picks up its white-index regardless of which palette
+    // entry holds white. No-op at 640x480.
+    if (!Image_LoadCenteredFillFromEdge(tmpFilePath, Log, PCR_LOGO))
         TheEndCheckFile(tmpFilePath);
 
     if (!Load_HQR(tmpFilePath, PalettePcx, PCR_LOGO + 1))
@@ -4757,7 +4762,24 @@ S32 ShowLogo(S32 numscr, S32 nsec) {
     char tmpFilePath[ADELINE_MAX_PATH];
 
     GetResPath(tmpFilePath, ADELINE_MAX_PATH, SCREEN_HQR_NAME);
-    if (Image_LoadCentered(tmpFilePath, Log, numscr)
+    // Widescreen sidebars treatment: the Adeline studio bumper PCX has
+    // a white background that should extend across the framebuffer, so
+    // the fade-in reads as one contiguous frame instead of a centred
+    // white logo with black wings. Sampling the PCX's top-left pixel
+    // via Image_LoadCenteredFillFromEdge handles this without hard-
+    // coding the palette's white-index. All other PCRs (distributor
+    // logos: Activision / EA / Virgin / publisher bumpers) pre-clear
+    // Log to 0 so the sidebars are explicit black instead of whatever
+    // leftover bytes the previous frame left behind. Both branches are
+    // no-ops at 640x480 (image fully overwrites the buffer).
+    U32 loaded;
+    if (numscr == PCR_BUMPER) {
+        loaded = Image_LoadCenteredFillFromEdge(tmpFilePath, Log, numscr);
+    } else {
+        memset(Log, 0, (size_t)ModeDesiredX * (size_t)ModeDesiredY);
+        loaded = Image_LoadCentered(tmpFilePath, Log, numscr);
+    }
+    if (loaded
             AND Load_HQR(tmpFilePath, PalettePcx, numscr + 1)) {
         WaitNoInput();
 

--- a/SOURCES/IMAGE_LOAD.CPP
+++ b/SOURCES/IMAGE_LOAD.CPP
@@ -61,6 +61,23 @@ U32 Image_LoadStretched(const char *file, void *dest, S32 index) {
     return size;
 }
 
+U32 Image_LoadCenteredFillFromEdge(const char *file, void *dest, S32 index) {
+    U32 size = Load_HQR(file, ImageStaging, index);
+    if (size == 0)
+        return 0;
+    /* Sample the loaded bitmap's top-left pixel and use it as the
+       sidebar fill. For centred-on-uniform-bg PCXs (boot bumpers, the
+       Adeline logo with its white background) the edge colour is the
+       natural background colour, so widescreen sidebars composite
+       seamlessly with the image. At 640x480 the memset is fully
+       overwritten by the centred copy, so this is byte-identical to
+       Image_LoadCentered at the canonical width. */
+    memset(dest, ImageStaging[0],
+           (size_t)ModeDesiredX * (size_t)ModeDesiredY);
+    Image_CopyCenteredFromStaging(dest);
+    return size;
+}
+
 void Image_RenderCenteredFromStaging(void *dest) {
     Image_CopyCenteredFromStaging(dest);
 }

--- a/SOURCES/IMAGE_LOAD.H
+++ b/SOURCES/IMAGE_LOAD.H
@@ -55,6 +55,16 @@ U32 Image_LoadCentered(const char *file, void *dest, S32 index);
    content to fill the entire (ModeDesiredX, ModeDesiredY) area of <dest>. */
 U32 Image_LoadStretched(const char *file, void *dest, S32 index);
 
+/* Same as Image_LoadCentered but fills <dest> with the loaded bitmap's
+   top-left pixel before the centred row-copy. At widescreens the result
+   is sidebars that match the PCX's authored edge colour — for the
+   Adeline bumper (PCR_LOGO / PCR_BUMPER), the white background appears
+   contiguous across the framebuffer instead of black-cropped at 640.
+   At 640x480 the memset is fully overwritten by the centred copy, so
+   this is byte-identical to Image_LoadCentered. Returns the loaded byte
+   count (0 on failure). */
+U32 Image_LoadCenteredFillFromEdge(const char *file, void *dest, S32 index);
+
 /* Row-copy the staging buffer (whatever's currently in it) centred into
    <dest>, without re-loading. Used by transitions / fades that read
    repeatedly from a previously-loaded bitmap. */


### PR DESCRIPTION
## Summary

At widescreens the boot Adeline logo (PCR_LOGO) and studio bumper (PCR_BUMPER) loaded centred via Image_LoadCentered, which leaves the framebuffer area outside the 640×480 inscribed image untouched. Whatever bytes happened to be in Log from the previous frame showed through the sidebars during the FadeToPal — a white logo with two black wings, breaking the fade-in effect the bumper relies on.

Adds Image_LoadCenteredFillFromEdge: same row-copy as the existing centred loader, but memsets the destination with the PCX's top-left pixel before the copy. For a uniform-background bumper that's the authored edge colour — white for Adeline branding, dark for distributor logos — without hardcoding palette indices that vary per PCX.

Apply at two sites:

- AdelineLogo (loads PCR_LOGO directly) → Image_LoadCenteredFillFromEdge.
- BumperLogo → via ShowLogo, which now switches on numscr == PCR_BUMPER to pick the edge-fill path. Other ShowLogo callers (DistribLogo for Activision / EA / Virgin) pre-clear Log to 0 so sidebars are explicit black, removing the lottery on previous-frame leftovers.

Both branches are no-ops at 640×480 (the centred copy fully overwrites the buffer), so existing automation stays byte-identical.

HD strategy is deliberately out of scope — at Y>480 we'd want a sympathetic vertical treatment and possibly an upscaled bumper, not a centred 640×480 anchor.

## Test plan

- [x] All 10 ui_* automation tests pass byte-identical (640×480 is the headless capture width, and both code paths are no-ops there).
- [x] Eyeball at a real display, 768×480 or wider:
  - Launch the game; boot sequence should show the distributor logo, then the Adeline bumper with a contiguous white fade-in (no black wings).
  - Both sidebars should match the bumper's white centre.
  - Distributor bumpers (Activision / EA / Virgin) should have black sidebars instead of the previous-frame leftovers.