### PR TITLE
docs: centralize code style into CODESTYLE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ This document helps AI coding assistants (Cursor, Copilot, Claude, etc.) work ef
 
 Operational complements to the principles above.
 
-- **ASM is the source of truth.** All equivalence tests compare ASM vs C++ byte-for-byte. Use `ASSERT_ASM_CPP_EQ_INT` for scalars, `ASSERT_ASM_CPP_MEM_EQ` for buffers. See `docs/ASM_TEST_COVERAGE_AUDIT.md` for what "covered" means in practice (branches, side effects, edge inputs, ASM-invalid domains).
+- **ASM is the source of truth.** All equivalence tests compare ASM vs C++ byte-for-byte. Use `ASSERT_ASM_CPP_EQ_INT` for scalars, `ASSERT_ASM_CPP_MEM_EQ` for buffers. See `docs/ASM_TEST_COVERAGE_AUDIT.md` for what "covered" means in practice (branches, side effects, edge inputs, ASM-invalid domains). This applies to ported engine code (LIB386, SOURCES/3DEXT). New SOURCES infrastructure with no ASM original (e.g. console, logging, control harness) is verified by host tests, not ASM equivalence.
 - **Think like an archaeologist:** This codebase is a window into 1990s game dev at Adeline Software. Surface historical context when relevant. See `docs/FRENCH_COMMENTS.md` and `docs/ASCII_ART.md`.
 - **Search before adding:** Check for existing implementations before adding new code; avoid duplication.
 - **Pin fixes with a test or a repro hook.** When fixing a bug, first ask whether the affected logic is pure-data (parsing, serialization, math, projection, sort) — if yes, extracting it into a pure function and adding a host test is usually a small additional refactor and should be done as part of the fix. When automation is impractical (state, timing, UI), ship a manual repro hook instead (a console command, debug menu entry, or build flag). See [CONTRIBUTING.md "Doing good work here"](CONTRIBUTING.md#doing-good-work-here) for the rationale.
@@ -89,11 +89,12 @@ Apply these behavior rules on every non-trivial task:
 
 ## Code conventions
 
-- Indentation: 4 spaces (C/C++); tabs preserved in ASM
+Style rules and rationale (language dialect, indentation, types, C++98, preservation) live in [CODESTYLE.md](CODESTYLE.md) — read it before writing engine code. The agent-critical invariant: **ported original code stays C-style to mirror the ASM; new infrastructure with no ASM original may use conservative C++98 features.** Never modernize game code (see the Never list). When unsure, match the file you are editing.
+
+Formatting mechanics (agent-operational):
+
 - Formatting: clang-format with checked-in `.clang-format`; exclusions live in `.clang-format-ignore` (ASM, `LIB386/libsmacker/`, vendored `stb_*`, and a handful of legacy lookup-table files). When adding vendored third-party code or generated/hand-tuned lookup tables, add the path to `.clang-format-ignore` in the same commit — single source of truth for local scripts, CI, and the pre-commit hook.
 - Pre-commit hook (optional, recommended): `git config core.hooksPath scripts/git-hooks` once per clone. It runs clang-format `--dry-run` on staged C/C++ files (respecting `.clang-format-ignore`) and blocks commits with violations. Fix with `bash ./scripts/ci/apply-format.sh && git add -u`. Bypass with `git commit --no-verify` or `SKIP_FORMAT=1` when warranted.
-- Types: S32, U32 from `LIB386/H/SYSTEM/ADELINE_TYPES.H`
-- C++98 for game code; tests may use C11/C++11
 
 ## Editing docs
 
@@ -165,7 +166,8 @@ both: e.g. `fix(credits): ... (#65) (#66)`. Reference issues in the PR
 ## Further reading
 
 - [LICENSE](LICENSE) — GPL v2; project license
-- [CONTRIBUTING.md](CONTRIBUTING.md) — Code style, preservation, PR workflow
+- [CODESTYLE.md](CODESTYLE.md) — Canonical code-style rules: language dialect by zone, indentation, types, C++98, preservation
+- [CONTRIBUTING.md](CONTRIBUTING.md) — Contribution workflow, formatter mechanics, PR workflow
 - [.github/copilot-instructions.md](.github/copilot-instructions.md) — Detailed ASM↔CPP workflow, polyrec debugging, test patterns, common pitfalls
 - [docs/FEATURE_WORKFLOW.md](docs/FEATURE_WORKFLOW.md) — Reasoning and docs for big features (console, headless, menu, camera)
 - [docs/README.md](docs/README.md) — Full documentation index

--- a/CODESTYLE.md
+++ b/CODESTYLE.md
@@ -1,0 +1,41 @@
+# Code style
+
+Canonical reference for code-style *decisions* in this repository — the rules and the reasoning behind them. It is the single source of truth that [CONTRIBUTING.md](CONTRIBUTING.md) and [AGENTS.md](AGENTS.md) point to, so a rule lives here once instead of drifting across both.
+
+This covers *what* the code should look like and *why*. The *how* of running the formatter — `clang-format` scripts, the pre-commit hook, `.clang-format-ignore`, EditorConfig, VS Code setup — is a development-environment concern and stays in [CONTRIBUTING.md "Code style"](CONTRIBUTING.md#code-style).
+
+Overriding rule when in doubt: **match the style of the file you are editing.**
+
+## Language dialect — C-in-`.cpp`, by zone
+
+The `.CPP`/`.H` extensions and `extern "C"` blocks are a compilation and linkage detail, not a signal that the engine is object-oriented. The whole engine compiles as **C++98** (`CMAKE_CXX_STANDARD 98` in [CMakeLists.txt](CMakeLists.txt)); there is no STL, no templates, and no class hierarchy in shipped code, and that is deliberate.
+
+**Guiding principles.** Whatever the zone, the house dialect favours restraint over machinery:
+
+- Reach for a language feature only when it earns its keep; prefer the simplest construct that does the job.
+- Plain structs and value semantics over object hierarchies. No deep inheritance, no RTTI, no exceptions.
+- No STL in shipped or per-frame code. If a container is unavoidable, keep it explicit and allocation-aware.
+- Optimise for readability and predictable performance, not for abstraction.
+
+Within that, which features to reach for depends on the zone you are in:
+
+- **Ported original code** (`LIB386/`, `SOURCES/3DEXT/`, and game logic in `SOURCES/` that mirrors the 1997 source or the ASM): stays closest to its origin. It must keep mapping recognisably to the ASM the equivalence tests pin and to the original Adeline source — that correspondence is what the `--bisect` workflow and the byte-for-byte tests depend on — so preserve its C-style structure rather than reshaping it into classes or `std::` containers. `extern "C"` stays.
+- **New infrastructure with no ASM original** (console, logging, control harness, resolution/discovery helpers, future tooling): the guiding principles above are the whole rule. Conservative C++98 features are welcome where they earn their keep — anonymous namespaces for internal linkage, references, small helper classes / RAII for resource lifetimes. This is the zone where [`SOURCES/RES_PICKER.CPP`](SOURCES/RES_PICKER.CPP)'s `namespace {}` already lives; that is the intended style, not an inconsistency.
+- **Tests** (`tests/`): free to use newer C++ (C11/C++11) and `std::` — they verify the engine, they are not shipped with it.
+
+Rule of thumb: if a file has an ASM counterpart or a line-for-line ancestor in the original, it stays C. If you are writing something new that never existed in 1997, idiomatic (but conservative) C++98 is fine.
+
+## Layout and naming
+
+- **Indentation:** 4 spaces in C/C++. Tabs are preserved in ASM. The original used tabs; there is an ongoing migration to 4 spaces, so new contributions use 4 spaces.
+- **Types:** use the fixed-width aliases `S32`/`U32`/`S16`/`U16`/`U8` from [`LIB386/H/SYSTEM/ADELINE_TYPES.H`](LIB386/H/SYSTEM/ADELINE_TYPES.H), not bare `int`/`unsigned`, in ported and engine code.
+- **Standard:** C++98 for engine and game code; tests may use C11/C++11.
+
+## Preservation of original code
+
+This project is a preservation effort. When modifying original source files:
+
+- Do not remove original French comments — they are part of the codebase's history. See [docs/FRENCH_COMMENTS.md](docs/FRENCH_COMMENTS.md).
+- Do not remove or alter ASCII art banners in source files. See [docs/ASCII_ART.md](docs/ASCII_ART.md).
+- Add clarifying comments alongside the originals rather than replacing them.
+- When documenting history or culture, attribute to the original codebase (lba2-classic) and note when content was preserved during an ASM→C++ port in this fork.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,9 +65,7 @@ To run the game you need retail data (not in the repo); see [docs/GAME_DATA.md](
 
 ### Code style
 
-The original codebase uses tabs for indentation. There is an ongoing effort to migrate to 4 spaces -- new contributions should use 4 spaces for indentation.
-
-The codebase is based on C and C++ (C++98) along with x86 assembly (UASM) for reference and equivalence tests. Please keep changes consistent with the style of the file you are modifying.
+The style rules and the reasoning behind them — language dialect (C-in-`.cpp` by zone), indentation, types, the C++98 standard, and preservation of original code — live in [CODESTYLE.md](CODESTYLE.md). Read it before writing code, and keep changes consistent with the style of the file you are modifying. The rest of this section covers the *mechanics* of running the formatter.
 
 For C and C++ files, the repository now uses `clang-format` with a checked-in style file. In VS Code, workspace settings enable format-on-save for C and C++ when the recommended `ms-vscode.cpptools` extension is installed.
 
@@ -108,12 +106,7 @@ After the bootstrap formatting commit exists, add its SHA to `.git-blame-ignore-
 
 ### Preservation of original code
 
-This project values preservation. When modifying original source files:
-
-- Do not remove original French comments -- they are part of the codebase's history
-- Do not remove or alter ASCII art banners in source files
-- If you need to add clarifying comments, add them alongside the originals rather than replacing them
-- When adding or changing documentation about history or culture, attribute to the original codebase (lba2-classic) and note when content was preserved during an ASM→C++ port in this fork
+This project values preservation: original French comments and ASCII art banners stay, clarifying comments go alongside the originals rather than replacing them, and history/culture content is attributed to the original codebase (lba2-classic). The full rules are in [CODESTYLE.md "Preservation of original code"](CODESTYLE.md#preservation-of-original-code).
 
 ## Contributing to the documentation
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Please note this license only applies to **Little Big Adventure 2** engine sourc
 
 ## How can I contribute?
 
-Read our [Contribution Guidelines](https://github.com/LBALab/lba2-classic-community/blob/main/CONTRIBUTING.md).
+Read our [Contribution Guidelines](https://github.com/LBALab/lba2-classic-community/blob/main/CONTRIBUTING.md) and the [Code Style](https://github.com/LBALab/lba2-classic-community/blob/main/CODESTYLE.md) reference.
 
 ## Links
 


### PR DESCRIPTION
## What

Adds `CODESTYLE.md` as the single source of truth for code-style decisions and the reasoning behind them, and points the other docs at it instead of duplicating (and drifting) the rules.

- **`CODESTYLE.md` (new):** language dialect (C-in-`.cpp` by zone — ported code stays C-style to mirror the ASM and the equivalence tests; new infrastructure with no ASM original may use conservative C++98 features), indentation, fixed-width types, the C++98 standard, and preservation of original French comments and ASCII art.
- **`CONTRIBUTING.md`:** code-style section now defers to `CODESTYLE.md` and keeps only the formatter *mechanics* (clang-format, pre-commit hook).
- **`AGENTS.md`:** Code conventions defer to `CODESTYLE.md`; retains the agent-critical invariant and formatting mechanics. Clarifies the "ASM is the source of truth" golden rule — it applies to ported engine code (LIB386, SOURCES/3DEXT); new SOURCES infrastructure (console, logging, control harness) is verified by host tests, not ASM equivalence.
- **`README.md`:** links the Code Style reference alongside the contribution guide.

## Why

Code-style rules were split across `AGENTS.md` and `CONTRIBUTING.md` and had started to diverge. Centralizing them keeps one rule in one place. The golden-rule clarification removes ambiguity about how new, non-ported subsystems get tested.

Docs-only; no code or build changes.