### PR TITLE
refactor(log): route LogPrintf/LogPuts through the fan-out (U2)

### DIFF
--- a/LIB386/H/SYSTEM/LOG.H
+++ b/LIB386/H/SYSTEM/LOG.H
@@ -78,6 +78,11 @@ LogSeverity Log_GetConsoleSeverity(void);
 void Log_AddSink(LogSink *sink);
 void Log_RemoveSink(LogSink *sink);
 
+/* True once at least one sink is registered (the fan-out is live). Legacy
+ * LogPrintf/LogPuts use this to choose between routing through the fan-out and
+ * an early-boot direct write (before any sink exists). */
+int Log_HasSinks(void);
+
 #ifdef __cplusplus
 }
 

--- a/LIB386/H/SYSTEM/LOGPRINT.H
+++ b/LIB386/H/SYSTEM/LOGPRINT.H
@@ -14,10 +14,6 @@ extern "C" {
 #endif
 
 //----------------------------------------------------------------------------
-extern U32 Log2File;
-extern U32 QuietLog; ///< If TRUE then will not write to console, only to file
-
-//----------------------------------------------------------------------------
 extern void CreateLog(const char *filePath);
 
 //----------------------------------------------------------------------------

--- a/LIB386/SYSTEM/LOG.CPP
+++ b/LIB386/SYSTEM/LOG.CPP
@@ -451,4 +451,6 @@ void Log_RemoveSink(LogSink *sink) {
     }
 }
 
+int Log_HasSinks(void) { return g_active_count > 0; }
+
 } // extern "C"

--- a/LIB386/SYSTEM/LOGPRINT.CPP
+++ b/LIB386/SYSTEM/LOGPRINT.CPP
@@ -1,5 +1,6 @@
 //----------------------------------------------------------------------------
 #include <SYSTEM/ADELINE.H>
+#include <SYSTEM/LOG.H>
 #include <SYSTEM/LOGPRINT.H>
 #include <SYSTEM/LIMITS.H>
 
@@ -8,9 +9,7 @@
 #include <string.h>
 
 //----------------------------------------------------------------------------
-U32 QuietLog = FALSE;
 static char LogName[ADELINE_MAX_PATH] = "";
-static char LogStr[256];
 
 //----------------------------------------------------------------------------
 void CreateLog(const char *filePath) {
@@ -34,42 +33,68 @@ void CreateLog(const char *filePath) {
 }
 
 //----------------------------------------------------------------------------
-void LogPrintf(const char *format, ...) {
-    char *ptr;
-    va_list arglist;
+// Legacy LogPrintf/LogPuts now feed the structured log fan-out (SYSTEM/LOG) so
+// their ~100 call sites share the file/terminal/console sinks, per-sink severity
+// filtering, and TTY gating instead of writing straight to stdout + the file.
+// Lines are emitted verbatim (REC_RAW, no severity tag) to preserve their
+// original appearance. Before any sink exists (early boot: a pre-init failure,
+// or CreateLog's own warning) there is nothing to fan out to, so we fall back to
+// a direct write -- stderr plus the log file if one is open -- so nothing is lost.
 
-    va_start(arglist, format);
+// Emit one line (without its terminating newline) verbatim through the fan-out.
+static void EmitLine(const char *p, size_t len) {
+    char line[1024];
+    if (len >= sizeof(line))
+        len = sizeof(line) - 1;
+    memcpy(line, p, len);
+    line[len] = '\0';
+    Log_Raw("%s", line); // line is the argument, not the format
+}
 
-    (void)vsnprintf(LogStr, sizeof(LogStr), format, arglist);
-
-    for (ptr = LogStr; *ptr; ptr++) {
-        if (*ptr == '\n') {
-            memmove(ptr + 2, ptr + 1, strlen(ptr));
-            *ptr++ = '\r';
-            *ptr = '\n';
+// Treat '\n' as a line terminator: one record per line. Each sink appends its
+// own newline, so this avoids doubled newlines; blank lines are preserved.
+static void RouteOrFallback(const char *s) {
+    if (Log_HasSinks()) {
+        const char *p = s;
+        for (;;) {
+            const char *nl = strchr(p, '\n');
+            if (nl) {
+                EmitLine(p, (size_t)(nl - p));
+                p = nl + 1;
+            } else {
+                if (*p)
+                    EmitLine(p, strlen(p));
+                break;
+            }
         }
-    }
-
-    va_end(arglist);
-
-    if (!QuietLog) {
-        printf("%s", LogStr);
-    }
-
-    if (*LogName) {
-        FILE *logfile;
-
-        logfile = fopen(LogName, "ab+");
-        if (logfile) {
-            fprintf(logfile, "%s", LogStr);
-            fclose(logfile);
+    } else {
+        // No sinks yet -- preserve the message directly so it is not lost.
+        fputs(s, stderr);
+        if (LogName[0]) {
+            FILE *logfile = fopen(LogName, "ab+");
+            if (logfile) {
+                fputs(s, logfile);
+                fclose(logfile);
+            }
         }
     }
 }
 
 //----------------------------------------------------------------------------
+void LogPrintf(const char *format, ...) {
+    char buf[1024];
+    va_list arglist;
+
+    va_start(arglist, format);
+    (void)vsnprintf(buf, sizeof(buf), format, arglist);
+    va_end(arglist);
+
+    RouteOrFallback(buf);
+}
+
+//----------------------------------------------------------------------------
 void LogPuts(const char *string) {
-    LogPrintf("%s\n", string);
+    LogPrintf("%s\n", string); // passes the string as an argument -> '%' is safe
 }
 
 //----------------------------------------------------------------------------

--- a/SOURCES/MESSAGE.CPP
+++ b/SOURCES/MESSAGE.CPP
@@ -462,10 +462,7 @@ void ClearVoiceFile() {
         return;
 
 #ifdef DEBUG_TOOLS
-    if (!QuietLog)
-        LogPrintf("FlagKeepVoice=0 !!!!!");
-    else
-        Message("FlagKeepVoice=0 !!!!!", TRUE);
+    LogPrintf("FlagKeepVoice=0 !!!!!");
     return;
 #else
 

--- a/tests/deffile/CMakeLists.txt
+++ b/tests/deffile/CMakeLists.txt
@@ -3,11 +3,16 @@ add_executable(test_deffile_latin1 test_deffile_latin1.cpp
     ${CMAKE_SOURCE_DIR}/LIB386/SYSTEM/FILES.CPP
     ${CMAKE_SOURCE_DIR}/LIB386/SYSTEM/LOADSAVE.CPP
     ${CMAKE_SOURCE_DIR}/LIB386/SYSTEM/LOGPRINT.CPP
+    ${CMAKE_SOURCE_DIR}/LIB386/SYSTEM/LOG.CPP
     ${CMAKE_SOURCE_DIR}/LIB386/SYSTEM/ITOA.CPP)
 
 target_include_directories(test_deffile_latin1 PRIVATE
     ${CMAKE_SOURCE_DIR}/LIB386/H
 )
+
+# LogPrintf now routes through the structured log core (LOG.CPP); pull it in and
+# bypass the SDL_Log spine so this test needs no SDL.
+target_compile_definitions(test_deffile_latin1 PRIVATE LBA_LOG_NO_SDL)
 
 set_target_properties(test_deffile_latin1 PROPERTIES CXX_STANDARD 11)
 

--- a/tests/logging/CMakeLists.txt
+++ b/tests/logging/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(test_log
     test_log.cpp
-    ${CMAKE_SOURCE_DIR}/LIB386/SYSTEM/LOG.CPP)
+    ${CMAKE_SOURCE_DIR}/LIB386/SYSTEM/LOG.CPP
+    ${CMAKE_SOURCE_DIR}/LIB386/SYSTEM/LOGPRINT.CPP)
 
 target_include_directories(test_log PRIVATE
     ${CMAKE_SOURCE_DIR}/LIB386/H

--- a/tests/logging/test_log.cpp
+++ b/tests/logging/test_log.cpp
@@ -4,6 +4,7 @@
  * straight to the fan-out with no SDL_Init — the file sink is exercised
  * end-to-end and its on-disk content asserted. */
 #include <SYSTEM/LOG.H>
+#include <SYSTEM/LOGPRINT.H>
 #include "test_harness.h"
 
 #include <stdio.h>
@@ -211,6 +212,82 @@ static void test_remove_sink(void) {
     remove(TMP);
 }
 
+/* --- Legacy LogPrintf/LogPuts shim (U2): routes through the fan-out --------- */
+
+/* LogPrintf reaches the sinks verbatim — no [INFO] tag, exactly one trailing
+ * newline (the sink adds it), no doubling. */
+static void test_logprintf_routes_through_fanout(void) {
+    remove(TMP);
+    Log_Init();
+    Log_AddSink(Log_MakeFileSink(TMP, LOG_DEBUG));
+    LogPrintf("hello %d\n", 42);
+    Log_Shutdown();
+
+    char buf[4096];
+    slurp(TMP, buf, sizeof buf);
+    ASSERT_TRUE(strcmp(buf, "hello 42\n") == 0);
+    remove(TMP);
+}
+
+/* A multi-line message becomes one record per line: no doubled newlines, no
+ * spurious trailing blank line. */
+static void test_logprintf_multiline_split(void) {
+    remove(TMP);
+    Log_Init();
+    Log_AddSink(Log_MakeFileSink(TMP, LOG_DEBUG));
+    LogPrintf("a\nb\n");
+    Log_Shutdown();
+
+    char buf[4096];
+    slurp(TMP, buf, sizeof buf);
+    ASSERT_TRUE(strcmp(buf, "a\nb\n") == 0);
+    remove(TMP);
+}
+
+/* LogPuts passes its string as an argument, so '%' is never a format. */
+static void test_logputs_percent_safe(void) {
+    remove(TMP);
+    Log_Init();
+    Log_AddSink(Log_MakeFileSink(TMP, LOG_DEBUG));
+    LogPuts("100% complete");
+    Log_Shutdown();
+
+    char buf[4096];
+    slurp(TMP, buf, sizeof buf);
+    ASSERT_TRUE(strcmp(buf, "100% complete\n") == 0);
+    remove(TMP);
+}
+
+/* A message with no trailing newline becomes one terminated line (the fan-out
+ * is line-oriented). Documents the one behavior change from byte-concatenation. */
+static void test_logprintf_partial_line_terminated(void) {
+    remove(TMP);
+    Log_Init();
+    Log_AddSink(Log_MakeFileSink(TMP, LOG_DEBUG));
+    LogPrintf("partial");
+    Log_Shutdown();
+
+    char buf[4096];
+    slurp(TMP, buf, sizeof buf);
+    ASSERT_TRUE(strcmp(buf, "partial\n") == 0);
+    remove(TMP);
+}
+
+/* Before any sink exists the shim must not lose the line: it falls back to a
+ * direct write to the log file (and stderr). */
+static void test_logprintf_early_boot_fallback(void) {
+    remove("shim_fallback.tmp");
+    Log_Init();                     /* resets the registry; no sink added */
+    CreateLog("shim_fallback.tmp"); /* sets the log path, truncates it */
+    LogPrintf("early-boot\n");      /* no sinks -> direct fallback to the file */
+    Log_Shutdown();
+
+    char buf[4096];
+    slurp("shim_fallback.tmp", buf, sizeof buf);
+    ASSERT_TRUE(strstr(buf, "early-boot") != NULL);
+    remove("shim_fallback.tmp");
+}
+
 int main(void) {
     RUN_TEST(test_severity_prefixes);
     RUN_TEST(test_min_severity_filter);
@@ -220,6 +297,11 @@ int main(void) {
     RUN_TEST(test_fanout_to_all_sinks);
     RUN_TEST(test_sink_pool_limit);
     RUN_TEST(test_remove_sink);
+    RUN_TEST(test_logprintf_routes_through_fanout);
+    RUN_TEST(test_logprintf_multiline_split);
+    RUN_TEST(test_logputs_percent_safe);
+    RUN_TEST(test_logprintf_partial_line_terminated);
+    RUN_TEST(test_logprintf_early_boot_fallback);
     TEST_SUMMARY();
     return test_failures != 0;
 }


### PR DESCRIPTION
**U2 of the logging unification** ([docs/LOGGING_UNIFICATION.md](docs/LOGGING_UNIFICATION.md)), on top of U1 (#274). The high-leverage step: the ~109 legacy `LogPrintf`/`LogPuts` sites now feed the one fan-out instead of bypassing it.

## What changed
- **`LogPrintf`/`LogPuts` emit through `Log_Raw`** — verbatim (`REC_RAW`, no severity tag, so their appearance is unchanged). `'\n'` is treated as a line terminator: one record per line, so each sink's per-record newline never doubles and blank lines are preserved. `LogPuts` keeps `"%s\n"`, so `%` in the string stays safe.
- **Early-boot fallback** — before any sink exists (a pre-init failure, `CreateLog`'s own warning) the shim writes directly to stderr + the log file, so nothing is lost. Gated on a new `Log_HasSinks()` in the core.
- **Removed:** the manual CRLF pass (and the latent overflow in its in-place `memmove`); the unconditional `printf(stdout)` (which collided with stdout-as-data modes like the LZ self-test); and the dead globals `Log2File` (never used) and `QuietLog` (always FALSE — its one `DEBUG_TOOLS` reader in `MESSAGE.CPP` is simplified to the live branch).
- `LogPrintf` now depends on the log core, so the two host tests that cherry-pick `LOGPRINT.CPP` (`deffile`, `logging`) also pull `LOG.CPP` with `LBA_LOG_NO_SDL`.

## Verification
- **`adeline.log` is byte-identical to a `main` baseline except `\r\n`→`\n`** (same lines, same order, no duplicates, no doubled blanks).
- **stdout no longer carries log lines** (the version banner + `OK.` are gone from stdout — pure gain for stdout-as-data).
- 16/16 host tests pass, incl. **5 new shim tests**: routing-verbatim, multi-line split (no doubling), `%`-safety, partial-line termination, early-boot fallback.
- Clean under clang-format 17 (CI) and 18.

U3 (the per-subsystem severity pass + the 2 format-string fixes) is the optional follow-up.