### PR TITLE
feat: Funfrock framing header for the boot log

### DIFF
--- a/SOURCES/INITADEL.C
+++ b/SOURCES/INITADEL.C
@@ -37,6 +37,18 @@ int WriteEmbeddedDefaultLba2Cfg(const char *destPath);
 #endif
 #include <unistd.h>
 
+#include <SDL3/SDL_cpuinfo.h> /* SDL_GetNumLogicalCPUCores, SDL_GetSystemRAM */
+
+#if defined(_WIN32)
+#define LOG_PLATFORM_NAME "Windows"
+#elif defined(__APPLE__)
+#define LOG_PLATFORM_NAME "macOS"
+#elif defined(__linux__)
+#define LOG_PLATFORM_NAME "Linux"
+#else
+#define LOG_PLATFORM_NAME "Unknown"
+#endif
+
 // -----------------------------------------------------------------------------
 #include "BUILD_INFO.h"
 #ifdef DEMO
@@ -83,7 +95,17 @@ void InitAdeline(S32 argc, char *argv[]) {
         Log_AddSink(Log_MakeTerminalSink(LOG_DEBUG));
         atexit(Log_Shutdown);
 
-        Log_Info("Starting game...");
+        /* Funfrock framing header — the one bit of flavour in the log path;
+           the straight-faced sections below are the contrast. */
+        Log_Raw("TWINSUN CENTRAL COMMAND -- CITIZEN ACCESS TERMINAL");
+        Log_Raw("By order of Dr. FunFrock, all activity is monitored.");
+        Log_Raw("");
+        Log_Raw("%s  %s  (built %s %s)", APPNAME, LOG_PLATFORM_NAME, __DATE__,
+                __TIME__);
+        Log_Raw("%d logical cores, %d MB RAM", SDL_GetNumLogicalCPUCores(),
+                SDL_GetSystemRAM());
+        Log_Raw("");
+
         Log_Info("Paths:");
         Log_Info("  Assets: %s", resFolderPath);
         Log_Info("  Saves:  %s", saveFolderPath);

--- a/SOURCES/LOG/LOG.CPP
+++ b/SOURCES/LOG/LOG.CPP
@@ -19,6 +19,7 @@
 #define LBA_CAT_LOG (SDL_LOG_CATEGORY_CUSTOM + 0)
 #define LBA_CAT_SECTION (SDL_LOG_CATEGORY_CUSTOM + 1)
 #define LBA_CAT_SECTION_END (SDL_LOG_CATEGORY_CUSTOM + 2)
+#define LBA_CAT_RAW (SDL_LOG_CATEGORY_CUSTOM + 3)
 #endif
 
 #define LOG_MSG_MAX 1024
@@ -32,7 +33,8 @@ namespace {
 /* Record kind, carried alongside severity through the fan-out. */
 enum { REC_NORMAL = 0,
        REC_SECTION_BEGIN = 1,
-       REC_SECTION_END = 2 };
+       REC_SECTION_END = 2,
+       REC_RAW = 3 };
 
 typedef void (*SinkWriteFn)(LogSink *sink, LogSeverity sev, int kind,
                             const char *msg);
@@ -88,6 +90,8 @@ void file_sink_write(LogSink *s, LogSeverity sev, int kind, const char *msg) {
         fprintf(s->fp, "==== %s ====\n", msg);
     else if (kind == REC_SECTION_END)
         ; /* no closer in the file */
+    else if (kind == REC_RAW)
+        fprintf(s->fp, "%s\n", msg);
     else
         fprintf(s->fp, "[%s] %s\n", severity_tag(sev), msg);
     fflush(s->fp);
@@ -122,6 +126,8 @@ void term_sink_write(LogSink *s, LogSeverity sev, int kind, const char *msg) {
         for (int i = 0; i < LOG_TERM_WIDTH; ++i)
             fputc('-', out);
         fputs("\033[0m\n", out);
+    } else if (kind == REC_RAW) {
+        fprintf(out, "%s\n", msg);
     } else {
         fprintf(out, "%s%s\033[0m\n", severity_color(sev), msg);
     }
@@ -207,6 +213,8 @@ int sdl_category_to_kind(int category) {
         return REC_SECTION_BEGIN;
     if (category == LBA_CAT_SECTION_END)
         return REC_SECTION_END;
+    if (category == LBA_CAT_RAW)
+        return REC_RAW;
     return REC_NORMAL;
 }
 
@@ -215,6 +223,8 @@ int kind_to_sdl_category(int kind) {
         return LBA_CAT_SECTION;
     if (kind == REC_SECTION_END)
         return LBA_CAT_SECTION_END;
+    if (kind == REC_RAW)
+        return LBA_CAT_RAW;
     return LBA_CAT_LOG;
 }
 
@@ -261,6 +271,7 @@ void Log_Init(void) {
     SDL_SetLogPriority(LBA_CAT_LOG, SDL_LOG_PRIORITY_DEBUG);
     SDL_SetLogPriority(LBA_CAT_SECTION, SDL_LOG_PRIORITY_DEBUG);
     SDL_SetLogPriority(LBA_CAT_SECTION_END, SDL_LOG_PRIORITY_DEBUG);
+    SDL_SetLogPriority(LBA_CAT_RAW, SDL_LOG_PRIORITY_DEBUG);
     SDL_SetLogOutputFunction(sdl_output, 0);
 #endif
 }
@@ -305,6 +316,15 @@ void Log_Error(const char *fmt, ...) {
     va_start(ap, fmt);
     emit_va(LOG_ERROR, fmt, ap);
     va_end(ap);
+}
+
+void Log_Raw(const char *fmt, ...) {
+    char buf[LOG_MSG_MAX];
+    va_list ap;
+    va_start(ap, fmt);
+    (void)vsnprintf(buf, sizeof buf, fmt, ap);
+    va_end(ap);
+    emit_formatted(LOG_INFO, REC_RAW, buf);
 }
 
 void Log_BeginSection(const char *title) {

--- a/SOURCES/LOG/LOG.H
+++ b/SOURCES/LOG/LOG.H
@@ -33,6 +33,11 @@ void Log_Info(const char *fmt, ...);
 void Log_Warn(const char *fmt, ...);
 void Log_Error(const char *fmt, ...);
 
+/* Verbatim line — no severity prefix, no section idiom; sinks print it as-is.
+ * For framing/banner output (e.g. the boot header). Admitted at INFO level for
+ * per-sink filtering. */
+void Log_Raw(const char *fmt, ...);
+
 /* Section markers — sinks render the header in their own idiom (the file sink
  * uses "==== Title ===="). EndSection has no file-sink output; it exists for
  * sinks that bracket (terminal/console, later phases) and for ScopedSection. */

--- a/docs/BOOT_LOG_PLAN.md
+++ b/docs/BOOT_LOG_PLAN.md
@@ -1,6 +1,6 @@
 # Boot Log + Exit Screen
 
-**Status:** Decisions locked. Phases 6 (exit screen), 1 (core log + file sink), 3 (terminal sink), and 4 (boot-path wiring) done; Phases 2, 5 pending. Recommended order: 6 → 1 → 3 → 4 → 5 → 2.
+**Status:** Decisions locked. Phases 6 (exit screen), 1 (core log + file sink), 3 (terminal sink), 4 (boot-path wiring), and 5 (Funfrock header) done; Phase 2 (console sink) pending. Recommended order: 6 → 1 → 3 → 4 → 5 → 2.
 
 ## Goal
 
@@ -310,19 +310,31 @@ Build targets: GCC (`linux` preset) and MinGW (`cross_linux2win` /
 - Only the major subsystems are wrapped; minor steps (joystick, OS, CPU,
   keyboard, mouse, timer) keep their existing lines for now.
 
-### Phase 5 — Funfrock framing header
+### Phase 5 — Funfrock framing header — done
 
-- At the very top of `Log_Init()` (before any section), emit a 2-line
-  banner:
+- Emit, at the top of the log (in `InitAdeline` right after the sinks register —
+  *not* inside `Log_Init`, which runs before any sink exists), a 2-line banner:
   ```
-  TWINSUN CENTRAL COMMAND — CITIZEN ACCESS TERMINAL
+  TWINSUN CENTRAL COMMAND -- CITIZEN ACCESS TERMINAL
   By order of Dr. FunFrock, all activity is monitored.
   ```
-- Followed by the build identity line:
-  `LBA2-CE <version> <platform> <build-date>`
-- Followed by a CPU/memory line (Doom 3 convention).
-- This is the *only* flavor in the log path. Everything below is straight-faced
-  diagnostic output. The contrast is the joke.
+- Followed by the build-identity line (`<product> <version>  <platform>  (built
+  <date> <time>)`) and a CPU/memory line (`N logical cores, M MB RAM`).
+- This is the *only* flavour in the log path; the straight-faced sections below
+  are the contrast.
+
+**Decisions taken (Phase 5):**
+
+- Added a `Log_Raw()` primitive (record kind `REC_RAW`, fourth SDL category) so
+  banner lines render verbatim — no `[INFO]` prefix, no section dashes. Both
+  sinks print it as-is.
+- Banner emitted from `InitAdeline` after the sinks are added (the plan's "top
+  of `Log_Init()`" predates the sink-agnostic `Log_Init`); it is the first thing
+  in the log after CreateLog's own line.
+- Build identity uses the existing `APPNAME` (product + version) +
+  compile-time platform macro + `__DATE__`/`__TIME__`; CPU/RAM via
+  `SDL_GetNumLogicalCPUCores()` / `SDL_GetSystemRAM()` (no engine-internal
+  probing). Verified in `adeline.log` and via the boot run.
 
 ### Phase 6 — Exit screen module — done
 


### PR DESCRIPTION
Phase 5 of the boot-log work (`docs/BOOT_LOG_PLAN.md`). **Stacked on #267 → #266 → #265** — merge those first; retargets to `main` as the stack lands.

Emits a framing header at the top of the log (in `InitAdeline`, right after the sinks register):

```
TWINSUN CENTRAL COMMAND -- CITIZEN ACCESS TERMINAL
By order of Dr. FunFrock, all activity is monitored.

LBA2 Classic Community 0.11.0-dev  Linux  (built May 29 2026 23:55:53)
6 logical cores, 32068 MB RAM
```

The one bit of flavour in the log path — the straight-faced sections below are the contrast. CPU/RAM come from `SDL_GetNumLogicalCPUCores()` / `SDL_GetSystemRAM()`; no engine-internal probing.

Adds a small `Log_Raw()` primitive (record kind `REC_RAW`, a fourth SDL category) so banner lines render verbatim — no `[INFO]` prefix, no section dashes. Verified in `adeline.log` and a boot run; Phase 1 host test still green.