### PR TITLE
feat: wire the boot path through the structured log

### DIFF
--- a/SOURCES/INITADEL.C
+++ b/SOURCES/INITADEL.C
@@ -6,6 +6,7 @@
 
 #include "AIL/COMMON.H"
 #include "CONTROL.H"
+#include "LOG/LOG.H"
 #include "SVGA/INITMODE.H"
 #include "SVGA/SCREEN.H"
 #include "SVGA/VIDEO.H"
@@ -72,20 +73,31 @@ void InitAdeline(S32 argc, char *argv[]) {
 
         GetLogPath(logFilePath, ADELINE_MAX_PATH, LOG_NAME);
         CreateLog(logFilePath);
-        LogPuts("Starting game...");
-        LogPuts("Paths used:");
-        LogPrintf("\t* Assets:\t%s\n"
-                  "\t* Saves:\t%s\n"
-                  "\t* Config:\t%s\n",
-                  resFolderPath, saveFolderPath, cfgFolderPath);
+
+        /* Structured boot log (docs/BOOT_LOG_PLAN.md). The file sink reuses
+           adeline.log — CreateLog above truncated it for this launch, the sink
+           appends; both it and the legacy LogPrintf sites share the one file.
+           The terminal sink colours stderr when launched from a real TTY. */
+        Log_Init();
+        Log_AddSink(Log_MakeFileSink(logFilePath, LOG_DEBUG));
+        Log_AddSink(Log_MakeTerminalSink(LOG_DEBUG));
+        atexit(Log_Shutdown);
+
+        Log_Info("Starting game...");
+        Log_Info("Paths:");
+        Log_Info("  Assets: %s", resFolderPath);
+        Log_Info("  Saves:  %s", saveFolderPath);
+        Log_Info("  Config: %s", cfgFolderPath);
     }
 
     // ··········································································
     {
-        LogPuts("\nInitialising Event system. Please wait...\n");
+        Log_BeginSection("Initializing event system");
         if (!InitEvents()) {
+            Log_Error("event system init failed");
             exit(1); // TODO: Implement graceful exit
         }
+        Log_EndSection();
     }
 
     // ··········································································
@@ -96,10 +108,13 @@ void InitAdeline(S32 argc, char *argv[]) {
 
     // --- WINDOW ----------------------------------------------------------------
     {
-        LogPuts("\nInitialising Window. Please wait...\n");
+        Log_BeginSection("Initializing window");
+        Log_Info("title: %s", APPNAME);
         if (!InitWindow(APPNAME)) {
+            Log_Error("window init failed");
             exit(1); // TODO: Implement graceful exit
         }
+        Log_EndSection();
     }
 
     // ··········································································
@@ -165,13 +180,15 @@ void InitAdeline(S32 argc, char *argv[]) {
     // --- VIDEO
     // -------------------------------------------------------------------
 
-    LogPuts("\nInitialising Video. Please wait...\n");
+    Log_BeginSection("Initializing video");
 
     if (!InitVideo()) {
+        Log_Error("video init failed");
         exit(1); // TODO: Implement graceful exit
     }
 
     if (!InitScreen()) {
+        Log_Error("screen init failed");
         exit(1); // TODO: Implement graceful exit
     }
 
@@ -188,20 +205,26 @@ void InitAdeline(S32 argc, char *argv[]) {
         U32 reqResX, reqResY;
         Res_LoadBootDimensions(&reqResX, &reqResY);
         if (!InitGraphics(reqResX, reqResY)) {
+            Log_Error("graphics init failed");
             exit(1); // TODO: Implement graceful exit
         }
+        Log_Info("render resolution: %ux%u", reqResX, reqResY);
     }
+    Log_EndSection();
 
     // ··········································································
-    //  Midi device
+    //  Midi + Sample devices
+    Log_BeginSection("Initializing audio");
 
 #if ((inits) & INIT_MIDI)
 #ifndef LIB_AIL
 #error ADELINE: you need to include AIL.H
 #endif
-    LogPuts("\nInitialising Midi device. Please wait...\n");
-    if (!InitMidiDriver(NULL))
+    Log_Info("MIDI device");
+    if (!InitMidiDriver(NULL)) {
+        Log_Error("MIDI device init failed");
         exit(1);
+    }
 #endif
 
     // ··········································································
@@ -210,7 +233,7 @@ void InitAdeline(S32 argc, char *argv[]) {
 #ifndef LIB_AIL
 #error ADELINE: you need to include AIL.H
 #endif
-        LogPuts("\nInitialising Sample device. Please wait...\n");
+        Log_Info("sample device");
         if (!InitSampleDriver(NULL)) {
             /* No usable audio output (host has no audio device, SDL_AUDIODRIVER
                points at something invalid, the audio subsystem failed to come
@@ -222,9 +245,12 @@ void InitAdeline(S32 argc, char *argv[]) {
                bypass the SDL dummy driver's nanosleep pacing (~58% of sys time
                in projection_demo); a player whose audio device fails just
                loses sound instead of being unable to launch the game. */
-            LogPuts("\nWarning: no audio output — running silently.\n");
+            Log_Warn("no audio output -- running silently");
         }
+    } else {
+        Log_Info("audio disabled (--no-audio)");
     }
+    Log_EndSection();
 
     // ··········································································
     //  Smacker

--- a/SOURCES/LOG/LOG.CPP
+++ b/SOURCES/LOG/LOG.CPP
@@ -253,6 +253,14 @@ void Log_Init(void) {
     for (int i = 0; i < LOG_MAX_SINKS; ++i)
         g_pool[i].in_use = 0;
 #ifndef LBA_LOG_NO_SDL
+    /* SDL applies a per-category priority filter *before* calling the output
+       function, and custom categories default to a high threshold — so without
+       this our INFO/DEBUG records would be dropped before reaching any sink.
+       Open our categories down to DEBUG and let the per-sink min-severity do the
+       real filtering. */
+    SDL_SetLogPriority(LBA_CAT_LOG, SDL_LOG_PRIORITY_DEBUG);
+    SDL_SetLogPriority(LBA_CAT_SECTION, SDL_LOG_PRIORITY_DEBUG);
+    SDL_SetLogPriority(LBA_CAT_SECTION_END, SDL_LOG_PRIORITY_DEBUG);
     SDL_SetLogOutputFunction(sdl_output, 0);
 #endif
 }

--- a/docs/BOOT_LOG_PLAN.md
+++ b/docs/BOOT_LOG_PLAN.md
@@ -1,6 +1,6 @@
 # Boot Log + Exit Screen
 
-**Status:** Decisions locked. Phases 6 (exit screen), 1 (core log + file sink), and 3 (terminal sink) done; Phases 2, 4, 5 pending. Recommended order: 6 → 1 → 3 → 4 → 5 → 2.
+**Status:** Decisions locked. Phases 6 (exit screen), 1 (core log + file sink), 3 (terminal sink), and 4 (boot-path wiring) done; Phases 2, 5 pending. Recommended order: 6 → 1 → 3 → 4 → 5 → 2.
 
 ## Goal
 
@@ -280,17 +280,35 @@ Build targets: GCC (`linux` preset) and MinGW (`cross_linux2win` /
 - No host test: ANSI/TTY rendering is environmental; verified by pty smoke (the
   shared record path stays covered by the Phase 1 file-sink test).
 
-### Phase 4 — Wire boot path
+### Phase 4 — Wire boot path — done
 
-- Replace ad-hoc `printf` / `SDL_Log` / `LogPrintf` calls in the boot path with
-  `Log_*` calls.
-- Add `ScopedSection` blocks around each subsystem init: SDL, file system,
-  audio, game data, input. Respect the exit-safety caveat (sections may not
-  close cleanly on `exit(1)` failure paths).
-- Each subsystem block emits *useful diagnostic detail* — versions, paths,
-  counts, sizes — not just "ok".
-- **Verification:** boot log reads coherently when scrolled back through the
-  in-engine console and in `adeline.log`.
+- `Log_Init()` + register the file sink (adeline.log) and terminal sink, and
+  `atexit(Log_Shutdown)`, in `InitAdeline` right after `CreateLog`.
+- Convert the boot banner + the major subsystem inits (event system, window,
+  video, audio) to `Log_BeginSection`/`Log_Info`/`Log_Error`/`Log_EndSection`,
+  with real detail (paths, window title, render resolution, audio status). On a
+  failed init the section stays open before `exit(1)` — informative, and the
+  per-line flush means the records are already on disk.
+- **Verification:** headless boot writes the sections to `adeline.log`,
+  interleaved with the legacy lines; a pty boot shows the cyan section rules in
+  colour on stderr (terminal sink via the real SDL spine); redirected stderr has
+  zero escapes; clean exit.
+
+**Decisions taken (Phase 4):**
+
+- **SDL filters per category before the output function.** Custom categories
+  default to a high threshold, so the first headless boot dropped every
+  INFO/DEBUG record. Fix: `Log_Init` lowers our three categories to
+  `SDL_LOG_PRIORITY_DEBUG`; the per-sink min-severity is the real filter.
+- **Legacy `LogPrintf` left in place** (the boot path still has unconverted
+  lines like "Initialising Joystick", "Platform: Linux", the version footer).
+  Only the banner + four major subsystems were converted; a full `LogPrintf`
+  purge is deferred until the system is proven. Both writers share `adeline.log`
+  (CreateLog truncates per launch; the file sink and LogPrintf both append).
+- Sinks registered inside `InitAdeline` (not `main`) so they exist before the
+  subsystem inits but after `CreateLog` truncates the file.
+- Only the major subsystems are wrapped; minor steps (joystick, OS, CPU,
+  keyboard, mouse, timer) keep their existing lines for now.
 
 ### Phase 5 — Funfrock framing header
 


### PR DESCRIPTION
Phase 4 of the boot-log work (`docs/BOOT_LOG_PLAN.md`). **Stacked on #266 → #265** — merge those first; this retargets to `main` as the stack lands.

Makes the log *live*. `InitAdeline` now calls `Log_Init()`, registers the file sink (`adeline.log`) + terminal sink, and `atexit(Log_Shutdown)`; the major subsystem inits (event system, window, video, audio) are wrapped in `Log_BeginSection`/…/`Log_EndSection` with real detail, replacing their `LogPuts` lines.

Found and fixed a real gotcha while wiring: **SDL filters per category before the output function**, and custom categories default high — so the first headless boot silently dropped every INFO/DEBUG record. `Log_Init` now lowers our categories to `DEBUG` and lets the per-sink min-severity filter.

Legacy `LogPrintf` boot lines are intentionally left for now (full purge deferred until the system is proven); both writers share the one `adeline.log`.

Verified end-to-end: headless boot writes the `[INFO]`/`==== … ====` sections to `adeline.log` interleaved with the legacy lines; a pty boot renders the cyan section rules on stderr through the real SDL spine; redirected stderr has zero escape codes; clean exit; Phase 1 host test still green.