### PR TITLE
refactor(log): early-boot fallback for Log_*, convert data-dir errors (U3)

### DIFF
--- a/LIB386/SYSTEM/LOG.CPP
+++ b/LIB386/SYSTEM/LOG.CPP
@@ -280,10 +280,34 @@ void SDLCALL sdl_output(void *userdata, int category, SDL_LogPriority pri,
 }
 #endif /* !LBA_LOG_NO_SDL */
 
+/* Direct fallback used when no sink is registered yet — before Log_Init /
+ * Log_AddSink (e.g. the game-data-directory checks in main, which run before
+ * InitAdeline) or after Log_Shutdown. Writes to stderr in the file sink's idiom
+ * and bypasses the SDL spine (which may not even be installed pre-Log_Init), so
+ * an early Log_Error/Log_Warn is still seen. Mirrors LogPrintf's fallback. */
+void log_fallback_write(LogSeverity sev, int kind, const char *msg) {
+    if (!msg)
+        msg = "";
+    if (kind == REC_SECTION_END)
+        return;
+    if (kind == REC_SECTION_BEGIN)
+        fprintf(stderr, "==== %s ====\n", msg);
+    else if (kind == REC_RAW)
+        fprintf(stderr, "%s\n", msg);
+    else
+        fprintf(stderr, "[%s] %s\n", severity_tag(sev), msg);
+    fflush(stderr);
+}
+
 /* Transport seam: format-then-dispatch. Under SDL the record rides the log
  * spine and comes back through sdl_output; in host tests it goes straight to
- * the fan-out, so the core needs no SDL_Init. */
+ * the fan-out, so the core needs no SDL_Init. With no sinks registered, fall
+ * back to a direct write so nothing is lost before the sinks come up. */
 void emit_formatted(LogSeverity sev, int kind, const char *msg) {
+    if (g_active_count == 0) {
+        log_fallback_write(sev, kind, msg);
+        return;
+    }
 #ifdef LBA_LOG_NO_SDL
     log_emit(sev, kind, msg);
 #else

--- a/SOURCES/DIRECTORIES.CPP
+++ b/SOURCES/DIRECTORIES.CPP
@@ -3,6 +3,7 @@
 #include <SYSTEM/ADELINE.H>
 #include <SYSTEM/FILES.H>
 #include <SYSTEM/LIMITS.H>
+#include <SYSTEM/LOG.H>
 #include <SYSTEM/LOGPRINT.H>
 
 #include <SDL3/SDL_filesystem.h>
@@ -161,21 +162,21 @@ void InitDirectories(const char *userDir, const char *resDir,
     strncpy(directoriesUserDir, userDir, ADELINE_MAX_PATH);
     directoriesUserDir[ADELINE_MAX_PATH - 1] = '\0'; // Guarantee
     if (!ExistsFileOrDir(directoriesUserDir)) {
-        LogPrintf("Error: Invalid user directory '%s'\n", directoriesUserDir);
+        Log_Error("Invalid user directory '%s'", directoriesUserDir);
         exit(EXIT_FAILURE);
     }
 
     strncpy(directoriesResDir, resDir, ADELINE_MAX_PATH);
     directoriesResDir[ADELINE_MAX_PATH - 1] = '\0'; // Guarantee
     if (!IsValidResourceDir(directoriesResDir)) {
-        LogPrintf("Error: Invalid resource directory '%s'\n", directoriesResDir);
+        Log_Error("Invalid resource directory '%s'", directoriesResDir);
         exit(EXIT_FAILURE);
     }
 
     strncpy(directoriesCfgDir, cfgDir, ADELINE_MAX_PATH);
     directoriesCfgDir[ADELINE_MAX_PATH - 1] = '\0'; // Guarantee
     if (!ExistsFileOrDir(directoriesCfgDir)) {
-        LogPrintf("Error: Invalid config directory '%s'\n", directoriesCfgDir);
+        Log_Error("Invalid config directory '%s'", directoriesCfgDir);
         exit(EXIT_FAILURE);
     }
 
@@ -183,8 +184,7 @@ void InitDirectories(const char *userDir, const char *resDir,
     directoriesCDPrefix[ADELINE_MAX_PATH - 1] = '\0'; // Guarantee
     if (strlen(directoriesCDPrefix) > 0) {
         if (!ExistsFileOrDir(directoriesCDPrefix)) {
-            LogPrintf("Error: Invalid CD drive or directory '%s'\n",
-                      directoriesCDPrefix);
+            Log_Error("Invalid CD drive or directory '%s'", directoriesCDPrefix);
             exit(EXIT_FAILURE);
         }
     }
@@ -213,8 +213,7 @@ void GetCurrentRunningDir(char *outDir) {
         return;
     }
     if (SDL_strlen(sdlBasePath) >= ADELINE_MAX_PATH) {
-        LogPrintf("Error: Current directory path too long (>= %d)\n",
-                  ADELINE_MAX_PATH);
+        Log_Error("Current directory path too long (>= %d)", ADELINE_MAX_PATH);
         SDL_free(sdlBasePath);
         outDir[0] = '\0';
         return;

--- a/SOURCES/RES_DISCOVERY.CPP
+++ b/SOURCES/RES_DISCOVERY.CPP
@@ -5,6 +5,7 @@
 #include <SYSTEM/ADELINE.H>
 #include <SYSTEM/FILES.H>
 #include <SYSTEM/LIMITS.H>
+#include <SYSTEM/LOG.H>
 #include <SYSTEM/LOGPRINT.H>
 
 #include <SDL3/SDL.h>
@@ -101,7 +102,7 @@ bool NormalizeAndTry(const char *pathIn, char *outDir, U16 outMax,
 }
 
 void LogFailure(const char tried[][ADELINE_MAX_PATH], int triedCount) {
-    LogPrintf("Error: No valid game data directory (need lba2.hqr). Tried %d path(s).\n",
+    Log_Error("No valid game data directory (need lba2.hqr). Tried %d path(s).",
               triedCount);
     for (int i = 0; i < triedCount; i++) {
         LogPrintf("  - %s\n", tried[i]);

--- a/tests/logging/test_log.cpp
+++ b/tests/logging/test_log.cpp
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h> /* dup/dup2 — capture stderr for the no-sink fallback test */
 
 #define TMP "test_log_phase1.tmp"
 
@@ -288,6 +289,32 @@ static void test_logprintf_early_boot_fallback(void) {
     remove("shim_fallback.tmp");
 }
 
+/* With no sink registered, Log_* must still surface — it falls back to a direct
+ * stderr write (bypassing the SDL spine). This is what keeps the pre-Log_Init
+ * game-data-directory errors visible. Capture stderr to assert it. */
+static void test_log_fallback_no_sinks(void) {
+    Log_Init(); /* no sink added -> g_active_count == 0 */
+
+    fflush(stderr);
+    int saved = dup(fileno(stderr));
+    FILE *cap = fopen("fallback_stderr.tmp", "w");
+    ASSERT_TRUE(cap != NULL);
+    dup2(fileno(cap), fileno(stderr));
+
+    Log_Error("orphan-%d", 9); /* no sinks -> direct fallback to stderr */
+
+    fflush(stderr);
+    dup2(saved, fileno(stderr)); /* restore */
+    close(saved);
+    fclose(cap);
+
+    char buf[1024];
+    slurp("fallback_stderr.tmp", buf, sizeof buf);
+    ASSERT_TRUE(strstr(buf, "[ERROR] orphan-9") != NULL);
+    remove("fallback_stderr.tmp");
+    Log_Shutdown();
+}
+
 int main(void) {
     RUN_TEST(test_severity_prefixes);
     RUN_TEST(test_min_severity_filter);
@@ -302,6 +329,7 @@ int main(void) {
     RUN_TEST(test_logputs_percent_safe);
     RUN_TEST(test_logprintf_partial_line_terminated);
     RUN_TEST(test_logprintf_early_boot_fallback);
+    RUN_TEST(test_log_fallback_no_sinks);
     TEST_SUMMARY();
     return test_failures != 0;
 }


### PR DESCRIPTION
Completes the U3 severity pass for the data-dir diagnostics — the one user-facing error group #278 had to leave behind.

## Why these needed a fallback first
`RES_DISCOVERY` ("no valid game data directory") and `DIRECTORIES` ("invalid user/resource/config dir") errors fire in `main()` **before `InitAdeline` registers the sinks**. `Log_Error`/`Log_Warn` had no fallback, so converting them would have made the errors *vanish* on a broken install — which is why #278 deliberately left them on `LogPrintf`.

## What changed
- **`Log_*` core early-boot fallback:** when no sink is registered, `emit_formatted` writes the record straight to stderr in the file-sink idiom (`[ERROR] msg`) and **bypasses the SDL spine** (which may not be installed pre-`Log_Init`). Mirrors `LogPrintf`'s fallback; gated on `g_active_count == 0`, so normal logging is completely untouched.
- **Converted the data-dir errors** to `Log_Error` — `RES_DISCOVERY` headline + `DIRECTORIES` 5 sites. The path-list detail under the `RES_DISCOVERY` headline stays `LogPrintf` (raw detail lines).

## Verification
- New `test_log_fallback_no_sinks` captures stderr (dup2) and asserts a no-sink `Log_Error` reaches it as `[ERROR] …`. **14/14** host tests pass.
- Normal boot log **byte-identical to baseline** — the fallback never fires when sinks exist.
- (The real pre-`Log_Init` failure is hard to trigger here since auto-discovery always finds the data; the unit test exercises the exact fallback path directly.)
- Clean under clang-format 17 and 18.