### PR TITLE
fix(window): create the SDL window fullscreen up front when configured

### DIFF
--- a/LIB386/H/SVGA/INITMODE.H
+++ b/LIB386/H/SVGA/INITMODE.H
@@ -8,7 +8,7 @@ extern "C" {
 #endif
 
 // --- Initialization ----------------------------------------------------------
-bool InitGraphics(U32 resX, U32 resY);
+bool InitGraphics(U32 resX, U32 resY, bool fullscreen);
 void EndGraphics();
 
 // =============================================================================

--- a/LIB386/H/SYSTEM/WINDOW.H
+++ b/LIB386/H/SYSTEM/WINDOW.H
@@ -16,7 +16,10 @@ void EndWindow();
 bool IsWindowInitialized();
 
 // --- Interface ---------------------------------------------------------------
-bool CreateWindowSurface(U32 resX, U32 resY);
+/** Create the SDL window, renderer, and streaming texture at resX*resY. When
+ *  `fullscreen` is true the window is created fullscreen up front (via the
+ *  SDL create-time property), avoiding a windowed-then-flipped frame on boot. */
+bool CreateWindowSurface(U32 resX, U32 resY, bool fullscreen);
 void DestroyWindowSurface();
 
 /** Resize the existing window + streaming texture in place, without

--- a/LIB386/SVGA/INITMODE.CPP
+++ b/LIB386/SVGA/INITMODE.CPP
@@ -13,14 +13,14 @@ extern "C" {
 #endif
 
 // --- Initialization ----------------------------------------------------------
-bool InitGraphics(U32 resX, U32 resY) {
+bool InitGraphics(U32 resX, U32 resY, bool fullscreen) {
     if (resY > ADELINE_MAX_Y_RES) {
         return false;
     }
 
     LogPrintf("\nDesired resolution: %i*%i\n", resX, resY);
 
-    if (!CreateWindowSurface(resX, resY)) {
+    if (!CreateWindowSurface(resX, resY, fullscreen)) {
         return false;
     }
 

--- a/LIB386/SYSTEM/WINDOW.CPP
+++ b/LIB386/SYSTEM/WINDOW.CPP
@@ -129,9 +129,15 @@ bool IsWindowInitialized() {
 }
 
 // --- Interface ---------------------------------------------------------------
-bool CreateWindowSurface(U32 resX, U32 resY) {
+bool CreateWindowSurface(U32 resX, U32 resY, bool fullscreen) {
     assert(windowSystemInitialized == true);
     assert(sdlWindow == NULL);
+
+    /* Seed the cached state from the caller's choice so a fullscreen boot is
+       fullscreen from the first frame. The create-time property below asks SDL
+       to bring the window up fullscreen directly (no windowed flash); the
+       post-create apply is kept as a fallback for backends that ignore it. */
+    windowFullscreenEnabled = fullscreen;
 
     SDL_PropertiesID props = SDL_CreateProperties();
     SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_TITLE_STRING, windowTitle);
@@ -140,6 +146,7 @@ bool CreateWindowSurface(U32 resX, U32 resY) {
     SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, resX);
     SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, resY);
     SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_RESIZABLE_BOOLEAN, true);
+    SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_FULLSCREEN_BOOLEAN, fullscreen);
     sdlWindow = SDL_CreateWindowWithProperties(props);
     SDL_DestroyProperties(props);
     if (sdlWindow == NULL) {

--- a/SOURCES/INITADEL.C
+++ b/SOURCES/INITADEL.C
@@ -187,7 +187,11 @@ void InitAdeline(S32 argc, char *argv[]) {
            which makes scene rendering clip to the smaller dimensions. */
         U32 reqResX, reqResY;
         Res_LoadBootDimensions(&reqResX, &reqResY);
-        if (!InitGraphics(reqResX, reqResY)) {
+        /* Read the fullscreen choice now so the window is created fullscreen up
+           front; the later ReadConfigFile -> SetWindowFullscreen pass then just
+           confirms it instead of flipping a windowed window. */
+        const bool reqFullscreen = Res_LoadBootFullscreen();
+        if (!InitGraphics(reqResX, reqResY, reqFullscreen)) {
             exit(1); // TODO: Implement graceful exit
         }
     }

--- a/SOURCES/RES_SWITCH.CPP
+++ b/SOURCES/RES_SWITCH.CPP
@@ -277,6 +277,28 @@ void Res_LoadBootDimensions(U32 *outW, U32 *outH) {
     *outH = RESOLUTION_Y;
 }
 
+/*══════════════════════════════════════════════════════════════════════════*/
+bool Res_LoadBootFullscreen(void) {
+    /* Same transient, heap-free cfg read as Res_LoadBootDimensions (see the
+       rationale there). Read DisplayFullScreen so InitGraphics can create the
+       window fullscreen up front, instead of the historical "create windowed,
+       then ReadConfigFile -> SetWindowFullscreen flips it" — which flashed a
+       windowed frame on every fullscreen boot. ReadConfigFile still applies the
+       same value later; on boot that becomes a no-op since the state matches,
+       and it remains the authoritative path for the in-game menu toggle.
+
+       Default windowed, matching ReadConfigFile's DisplayFullScreen default
+       (FALSE) and its <0/>1 clamp — keep the two in sync. */
+    if (PathConfigFile[0] != '\0' && ExistsFileOrDir(PathConfigFile)) {
+        static char tmpCfgBuf[8192];
+        if (DefFileBufferInit(PathConfigFile, tmpCfgBuf, (S32)sizeof tmpCfgBuf)) {
+            const long fs = DefFileBufferReadValueDefault("DisplayFullScreen", 0);
+            return fs == 1;
+        }
+    }
+    return false;
+}
+
 /*══════════════════════════════════════════════════════════════════════════*
  *   Safety gate                                                             *
  *══════════════════════════════════════════════════════════════════════════*/

--- a/SOURCES/RES_SWITCH.H
+++ b/SOURCES/RES_SWITCH.H
@@ -74,6 +74,14 @@ bool Res_ValidateDimensions(U32 w, U32 h);
    the cfg held an invalid value so the player can spot a corrupted key. */
 void Res_LoadBootDimensions(U32 *outW, U32 *outH);
 
+/* Read the boot fullscreen choice (lba2.cfg DisplayFullScreen) the same
+   transient, heap-free way as Res_LoadBootDimensions, so the window can be
+   created fullscreen from the start instead of created windowed then flipped
+   by the later ReadConfigFile pass. Returns false (windowed) when the key is
+   absent/invalid or the cfg can't be read. Requires PathConfigFile resolved
+   first (call GetCfgPath). */
+bool Res_LoadBootFullscreen(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Problem

When `DisplayFullScreen` is set, the engine still creates the window **windowed**, then flips it to fullscreen later in `ReadConfigFile` (which runs after `InitProgram`, well after the window is already on screen). The result is a visible windowed frame plus the window manager's fullscreen-transition animation on every fullscreen launch — "create, then correct" instead of "create correct".

The machinery to create-fullscreen-directly already existed (`CreateWindowSurface` applies `windowFullscreenEnabled` right after `SDL_CreateWindow`), but on the boot path that flag was always `false` — the only thing that sets it (`SetWindowFullscreen`) runs after creation.

## Fix

- Read `DisplayFullScreen` during boot the same transient, heap-free way the resolution is already read — new `Res_LoadBootFullscreen()`, mirroring `Res_LoadBootDimensions()`.
- Thread it through `InitGraphics(..., fullscreen)` → `CreateWindowSurface(..., fullscreen)`.
- Set `SDL_PROP_WINDOW_CREATE_FULLSCREEN_BOOLEAN` so SDL brings the window up fullscreen **at creation** — no windowed flash. Seed the cached `windowFullscreenEnabled` to match; keep the existing post-create `SetWindowFullscreen` as a fallback for backends that ignore the property.

`ReadConfigFile`'s `SetWindowFullscreen` is unchanged — on boot it now just confirms the already-correct state (no-op) and remains the authoritative path for the in-game menu toggle. The runtime resolution switcher uses `ResizeWindowSurface` (in-place) and is unaffected.

## Testing

- `DisplayFullScreen: 1` → resolves to fullscreen; `0` → windowed (verified via temporary diagnostic, since removed).
- Both states boot clean (exit 0), no "Unable to switch to fullscreen" warning.
- `clang-format` clean; only the boot/window path touched.

## Note

This only removes the *boot* flash. The fullscreen *behavior* on a given platform is unchanged (e.g. WSLg's borderless-desktop handling is the same as before).