### PR TITLE
fix(input): save with keyboard text-entry only on a physical keyboard

### DIFF
--- a/LIB386/SYSTEM/KEYBOARD.CPP
+++ b/LIB386/SYSTEM/KEYBOARD.CPP
@@ -20,12 +20,14 @@ S32 AsciiMode = FALSE;
 S32 Key;
 U8 TabKeys[TABKEYS_NUM_KEYS];
 
-// Last-input-wins device flag, read by the save menu to skip text entry on
-// gamepad-only setups. Declared extern in SOURCES/C_EXTERN.H. Defined here
-// (rather than SOURCES/GLOBAL.CPP) so the symbol lives in libsys.a, which
-// every test binary links; otherwise tests that pull libsys.a but not the
-// SOURCES objects fail to link the HandleEventsXxx consumers below.
-S32 LastInputWasGamepad = 0;
+// Last-input-wins device flag: 1 = the most recent input was a physical
+// keyboard key-down, 0 = anything else (mouse, gamepad, touch). Read by the
+// save menu to offer text entry only when a real keyboard is in use. Declared
+// extern in SOURCES/C_EXTERN.H. Defined here (rather than SOURCES/GLOBAL.CPP)
+// so the symbol lives in libsys.a, which every test binary links; otherwise
+// tests that pull libsys.a but not the SOURCES objects fail to link the
+// HandleEventsXxx consumers below.
+S32 LastInputWasKeyboard = 0;
 
 // Weak hook for virtual-input sources (touch overlay, etc.) to re-apply
 // their key states after UpdateKeyboardState clears TabKeys[0..255].
@@ -105,14 +107,15 @@ void ManageKeyboard() {
 void HandleEventsKeyboard(const void *event) {
     // Keyboard *state* is read via SDL_GetKeyboardState in UpdateKeyboardState;
     // we don't consume key events to drive TabKeys. The one thing we do here
-    // is sample SDL_EVENT_KEY_DOWN to maintain the "last input was gamepad"
-    // signal: a real key-down is unambiguous evidence the user is on the
-    // keyboard, in a way that polled state isn't (polled state reads "down"
-    // on every frame a held key is depressed and would constantly fight any
-    // gamepad signal during normal play).
+    // is sample SDL_EVENT_KEY_DOWN to maintain the "last input was keyboard"
+    // signal: a real key-down is unambiguous evidence the user is on a
+    // physical keyboard, in a way that polled state isn't (polled state reads
+    // "down" on every frame a held key is depressed). The touch overlay pokes
+    // TabKeys directly and never reaches here, so touch never counts as
+    // keyboard.
     const SDL_Event *ev = (const SDL_Event *)event;
     if (ev->type == SDL_EVENT_KEY_DOWN) {
-        LastInputWasGamepad = 0;
+        LastInputWasKeyboard = 1;
     }
 }
 

--- a/LIB386/SYSTEM/MOUSE.CPP
+++ b/LIB386/SYSTEM/MOUSE.CPP
@@ -45,11 +45,11 @@ static void MousePointerMarkActivity(void) {
 // TODO: Convert the asm to .h to hold the data (currently on MOUSEDAT.ASM)
 extern U8 BinGphMouse[];
 
-// Game-side "last input was gamepad" flag, defined in SOURCES/GLOBAL.CPP and
-// declared in C_EXTERN.H (which LIB386 cannot include for layering reasons).
-// Cleared here on any mouse activity so the save menu routes through the
-// keyboard/mouse named-save flow when the user reaches for the mouse.
-extern "C" S32 LastInputWasGamepad;
+// Game-side "last input was keyboard" flag, defined in LIB386/SYSTEM/KEYBOARD.CPP
+// and declared in C_EXTERN.H (which LIB386 cannot include for layering reasons).
+// Cleared here on any mouse activity: a mouse is not a keyboard, so the save
+// menu uses the auto-name (controller) flow when the user reaches for the mouse.
+extern "C" S32 LastInputWasKeyboard;
 
 // --- Initialization ----------------------------------------------------------
 void InitMouse() {
@@ -175,7 +175,7 @@ void HandleEventsMouse(const void *event) {
 
         MousePointerMarkActivity();
         s_mouseMotionFlag = true;
-        LastInputWasGamepad = 0;
+        LastInputWasKeyboard = 0;
 
         if (s_showSpriteAfterFirstMotion) {
             s_showSpriteAfterFirstMotion = false;
@@ -187,7 +187,7 @@ void HandleEventsMouse(const void *event) {
         MousePointerMarkActivity();
         Click |= (sdlEvent->button.button == 1) ? 1 : 0;
         Click |= (sdlEvent->button.button == 3) ? 2 : 0;
-        LastInputWasGamepad = 0;
+        LastInputWasKeyboard = 0;
         break;
 
     case SDL_EVENT_MOUSE_BUTTON_UP:
@@ -199,7 +199,7 @@ void HandleEventsMouse(const void *event) {
     case SDL_EVENT_MOUSE_WHEEL:
         MousePointerMarkActivity();
         MouseWheelYAccum += (S32)lround((double)sdlEvent->wheel.y);
-        LastInputWasGamepad = 0;
+        LastInputWasKeyboard = 0;
         break;
     }
 }

--- a/SOURCES/C_EXTERN.H
+++ b/SOURCES/C_EXTERN.H
@@ -61,12 +61,12 @@ extern S32 LastIdxPalette; // numéro de la palette précédente dans le HQR
 
 extern S32 MyKey;
 
-// 1 = the most recent user input came from a gamepad (button press or stick
-// motion past the deadzone); 0 = keyboard or mouse. Last-input-wins, updated
-// from the SDL event loop. Read by the save menu to skip text entry on
-// gamepad-only setups. Defined in LIB386/SYSTEM/KEYBOARD.CPP (rather than
+// 1 = the most recent user input was a physical keyboard key-down; 0 = any
+// other device (mouse, gamepad, touch). Last-input-wins, updated from the SDL
+// event loop. Read by the save menu to offer text entry only when a real
+// keyboard is in use. Defined in LIB386/SYSTEM/KEYBOARD.CPP (rather than
 // GLOBAL.CPP) so the symbol is in libsys.a, which every test binary links.
-extern S32 LastInputWasGamepad;
+extern S32 LastInputWasKeyboard;
 
 extern S32 LastJoyFlag;
 extern S32 Jumping;

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -14,6 +14,7 @@
 #include <FILEIO/SAVEPNG.H>
 #include <SVGA/SCREEN.H>
 #include <SVGA/VIDEO.H>
+#include <SYSTEM/ANDROID.H>
 #include <SYSTEM/KEYBOARD.H>
 #include <SYSTEM/KEYBOARD_KEYS.H>
 #include <SYSTEM/STRING.H>
@@ -1248,10 +1249,10 @@ static S32 GameMenuSaveListHitTest(U32 mx, U32 my, S32 nb, S32 start, S32 *outSe
     return 0;
 }
 
-// TODO(gamepad): uses GetAscii() (keyboard-only) — pure-gamepad users cannot enter
-// save/profile names. Pure-pad users are routed past this function inside
-// ChoosePlayerName: new-game slot gets a datetime stem, existing slot keeps
-// its current name (overwrite). See the LastInputWasGamepad branch there.
+// TODO(input): uses GetAscii() (keyboard-only) — non-keyboard users cannot enter
+// save/profile names. They are routed past this function inside ChoosePlayerName:
+// new-game slot gets a datetime stem, existing slot keeps its current name
+// (overwrite). See the !LastInputWasKeyboard branch there.
 S32 InputPlayerName(S32 choice, char *name) {
     char memoplayername[255];
     S32 flag = 1;
@@ -1939,15 +1940,21 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                 while (Input & I_FIRE OR MyKey == K_ENTER)
                     MyGetInput();
 
-                // Gamepad routing: pure-pad users have no practical way to
-                // type a name (InputPlayerName is keyboard-only). For a
-                // "New Game" slot we synthesise a local-time datetime stem;
-                // for an existing slot we keep the slot's own name and just
-                // overwrite. Same-second collision overwrites silently —
-                // matches the quick-save reflex chosen during design. The
-                // menu UI (slot list + New Game entry) is identical to the
-                // keyboard flow; only the text-entry step is bypassed.
-                if (LastInputWasGamepad) {
+                // Non-keyboard routing: unless the last input was a physical
+                // keyboard, the player has no practical way to type a name
+                // (InputPlayerName is keyboard-only) — this covers gamepad,
+                // touch, and mouse. Android TV is forced down this path too:
+                // there is no text keyboard on a remote, and SDL's routing of
+                // remote D-pad keys is device-dependent, so IsAndroidTVDevice()
+                // makes the choice deterministic (it is a no-op stub off
+                // Android, so desktop and phone are unaffected). For a "New
+                // Game" slot we synthesise a local-time datetime stem; for an
+                // existing slot we keep the slot's own name and just overwrite.
+                // Same-second collision overwrites silently — matches the
+                // quick-save reflex chosen during design. The menu UI (slot
+                // list + New Game entry) is identical to the keyboard flow;
+                // only the text-entry step is bypassed.
+                if (!LastInputWasKeyboard || IsAndroidTVDevice()) {
                     S32 ok = TRUE;
                     if (select == nb - 1) {
                         char datetime[32];

--- a/SOURCES/GLOBAL.CPP
+++ b/SOURCES/GLOBAL.CPP
@@ -37,7 +37,7 @@ U8 *BufSpeak;
 U8 *LbaFont;
 U8 PalettePcx[768 + 500];
 S32 MyKey = 0;
-// LastInputWasGamepad is defined in LIB386/SYSTEM/KEYBOARD.CPP so libsys.a
+// LastInputWasKeyboard is defined in LIB386/SYSTEM/KEYBOARD.CPP so libsys.a
 // carries the symbol (test binaries link only LIB386 archives, not the
 // SOURCES objects). Declared extern in C_EXTERN.H.
 U8 *PtrPal;

--- a/SOURCES/JOYSTICK.CPP
+++ b/SOURCES/JOYSTICK.CPP
@@ -143,21 +143,20 @@ void HandleEventsJoystick(const void *event) {
             ClearGamepadBits();
             s_prevLeftDir = DIR_NEUTRAL;
             s_prevRightDir = DIR_NEUTRAL;
-            // Pad gone: a stale "gamepad last" flag would mislead the save
-            // menu router. Reset so the next keyboard/mouse action picks the
-            // expected named-save flow without first having to fire an event.
-            LastInputWasGamepad = 0;
+            // A device removal is not an input, so it leaves LastInputWasKeyboard
+            // alone: it is already 0 from the pad's own activity, and the next
+            // real key/mouse/pad event sets it correctly.
             OpenFirstAvailableGamepad();
         }
         break;
     case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
-        LastInputWasGamepad = 1;
+        LastInputWasKeyboard = 0;
         break;
     case SDL_EVENT_GAMEPAD_AXIS_MOTION:
         // Past-deadzone test: rest-state jitter on the sticks fires constant
-        // axis events and would otherwise pin the flag to 1 forever.
+        // axis events and would otherwise pin the flag forever.
         if (ev->gaxis.value > JoystickDeadzone || ev->gaxis.value < -JoystickDeadzone) {
-            LastInputWasGamepad = 1;
+            LastInputWasKeyboard = 0;
         }
         break;
     default:

--- a/SOURCES/TOUCH_INPUT.CPP
+++ b/SOURCES/TOUCH_INPUT.CPP
@@ -24,6 +24,11 @@ extern "C" {
 /* The SDL window handle, defined in LIB386/SYSTEM/WINDOW.CPP under C linkage. */
 extern SDL_Window *sdlWindow;
 
+/* Last-input device flag (C linkage, defined in LIB386/SYSTEM/KEYBOARD.CPP).
+ * A touch tap is not a physical keyboard, so clear it: the save menu then uses
+ * the auto-name (controller) flow instead of a keyboard prompt we cannot fill. */
+extern S32 LastInputWasKeyboard;
+
 /* ---------------------------------------------------------------------------
  * Constants
  * ---------------------------------------------------------------------------
@@ -180,6 +185,11 @@ static void SetButtonState(S32 idx, S32 pressed) {
     if (s_pressed[idx] == pressed)
         return;
     s_pressed[idx] = pressed;
+    if (pressed) {
+        // A touch tap is not a physical keyboard; keep the save menu on the
+        // auto-name (controller) flow.
+        LastInputWasKeyboard = 0;
+    }
     U32 sc = kButtons[idx].scanCode;
     if (sc < 256) {
         if (pressed) {

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -162,8 +162,10 @@ by editing the `kButtons[]` table (normalised 0..1 coordinates).
   On older 32-bit ARM (armeabi-v7a) devices, expect lower framerates.
 - **CD audio**: CD-ROM music tracks are not available. Use the digital
   sample backend (`SOUND_BACKEND=sdl`).
-- **Text input**: Save-game naming and console commands require a hardware
-  keyboard or IME integration (future work).
+- **Text input**: Console commands still require a hardware keyboard. Save-game
+  naming no longer does — without a physical keyboard (touch, gamepad, or
+  Android TV) the save menu auto-generates a name from the date and the current
+  island instead of prompting.
 - **Save/resume**: Android lifecycle pause/resume is handled by SDL3
   (window focus events). Surface re-creation is managed by the existing
   SDL3 infrastructure.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_subdirectory(image_load)
 add_subdirectory(ambiance_balance)
 add_subdirectory(timer)
 add_subdirectory(staging_buffer)
+add_subdirectory(input_device)
 
 if(LBA2_BUILD_ASM_EQUIV_TESTS)
 include(cmake/asm_test_helpers.cmake)

--- a/tests/input_device/CMakeLists.txt
+++ b/tests/input_device/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_executable(test_input_device
+    test_input_device.cpp
+    ${CMAKE_SOURCE_DIR}/LIB386/SYSTEM/KEYBOARD.CPP
+    ${CMAKE_SOURCE_DIR}/LIB386/SYSTEM/MOUSE.CPP)
+
+target_include_directories(test_input_device PRIVATE
+    ${CMAKE_SOURCE_DIR}/LIB386/H
+)
+
+target_link_libraries(test_input_device PRIVATE SDL3::SDL3)
+
+add_test(NAME test_input_device COMMAND test_input_device)
+
+register_host_test(test_input_device)

--- a/tests/input_device/test_input_device.cpp
+++ b/tests/input_device/test_input_device.cpp
@@ -1,0 +1,94 @@
+/* Host-only test for the save-menu input-device classification.
+ *
+ * The save menu (ChoosePlayerName, SOURCES/GAMEMENU.CPP) offers keyboard text
+ * entry only when the last input came from a physical keyboard; every other
+ * device (mouse, gamepad, touch) routes to the auto-name "controller" flow.
+ * That decision reads one last-input-wins flag, LastInputWasKeyboard, kept up
+ * to date by the SDL event handlers. This test drives the real
+ * HandleEventsKeyboard / HandleEventsMouse with synthesized SDL events and
+ * asserts the flag lands where the save menu expects.
+ *
+ * Gamepad (SOURCES/JOYSTICK.CPP) and touch (SOURCES/TOUCH_INPUT.CPP) clear the
+ * same flag the same way the mouse handler does here; their end-to-end save
+ * flow is verified on-device. The Android-TV guard (IsAndroidTVDevice) is a
+ * no-op stub off Android, so it does not affect this host classification.
+ */
+#include <SYSTEM/EVENTS.H>   // ManageEvents (stubbed below)
+#include <SYSTEM/KEYBOARD.H> // HandleEventsKeyboard
+#include <SYSTEM/MOUSE.H>    // HandleEventsMouse
+#include <SYSTEM/WINDOW.H>   // WindowToSurfaceCoords (stubbed below)
+
+#include <SDL3/SDL.h>
+
+#include <cstdio>
+
+extern "C" S32 LastInputWasKeyboard; // defined in LIB386/SYSTEM/KEYBOARD.CPP
+
+// --- Link stubs: symbols the handler TUs reference on paths this test never
+// drives, provided so the two real handlers link standalone. ---
+void ManageEvents() {}
+void WindowToSurfaceCoords(S32 wx, S32 wy, S32 *sx, S32 *sy) {
+    *sx = wx;
+    *sy = wy;
+}
+extern "C" {
+U8 BinGphMouse[4096] = {0};
+}
+U32 ModeDesiredX = 640; // MOUSE.CPP SetMousePos clamp (unreached path here)
+U32 ModeDesiredY = 480;
+
+static int fails = 0;
+
+static void expect(S32 got, S32 want, const char *label) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL: %s: LastInputWasKeyboard=%d (want %d)\n", label, got, want);
+        fails++;
+    }
+}
+
+static SDL_Event mkEvent(Uint32 type) {
+    SDL_Event e;
+    SDL_memset(&e, 0, sizeof e);
+    e.type = type;
+    return e;
+}
+
+int main() {
+    SDL_Event keyDown = mkEvent(SDL_EVENT_KEY_DOWN);
+    SDL_Event keyUp = mkEvent(SDL_EVENT_KEY_UP);
+    SDL_Event mouseBtn = mkEvent(SDL_EVENT_MOUSE_BUTTON_DOWN);
+    SDL_Event mouseWheel = mkEvent(SDL_EVENT_MOUSE_WHEEL);
+
+    // Default: not a keyboard, so a touch-only phone / fresh boot routes to the
+    // auto-name flow rather than a keyboard prompt nothing can fill.
+    expect(LastInputWasKeyboard, 0, "default is 0 (not keyboard)");
+
+    // Physical key-down => keyboard path.
+    HandleEventsKeyboard(&keyDown);
+    expect(LastInputWasKeyboard, 1, "key-down -> keyboard");
+
+    // Mouse activity => not keyboard. This is the deliberate desktop behavior
+    // change: a mouse no longer offers typed save names.
+    HandleEventsMouse(&mouseBtn);
+    expect(LastInputWasKeyboard, 0, "mouse button -> not keyboard");
+
+    HandleEventsKeyboard(&keyDown);
+    HandleEventsMouse(&mouseWheel);
+    expect(LastInputWasKeyboard, 0, "mouse wheel -> not keyboard");
+
+    // Last-input-wins: a key-down reclaims the keyboard path after the mouse.
+    HandleEventsKeyboard(&keyDown);
+    expect(LastInputWasKeyboard, 1, "key-down after mouse -> keyboard");
+
+    // Only a KEY_DOWN flips it; a key-up (or any non-down event) leaves it.
+    HandleEventsMouse(&mouseBtn); // -> 0
+    HandleEventsKeyboard(&keyUp); // not a down event
+    expect(LastInputWasKeyboard, 0, "key-up does not set keyboard");
+
+    if (fails == 0) {
+        std::printf("test_input_device: all checks passed\n");
+        return 0;
+    }
+    std::fprintf(stderr, "test_input_device: %d failure(s)\n", fails);
+    return 1;
+}


### PR DESCRIPTION
The save menu offered typed save names unless the last input was a gamepad, so it routed touch and mouse into `InputPlayerName` (keyboard-only). On a phone or TV with no physical keyboard the name prompt can't be filled and saving stalls — touch especially, since it pokes `TabKeys` directly and never reaches the keyboard handler, so the flag stayed at its keyboard-path default.

**The fix** inverts the single last-input-device flag the save menu reads:
- `LastInputWasGamepad` → `LastInputWasKeyboard`, set to `1` only on a real SDL key-down.
- Keyboard text entry is offered only when the last input was a physical keyboard; **mouse, gamepad, touch and joystick** all take the existing auto-name (datetime / island-name) flow. Touch clears the flag on a tap too.
- One reader (the save menu), four writers (keyboard/mouse/gamepad/touch): the rename + polarity flip is mechanical; the behaviour change is the single decision `if (!LastInputWasKeyboard || IsAndroidTVDevice())`.

**Android TV** is forced down the auto-name path via `IsAndroidTVDevice()` (the no-op stub off Android, from #284). There's no text keyboard on a remote, and SDL's routing of remote D-pad keys to the keyboard vs joystick source is device-dependent, so the guard makes TV deterministic without touching desktop or phone. TV input isn't testable on the emulator yet; the guard is inert on everything that *is* testable (it returns 0 off Android), so it's risk-free insurance for the one path we can't reach.

**Deliberate desktop change:** clicking a save slot with the mouse now yields an auto-name instead of a typed name (press a key first to type). Mouse was explicitly in scope for "anything that isn't a keyboard."

**Testing**
- New host test `test_input_device` drives the real `HandleEventsKeyboard` / `HandleEventsMouse` with synthesized SDL events and asserts the flag transitions: key-down → keyboard, mouse → not-keyboard, last-input-wins, key-up no-op. Negative-tested (breaking the handler fails it). Runs in CI, no device.
- Phone emulator: builds for arm64, boots/renders/overlay fine; save-to-auto-name confirmed manually.
- Desktop classification is covered by the host test.
