### PR TITLE
feat: native dialog + non-zero exit on fatal boot errors

### DIFF
--- a/SOURCES/INITADEL.C
+++ b/SOURCES/INITADEL.C
@@ -2,6 +2,7 @@
 
 #include "C_EXTERN.H"
 #include "DIRECTORIES.H"
+#include "PERSO.H"      /* BootFatal — fatal exit for init failures */
 #include "RES_SWITCH.H" /* Res_LoadBootDimensions — CLI > cfg > default */
 
 #include "AIL/COMMON.H"
@@ -123,8 +124,7 @@ void InitAdeline(S32 argc, char *argv[]) {
     // ··········································································
     {
         if (!InitEvents()) {
-            Log_Error("events: init failed");
-            exit(1); // TODO: Implement graceful exit
+            BootFatal("The input/event system could not be initialized.");
         }
         Log_Info("Events     ok");
     }
@@ -140,8 +140,7 @@ void InitAdeline(S32 argc, char *argv[]) {
        surface dimensions and mode are known. */
     {
         if (!InitWindow(APPNAME)) {
-            Log_Error("window: init failed");
-            exit(1); // TODO: Implement graceful exit
+            BootFatal("The game window could not be created.");
         }
     }
 
@@ -157,16 +156,14 @@ void InitAdeline(S32 argc, char *argv[]) {
             LogPuts("Default config not in assets folder; writing embedded template...");
 
             if (!WriteEmbeddedDefaultLba2Cfg(PathConfigFile)) {
-                LogPrintf("Error: Can't write embedded default config to '%s'\n\n",
+                BootFatal("Could not write a default configuration file to '%s'.",
                           PathConfigFile);
-                exit(1);
             }
         } else {
             const bool copyResult = Copy(PathDefaultConfigFile, PathConfigFile);
             if (!copyResult) {
-                LogPrintf("Error: Can't copy config file from '%s' to '%s'\n\n",
-                          PathDefaultConfigFile, PathConfigFile);
-                exit(1);
+                BootFatal("Could not copy the configuration file to '%s'.",
+                          PathConfigFile);
             }
         }
     }
@@ -206,13 +203,11 @@ void InitAdeline(S32 argc, char *argv[]) {
     // -------------------------------------------------------------------
 
     if (!InitVideo()) {
-        Log_Error("video: init failed");
-        exit(1); // TODO: Implement graceful exit
+        BootFatal("The video system could not be initialized.");
     }
 
     if (!InitScreen()) {
-        Log_Error("screen: init failed");
-        exit(1); // TODO: Implement graceful exit
+        BootFatal("The display surface could not be created.");
     }
 
     {
@@ -232,8 +227,8 @@ void InitAdeline(S32 argc, char *argv[]) {
            confirms it instead of flipping a windowed window. */
         const bool reqFullscreen = Res_LoadBootFullscreen();
         if (!InitGraphics(reqResX, reqResY, reqFullscreen)) {
-            Log_Error("graphics: init failed");
-            exit(1); // TODO: Implement graceful exit
+            BootFatal("The graphics mode %ux%u could not be set.", reqResX,
+                      reqResY);
         }
         /* The "Display" status line is logged from main() after InitProgram,
            alongside the rest of the post-init summary. */
@@ -247,8 +242,7 @@ void InitAdeline(S32 argc, char *argv[]) {
 #error ADELINE: you need to include AIL.H
 #endif
     if (!InitMidiDriver(NULL)) {
-        Log_Error("audio: MIDI init failed");
-        exit(1);
+        BootFatal("The MIDI audio device could not be initialized.");
     }
 #endif
 

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -31,6 +31,7 @@ static inline U32 DosAvailableMem(void) { return 0; }
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
 #include <ctype.h>
+#include <stdarg.h>
 #include <dirent.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -2115,7 +2116,9 @@ LBA_NORETURN void TheEndCheckFile(const char *filename) {
 
     End_Error = filename;
 
-    exit(0);
+    /* Always an error path -> non-zero so launchers/scripts/Steam can tell.
+       (The visible message for GUI launches is shown by TheEndInfo.) */
+    exit(EXIT_FAILURE);
 }
 
 /*══════════════════════════════════════════════════════════════════════════*/
@@ -2129,7 +2132,8 @@ void TheEnd(S32 num, const char *error) {
     End_Num = num;
     End_Error = error;
 
-    exit(0);
+    /* Clean exit only for PROGRAM_OK; every other End_Num is a failure. */
+    exit(num == PROGRAM_OK ? 0 : EXIT_FAILURE);
 }
 
 /*══════════════════════════════════════════════════════════════════════════*/
@@ -2156,6 +2160,46 @@ void V_ColorLine(U8 text, U8 back, U16 ncars) {
 }
 
 /*══════════════════════════════════════════════════════════════════════════*/
+/* Native fatal-error dialog for terminal-less launches (double-clicked
+   .app/.exe, Steam Deck), where the log/terminal is invisible. No-op on a dev
+   terminal run (the log is right there), under the control harness (never block
+   automation), or when no display is available (headless -> log only). Mirrors
+   the no-game-data dialog in RES_PICKER. */
+static void ShowFatalErrorDialog(const char *title, const char *message) {
+    if (isatty(fileno(stderr)))
+        return;
+    if (Control_IsActive())
+        return;
+    if (!SDL_WasInit(SDL_INIT_VIDEO) && !SDL_InitSubSystem(SDL_INIT_VIDEO))
+        return;
+    SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, title, message, NULL);
+}
+
+/*══════════════════════════════════════════════════════════════════════════*/
+/* Fatal exit for InitAdeline init failures -- see PERSO.H for why these can't
+   go through TheEnd/TheEndInfo. Logs the reason, surfaces the native dialog on
+   terminal-less launches, exits non-zero. No teardown: the failing subsystem
+   never finished coming up, so there is nothing safe to tear down. */
+LBA_NORETURN void BootFatal(const char *fmt, ...) {
+    char reason[512];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(reason, sizeof reason, fmt, ap);
+    va_end(ap);
+
+    Log_Error("%s", reason);
+
+    char logPath[ADELINE_MAX_PATH] = "";
+    GetLogPath(logPath, ADELINE_MAX_PATH, LOG_NAME);
+    char msg[ADELINE_MAX_PATH + 640];
+    snprintf(msg, sizeof msg, "%s\n\nThe game can't start.\nDetails: %s", reason,
+             logPath);
+    ShowFatalErrorDialog("LBA2 — cannot start", msg);
+
+    exit(EXIT_FAILURE);
+}
+
+/*══════════════════════════════════════════════════════════════════════════*/
 void TheEndInfo() {
     S32 err = FALSE;
 
@@ -2164,8 +2208,8 @@ void TheEndInfo() {
 #endif
     StopMusic();
 
-    LogPrintf(Version); // dans version.cpp
-    LogPrintf("%s\n", BuildInfo ? BuildInfo : "(no build info)");
+    /* No version/build footer here — the boot header already stamps version,
+       build, platform, and backends at the top of every log. */
 
 #if defined(DEBUG_TOOLS) || defined(TEST_TOOLS)
     LogPrintf("* Start Extended Memory was %ld\n", MemoMemory);
@@ -2237,9 +2281,26 @@ void TheEndInfo() {
             LogPrintf("%s\n", End_Error);
         }
 #endif
-        LogPrintf("%s\n", End_Error);
-        LogPrintf("\nOK.\n");
+        if (End_Error && End_Error[0])
+            LogPrintf("%s\n", End_Error);
+        LogPrintf("OK.\n");
         break;
+    }
+
+    /* Make fatal errors visible when there's no terminal to read the log. */
+    if (End_Num == ERROR_NOT_FOUND_FILE || End_Num == NAME_NOT_FOUND ||
+        End_Num == NOT_ENOUGH_MEM) {
+        char logPath[ADELINE_MAX_PATH] = "";
+        GetLogPath(logPath, ADELINE_MAX_PATH, LOG_NAME);
+        const char *headline =
+            (End_Num == NOT_ENOUGH_MEM)   ? "The game ran out of memory."
+            : (End_Num == NAME_NOT_FOUND) ? "A required game object is missing."
+                                          : "Game data is missing or unreadable.";
+        char msg[ADELINE_MAX_PATH + 256];
+        snprintf(msg, sizeof msg,
+                 "%s\n\n%s\n\nThe game can't continue.\nDetails: %s", headline,
+                 End_Error ? End_Error : "", logPath);
+        ShowFatalErrorDialog("LBA2 — cannot start", msg);
     }
 
     WriteConfigFile();
@@ -2425,12 +2486,12 @@ int main(int argc, char *argv[]) {
                  Window_IsFullscreen() ? "fullscreen" : "windowed");
     }
 
-    /* Fail fast on missing required data: list it all (done inside), then abort
-       with a clear message instead of dying later at an arbitrary load — and
-       before we'd print "Ready". Exits non-zero (unlike TheEndCheckFile). */
+    /* Fail fast on missing required data: AssetPreflight has logged each missing
+       file; bail here (before any heavy load and before "Ready") via TheEnd so it
+       flows through the same fatal surface as every other error — non-zero exit
+       plus the native dialog in TheEndInfo for terminal-less launches. */
     if (AssetPreflight() > 0) {
-        Log_Error("cannot start: required game data is missing (see above)");
-        exit(EXIT_FAILURE);
+        TheEnd(ERROR_NOT_FOUND_FILE, "required game data is missing (see the log)");
     }
 
 #ifdef ONE_GAME_DIRECTORY

--- a/SOURCES/PERSO.H
+++ b/SOURCES/PERSO.H
@@ -32,6 +32,16 @@ extern void InitTheEnd(S32 num, char *error);
 /*--------------------------------------------------------------------------*/
 extern void TheEnd(S32 num, const char *error);
 /*--------------------------------------------------------------------------*/
+/* Boot-time fatal exit for the InitAdeline init failures (events, window,
+   video, screen, graphics, config, MIDI). These run before atexit(TheEndInfo)
+   is registered and use a bare exit(), so they bypass TheEndInfo's error
+   footer + native dialog entirely -- silent on a double-clicked launcher.
+   BootFatal logs the reason, shows the same native dialog as TheEndInfo (when
+   there is no terminal to read), and exits non-zero. It deliberately skips
+   TheEndInfo's heavy teardown (WriteConfigFile / Clear3dExt), which would
+   touch subsystems that an early failure never finished initialising. */
+extern LBA_NORETURN void BootFatal(const char *fmt, ...);
+/*--------------------------------------------------------------------------*/
 extern void TheEndInfo(void);
 /*--------------------------------------------------------------------------*/
 extern void Message(const char *mess, S32 flag);

--- a/docs/BOOT_LOG_PLAN.md
+++ b/docs/BOOT_LOG_PLAN.md
@@ -504,6 +504,58 @@ it before the quote, re-add the Windows VT enable
 
 (Per-phase PRs append their own "decisions taken" notes here as they merge.)
 
+## Fatal-error visibility on terminal-less launches
+
+The boot log + asset preflight report failures to the terminal and `adeline.log`.
+On a double-clicked `.app`/`.exe`, Steam Deck, or mobile there is no terminal and
+nobody hunts for the log, so a fatal boot error (incomplete data, missing HQR,
+out of memory) would just make the app vanish. The engine already solves the
+"no game **directory**" case with a native dialog (`RES_PICKER`, explicitly to
+avoid the log "buried in the terminal"); this extends the same treatment to the
+other fatal paths. (Its own PR — touches the `TheEnd*` family, not the sinks.)
+
+- `ShowFatalErrorDialog` (`PERSO.CPP`) wraps `SDL_ShowSimpleMessageBox`, gated so
+  it only fires on an interactive, terminal-less launch:
+  `!isatty(stderr)` (a terminal already shows the log) **and**
+  `!Control_IsActive()` (never block the automation harness) **and** a display is
+  available (`SDL_WasInit`/`SDL_InitSubSystem(SDL_INIT_VIDEO)` — headless falls
+  back to log-only). Mobile: shown where SDL supports it, else log-only — no
+  worse than today.
+- Wired into `TheEndInfo` (the `atexit` every fatal path funnels through): the
+  `ERROR_NOT_FOUND_FILE` / `NAME_NOT_FOUND` / `NOT_ENOUGH_MEM` cases build a
+  friendly message (+ the log path) and call it. One change → every fatal exit is
+  GUI-visible, not just the preflight.
+- The asset-preflight abort now calls `TheEnd(ERROR_NOT_FOUND_FILE, …)` instead
+  of `exit()`, so it flows through that same surface.
+- **Exit codes fixed:** `TheEnd`/`TheEndCheckFile` now exit non-zero on any error
+  (only `PROGRAM_OK` → 0), so launchers/scripts/Steam/CI can detect a failed
+  boot. Previously every exit was 0.
+- Verified: GUI-like run (no tty, not harness, display) blocks on the dialog;
+  harness run exits 1 with no dialog; all-present exits 0.
+
+### The `InitAdeline` gap (`BootFatal`)
+
+`TheEndInfo` only covers the fatal paths that run *after* `main` registers
+`atexit(TheEndInfo)` (`PERSO.CPP`) — which is *after* `InitAdeline` returns. The
+subsystem-init failures inside `InitAdeline` (events, window, config write/copy,
+video, screen, graphics, MIDI) used a bare `exit(1)`: no `End_Num`, no dialog,
+and registered before `atexit` anyway — so they vanished silently on a
+double-clicked launcher, exactly the "can't even open the window" case where a
+GUI user most needs to see why.
+
+- `BootFatal(fmt, …)` (`PERSO.CPP`, declared in `PERSO.H`) is the fix: it logs
+  the reason at `Error`, reuses `ShowFatalErrorDialog` (same gating), and exits
+  non-zero. Each `InitAdeline` failure now calls it with a one-line cause.
+- It deliberately skips `TheEndInfo`'s teardown (`WriteConfigFile`,
+  `Clear3dExt`): a subsystem that never finished initialising has nothing safe
+  to tear down, and those calls would touch un-anchored state.
+- A video/window-init failure can't show a graphical dialog (no display) — the
+  `SDL_InitSubSystem(VIDEO)` probe fails and it degrades to log-only. The config
+  / MIDI failures happen after the window is up, so those *do* get the dialog.
+- Verified: forcing `SDL_VIDEODRIVER=<invalid>` makes `InitWindow` fail →
+  `[ERROR] The game window could not be created.` logged, exit 1, no hang,
+  dialog correctly skipped under the harness and when video is unavailable.
+
 ## Out of scope (explicitly)
 
 - The overlay sink (deferred — open question 5).


### PR DESCRIPTION
**Stacked on #269** — review/merge that first; retargets to `main` once it lands.

On a terminal-less launch (double-clicked `.app`/`.exe`, Steam Deck), boot-log and asset-preflight failures went only to the terminal and `adeline.log`, so a fatal error made the app vanish silently. This extends the native-dialog treatment the no-game-data path already uses (`RES_PICKER`) to the rest of the fatal paths, and fixes the exit codes.

- `ShowFatalErrorDialog` (`PERSO.CPP`) wraps `SDL_ShowSimpleMessageBox`, gated to fire only on an interactive terminal-less launch: `!isatty(stderr)` **and** `!Control_IsActive()` **and** a display is available (else log-only — headless/CI).
- Wired into `TheEndInfo` (the `atexit` every *post-init* fatal path funnels through) for the `ERROR_NOT_FOUND_FILE` / `NAME_NOT_FOUND` / `NOT_ENOUGH_MEM` cases. The asset-preflight abort routes through `TheEnd(...)` to share that surface.
- **`BootFatal` for the `InitAdeline` init failures** (events, window, config write/copy, video, screen, graphics, MIDI). These run *before* `atexit(TheEndInfo)` is registered and used a bare `exit(1)`, so they bypassed the dialog + error footer entirely — silent on a double-clicked launcher. `BootFatal` (`PERSO.CPP`, declared in `PERSO.H`) logs the cause, shows the same gated dialog, and exits non-zero. It deliberately skips `TheEndInfo`'s teardown (`WriteConfigFile`/`Clear3dExt`), which a half-initialised subsystem can't survive. (A window/video-init failure still can't draw a dialog — no display — so it degrades to log-only.)
- **Exit codes fixed:** `TheEnd`/`TheEndCheckFile` now exit non-zero on error (only `PROGRAM_OK` → 0). Previously every exit was 0, hiding boot failures from launchers/scripts/Steam/CI.
- **Exit-log trim:** dropped the version/build footer `TheEndInfo` printed at exit (the boot header already stamps it) and tightened the clean-exit tail to a bare `OK.`.

Verified: forcing an `InitAdeline` failure (`SDL_VIDEODRIVER=<invalid>`) logs the cause and exits 1 with the dialog skipped under the harness; a GUI-like run blocks on the dialog; a control-harness run exits 1 with no dialog; all-present exits 0; host suite green.