### PR TITLE
feat(cheat): add GOD and SENDELL debug cheats

### DIFF
--- a/SOURCES/CHEATCOD.CPP
+++ b/SOURCES/CHEATCOD.CPP
@@ -23,6 +23,7 @@ enum {
     CHEAT_CLOVER,    // 5
     CHEAT_CLOVERBOX, // 6
     CHEAT_PINGOUIN,  // 7
+    CHEAT_GOD,       // 8
 };
 
 #ifdef DEBUG_TOOLS
@@ -35,6 +36,7 @@ T_CODE DefCheatCode[] = {
     {6, {K_C, K_L, K_O, K_V, K_E, K_R}},           // CLOVER
     {3, {K_B, K_O, K_X}},                          // BOX
     {8, {K_P, K_I, K_N, K_G, K_O, K_U, K_I, K_N}}, // PINGOUIN
+    {3, {K_G, K_O, K_D}},                          // GOD
 };
 #else
 T_CODE DefCheatCode[] = {
@@ -46,6 +48,7 @@ T_CODE DefCheatCode[] = {
     {6, {K_C, K_L, K_O, K_V, K_E, K_R}},           // CLOVER
     {3, {K_B, K_O, K_X}},                          // BOX
     {8, {K_P, K_I, K_N, K_G, K_O, K_U, K_I, K_N}}, // PINGOUIN
+    {3, {K_G, K_O, K_D}},                          // GOD
 };
 #endif
 
@@ -70,11 +73,13 @@ const char *CheatText[] = {
     "Frame Rate Off",
     "Clover Found",
     "CloverBox Found",
-    "MecaPingouin Found"};
+    "MecaPingouin Found",
+    "God Mode On",   // 10
+    "God Mode Off"}; // 11
 
 /* Cheat names for console (lowercase). Order must match enum. */
 static const char *CheatNames[] = {
-    "life", "magic", "full", "gold", "speed", "clover", "box", "pingouin"};
+    "life", "magic", "full", "gold", "speed", "clover", "box", "pingouin", "god"};
 
 static void tolower_str(char *dst, const char *src, size_t cap) {
     size_t i = 0;
@@ -150,6 +155,10 @@ static void ApplyCheat(S32 cheat, S32 *text, S32 *sprite) {
             ListVarGame[FLAG_MECA_PINGOUIN] += 5;
             *text = 9;
         }
+        break;
+    case CHEAT_GOD:
+        GodMode ^= 1;
+        *text = GodMode ? 10 : 11;
         break;
     }
 }

--- a/SOURCES/CHEATCOD.CPP
+++ b/SOURCES/CHEATCOD.CPP
@@ -24,6 +24,7 @@ enum {
     CHEAT_CLOVERBOX, // 6
     CHEAT_PINGOUIN,  // 7
     CHEAT_GOD,       // 8
+    CHEAT_SENDELL,   // 9
 };
 
 #ifdef DEBUG_TOOLS
@@ -37,6 +38,7 @@ T_CODE DefCheatCode[] = {
     {3, {K_B, K_O, K_X}},                          // BOX
     {8, {K_P, K_I, K_N, K_G, K_O, K_U, K_I, K_N}}, // PINGOUIN
     {3, {K_G, K_O, K_D}},                          // GOD
+    {7, {K_S, K_E, K_N, K_D, K_E, K_L, K_L}},      // SENDELL
 };
 #else
 T_CODE DefCheatCode[] = {
@@ -49,6 +51,7 @@ T_CODE DefCheatCode[] = {
     {3, {K_B, K_O, K_X}},                          // BOX
     {8, {K_P, K_I, K_N, K_G, K_O, K_U, K_I, K_N}}, // PINGOUIN
     {3, {K_G, K_O, K_D}},                          // GOD
+    {7, {K_S, K_E, K_N, K_D, K_E, K_L, K_L}},      // SENDELL
 };
 #endif
 
@@ -74,12 +77,23 @@ const char *CheatText[] = {
     "Clover Found",
     "CloverBox Found",
     "MecaPingouin Found",
-    "God Mode On",   // 10
-    "God Mode Off"}; // 11
+    "God Mode On",
+    "God Mode Off",
+    "Sendell Power On",
+    "Sendell Power Off"};
 
 /* Cheat names for console (lowercase). Order must match enum. */
 static const char *CheatNames[] = {
-    "life", "magic", "full", "gold", "speed", "clover", "box", "pingouin", "god"};
+    "life",
+    "magic",
+    "full",
+    "gold",
+    "speed",
+    "clover",
+    "box",
+    "pingouin",
+    "god",
+    "sendell"};
 
 static void tolower_str(char *dst, const char *src, size_t cap) {
     size_t i = 0;
@@ -159,6 +173,10 @@ static void ApplyCheat(S32 cheat, S32 *text, S32 *sprite) {
     case CHEAT_GOD:
         GodMode ^= 1;
         *text = GodMode ? 10 : 11;
+        break;
+    case CHEAT_SENDELL:
+        OnePunch ^= 1;
+        *text = OnePunch ? 12 : 13;
         break;
     }
 }

--- a/SOURCES/C_EXTERN.H
+++ b/SOURCES/C_EXTERN.H
@@ -7,6 +7,8 @@ extern S32 DebugFps;
 
 extern S32 GodMode;
 
+extern S32 OnePunch;
+
 extern S32 DistribVersion;
 
 extern const char *BuildInfo; /* Build timestamp and flags (BUILD_INFO.CPP) */

--- a/SOURCES/C_EXTERN.H
+++ b/SOURCES/C_EXTERN.H
@@ -5,6 +5,8 @@ extern S32 BodyComportement;
 
 extern S32 DebugFps;
 
+extern S32 GodMode;
+
 extern S32 DistribVersion;
 
 extern const char *BuildInfo; /* Build timestamp and flags (BUILD_INFO.CPP) */

--- a/SOURCES/GLOBAL.CPP
+++ b/SOURCES/GLOBAL.CPP
@@ -14,6 +14,8 @@ S32 DebugFps = FALSE;
 S32 DebugFps = TRUE;
 #endif
 
+S32 GodMode = FALSE; // GOD cheat: Twinsen ignores combat damage (runtime-only)
+
 S32 DistribVersion = ACTIVISION_VERSION;
 
 char MessageNoCD[50];

--- a/SOURCES/GLOBAL.CPP
+++ b/SOURCES/GLOBAL.CPP
@@ -14,7 +14,8 @@ S32 DebugFps = FALSE;
 S32 DebugFps = TRUE;
 #endif
 
-S32 GodMode = FALSE; // GOD cheat: Twinsen ignores combat damage (runtime-only)
+S32 GodMode = FALSE;  // GOD cheat: Twinsen ignores combat damage (runtime-only)
+S32 OnePunch = FALSE; // SENDELL cheat: Twinsen one-shots anything he hits
 
 S32 DistribVersion = ACTIVISION_VERSION;
 

--- a/SOURCES/OBJECT.CPP
+++ b/SOURCES/OBJECT.CPP
@@ -1457,6 +1457,14 @@ void HitObj(U8 numhitter, U8 num, S32 hitforce, S32 beta) {
     if (num == NUM_PERSO AND GodMode) // GOD cheat: ignore combat damage
         return;
 
+    // SENDELL cheat: Twinsen one-shots anything he can legitimately hit
+    // (NO_CHOC / already-dead targets are already filtered out above).
+    if (OnePunch AND numhitter == NUM_PERSO AND num != NUM_PERSO) {
+        ptrobjt->HitBy = numhitter;
+        ptrobjt->LifePoint = 0;
+        return;
+    }
+
     // Blindage MécaPingouin lorsque Twinsen est en automatique
     if (num == NUM_PERSO AND numhitter == NUM_PERSO AND ptrobjt->Move == NO_MOVE) {
         return;

--- a/SOURCES/OBJECT.CPP
+++ b/SOURCES/OBJECT.CPP
@@ -1454,6 +1454,8 @@ void HitObj(U8 numhitter, U8 num, S32 hitforce, S32 beta) {
         return;
     if (ptrobjt->WorkFlags & FRAME_SHIELD)
         return;
+    if (num == NUM_PERSO AND GodMode) // GOD cheat: ignore combat damage
+        return;
 
     // Blindage MécaPingouin lorsque Twinsen est en automatique
     if (num == NUM_PERSO AND numhitter == NUM_PERSO AND ptrobjt->Move == NO_MOVE) {
@@ -1533,6 +1535,8 @@ void FoudroieObj(U8 numhitter, U8 num, S32 armure) {
     if (ptrobjt->Flags & NO_CHOC)
         return;
     if (ptrobjt->LifePoint <= 0)
+        return;
+    if (num == NUM_PERSO AND GodMode) // GOD cheat: ignore combat damage
         return;
 
     ptrobjt->HitBy = numhitter;


### PR DESCRIPTION
Two toggleable debug cheats, added next to the existing LIFE/MAGIC/FULL/etc. codes. Both are typed in-game like the originals and also work as `god` / `sendell` commands in the dev console (CONSOLE_MODULE builds — they route through the existing `TryExecuteCheatByName`).

## GOD — invincibility
Type `GOD` to toggle. While on, Twinsen ignores all combat damage. Gated at the two damage entry points (`HitObj`, `FoudroieObj`) for `NUM_PERSO` only, so enemy attacks, projectiles, and the lightning/zap path all no-op.

Scope is combat only. Fall/drown damage and scripted deaths (`LM_KILL_OBJ`/`LM_SUICIDE`) are deliberately left alone — blocking a scripted death would softlock the story.

## SENDELL — one-punch
Type `SENDELL` to toggle. While on, anything Twinsen hits — magic ball, thrown extras, melee contact — dies in one hit, armour ignored. A single guard at the top of `HitObj` (the shared damage chokepoint), keyed on `numhitter == NUM_PERSO` and a non-self target. It sits below the existing `NO_CHOC` / already-dead guards, so invulnerable and scripted objects stay protected — it only one-shots things Twinsen could already legitimately hit.

Named for the Ball of Sendell, the game's ultimate weapon.

## Notes
- Both flags are runtime-only and not persisted to saves.
- Implementation mirrors the existing `SPEED` toggle: one global, one cheat-table entry (both the DEBUG and release tables), one `ApplyCheat` case. No new subsystems.
- Builds clean; `check-format` passes.