### PR TITLE
feat: boot-log terminal sink (ANSI, TTY-gated)

### DIFF
--- a/SOURCES/LOG/LOG.CPP
+++ b/SOURCES/LOG/LOG.CPP
@@ -2,24 +2,39 @@
 
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+
+#if defined(_WIN32)
+#include <io.h>      /* _isatty, _fileno */
+#include <windows.h> /* GetStdHandle, SetConsoleMode (VT enable) */
+#else
+#include <unistd.h> /* isatty, fileno */
+#endif
 
 #ifndef LBA_LOG_NO_SDL
 #include <SDL3/SDL_log.h>
-/* App-defined SDL log categories: one for ordinary records, one to tag section
- * headers so the trampoline can recover is-header without parsing the text. */
+/* App-defined SDL log categories: ordinary records, section begin, section end —
+ * so the trampoline recovers the record kind without parsing the text. */
 #define LBA_CAT_LOG (SDL_LOG_CATEGORY_CUSTOM + 0)
 #define LBA_CAT_SECTION (SDL_LOG_CATEGORY_CUSTOM + 1)
+#define LBA_CAT_SECTION_END (SDL_LOG_CATEGORY_CUSTOM + 2)
 #endif
 
 #define LOG_MSG_MAX 1024
 #define LOG_MAX_SINKS 8
+#define LOG_TERM_WIDTH 60 /* section rule width for the terminal sink */
 
 /* Internals in an anonymous namespace for internal linkage — the house
  * new-infrastructure style (see SOURCES/RES_PICKER.CPP). */
 namespace {
 
-typedef void (*SinkWriteFn)(LogSink *sink, LogSeverity sev, int is_header,
+/* Record kind, carried alongside severity through the fan-out. */
+enum { REC_NORMAL = 0,
+       REC_SECTION_BEGIN = 1,
+       REC_SECTION_END = 2 };
+
+typedef void (*SinkWriteFn)(LogSink *sink, LogSeverity sev, int kind,
                             const char *msg);
 
 } // namespace
@@ -30,7 +45,8 @@ struct LogSink {
     int in_use;
     LogSeverity min_severity;
     SinkWriteFn write;
-    FILE *fp; /* file sink only */
+    FILE *fp;    /* file sink: owned; terminal sink: stderr (not owned) */
+    int owns_fp; /* close fp on shutdown (file sink only) */
 };
 
 namespace {
@@ -54,25 +70,93 @@ const char *severity_tag(LogSeverity sev) {
 }
 
 /* Fan-out: write the record to every active sink that admits this severity. */
-void log_emit(LogSeverity sev, int is_header, const char *msg) {
+void log_emit(LogSeverity sev, int kind, const char *msg) {
     for (int i = 0; i < g_active_count; ++i) {
         LogSink *s = g_active[i];
         if (sev < s->min_severity)
             continue;
-        s->write(s, sev, is_header, msg);
+        s->write(s, sev, kind, msg);
     }
 }
 
-void file_sink_write(LogSink *s, LogSeverity sev, int is_header,
-                     const char *msg) {
+/* --- File sink: plain text, one record per line ------------------------- */
+
+void file_sink_write(LogSink *s, LogSeverity sev, int kind, const char *msg) {
     if (!s->fp)
         return;
-    if (is_header)
+    if (kind == REC_SECTION_BEGIN)
         fprintf(s->fp, "==== %s ====\n", msg);
+    else if (kind == REC_SECTION_END)
+        ; /* no closer in the file */
     else
         fprintf(s->fp, "[%s] %s\n", severity_tag(sev), msg);
     fflush(s->fp);
 }
+
+/* --- Terminal sink: ANSI 16-colour on stderr, TTY-gated ----------------- */
+
+const char *severity_color(LogSeverity sev) {
+    switch (sev) {
+    case LOG_DEBUG:
+        return "\033[90m"; /* dim grey */
+    case LOG_WARN:
+        return "\033[33m"; /* yellow */
+    case LOG_ERROR:
+        return "\033[31m"; /* red */
+    case LOG_INFO:
+        return ""; /* default */
+    }
+    return "";
+}
+
+void term_sink_write(LogSink *s, LogSeverity sev, int kind, const char *msg) {
+    FILE *out = s->fp; /* stderr */
+    if (kind == REC_SECTION_BEGIN) {
+        fprintf(out, "\033[36m------ %s ", msg);
+        int used = 7 + (int)strlen(msg) + 1; /* "------ " + msg + " " */
+        for (int i = used; i < LOG_TERM_WIDTH; ++i)
+            fputc('-', out);
+        fputs("\033[0m\n", out);
+    } else if (kind == REC_SECTION_END) {
+        fputs("\033[36m", out);
+        for (int i = 0; i < LOG_TERM_WIDTH; ++i)
+            fputc('-', out);
+        fputs("\033[0m\n", out);
+    } else {
+        fprintf(out, "%s%s\033[0m\n", severity_color(sev), msg);
+    }
+    fflush(out);
+}
+
+/* Registered but inert: the terminal sink's no-op when stderr is not a TTY (or
+ * NO_COLOR is set), so redirected output never gets ANSI escapes. */
+void noop_write(LogSink *, LogSeverity, int, const char *) {}
+
+int terminal_enabled(void) {
+#if defined(_WIN32)
+    if (!_isatty(_fileno(stderr)))
+        return 0;
+#else
+    if (!isatty(fileno(stderr)))
+        return 0;
+#endif
+    const char *nc = getenv("NO_COLOR");
+    if (nc && nc[0] != '\0')
+        return 0;
+#if defined(_WIN32)
+    /* Turn on ANSI escape processing for the console; bail if unavailable so we
+     * don't spew raw escapes. */
+    HANDLE h = GetStdHandle(STD_ERROR_HANDLE);
+    DWORD mode = 0;
+    if (h == INVALID_HANDLE_VALUE || !GetConsoleMode(h, &mode))
+        return 0;
+    if (!SetConsoleMode(h, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING))
+        return 0;
+#endif
+    return 1;
+}
+
+/* --- Sink pool ---------------------------------------------------------- */
 
 LogSink *alloc_sink(void) {
     for (int i = 0; i < LOG_MAX_SINKS; ++i) {
@@ -82,6 +166,7 @@ LogSink *alloc_sink(void) {
             s->min_severity = LOG_DEBUG;
             s->write = 0;
             s->fp = 0;
+            s->owns_fp = 0;
             return s;
         }
     }
@@ -117,31 +202,46 @@ LogSeverity sdl_to_sev(SDL_LogPriority pri) {
     }
 }
 
+int sdl_category_to_kind(int category) {
+    if (category == LBA_CAT_SECTION)
+        return REC_SECTION_BEGIN;
+    if (category == LBA_CAT_SECTION_END)
+        return REC_SECTION_END;
+    return REC_NORMAL;
+}
+
+int kind_to_sdl_category(int kind) {
+    if (kind == REC_SECTION_BEGIN)
+        return LBA_CAT_SECTION;
+    if (kind == REC_SECTION_END)
+        return LBA_CAT_SECTION_END;
+    return LBA_CAT_LOG;
+}
+
 /* The single fan-out point. Installing this also routes the engine's existing
  * SDL_Log sites and SDL's own messages through our sinks (see the plan). */
 void SDLCALL sdl_output(void *userdata, int category, SDL_LogPriority pri,
                         const char *message) {
     (void)userdata;
-    log_emit(sdl_to_sev(pri), category == LBA_CAT_SECTION, message);
+    log_emit(sdl_to_sev(pri), sdl_category_to_kind(category), message);
 }
 #endif /* !LBA_LOG_NO_SDL */
 
 /* Transport seam: format-then-dispatch. Under SDL the record rides the log
  * spine and comes back through sdl_output; in host tests it goes straight to
  * the fan-out, so the core needs no SDL_Init. */
-void emit_formatted(LogSeverity sev, int is_header, const char *msg) {
+void emit_formatted(LogSeverity sev, int kind, const char *msg) {
 #ifdef LBA_LOG_NO_SDL
-    log_emit(sev, is_header, msg);
+    log_emit(sev, kind, msg);
 #else
-    SDL_LogMessage(is_header ? LBA_CAT_SECTION : LBA_CAT_LOG, sev_to_sdl(sev),
-                   "%s", msg);
+    SDL_LogMessage(kind_to_sdl_category(kind), sev_to_sdl(sev), "%s", msg);
 #endif
 }
 
 void emit_va(LogSeverity sev, const char *fmt, va_list ap) {
     char buf[LOG_MSG_MAX];
     (void)vsnprintf(buf, sizeof buf, fmt, ap);
-    emit_formatted(sev, 0, buf);
+    emit_formatted(sev, REC_NORMAL, buf);
 }
 
 } // namespace
@@ -162,7 +262,7 @@ void Log_Shutdown(void) {
     SDL_SetLogOutputFunction(0, 0);
 #endif
     for (int i = 0; i < LOG_MAX_SINKS; ++i) {
-        if (g_pool[i].in_use && g_pool[i].fp) {
+        if (g_pool[i].in_use && g_pool[i].owns_fp && g_pool[i].fp) {
             fclose(g_pool[i].fp);
             g_pool[i].fp = 0;
         }
@@ -200,11 +300,11 @@ void Log_Error(const char *fmt, ...) {
 }
 
 void Log_BeginSection(const char *title) {
-    emit_formatted(LOG_INFO, 1, title ? title : "");
+    emit_formatted(LOG_INFO, REC_SECTION_BEGIN, title ? title : "");
 }
 
 void Log_EndSection(void) {
-    /* No file-sink output; bracketing sinks (later phases) hook here. */
+    emit_formatted(LOG_INFO, REC_SECTION_END, "");
 }
 
 LogSink *Log_MakeFileSink(const char *path, LogSeverity min_severity) {
@@ -218,8 +318,19 @@ LogSink *Log_MakeFileSink(const char *path, LogSeverity min_severity) {
         s->in_use = 0;
         return 0;
     }
+    s->owns_fp = 1;
     s->min_severity = min_severity;
     s->write = file_sink_write;
+    return s;
+}
+
+LogSink *Log_MakeTerminalSink(LogSeverity min_severity) {
+    LogSink *s = alloc_sink();
+    if (!s)
+        return 0;
+    s->fp = stderr; /* not owned — never closed on shutdown */
+    s->min_severity = min_severity;
+    s->write = terminal_enabled() ? term_sink_write : noop_write;
     return s;
 }
 

--- a/SOURCES/LOG/LOG.H
+++ b/SOURCES/LOG/LOG.H
@@ -44,6 +44,12 @@ void Log_EndSection(void);
  * resolved path (GetLogPath) — one log file, reused, not a second one. */
 LogSink *Log_MakeFileSink(const char *path, LogSeverity min_severity);
 
+/* Terminal sink: ANSI 16-colour records on stderr (severity-coloured, cyan
+ * "------ Title ------" section rules). Active only when stderr is a real TTY
+ * and NO_COLOR is unset (Windows: also enables VT processing); otherwise it
+ * registers but writes nothing, so redirected output never gets escape codes. */
+LogSink *Log_MakeTerminalSink(LogSeverity min_severity);
+
 void Log_AddSink(LogSink *sink);
 void Log_RemoveSink(LogSink *sink);
 

--- a/docs/BOOT_LOG_PLAN.md
+++ b/docs/BOOT_LOG_PLAN.md
@@ -1,6 +1,6 @@
 # Boot Log + Exit Screen
 
-**Status:** Decisions locked. Phases 6 (exit screen) and 1 (core log + file sink) done; Phases 2–5 pending. Recommended order: 6 → 1 → 3 → 4 → 5 → 2.
+**Status:** Decisions locked. Phases 6 (exit screen), 1 (core log + file sink), and 3 (terminal sink) done; Phases 2, 4, 5 pending. Recommended order: 6 → 1 → 3 → 4 → 5 → 2.
 
 ## Goal
 
@@ -148,7 +148,7 @@ void Log_Info(const char *fmt, ...);   /* and Log_Debug/Log_Warn/Log_Error */
 void Log_BeginSection(const char *title);
 void Log_EndSection(void);
 LogSink *Log_MakeConsoleBufferSink(void);
-LogSink *Log_MakeTerminalSink(void);
+LogSink *Log_MakeTerminalSink(LogSeverity min_severity);
 LogSink *Log_MakeFileSink(const char *path, LogSeverity min_severity);
 void Log_AddSink(LogSink *sink);
 void Log_RemoveSink(LogSink *sink);
@@ -253,20 +253,32 @@ Build targets: GCC (`linux` preset) and MinGW (`cross_linux2win` /
 - **Verification:** boot the engine, open the console (F12), scroll back,
   confirm the boot log is visible.
 
-### Phase 3 — Terminal sink
+### Phase 3 — Terminal sink — done
 
-- Implement `MakeTerminalSink()` with the rules in decision 4 (`isatty`,
-  runtime `getenv("NO_COLOR")`, Windows VT-mode enable for our ANSI). On any
-  failure, the sink registers but its `Write` is a no-op.
-- Use ANSI 16-color codes (not 256, not truecolor) for portability. Severity →
-  color: Info default, Warn yellow, Error red, Debug dim grey. Section headers
-  cyan.
-- Section header rendering: `------ Title ------` padded to ~60 chars; closer is
-  a matching all-dash line.
-- Register during `Log_Init()` (Debug+ filtering).
-- **Verification:** launch from a Linux terminal, see colored boot log on
-  stderr. Launch with `2> /tmp/x`, confirm `/tmp/x` is empty. Launch with
-  `NO_COLOR=1`, confirm no escape codes in stderr or the file.
+- Implement `Log_MakeTerminalSink(min_severity)` with the rules in decision 4
+  (`isatty(stderr)`, runtime `getenv("NO_COLOR")`, Windows VT-mode enable for
+  our ANSI). On any failure the sink registers but its write is a no-op.
+- ANSI 16-color (not 256, not truecolor). Severity → color: Info default, Warn
+  yellow, Error red, Debug dim grey. Section headers cyan.
+- Section header `------ Title ------` padded to 60 chars; closer is a matching
+  all-dash line (needs a section-end record — added to the core, see below).
+- **Verification:** pty smoke shows coloured records + section rules on stderr;
+  redirect stderr → empty; `NO_COLOR=1` → empty. Phase 1 host test still passes
+  (file sink unchanged through the new record path).
+
+**Decisions taken (Phase 3):**
+
+- Sections now carry a *kind* (normal / begin / end) through the fan-out — over
+  the SDL spine via three categories (`LBA_CAT_LOG` / `_SECTION` / `_SECTION_END`).
+  The file sink ignores the end record; the terminal sink draws the closer rule.
+- Terminal sink writes to `stderr` (not owned — never `fclose`d on shutdown; the
+  file sink keeps `owns_fp`). Gate evaluated at `Log_MakeTerminalSink` time;
+  failure swaps in a `noop_write`.
+- **Not auto-registered in `Log_Init()`** (the plan's earlier "register during
+  Log_Init" wording). Like the file sink, sinks are created via `Log_Make*Sink`
+  and added explicitly — the boot setup wires them in Phase 4. Dormant until then.
+- No host test: ANSI/TTY rendering is environmental; verified by pty smoke (the
+  shared record path stays covered by the Phase 1 file-sink test).
 
 ### Phase 4 — Wire boot path
 


### PR DESCRIPTION
Phase 3 of the boot-log work (`docs/BOOT_LOG_PLAN.md`). **Stacked on #265** (Phase 1) — review/merge that first; this targets the Phase 1 branch and will retarget to `main` once #265 lands.

Adds `Log_MakeTerminalSink()`: ANSI 16-colour records on stderr — severity-coloured lines (Info default, Warn yellow, Error red, Debug dim grey) and cyan `------ Title ------` section rules with an all-dash closer. Active only when stderr is a real TTY and `NO_COLOR` is unset (Windows: enables VT processing too); otherwise it registers but writes nothing, so redirected output never gets escape codes.

Also adds a section-end record kind to the core (carried over the SDL spine via a third log category) so sinks can bracket sections — the terminal sink draws the closer; the file sink ignores it.

Not wired into the boot path yet (Phase 4); dormant. Verified by pty smoke (coloured rules on a TTY, empty when redirected or `NO_COLOR=1`); the Phase 1 file-sink host test still passes through the new record path.