### PR TITLE
docs(android): correct ANDROID.md, index it, note Android in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This document helps AI coding assistants (Cursor, Copilot, Claude, etc.) work ef
 
 4. **Quality over speed:** Equivalence tests must pass. Do not relax tests to unblock. Prefer smaller, well-tested changes. Fix bugs before merging.
 
-5. **Cross-platform priority:** Support Linux, macOS, and Windows. Contributors and agents may be on any of these—do not assume Linux. Avoid platform-specific assumptions (paths, case sensitivity, toolchains). Prefer portable C/C++. No inline x86 in library code. The engine builds on SDL3, which supports [many more platforms](https://github.com/libsdl-org/SDL/blob/main/docs/README-platforms.md)—writing portable code today keeps that door open.
+5. **Cross-platform priority:** Support Linux, macOS, and Windows (desktop) and Android (arm64-v8a / armeabi-v7a, mobile). Contributors and agents may be on any desktop host—do not assume Linux. Avoid platform-specific assumptions (paths, case sensitivity, toolchains). Prefer portable C/C++. No inline x86 in library code. The engine builds on SDL3, which supports [many more platforms](https://github.com/libsdl-org/SDL/blob/main/docs/README-platforms.md)—writing portable code today keeps that door open.
 
 ## Never
 
@@ -77,6 +77,7 @@ Apply these behavior rules on every non-trivial task:
 | SOURCES/3DEXT/ | Same as LIB386; check ASM_TO_CPP_REFERENCE | docs/ASM_TO_CPP_REFERENCE.md |
 | Adding ASM↔CPP test | Use `add_asm_cpp_test()`, include stress test, update `docs/ASM_VALIDATION_PROGRESS.md`; check `docs/ASM_TEST_COVERAGE_AUDIT.md` for the coverage rubric | docs/TESTING.md, docs/ASM_TEST_COVERAGE_AUDIT.md, .github/copilot-instructions.md |
 | Audio/video | AIL in LIB386/AIL/; backends SDL, Miles, null | docs/AUDIO.md |
+| Android-specific behaviour (JNI, TV detection, storage permission) | Put it behind `LIB386/SYSTEM/ANDROID.{CPP,H}` with a stub-on-desktop; keep callers `#ifdef`-free; `<jni.h>` in that TU only; LIB386 must not include `SOURCES/` | docs/ANDROID.md, docs/PLATFORM.md §8 |
 | Debug tools | DEBUG_TOOLS (console is always available) | docs/DEBUG.md, docs/CONSOLE.md |
 | Verifying a runtime change (scene, hero, inventory, render) | Drive the engine non-interactively and assert on dumped state / a screenshot instead of manual play | docs/CONTROL.md |
 | Config / lba2.cfg | Keys, persistence, installer vs game, embedded default | docs/CONFIG.md, docs/GAME_DATA.md |

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -1,11 +1,12 @@
 # LBA2 Classic Community — Android
 
-This directory contains scripts and configuration for building
-LBA2 Classic Community on Android (arm64-v8a and armeabi-v7a).
+How to build, package, and run LBA2 Classic Community on Android
+(arm64-v8a and armeabi-v7a). The build and packaging scripts live under
+`scripts/dev/` and `scripts/packaging/`.
 
 ## Quick start
 
-Minimum Android version: **7.0 (API 24)**. The APK targets API 24 (required by SDL3) and is tested on API 24–34.
+Minimum Android version: **7.0 (API 24)**. The APK targets API 24 (required by SDL3) and is tested on API 24–36.
 
 You need:
 
@@ -89,34 +90,40 @@ Android TV) is always 4 KB.
 
 ## Game data on Android
 
-Place your retail LBA2 `.HQR` files on the device via ADB:
+Place your retail LBA2 `.HQR` files on the device with ADB. **Recommended:
+`/sdcard/lba2cc/`** — the game probes it ahead of the other external roots and
+it survives an uninstall/reinstall:
 
 ```bash
-# Android 11+ and Android TV (scoped storage): file managers can't access Android/data/
-# Use ADB instead:
-adb push lba2.hqr /sdcard/Android/data/org.lbalab.lba2cc/files/
-adb push libraa.hqr /sdcard/Android/data/org.lbalab.lba2cc/files/
-
-# (Recommended) place inside /sdcard/lba2cc/ — keeps loose files clean and the
-# game automatically probes this path on startup:
 adb push lba2.hqr /sdcard/lba2cc/
-adb push libraa.hqr /sdcard/lba2cc/
-
-# Also probes /sdcard/ directly as a fallback:
-adb push lba2.hqr /sdcard/
-adb push libraa.hqr /sdcard/
+adb push ress.hqr /sdcard/lba2cc/
+# ...and the rest of your retail HQR set
 ```
 
-The game's `ResolveGameDataDir` scans these paths automatically:
+`/sdcard/lba2cc/` is general external storage, so on **Android 11+ (API 30+)**
+the app needs **All Files Access** (`MANAGE_EXTERNAL_STORAGE`). The game checks
+for it on launch and opens the system Settings page if it is missing — grant it
+and relaunch. You can also pre-grant it:
 
-1. `--game-dir` CLI flag
+```bash
+adb shell appops set org.lbalab.lba2cc MANAGE_EXTERNAL_STORAGE allow
+```
+
+The **app-specific** dir `/sdcard/Android/data/org.lbalab.lba2cc/files/` needs
+no permission, but on stricter API 30+ / TV images files `adb push`ed there can
+be invisible to the app's own view, so prefer `/sdcard/lba2cc/`.
+
+`ResolveGameDataDir` (`SOURCES/RES_DISCOVERY.CPP`) scans, in order:
+
+1. `--game-dir` / `--data-dir` CLI flag
 2. `LBA2_GAME_DIR` environment variable
-3. Persisted last-used directory
-4. SDL base path and subdirs (`./data/`, `./game/`)
-5. Current directory and parent walk (up to 8 levels)
-6. **`/sdcard/`** and **`/storage/emulated/0/`** (Android external root)
-7. Parent sibling directories (e.g. `../LBA2/`, `../game/`)
-8. Folder picker fallback (if compiled with debug tools)
+3. Persisted last-used directory (from a previous picker session)
+4. SDL base path and its `data/` / `game/` subdirs
+5. Current running directory
+6. App-specific external-files dir (Android; no permission) — `/sdcard/Android/data/<pkg>/files/`
+7. **`/sdcard/lba2cc/`** and `/storage/emulated/0/lba2cc/`, then `/sdcard/` and `/storage/emulated/0/`
+8. Parent-directory walk
+9. Folder picker fallback (if compiled with debug tools)
 
 ## Key mapping (touch overlay)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Index of documentation in this repository.
 | Doc | Description |
 |-----|-------------|
 | [WINDOWS.md](WINDOWS.md) | Building on Windows with MSYS2; game files, toolchain. |
+| [ANDROID.md](ANDROID.md) | Building, packaging, and running on Android (arm64-v8a / armeabi-v7a): NDK + SDL3 cross-build, APK bundler, 16 KB pages, game-data placement, touch overlay. |
 | [GAME_DATA.md](GAME_DATA.md) | Retail game files: `LBA2_GAME_DIR`, `--game-dir`, discovery order, dev layouts. |
 | [DEBUG.md](DEBUG.md) | Original Adeline debug tools (DEBUG_TOOLS=ON): overlay, F9 screenshot, bug save/load, cheats, scene selection. |
 | [CONSOLE.md](CONSOLE.md) | Quake-style debug console (always available): backtick/F12, commands and cvars. |


### PR DESCRIPTION
Brings the Android docs in line with the current state (16 KB build, the platform seam from #284, scoped-storage reality) and fixes gaps the survey turned up. Verified against the code before editing.

**docs/ANDROID.md**
- Intro said *"this directory contains scripts"* — it's `docs/`, and the build/packaging scripts live under `scripts/dev/` + `scripts/packaging/`.
- Tested API range was 24–34; we've run it on API 36 → now 24–36.
- **Game data** rewritten: leads with `/sdcard/lba2cc/` and the All Files Access (`MANAGE_EXTERNAL_STORAGE`) prompt the app now raises on launch (#284); caveats the app-specific dir (on API 30+/TV, `adb push`ed files there can be invisible to the app's own view — the trap that cost real debugging time); and the numbered probe list now matches `RES_DISCOVERY.CPP` (app-specific dir, then `/sdcard/lba2cc/` ahead of the bare roots).

**docs/README.md** (docs index): `ANDROID.md` was missing from Build & debug though `WINDOWS.md` was listed — added.

**AGENTS.md**: Android is a shipped target now, so it joins the cross-platform priority (was Linux/macOS/Windows only); plus a "when modifying Android-specific behaviour" row pointing at the `LIB386/SYSTEM/ANDROID.{CPP,H}` containment from #284.

Script paths in ANDROID.md were verified to exist; the touch-overlay key map matches `TOUCH_INPUT.CPP`. The "save-game naming needs a hardware keyboard" limitation is being flipped in #286, where that behaviour lands.
