### PR TITLE
feat: in-engine console buffer sink for the boot log

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE.CPP
+++ b/SOURCES/CONSOLE/CONSOLE.CPP
@@ -14,7 +14,9 @@
 
 #define CONSOLE_TEXT_COLOUR 15
 
-#define CONSOLE_SCROLLBACK_LINES 128
+/* Bumped from 128 so the boot log (now fed in via the Log_* console sink) isn't
+ * evicted by gameplay output before the player opens the console. */
+#define CONSOLE_SCROLLBACK_LINES 512
 #define CONSOLE_INPUT_MAX 256
 #define CONSOLE_HISTORY_SIZE 32
 #define CONSOLE_LINE_MAX 256

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -17,6 +17,7 @@
 #include "../INVENT.H"
 #include "../RES_SWITCH.H"
 #include "../PERFTRACE.H"
+#include "../LOG/LOG.H"
 #include <SYSTEM/FILES.H>
 #include <SYSTEM/STRING.H>
 #include <SYSTEM/WINDOW.H>
@@ -1075,6 +1076,41 @@ static void cmd_exit(int argc, const char *argv[]) {
     TheEnd(PROGRAM_OK, "Exit from console");
 }
 
+static const char *loglevel_name(LogSeverity sev) {
+    switch (sev) {
+    case LOG_DEBUG:
+        return "debug";
+    case LOG_INFO:
+        return "info";
+    case LOG_WARN:
+        return "warn";
+    case LOG_ERROR:
+        return "error";
+    }
+    return "info";
+}
+
+static void cmd_loglevel(int argc, const char *argv[]) {
+    if (argc >= 2) {
+        LogSeverity sev;
+        if (strcmp(argv[1], "debug") == 0)
+            sev = LOG_DEBUG;
+        else if (strcmp(argv[1], "info") == 0)
+            sev = LOG_INFO;
+        else if (strcmp(argv[1], "warn") == 0)
+            sev = LOG_WARN;
+        else if (strcmp(argv[1], "error") == 0)
+            sev = LOG_ERROR;
+        else {
+            Console_Print("Unknown level '%s'. Use: debug | info | warn | error",
+                          argv[1]);
+            return;
+        }
+        Log_SetConsoleSeverity(sev);
+    }
+    Console_Print("console log level: %s", loglevel_name(Log_GetConsoleSeverity()));
+}
+
 static void cmd_listsaves(int argc, const char *argv[]) {
     (void)argc;
     (void)argv;
@@ -1515,6 +1551,10 @@ void Console_RegisterAll(void) {
     Console_RegisterCommandEx("buildinfo", cmd_buildinfo, "Engine version, build timestamp, and CMake flags", "(no args)",
                               "Same string as logged at startup.");
     Console_RegisterCommandEx("exit", cmd_exit, "Exit the game immediately", "(no args)", "Clean shutdown.");
+    Console_RegisterCommandEx("loglevel", cmd_loglevel,
+                              "Show or set the console log level", "loglevel [debug|info|warn|error]",
+                              "Filters what the boot/runtime log shows in this console; file + "
+                              "terminal logs are unaffected. Default info.");
     Console_RegisterCommandEx("listsaves", cmd_listsaves, "List save games (names)", "(no args)", "Reads save/ directory.");
     Console_RegisterCommandEx("listbugs", cmd_listbugs, "List bug saves in bugs directory", "(no args)", "Reads bugs/ directory.");
     Console_RegisterCommandEx("timer", cmd_timer, "Advance timer by N ms (default 200)", "timer [ms]", "Advances high-res timer.");

--- a/SOURCES/INITADEL.C
+++ b/SOURCES/INITADEL.C
@@ -103,10 +103,12 @@ void InitAdeline(S32 argc, char *argv[]) {
         /* Structured boot log (docs/BOOT_LOG_PLAN.md). The file sink reuses
            adeline.log — CreateLog above truncated it for this launch, the sink
            appends; both it and the legacy LogPrintf sites share the one file.
-           The terminal sink colours stderr when launched from a real TTY. */
+           The terminal sink colours stderr when launched from a real TTY. The
+           console sink mirrors records into the in-engine F12 overlay. */
         Log_Init();
         Log_AddSink(Log_MakeFileSink(logFilePath, LOG_DEBUG));
         Log_AddSink(Log_MakeTerminalSink(LOG_DEBUG));
+        Log_AddSink(Log_MakeConsoleBufferSink());
         atexit(Log_Shutdown);
 
         /* Boot identity + key paths up top, so a pasted log is self-describing. */

--- a/SOURCES/LOG/LOG.CPP
+++ b/SOURCES/LOG/LOG.CPP
@@ -1,9 +1,15 @@
 #include "LOG.H"
 
+#include "../CONSOLE/CONSOLE.H" /* console buffer sink -> Console_Print */
+
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifndef LBA_LOG_NO_SDL
+#include <SDL3/SDL_thread.h> /* main-thread gate for the console sink */
+#endif
 
 #if defined(_WIN32)
 #include <io.h>      /* _isatty, _fileno */
@@ -56,6 +62,16 @@ namespace {
 LogSink g_pool[LOG_MAX_SINKS];    /* storage */
 LogSink *g_active[LOG_MAX_SINKS]; /* dispatch list */
 int g_active_count = 0;
+
+/* The one console sink, if registered — so Log_SetConsoleSeverity can find it
+ * without the caller threading the handle back through. */
+LogSink *g_console_sink = 0;
+
+#ifndef LBA_LOG_NO_SDL
+/* Captured in Log_Init (on the main thread). The console sink drops records
+ * from any other thread; the ring is not thread-safe. */
+SDL_ThreadID g_main_thread = 0;
+#endif
 
 const char *severity_tag(LogSeverity sev) {
     switch (sev) {
@@ -137,6 +153,29 @@ void term_sink_write(LogSink *s, LogSeverity sev, int kind, const char *msg) {
 /* Registered but inert: the terminal sink's no-op when stderr is not a TTY (or
  * NO_COLOR is set), so redirected output never gets ANSI escapes. */
 void noop_write(LogSink *, LogSeverity, int, const char *) {}
+
+/* --- Console buffer sink: monochrome text into the in-engine scrollback ---- */
+
+void console_sink_write(LogSink *s, LogSeverity sev, int kind, const char *msg) {
+    (void)s;
+#ifndef LBA_LOG_NO_SDL
+    /* The console scrollback ring is not thread-safe — only the main thread may
+     * push. Off-thread records (e.g. the audio callback) are dropped here; they
+     * still reach the file and terminal sinks. */
+    if (g_main_thread != 0 && SDL_GetCurrentThreadID() != g_main_thread)
+        return;
+#endif
+    if (!msg)
+        msg = "";
+    if (kind == REC_SECTION_END)
+        return; /* no closer line in the console */
+    else if (kind == REC_SECTION_BEGIN)
+        Console_Print("== %s ==", msg);
+    else if (kind == REC_RAW)
+        Console_Print("%s", msg); /* msg is the arg, not the format */
+    else
+        Console_Print("[%s] %s", severity_tag(sev), msg);
+}
 
 int terminal_enabled(void) {
 #if defined(_WIN32)
@@ -260,9 +299,11 @@ extern "C" {
 
 void Log_Init(void) {
     g_active_count = 0;
+    g_console_sink = 0;
     for (int i = 0; i < LOG_MAX_SINKS; ++i)
         g_pool[i].in_use = 0;
 #ifndef LBA_LOG_NO_SDL
+    g_main_thread = SDL_GetCurrentThreadID();
     /* SDL applies a per-category priority filter *before* calling the output
        function, and custom categories default to a high threshold — so without
        this our INFO/DEBUG records would be dropped before reaching any sink.
@@ -288,6 +329,7 @@ void Log_Shutdown(void) {
         g_pool[i].in_use = 0;
     }
     g_active_count = 0;
+    g_console_sink = 0;
 }
 
 void Log_Debug(const char *fmt, ...) {
@@ -360,6 +402,28 @@ LogSink *Log_MakeTerminalSink(LogSeverity min_severity) {
     s->min_severity = min_severity;
     s->write = terminal_enabled() ? term_sink_write : noop_write;
     return s;
+}
+
+LogSink *Log_MakeConsoleBufferSink(void) {
+    LogSink *s = alloc_sink();
+    if (!s)
+        return 0;
+    /* INFO by default: shows the boot log + warnings, hides DEBUG chatter. The
+     * verbose audio/SFX logs are gated off (sfxLogEnabled/musicLogEnabled), so
+     * INFO stays clean without filtering the boot log out of the ring. */
+    s->min_severity = LOG_INFO;
+    s->write = console_sink_write;
+    g_console_sink = s;
+    return s;
+}
+
+void Log_SetConsoleSeverity(LogSeverity min_severity) {
+    if (g_console_sink)
+        g_console_sink->min_severity = min_severity;
+}
+
+LogSeverity Log_GetConsoleSeverity(void) {
+    return g_console_sink ? g_console_sink->min_severity : LOG_INFO;
 }
 
 void Log_AddSink(LogSink *sink) {

--- a/SOURCES/LOG/LOG.H
+++ b/SOURCES/LOG/LOG.H
@@ -10,8 +10,8 @@ extern "C" {
  * SDL_SetLogOutputFunction owns the fan-out); host tests compile with
  * -DLBA_LOG_NO_SDL to bypass SDL entirely. See docs/BOOT_LOG_PLAN.md.
  *
- * Phase 1: core API + file sink. The console (Phase 2) and ANSI terminal
- * (Phase 3) sinks, and wiring into the boot path (Phase 4), come later. */
+ * Sinks: file (always), ANSI terminal (TTY-gated), and the in-engine console
+ * buffer. The boot path wires all three in InitAdeline. */
 
 typedef enum {
     LOG_DEBUG,
@@ -54,6 +54,21 @@ LogSink *Log_MakeFileSink(const char *path, LogSeverity min_severity);
  * and NO_COLOR is unset (Windows: also enables VT processing); otherwise it
  * registers but writes nothing, so redirected output never gets escape codes. */
 LogSink *Log_MakeTerminalSink(LogSeverity min_severity);
+
+/* Console buffer sink: pushes records into the in-engine console scrollback
+ * (Console_Print), so the boot log and warnings show on the F12 overlay.
+ * Monochrome — the console ring stores plain text with no per-line colour.
+ * Main-thread records only: the ring is not thread-safe, so off-thread records
+ * (e.g. the audio callback) are dropped here but still reach the file and
+ * terminal sinks. Defaults to INFO (the boot log is INFO/raw; the verbose
+ * audio/SFX logs are gated off by default, so INFO stays clean); adjust live
+ * with Log_SetConsoleSeverity / the `loglevel` console command. */
+LogSink *Log_MakeConsoleBufferSink(void);
+
+/* Raise/lower the console buffer sink's minimum severity at runtime. No-op if
+ * no console sink is registered. */
+void Log_SetConsoleSeverity(LogSeverity min_severity);
+LogSeverity Log_GetConsoleSeverity(void);
 
 void Log_AddSink(LogSink *sink);
 void Log_RemoveSink(LogSink *sink);

--- a/docs/BOOT_LOG_PLAN.md
+++ b/docs/BOOT_LOG_PLAN.md
@@ -1,6 +1,6 @@
 # Boot Log + Exit Screen
 
-**Status:** Decisions locked. Phases 6 (exit screen), 1 (core log + file sink), 3 (terminal sink), 4 (boot-path wiring), and 5 (Funfrock header) done, then reshaped to the terse Quake-style boot log + asset preflight (see "Boot-log shape" below). Phase 2 (console sink) pending; graceful optional-asset degradation is a separate PR (B). Recommended order: 6 → 1 → 3 → 4 → 5 → 2.
+**Status:** All phases done. Phases 6 (exit screen), 1 (core log + file sink), 3 (terminal sink), 4 (boot-path wiring), 5 (Funfrock header — later dropped), and 2 (console sink) implemented, then reshaped to the terse Quake-style boot log + asset preflight (see "Boot-log shape" below). Graceful optional-asset degradation remains a separate PR (B).
 
 ## Goal
 
@@ -237,21 +237,40 @@ Build targets: GCC (`linux` preset) and MinGW (`cross_linux2win` /
 - Verified: host test passes; full engine compiles/links `LOG.CPP` with the SDL
   spine. Dormant until Phase 4 wiring.
 
-### Phase 2 — Console buffer sink
+### Phase 2 — Console buffer sink — done
 
-- Reuse the console API (`Console_Print` / `Console_GetScrollback`). Do not
-  duplicate.
-- Implement `MakeConsoleBufferSink()`. **Monochrome in v1** — the console has no
-  per-line color storage, so severity is not color-coded (adding a color
-  attribute channel to `CONSOLE.CPP`'s ring + renderer is out of scope for v1).
-- **Bump `CONSOLE_SCROLLBACK_LINES`** (currently 128) so early boot lines aren't
-  evicted before the user opens the console.
-- **Main-thread records only:** capture the main thread id in `Init()`; the
-  console sink drops records from other threads (they still hit file/terminal).
-- Register the console buffer sink during `Log_Init()`, at console-level
-  filtering (Warn+ default).
-- **Verification:** boot the engine, open the console (F12), scroll back,
-  confirm the boot log is visible.
+- Reuse the console API (`Console_Print`). Do not duplicate.
+- `Log_MakeConsoleBufferSink()`. **Monochrome** — the console ring stores plain
+  text with no per-line colour, so severity is a text tag (`[WARN]`), not a
+  colour. Raw lines render verbatim; sections as `== Title ==`.
+- **Bumped `CONSOLE_SCROLLBACK_LINES` 128 -> 512** so the boot log isn't evicted
+  by gameplay output before the player opens the console.
+- **Main-thread records only:** the main thread id is captured in `Log_Init()`;
+  the console sink drops records from other threads (the ring is not
+  thread-safe). They still reach the file and terminal sinks.
+- Registered during `InitAdeline` alongside the file + terminal sinks.
+
+**Decisions taken (Phase 2):**
+
+- **Default `INFO`, not `Warn+` (revises decision 2 for this sink).** Decision 2
+  chose Warn+ to keep the overlay clear of the verbose audio/SFX logs — but those
+  are already gated behind `sfxLogEnabled`/`musicLogEnabled` (both default off),
+  so at INFO the overlay is clean *and* the boot log (INFO/raw) actually lands in
+  the ring. A literal Warn+ default would have filtered the boot log out at emit
+  time, contradicting "early boot lines survive in the ring" and the verification
+  below — the lines would never be captured, so lowering the level afterwards
+  couldn't bring them back.
+- **Runtime toggle:** the `loglevel [debug|info|warn|error]` console command
+  (`Log_SetConsoleSeverity` / `Log_GetConsoleSeverity`) adjusts only this sink;
+  the file and terminal sinks are unaffected.
+- The console sink lives in `LOG.CPP` with the other sinks and calls
+  `Console_Print`; host tests that compile `LOG.CPP` standalone provide a
+  `Console_Print` stub (a recording stub in `test_log`, a no-op in
+  `test_asset_preflight`).
+- **Verification:** host test (`test_console_sink`: filtering, tags, raw
+  verbatim, section idiom, runtime severity change); live boot — the full boot
+  log appears in the scrollback via `--dump-state`'s `log` array, and `loglevel`
+  responds via `--exec`.
 
 ### Phase 3 — Terminal sink — done
 

--- a/tests/asset_preflight/test_asset_preflight.cpp
+++ b/tests/asset_preflight/test_asset_preflight.cpp
@@ -17,6 +17,10 @@
 #include <stdio.h>
 #include <string.h>
 
+/* LOG.CPP's console buffer sink references Console_Print; this test links the
+ * log core but not the console module, so a no-op stub satisfies the linker. */
+extern "C" void Console_Print(const char *, ...) {}
+
 #define ROOT "asset_pf_testdir"
 
 static void touch(const char *rel) {

--- a/tests/logging/test_log.cpp
+++ b/tests/logging/test_log.cpp
@@ -6,10 +6,26 @@
 #include "LOG.H"
 #include "test_harness.h"
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
 
 #define TMP "test_log_phase1.tmp"
+
+/* Recording stub for the console buffer sink (LOG.CPP -> Console_Print). The
+ * real console module isn't linked into host tests; capture the pushed lines so
+ * the sink's rendering and filtering can be asserted. */
+static char g_console_capture[4096];
+extern "C" void Console_Print(const char *fmt, ...) {
+    char line[512];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(line, sizeof line, fmt, ap);
+    va_end(ap);
+    size_t used = strlen(g_console_capture);
+    snprintf(g_console_capture + used, sizeof g_console_capture - used, "%s\n", line);
+}
+static void console_capture_reset(void) { g_console_capture[0] = '\0'; }
 
 static void slurp(const char *path, char *out, int max) {
     FILE *f = fopen(path, "r");
@@ -99,11 +115,48 @@ static void test_scoped_section(void) {
     remove(TMP);
 }
 
+/* Console buffer sink: monochrome text into the scrollback, INFO default,
+ * raw verbatim, runtime severity change. (Thread gating is SDL-only and
+ * compiled out under LBA_LOG_NO_SDL, so the sink always writes here.) */
+static void test_console_sink(void) {
+    console_capture_reset();
+    Log_Init();
+    LogSink *s = Log_MakeConsoleBufferSink();
+    ASSERT_TRUE(s != NULL);
+    Log_AddSink(s);
+    ASSERT_TRUE(Log_GetConsoleSeverity() == LOG_INFO);
+
+    /* Default INFO: DEBUG dropped, INFO/WARN tagged, raw verbatim, section idiom. */
+    Log_Debug("dbg-line");
+    Log_Info("info-line");
+    Log_Warn("warn-line");
+    Log_Raw("raw-line");
+    Log_BeginSection("Boot");
+    ASSERT_TRUE(strstr(g_console_capture, "dbg-line") == NULL);
+    ASSERT_TRUE(strstr(g_console_capture, "[INFO] info-line") != NULL);
+    ASSERT_TRUE(strstr(g_console_capture, "[WARN] warn-line") != NULL);
+    ASSERT_TRUE(strstr(g_console_capture, "raw-line") != NULL);
+    ASSERT_TRUE(strstr(g_console_capture, "[INFO] raw-line") == NULL); /* verbatim */
+    ASSERT_TRUE(strstr(g_console_capture, "== Boot ==") != NULL);
+
+    /* loglevel raise to WARN now drops INFO. */
+    console_capture_reset();
+    Log_SetConsoleSeverity(LOG_WARN);
+    ASSERT_TRUE(Log_GetConsoleSeverity() == LOG_WARN);
+    Log_Info("info-after");
+    Log_Error("err-after");
+    ASSERT_TRUE(strstr(g_console_capture, "info-after") == NULL);
+    ASSERT_TRUE(strstr(g_console_capture, "[ERROR] err-after") != NULL);
+
+    Log_Shutdown();
+}
+
 int main(void) {
     RUN_TEST(test_severity_prefixes);
     RUN_TEST(test_min_severity_filter);
     RUN_TEST(test_section_header);
     RUN_TEST(test_scoped_section);
+    RUN_TEST(test_console_sink);
     TEST_SUMMARY();
     return test_failures != 0;
 }


### PR DESCRIPTION
Phase 2 of the boot-log work (`docs/BOOT_LOG_PLAN.md`) — the last sink. Mirrors `Log_*` records into the in-engine console scrollback so the boot log and runtime warnings appear on the F12 overlay, not just the file/terminal.

Stacked on #270 (`feat/fatal-error-msgbox`).

## What it does

- **`Log_MakeConsoleBufferSink()`** (`LOG.CPP`, calling `Console_Print`). Monochrome — the console ring stores plain text, so severity is a text tag (`[WARN]`), raw lines are verbatim, sections render as `== Title ==`.
- **Main-thread records only** — the main thread id is captured in `Log_Init()`; the sink drops off-thread records (the ring isn't thread-safe). They still reach the file/terminal sinks.
- **`CONSOLE_SCROLLBACK_LINES` 128 → 512** so the boot log isn't evicted before the player opens the console.
- **Runtime toggle:** the `loglevel [debug|info|warn|error]` console command (`Log_SetConsoleSeverity`/`Log_GetConsoleSeverity`) adjusts only this sink; file/terminal are unaffected.
- Registered in `InitAdeline` alongside the file + terminal sinks.

## Design note — default INFO, not the plan's literal Warn+

The plan's decision 2 chose Warn+ for the console to keep the overlay clear of verbose audio/SFX logs. But those are already gated behind `sfxLogEnabled`/`musicLogEnabled` (both default off), so at **INFO** the overlay is clean *and* the boot log (INFO/raw) actually lands in the ring. A literal Warn+ default would filter the boot log out at *emit* time — so it could never appear in the console, contradicting decision 6 ("early boot lines survive in the ring") and the Phase 2 verification. Documented in the plan's Phase 2 decisions. `loglevel warn` restores the quiet-overlay behavior for anyone who wants it.

## Testing

- Host: `test_console_sink` (filtering, severity tags, raw verbatim, section idiom, runtime severity change) via a recording `Console_Print` stub. `test_asset_preflight` gets a no-op stub since it links `LOG.CPP`. All 16 host tests pass.
- Live: `--dump-state` shows the full boot log in the scrollback `log` array; `loglevel` responds via `--exec`. Builds clean; clang-format clean.

With this, all boot-log phases are implemented.