### PR TITLE
test(log): cover the real SDL_Log spine

### DIFF
--- a/tests/logging/CMakeLists.txt
+++ b/tests/logging/CMakeLists.txt
@@ -15,3 +15,20 @@ set_target_properties(test_log PROPERTIES CXX_STANDARD 11)
 
 add_test(NAME test_log COMMAND test_log)
 register_host_test(test_log)
+
+# Companion target that exercises the REAL SDL_Log spine (no LBA_LOG_NO_SDL):
+# Log_* -> SDL_LogMessage -> output function -> log_emit -> sink. Links SDL3.
+add_executable(test_log_spine
+    test_log_spine.cpp
+    ${CMAKE_SOURCE_DIR}/LIB386/SYSTEM/LOG.CPP)
+
+target_include_directories(test_log_spine PRIVATE
+    ${CMAKE_SOURCE_DIR}/LIB386/H
+    ${CMAKE_SOURCE_DIR}/tests)
+
+target_link_libraries(test_log_spine PRIVATE SDL3::SDL3)
+
+set_target_properties(test_log_spine PROPERTIES CXX_STANDARD 11)
+
+add_test(NAME test_log_spine COMMAND test_log_spine)
+register_host_test(test_log_spine)

--- a/tests/logging/test_log_spine.cpp
+++ b/tests/logging/test_log_spine.cpp
@@ -1,0 +1,99 @@
+/* Host test for the REAL SDL_Log spine (docs/BOOT_LOG_PLAN.md).
+ *
+ * Unlike test_log (which compiles with -DLBA_LOG_NO_SDL and dispatches straight
+ * to the sinks), this target builds LOG.CPP *with* the SDL spine and links SDL3.
+ * It exercises the production path that test_log can't reach:
+ *
+ *   Log_* -> SDL_LogMessage -> the installed output function -> sdl_output ->
+ *   log_emit -> sink
+ *
+ * including the category<->kind and severity<->priority mapping and, crucially,
+ * the SDL_SetLogPriority(LBA_CAT_*, DEBUG) opens in Log_Init -- without those,
+ * SDL's per-category filter drops INFO/DEBUG before any sink sees them (the
+ * gotcha that bit the boot-log work). A break in the trampoline fails here. */
+#include <SYSTEM/LOG.H>
+#include "test_harness.h"
+
+#include <SDL3/SDL.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#define TMP "test_log_spine.tmp"
+
+static void slurp(const char *path, char *out, int max) {
+    FILE *f = fopen(path, "r");
+    if (!f) {
+        out[0] = '\0';
+        return;
+    }
+    size_t n = fread(out, 1, (size_t)(max - 1), f);
+    out[n] = '\0';
+    fclose(f);
+}
+
+/* Every severity + raw + section round-trips through the SDL spine to the file
+ * sink with its tag/idiom intact. (If the SetLogPriority opens regressed, the
+ * DEBUG/INFO assertions fail — SDL would have filtered them out.) */
+static void test_spine_roundtrip(void) {
+    remove(TMP);
+    Log_Init();
+    Log_AddSink(Log_MakeFileSink(TMP, LOG_DEBUG));
+    Log_Debug("dbg");
+    Log_Info("eye-%d", 7);
+    Log_Warn("warn");
+    Log_Error("err");
+    Log_Raw("raw-line");
+    Log_BeginSection("Sect");
+    Log_EndSection();
+    Log_Shutdown();
+
+    char buf[4096];
+    slurp(TMP, buf, sizeof buf);
+    ASSERT_TRUE(strstr(buf, "[DEBUG] dbg") != NULL);
+    ASSERT_TRUE(strstr(buf, "[INFO] eye-7") != NULL);
+    ASSERT_TRUE(strstr(buf, "[WARN] warn") != NULL);
+    ASSERT_TRUE(strstr(buf, "[ERROR] err") != NULL);
+    ASSERT_TRUE(strstr(buf, "raw-line") != NULL);
+    ASSERT_TRUE(strstr(buf, "==== Sect ====") != NULL);
+    remove(TMP);
+}
+
+/* The engine's existing bare SDL_Log() sites (the audio stack, etc.) also reach
+ * the fan-out once Log_Init installs the output function. */
+static void test_spine_routes_bare_sdl_log(void) {
+    remove(TMP);
+    Log_Init();
+    Log_AddSink(Log_MakeFileSink(TMP, LOG_DEBUG));
+    SDL_Log("bare-sdl-%d", 3); /* APPLICATION category, INFO priority */
+    Log_Shutdown();
+
+    char buf[4096];
+    slurp(TMP, buf, sizeof buf);
+    ASSERT_TRUE(strstr(buf, "bare-sdl-3") != NULL);
+    remove(TMP);
+}
+
+/* Per-sink severity filtering still applies on the spine path. */
+static void test_spine_min_severity(void) {
+    remove(TMP);
+    Log_Init();
+    Log_AddSink(Log_MakeFileSink(TMP, LOG_WARN));
+    Log_Info("dropped-info");
+    Log_Error("kept-error");
+    Log_Shutdown();
+
+    char buf[4096];
+    slurp(TMP, buf, sizeof buf);
+    ASSERT_TRUE(strstr(buf, "dropped-info") == NULL);
+    ASSERT_TRUE(strstr(buf, "[ERROR] kept-error") != NULL);
+    remove(TMP);
+}
+
+int main(void) {
+    RUN_TEST(test_spine_roundtrip);
+    RUN_TEST(test_spine_routes_bare_sdl_log);
+    RUN_TEST(test_spine_min_severity);
+    TEST_SUMMARY();
+    return test_failures != 0;
+}


### PR DESCRIPTION
Came out of a review of the logging-unification campaign. The campaign is solid — builds clean (normal + DEBUG_TOOLS), 16/16 host tests, no logic bugs — but it left one **major coverage hole**: every log test compiles with `-DLBA_LOG_NO_SDL`, which dispatches straight to the sinks and **never touches the production path**:

`Log_*` → `SDL_LogMessage` → installed output function → `sdl_output` → `log_emit` → sink

…including the `category↔kind` / `severity↔priority` mapping and the `SDL_SetLogPriority(LBA_CAT_*, DEBUG)` opens in `Log_Init`. A regression there ships silently.

## What this adds
`test_log_spine` — a companion target that builds `LOG.CPP` **with** the SDL spine and links SDL3. It asserts:
- every severity + raw + section round-trips to a file sink with its tag/idiom intact;
- a bare `SDL_Log()` (the engine's 44 audio sites) also reaches the fan-out;
- per-sink severity filtering still holds on the spine path.

## It has teeth
Neutering the `LBA_CAT_LOG` `SetLogPriority` open makes `test_spine_roundtrip` fail — SDL's per-category filter then drops **WARN/INFO/DEBUG** before any sink sees them (the exact gotcha that bit the boot-log work; turns out it drops WARN too, not just INFO/DEBUG).

Host suite goes 16 → 17. Clean under clang-format 17 and 18.