### PR TITLE
refactor(log): fix LogPrintf format-string risks, rejoin DebugHQR line (U3)

### DIFF
--- a/SOURCES/CONFIG/MAIN.CPP
+++ b/SOURCES/CONFIG/MAIN.CPP
@@ -79,7 +79,7 @@ void TheEnd(char *err) {
 
 //-------------------------------------------------------------------------
 void TheEndInfo(void) {
-    LogPrintf(End_Error);
+    LogPrintf("%s", End_Error); /* End_Error is data, not a format string */
 }
 
 //-------------------------------------------------------------------------

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2139,12 +2139,13 @@ void TheEnd(S32 num, const char *error) {
 /*══════════════════════════════════════════════════════════════════════════*/
 #if defined(DEBUG_TOOLS) || defined(TEST_TOOLS)
 void DebugHQR(const char *titre, T_HQR_HEADER *hqr) {
-    LogPrintf(titre);
-
+    /* One call per line: titre is a %s argument (not the format), so it is
+       safe and stays on the same line as its stats under the line-oriented
+       log fan-out (see docs/LOGGING_UNIFICATION.md). */
     if (hqr) {
-        LogPrintf(": %7ld - used: %7ld - MaxIndex: %4ld - NbIndex: %4ld\n", hqr->MaxSize, hqr->MaxSize - hqr->FreeSize, hqr->MaxIndex, hqr->NbIndex);
+        LogPrintf("%s: %7ld - used: %7ld - MaxIndex: %4ld - NbIndex: %4ld\n", titre, hqr->MaxSize, hqr->MaxSize - hqr->FreeSize, hqr->MaxIndex, hqr->NbIndex);
     } else {
-        LogPrintf(": xxxxxxx - used: xxxxxxx - MaxIndex: xxxx - NbIndex: xxxx\n");
+        LogPrintf("%s: xxxxxxx - used: xxxxxxx - MaxIndex: xxxx - NbIndex: xxxx\n", titre);
     }
 }
 #endif


### PR DESCRIPTION
First slice of **U3** ([docs/LOGGING_UNIFICATION.md](docs/LOGGING_UNIFICATION.md)) — the unambiguous correctness fixes. The output-changing severity pass is held for a separate, scoped PR.

Two `LogPrintf` sites passed a runtime string as the *format* (latent `%`-injection if the string ever held a percent):

- **`DebugHQR`** (`PERSO.CPP`, `DEBUG_TOOLS`): was `LogPrintf(titre)` then a second call for the stats. Combined into one `LogPrintf("%s: …", titre, …)` — `titre` is now an argument (safe), and the label + stats stay on one line under the line-oriented fan-out. This also **undoes the one cosmetic split U2 introduced** in `DEBUG_TOOLS` builds (the exit-time HQR memory dump).
- **`CONFIG/MAIN.CPP` `TheEndInfo`**: `LogPrintf(End_Error)` → `LogPrintf("%s", End_Error)`.

## Verification
- Normal build + 16/16 host tests pass.
- `DebugHQR` compiles clean under `DEBUG_TOOLS` (syntax-checked with the real build flags).
- No normal-build output change (both sites are `DEBUG_TOOLS` / a separate config tool).
- Clean under clang-format 17 and 18.