### PR TITLE
feat(android): 16 KB memory-page support for arm64

### DIFF
--- a/.github/workflows/reusable-build-android.yml
+++ b/.github/workflows/reusable-build-android.yml
@@ -80,13 +80,13 @@ jobs:
           sdkmanager --install \
             "platforms;android-34" \
             "build-tools;34.0.0" \
-            "ndk;26.1.10909125" \
+            "ndk;28.2.13676358" \
             "platform-tools" \
             2>&1
 
       - name: Set environment
         run: |
-          ANDROID_NDK="${ANDROID_HOME}/ndk/26.1.10909125"
+          ANDROID_NDK="${ANDROID_HOME}/ndk/28.2.13676358"
           echo "ANDROID_NDK=${ANDROID_NDK}" >> "$GITHUB_ENV"
           echo "${ANDROID_HOME}/build-tools/34.0.0" >> "$GITHUB_PATH"
           echo "${ANDROID_HOME}/platform-tools" >> "$GITHUB_PATH"
@@ -115,7 +115,8 @@ jobs:
             -DANDROID_STL=c++_shared \
             -DSDL_SHARED=ON \
             -DSDL_STATIC=OFF \
-            -DSDL_TEST=OFF
+            -DSDL_TEST=OFF \
+            -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384"
 
           cmake --build "$SDL3_BUILD" -- -j$(nproc)
           cmake --install "$SDL3_BUILD" --prefix "$SDL3_INSTALL"

--- a/.github/workflows/reusable-build-android.yml
+++ b/.github/workflows/reusable-build-android.yml
@@ -158,6 +158,12 @@ jobs:
             --cxx-shared-lib "$CXX_SHARED_LIB" \
             --output-dir dist
 
+      - name: Verify 16 KB page alignment (arm64-v8a)
+        if: matrix.arch == 'arm64-v8a'
+        run: |
+          APK=$(ls dist/*-arm64-v8a.apk | head -1)
+          bash scripts/dev/check-16k-align.sh "$APK"
+
       - name: Upload temporary artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/reusable-build-android.yml
+++ b/.github/workflows/reusable-build-android.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           sdkmanager --install \
             "platforms;android-34" \
-            "build-tools;34.0.0" \
+            "build-tools;35.0.0" \
             "ndk;28.2.13676358" \
             "platform-tools" \
             2>&1
@@ -88,7 +88,7 @@ jobs:
         run: |
           ANDROID_NDK="${ANDROID_HOME}/ndk/28.2.13676358"
           echo "ANDROID_NDK=${ANDROID_NDK}" >> "$GITHUB_ENV"
-          echo "${ANDROID_HOME}/build-tools/34.0.0" >> "$GITHUB_PATH"
+          echo "${ANDROID_HOME}/build-tools/35.0.0" >> "$GITHUB_PATH"
           echo "${ANDROID_HOME}/platform-tools" >> "$GITHUB_PATH"
 
       - name: Build SDL3 for Android

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -148,7 +148,8 @@
         "ANDROID_STL": "c++_shared",
         "SOUND_BACKEND": "sdl",
         "MVIDEO_BACKEND": "smacker",
-        "SDL3_DIR": "$env{SDL3_ANDROID_DIR}"
+        "SDL3_DIR": "$env{SDL3_ANDROID_DIR}",
+        "CMAKE_SHARED_LINKER_FLAGS": "-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384"
       }
     },
     {

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -9,7 +9,7 @@ Minimum Android version: **7.0 (API 24)**. The APK targets API 24 (required by S
 
 You need:
 
-1.  **Android NDK** r26 or later (recommended: r26.1.10909125).
+1.  **Android NDK** r28 or later (recommended: r28.2.13676358) — required for 16 KB memory-page support on arm64 (see [16 KB page support](#16-kb-page-support)).
 2.  **SDL3** built for your target ABI(s).
 3.  **Ninja** build system.
 4.  Retail **game data** (HQR files) — you must provide these.
@@ -17,28 +17,24 @@ You need:
 ### 1. Build SDL3 for Android
 
 ```bash
-# For arm64-v8a (modern phones/tablets, 64-bit Android TV)
-git clone --depth 1 --branch release-3.2.16 https://github.com/libsdl-org/SDL.git SDL3
-cd SDL3
-cmake -B build-arm64 -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
-    -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=24 -DSDL_SHARED=ON -DSDL_STATIC=OFF
-cmake --build build-arm64
-cmake --install build-arm64 --prefix $PWD/install-arm64
-
-# For armeabi-v7a (32-bit Android TV, older devices)
-cmake -B build-armv7a -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
-    -DANDROID_ABI=armeabi-v7a -DANDROID_PLATFORM=24 -DSDL_SHARED=ON -DSDL_STATIC=OFF
-cmake --build build-armv7a
-cmake --install build-armv7a --prefix $PWD/install-armv7a
+# arm64-v8a: clones SDL (release-3.2.16) to out/android/SDL3, installs to
+# out/android/sdl3-install, and applies the 16 KB-page linker flags.
+bash scripts/dev/build-sdl3-android.sh
 ```
+
+The source tree it leaves under `out/android/SDL3` is also the
+`--sdl3-java-src` the bundler needs for the SDLActivity Java sources. For
+`armeabi-v7a`, configure SDL3 by hand with `-DANDROID_ABI=armeabi-v7a`
+(the script targets arm64-v8a).
 
 ### 2. Build LBA2
 
 ```bash
-# From the repo root, point SDL3_ANDROID_DIR to the install for your target ABI
-export ANDROID_NDK=/path/to/android-ndk-r26
-export SDL3_ANDROID_DIR=/path/to/sdl3-install-arm64
-bash scripts/dev/build-android.sh
+# From the repo root, point SDL3_ANDROID_DIR at the install from step 1
+export ANDROID_NDK=$HOME/Android/Sdk/ndk/28.2.13676358
+export SDL3_ANDROID_DIR=$PWD/out/android/sdl3-install
+bash scripts/dev/build-android.sh                    # arm64-v8a (default)
+bash scripts/dev/build-android.sh --abi armeabi-v7a  # 32-bit
 ```
 
 ### 3. Install on device
@@ -54,11 +50,42 @@ bash scripts/packaging/bundle-android.sh \
     --arch arm64-v8a \
     --build-dir out/build/android_arm64 \
     --sdk-root $ANDROID_HOME \
+    --sdl3-java-src out/android/SDL3 \
+    --sdl3-lib $SDL3_ANDROID_DIR/lib/libSDL3.so \
+    --cxx-shared-lib $ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so \
     --output-dir dist
 
 # Install
 adb install -r dist/lba2cc-*-android-arm64-v8a.apk
 ```
+
+`--sdl3-lib` is required — without it `libSDL3.so` is omitted from the APK
+and the app fails to load. `--cxx-shared-lib` points the bundler at the
+NDK's `libc++_shared.so`; CI passes both explicitly.
+
+## 16 KB page support
+
+Android 15+ runs 64-bit apps on 16 KB memory pages on some devices. A
+native library whose `LOAD` segments are 4 KB-aligned fails to load there
+(`... program alignment (4096) cannot be smaller than system page size
+(16384)`). The arm64-v8a build is 16 KB-safe:
+
+- **NDK r28** ships `libc++_shared.so` 16 KB-aligned and defaults the
+  linker `max-page-size` to 16384. r26 cannot be fixed by flags alone —
+  its prebuilt STL is 4 KB-aligned.
+- `-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384`, set in the
+  `android_common` preset and the build scripts, keep `liblba2cc.so` and
+  `libSDL3.so` aligned even on r27.
+- The APK stores the `.so` uncompressed and 16 KB-zipaligned with
+  `extractNativeLibs="false"`, so the loader maps them straight from the
+  APK.
+- `scripts/dev/check-16k-align.sh <apk>` verifies all of the above; CI
+  runs it on every arm64 build.
+
+Backward-compatible: `max-page-size` sets a *maximum*, so a 4 KB-page
+kernel loads the libraries normally. **armeabi-v7a is unaffected** — 16 KB
+pages are a 64-bit concern; 32-bit ARM (older devices, all current
+Android TV) is always 4 KB.
 
 ## Game data on Android
 

--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -129,6 +129,7 @@ CMake presets cover the supported targets and toolchains. Cross-compile to Windo
 - Presets (`linux`, `linux_clang`, `linux_test`, `macos_arm64`, `macos_x86_64`, `windows_ucrt64`, `windows_mingw64`, `cross_linux2win`) — `CMakePresets.json`
 - Cross-toolchain — `cmake/mingw-w64-i686.cmake`
 - `LBA2_NATIVE_ARCH` (per-arch tuning flags) — `CMakeLists.txt`
+- Android arm64 native libs are 16 KB-page aligned (NDK r28 + `max-page-size`; stored uncompressed + `zipalign -P 16`; `extractNativeLibs="false"`), verified in CI by `scripts/dev/check-16k-align.sh` — see [ANDROID.md](ANDROID.md). 16 KB pages are 64-bit-only, so armeabi-v7a stays 4 KB.
 
 **Deep dive:** [WINDOWS.md](WINDOWS.md) for the MSYS2 path; root [README](../README.md) for the broader build instructions.
 

--- a/packaging/android/AndroidManifest.xml
+++ b/packaging/android/AndroidManifest.xml
@@ -36,7 +36,8 @@
         android:allowBackup="true"
         android:hasCode="true"
         android:icon="@mipmap/ic_launcher"
-        android:requestLegacyExternalStorage="true">
+        android:requestLegacyExternalStorage="true"
+        android:extractNativeLibs="false">
 
         <!-- SDL3 provides the Java Activity wrapper -->
         <activity android:name="org.libsdl.app.SDLActivity"

--- a/scripts/dev/build-android.sh
+++ b/scripts/dev/build-android.sh
@@ -5,13 +5,13 @@
 # Supports arm64-v8a (default) and armeabi-v7a (via --abi armeabi-v7a).
 #
 # Prerequisites:
-#   1. Android NDK r26+  — set ANDROID_NDK or install under $HOME/Android/Sdk/ndk/
+#   1. Android NDK r28+  — set ANDROID_NDK or install under $HOME/Android/Sdk/ndk/
 #   2. SDL3 built for the target ABI — set SDL3_ANDROID_DIR or run build-sdl3-android.sh first
 #   3. Ninja (build tool)
 #   4. Retail game data HQR files (NOT included in the repo)
 #
 # Usage:
-#   export ANDROID_NDK=$HOME/Android/Sdk/ndk/26.1.10909125
+#   export ANDROID_NDK=$HOME/Android/Sdk/ndk/28.2.13676358
 #   export SDL3_ANDROID_DIR=$PWD/out/android/sdl3-install-arm64
 #   bash scripts/dev/build-android.sh                         # arm64-v8a (default)
 #   bash scripts/dev/build-android.sh --abi armeabi-v7a        # 32-bit
@@ -25,7 +25,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # ---- Config ---------------------------------------------------------------
-ANDROID_NDK="${ANDROID_NDK:-${HOME}/Android/Sdk/ndk/26.1.10909125}"
+ANDROID_NDK="${ANDROID_NDK:-${HOME}/Android/Sdk/ndk/28.2.13676358}"
 SDL3_ANDROID_DIR="${SDL3_ANDROID_DIR:-${REPO_DIR}/out/android/sdl3-install}"
 ABI="${ABI:-arm64-v8a}"
 API_LEVEL=24
@@ -66,7 +66,8 @@ cmake -S "${REPO_DIR}" -B "${BUILD_DIR}" \
     -DANDROID_STL=c++_shared \
     -DSDL3_DIR="${SDL3_ANDROID_DIR}/lib/cmake/SDL3" \
     -DSOUND_BACKEND=sdl \
-    -DMVIDEO_BACKEND=smacker
+    -DMVIDEO_BACKEND=smacker \
+    -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384"
 
 # ---- Step 2: Build native library ----------------------------------------
 cmake --build "${BUILD_DIR}" -- -j$(nproc)

--- a/scripts/dev/build-sdl3-android.sh
+++ b/scripts/dev/build-sdl3-android.sh
@@ -2,10 +2,10 @@
 # ---------------------------------------------------------------------------
 # Build SDL3 for Android (arm64-v8a) and install to a known prefix.
 #
-# Prerequisites: Android NDK r26+, Ninja, git.
+# Prerequisites: Android NDK r28+, Ninja, git.
 #
 # Usage:
-#   export ANDROID_NDK=$HOME/Android/Sdk/ndk/26.1.10909125
+#   export ANDROID_NDK=$HOME/Android/Sdk/ndk/28.2.13676358
 #   bash scripts/dev/build-sdl3-android.sh
 #
 # Output:
@@ -20,7 +20,7 @@ SDL3_SRC="${OUT_DIR}/SDL3"
 SDL3_BUILD="${OUT_DIR}/sdl3-build"
 SDL3_INSTALL="${OUT_DIR}/sdl3-install"
 
-ANDROID_NDK="${ANDROID_NDK:-${HOME}/Android/Sdk/ndk/26.1.10909125}"
+ANDROID_NDK="${ANDROID_NDK:-${HOME}/Android/Sdk/ndk/28.2.13676358}"
 
 if [ ! -d "${ANDROID_NDK}" ]; then
     echo "ERROR: ANDROID_NDK not found at ${ANDROID_NDK}"
@@ -48,7 +48,8 @@ cmake -S "${SDL3_SRC}" -B "${SDL3_BUILD}" -G Ninja \
     -DANDROID_STL=c++_shared \
     -DSDL_SHARED=ON \
     -DSDL_STATIC=OFF \
-    -DSDL_TEST=OFF
+    -DSDL_TEST=OFF \
+    -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384"
 
 # Build
 cmake --build "${SDL3_BUILD}" -- -j$(nproc)

--- a/scripts/dev/check-16k-align.sh
+++ b/scripts/dev/check-16k-align.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Verify an Android APK is safe to load on 16 KB memory-page devices.
+#
+# Checks three things that together guarantee the native libraries can be
+# mmap'd straight from the APK on a 16 KB-page kernel (Android 15+, arm64):
+#
+#   1. Every .so LOAD segment is 16 KB-aligned (ELF p_align == 2**14).
+#      Fixed by NDK r28 / -Wl,-z,max-page-size=16384.
+#   2. The .so are STORED uncompressed. extractNativeLibs="false" maps them
+#      from the APK, which is impossible if they are deflated. (A zipalign
+#      check alone does NOT catch this — it reports compressed entries as OK.)
+#   3. zipalign agrees the stored .so sit on 16 KB boundaries in the zip.
+#
+# Usage:   check-16k-align.sh <app.apk>
+# Env:     ANDROID_NDK            (for llvm-readelf)
+#          ANDROID_HOME / ANDROID_SDK_ROOT  (for zipalign in build-tools)
+# Exit:    0 = 16 KB-safe, 1 = not safe / tooling missing.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+APK="${1:?usage: check-16k-align.sh <app.apk>}"
+[ -f "$APK" ] || { echo "check-16k-align: APK not found: $APK" >&2; exit 1; }
+
+NDK="${ANDROID_NDK:?check-16k-align: ANDROID_NDK must be set}"
+SDK="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+
+READELF=$(ls "$NDK"/toolchains/llvm/prebuilt/*/bin/llvm-readelf 2>/dev/null | head -1)
+[ -x "$READELF" ] || { echo "check-16k-align: llvm-readelf not found under NDK" >&2; exit 1; }
+ZIPALIGN=$(ls -d "$SDK"/build-tools/*/zipalign 2>/dev/null | sort -V | tail -1)
+[ -x "$ZIPALIGN" ] || { echo "check-16k-align: zipalign not found under SDK build-tools" >&2; exit 1; }
+
+fail=0
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# 1+2. Per-.so: stored uncompressed, and every LOAD segment >= 16 KB aligned.
+echo "== native libraries =="
+mapfile -t solist < <(unzip -Z1 "$APK" 'lib/*/*.so' 2>/dev/null)
+[ "${#solist[@]}" -gt 0 ] || { echo "  FAIL: no lib/*/*.so entries in APK" >&2; exit 1; }
+
+for entry in "${solist[@]}"; do
+    # compression method (unzip -v column 2): 'Stored' = uncompressed
+    method=$(unzip -v "$APK" "$entry" 2>/dev/null | awk -v e="$entry" '$NF==e{print $2}')
+    if [ "$method" = "Stored" ]; then
+        store_ok="stored"
+    else
+        store_ok="COMPRESSED(${method:-?})"; fail=1
+    fi
+
+    unzip -qo "$APK" "$entry" -d "$tmp"
+    minalign=$(( 1 << 30 ))
+    while read -r a; do
+        d=$(( a ))
+        [ "$d" -lt "$minalign" ] && minalign=$d
+    done < <("$READELF" -lW "$tmp/$entry" 2>/dev/null | awk '/LOAD/{print $NF}')
+    if [ "$minalign" -ge 16384 ]; then
+        align_ok="align>=16K(min=$minalign)"
+    else
+        align_ok="ALIGN<16K(min=$minalign)"; fail=1
+    fi
+
+    printf "  %-22s %-18s %s\n" "$(basename "$entry")" "$store_ok" "$align_ok"
+done
+
+# 3. zipalign confirms the stored .so sit on 16 KB zip boundaries.
+echo "== zipalign -c -P 16 =="
+if "$ZIPALIGN" -c -P 16 -v 4 "$APK" >/dev/null 2>&1; then
+    echo "  OK"
+else
+    echo "  FAIL: zip-entry 16 KB alignment check failed"; fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+    echo "16 KB-safe: PASS"
+else
+    echo "16 KB-safe: FAIL" >&2
+    exit 1
+fi

--- a/scripts/packaging/bundle-android.sh
+++ b/scripts/packaging/bundle-android.sh
@@ -199,13 +199,13 @@ if [[ -f classes.dex ]]; then
     "$AAPT" add "unsigned.apk" "classes.dex" 2>&1
 fi
 for lib in "lib/$ARCH/"*.so; do
-    [[ -f "$lib" ]] && "$AAPT" add -0 .so "unsigned.apk" "$lib" 2>&1
+    [[ -f "$lib" ]] && "$AAPT" add -0 '' "unsigned.apk" "$lib" 2>&1
 done
 cd "$REPO_ROOT"
 
-# 6. Zipalign
+# 6. Zipalign (-P 16: align uncompressed .so to 16 KB pages for 16 KB-page devices)
 echo "[bundle-android] aligning..."
-"$ZIPALIGN" -f -p 4 "$STAGING/unsigned.apk" "$STAGING/aligned.apk"
+"$ZIPALIGN" -f -P 16 4 "$STAGING/unsigned.apk" "$STAGING/aligned.apk"
 
 # 7. Debug-sign with the auto-generated debug keystore
 KEYSTORE="${HOME}/.android/debug.keystore"


### PR DESCRIPTION
Makes the Android arm64 build install and run on 16 KB memory-page devices (Android 15+) without regressing 4 KB-page devices or the 32-bit build.

A native library whose `LOAD` segments are 4 KB-aligned fails to load on a 16 KB-page kernel (`libc++_shared.so program alignment (4096) cannot be smaller than system page size (16384)`). Four parts:

- **Compile aligned** — bump NDK r26 → r28c (ships `libc++_shared.so` 16 KB-aligned; r26's prebuilt STL can't be fixed by flags alone) and add `-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384` to the `android_common` preset, both build scripts, and the CI SDL3 build.
- **Package aligned** — store the `.so` uncompressed (`aapt add -0 ''`; the prior `-0 .so` silently left them deflated), `zipalign -P 16`, and set `extractNativeLibs="false"` so the loader maps them straight from the APK. Bumps CI build-tools to 35 (needed for `zipalign -P`).
- **Gate it** — `scripts/dev/check-16k-align.sh` asserts every `.so` is stored, 16 KB ELF-aligned, and 16 KB zipaligned; CI runs it on every arm64 build. (A zipalign check alone passes compressed entries, so the stored check is its own assertion.)
- **Docs** — a 16 KB section in `docs/ANDROID.md` plus a `docs/PLATFORM.md` note.

Effect is arm64-only: `max-page-size` is a *maximum*, a no-op on 4 KB kernels, so armeabi-v7a and Android TV are unaffected.

Tested on two emulators:
- **16 KB arm64 (API 36):** the previously-crashing app launches and renders.
- **4 KB Android TV (armeabi-v7a, API 36):** the v7a APK loads its libs straight from the APK (`base.apk!/lib/... ok`) and runs — confirming the packaging is backward-compatible on 4 KB.

Stacked on #282 (the `android/` relocation) — that lands first; this PR's diff is only the 16 KB changes.
