### PR TITLE
refactor(log): give WINDOW/SDL display errors real severity (U3)

### DIFF
--- a/LIB386/SVGA/SDL.CPP
+++ b/LIB386/SVGA/SDL.CPP
@@ -2,6 +2,7 @@
 
 #include <SVGA/DIRTYBOX.H> // For BoxStaticAdd and BoxCleanClip
 #include <SVGA/SCREEN.H>   // For ModeDesiredX, ModeDesiredY and Log buffer
+#include <SYSTEM/LOG.H>
 #include <SYSTEM/LOGPRINT.H>
 #include <SYSTEM/WINDOW.H>
 
@@ -49,8 +50,8 @@ static void RebuildPaletteLUT() {
 // --- Initialization ----------------------------------------------------------
 bool InitVideo() {
     if (!IsWindowInitialized()) {
-        LogPrintf("Error: Unable to initialize Video subsystem.\n"
-                  "\tWindow subsystem was not initialized beforehand.\n");
+        Log_Error("Unable to initialize Video subsystem.\n"
+                  "\tWindow subsystem was not initialized beforehand.");
 
         return false;
     }
@@ -102,8 +103,8 @@ bool CreateVideoSurface(U32 resX, U32 resY) {
     sdlPalette = SDL_CreatePalette(PAL_MAX_COLORS);
     if (sdlPalette == NULL) {
         const char *errorMsg = SDL_GetError();
-        LogPrintf("Error: Unable to create SDL palette.\n"
-                  "\tSDL message: %s\n",
+        Log_Error("Unable to create SDL palette.\n"
+                  "\tSDL message: %s",
                   errorMsg);
 
         return false;
@@ -173,9 +174,9 @@ void SetVideoPalette(const U8 src[], S32 startIdx, S32 count) {
 
     if (!SDL_SetPaletteColors(sdlPalette, tmpColors, startIdx, count)) {
         const char *errorMsg = SDL_GetError();
-        LogPrintf("Warning: Unable to set SDL palette color.\n"
-                  "\tSDL message: %s\n",
-                  errorMsg);
+        Log_Warn("Unable to set SDL palette color.\n"
+                 "\tSDL message: %s",
+                 errorMsg);
     }
 
     RebuildPaletteLUT();
@@ -192,9 +193,9 @@ void SetVideoPaletteCol(S32 colorIdx, U8 r, U8 g, U8 b) {
 
     if (!SDL_SetPaletteColors(sdlPalette, &tmpColor, colorIdx, 1)) {
         const char *errorMsg = SDL_GetError();
-        LogPrintf("Warning: Unable to set SDL palette color.\n"
-                  "\tSDL message: %s\n",
-                  errorMsg);
+        Log_Warn("Unable to set SDL palette color.\n"
+                 "\tSDL message: %s",
+                 errorMsg);
     }
 
     paletteLUT[colorIdx] = ((U32)0xFF << 24) | ((U32)r << 16) | ((U32)g << 8) | b;

--- a/LIB386/SYSTEM/WINDOW.CPP
+++ b/LIB386/SYSTEM/WINDOW.CPP
@@ -1,5 +1,6 @@
 #include <SYSTEM/WINDOW.H>
 
+#include <SYSTEM/LOG.H>
 #include <SYSTEM/LOGPRINT.H>
 
 #include <SDL3/SDL.h>
@@ -102,8 +103,8 @@ bool InitWindow(const char *title) {
 
     if (!SDL_InitSubSystem(SDL_INIT_VIDEO)) {
         const char *errorMsg = SDL_GetError();
-        LogPrintf("Error: Unable to initialize SDL Window/Video subsystem.\n"
-                  "\tSDL Message: %s\n",
+        Log_Error("Unable to initialize SDL Window/Video subsystem.\n"
+                  "\tSDL Message: %s",
                   errorMsg);
 
         windowSystemInitialized = false;
@@ -151,26 +152,26 @@ bool CreateWindowSurface(U32 resX, U32 resY, bool fullscreen) {
     SDL_DestroyProperties(props);
     if (sdlWindow == NULL) {
         const char *errorMsg = SDL_GetError();
-        LogPrintf("Error: Unable to create SDL window.\n"
+        Log_Error("Unable to create SDL window.\n"
                   "\tResolution: %ux%u.\n"
-                  "\tSDL message: %s\n",
+                  "\tSDL message: %s",
                   resX, resY, errorMsg);
         return false;
     }
 
     if (windowFullscreenEnabled && !SDL_SetWindowFullscreen(sdlWindow, true)) {
         const char *errorMsg = SDL_GetError();
-        LogPrintf("Warning: Unable to switch SDL window to fullscreen.\n"
-                  "\tSDL message: %s\n",
-                  errorMsg);
+        Log_Warn("Unable to switch SDL window to fullscreen.\n"
+                 "\tSDL message: %s",
+                 errorMsg);
         windowFullscreenEnabled = false;
     }
 
     sdlRenderer = SDL_CreateRenderer(sdlWindow, NULL);
     if (sdlRenderer == NULL) {
         const char *errorMsg = SDL_GetError();
-        LogPrintf("Error: Unable to create SDL renderer.\n"
-                  "\tSDL message: %s\n",
+        Log_Error("Unable to create SDL renderer.\n"
+                  "\tSDL message: %s",
                   errorMsg);
         SDL_DestroyWindow(sdlWindow);
         sdlWindow = NULL;
@@ -183,9 +184,9 @@ bool CreateWindowSurface(U32 resX, U32 resY, bool fullscreen) {
                                    SDL_TEXTUREACCESS_STREAMING, resX, resY);
     if (sdlTexture == NULL) {
         const char *errorMsg = SDL_GetError();
-        LogPrintf("Error: Unable to create SDL streaming texture.\n"
+        Log_Error("Unable to create SDL streaming texture.\n"
                   "\tSize: %ux%u.\n"
-                  "\tSDL message: %s\n",
+                  "\tSDL message: %s",
                   resX, resY, errorMsg);
         SDL_DestroyRenderer(sdlRenderer);
         sdlRenderer = NULL;
@@ -245,8 +246,8 @@ bool ResizeWindowSurface(U32 newW, U32 newH) {
                                    SDL_TEXTUREACCESS_STREAMING, (int)newW, (int)newH);
     if (sdlTexture == NULL) {
         const char *errorMsg = SDL_GetError();
-        LogPrintf("Error: Unable to recreate SDL streaming texture at %ux%u.\n"
-                  "\tSDL message: %s\n",
+        Log_Error("Unable to recreate SDL streaming texture at %ux%u.\n"
+                  "\tSDL message: %s",
                   newW, newH, errorMsg);
         return false;
     }
@@ -358,9 +359,9 @@ void SetWindowFullscreen(bool fullscreen) {
 
     if (!SDL_SetWindowFullscreen(sdlWindow, fullscreen)) {
         const char *errorMsg = SDL_GetError();
-        LogPrintf("Warning: Unable to change SDL fullscreen state to %d.\n"
-                  "\tSDL message: %s\n",
-                  fullscreen ? 1 : 0, errorMsg);
+        Log_Warn("Unable to change SDL fullscreen state to %d.\n"
+                 "\tSDL message: %s",
+                 fullscreen ? 1 : 0, errorMsg);
         windowFullscreenEnabled = !fullscreen;
         return;
     }


### PR DESCRIPTION
Targeted slice of the U3 severity pass ([docs/LOGGING_UNIFICATION.md](docs/LOGGING_UNIFICATION.md)): the display-init diagnostics a player hits when video/window setup fails.

## What changed
The 11 `"Error:"`/`"Warning:"` `LogPrintf` lines in `WINDOW.CPP` (7) and `SDL.CPP` (4) become `Log_Error`/`Log_Warn` — so they get the `[ERROR]`/`[WARN]` tag, terminal colour, and F12-console visibility. The redundant `"Error: "`/`"Warning: "` text prefix is dropped (the tag conveys it) and the trailing `\n` is left to the sink.

## What was deliberately *not* converted — and why
`RES_DISCOVERY` and `DIRECTORIES` keep their `LogPrintf`. Their errors ("no valid game data directory", "invalid user/resource/config dir") fire in `main()` **before `InitAdeline` registers the sinks** (`ResolveGameDataDir`/`InitDirectories` at `main:2417`/`2432`; `Log_Init` is inside `InitAdeline` at `2457`). `Log_Error`/`Log_Warn` have **no early-boot fallback**, so converting them would make those errors **vanish** on exactly the broken-install case where they matter most. `LogPrintf`'s fallback (stderr + the log file) keeps them visible — so they stay `LogPrintf`.

(Making `Log_*` fallback-capable so those could convert too is a possible future change; out of scope here.)

## Verification
- Build + 16/16 host tests.
- Forcing a window-init failure (`SDL_VIDEODRIVER=<invalid>`) now logs `[ERROR] Unable to initialize SDL Window/Video subsystem.` (was `Error: …`).
- Normal boot output unchanged — these paths only fire on failure.
- Clean under clang-format 17 and 18.