### PR TITLE
docs(architecture): engine architecture foundations + LBA1 porting surface

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,88 @@
+# Engine architecture — overview and roadmap
+
+> **Status: living index (v0).** Entry point for the architecture-understanding effort.
+> This is groundwork: *understanding first, no engine changes yet.* Truth hierarchy:
+> code > this document > external sources.
+
+## North-star: one engine, two games
+
+`~/code/lba-hacking/lba1-classic` (LBA1, Relentless, 1994) and this repo (LBA2, 1997 +
+community port) share the Adeline lineage — same `LIB386/`+`SOURCES/` layout, same HQR
+format, same Life/Track script model. The long-term prospect is to understand the engine
+well enough that **LBA1 content could run on the lba2cc engine**. That port is not the
+immediate work; the immediate work is the *understanding* that would make it tractable —
+and which pays off now by telling us where to draw module boundaries (engine/game
+separation, strangler-fig). Architecture is the lever; comprehension is the fulcrum.
+
+## The three axes
+
+The engine is mapped along three orthogonal axes. Read them together — the payoff is the
+convergence.
+
+| Axis | Doc | Question it answers |
+|---|---|---|
+| **Structure** | [ARCHITECTURE_GLOBALS.md](ARCHITECTURE_GLOBALS.md) | Which domain owns which of the ~200 globals? Where is the shared-state bus? |
+| **Layer** | [ENGINE_GAME_SEAM.md](ENGINE_GAME_SEAM.md) | What is engine vs game vs platform? (validated against the LBA1 source) |
+| **Time** | [LIFECYCLES.md](LIFECYCLES.md) | When is state created, mutated, destroyed? (main loop, `ChangeCube`) |
+
+**The convergence is the signal.** The same small set of things surfaces on all three axes:
+`ListObjet`, `CubeMode`, `Comportement`, `ChangeCube`, and the Life/Track script VM. They
+are simultaneously the shared-bus offenders (structure), the engine/game membrane and
+mode switches (layer), and the lifecycle pivots (time). Where the axes agree is where the
+architecture actually lives — and where the first boundaries should be drawn.
+
+## The eight domains and their deeper docs
+
+Each domain in the structural map has a layer tag and, often, an existing subsystem doc
+that goes deeper. This table is the map-of-maps.
+
+| Domain | Layer | Deeper references |
+|---|---|---|
+| Gameplay / simulation | Game on engine substrate | [IMPACT_SCRIPTS.md](IMPACT_SCRIPTS.md), [LBA_EDITOR.md](LBA_EDITOR.md), [GLOSSARY.md](GLOSSARY.md) |
+| Rendering | Engine | [CAMERA.md](CAMERA.md), [SPRITES.md](SPRITES.md), [GFX_OPTIONS.md](GFX_OPTIONS.md), [POLYREC.md](POLYREC.md) |
+| World / cube transform | Engine | [SCENES.md](SCENES.md) |
+| Resources / assets | Engine | [GAME_DATA.md](GAME_DATA.md), [ABI.md](ABI.md) |
+| Audio | Engine + game scheduling | [AUDIO.md](AUDIO.md) |
+| Platform / IO | Platform | [PLATFORM.md](PLATFORM.md), [TIMING.md](TIMING.md), [CONFIG.md](CONFIG.md), [CONTROL.md](CONTROL.md) |
+| UI / text | Engine machinery + game content | [MENU.md](MENU.md), [GLOSSARY.md](GLOSSARY.md) |
+| Orchestration / lifecycle | Engine framework | [LIFECYCLES.md](LIFECYCLES.md), [SAVEGAME.md](SAVEGAME.md), [TIMING.md](TIMING.md) |
+
+## The engine/game membrane: the script VM
+
+The single most important seam. The engine runs a fixed main loop; the *game* is Life
+scripts (behaviour AI, dispatched at main-loop step 6, `DoLife`) and Track scripts
+(pathing, step 3, `DoTrack`), plus assets. `GERELIFE`/`GERETRAK`/`FUNC` implement the VM
+and are present in all three Adeline trees. If LBA1 uses the same script model, this
+interface is what lets its content run here. Detailed API spec: *forthcoming —
+ENGINE_GAME_INTERFACE.md (in progress).*
+
+## Gaps — what still needs mapping
+
+1. **The engine↔game interface spec** (the script-VM API: opcode catalog, the function
+   tables in `EXTFUNC`/`PTRFUNC`, what the engine exposes to scripts, script-variable
+   storage). *In progress.* This is the keystone for LBA1 portability.
+2. **The LBA1 ↔ LBA2 porting surface** (format and capability deltas: HQR, body/3D model,
+   anim, scene/grid, sprite, palette; render and audio capability gaps). *In progress.*
+3. **The call-graph / data-flow axis** — who mutates the shared-bus offenders, and from
+   where. The fourth axis; not yet mapped. Currently lives only in the code and the
+   codebase-memory graph (which is weak on exactly this — sparse function→function edges).
+
+## Strangler-fig roadmap (understanding → action, later)
+
+When the maps are solid enough to act on, the order the three axes agree on:
+
+1. **Keystone: the script VM facade** — the engine/game interface. Highest leverage;
+   aligns with the Life/Track tooling thread (#181).
+2. **First structural target: World / cube transform** — it dominates the shared-bus
+   offender list, and `ChangeCube`'s phases give the exact sequence a facade must preserve.
+3. **Platform: already underway** — the community layer is the PAL; PR #284–#286 formalise
+   the platform seam. Keep pushing host concerns there.
+
+Each step is a facade drawn *over* frozen code, proven behaviour-identical against the
+polyrec/projrec harnesses before the next. No rewrite.
+
+## How to use these docs
+
+Start here, then the three axes (structure → layer → time), then the per-domain subsystem
+doc when you need depth. The maps are a reasoning overlay; when they disagree with the
+code, the code wins.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 ## North-star: one engine, two games
 
-`~/code/lba-hacking/lba1-classic` (LBA1, Relentless, 1994) and this repo (LBA2, 1997 +
+The LBA1 community source (`lba1-classic`, Relentless, 1994) and this repo (LBA2, 1997 +
 community port) share the Adeline lineage — same `LIB386/`+`SOURCES/` layout, same HQR
 format, same Life/Track script model. The long-term prospect is to understand the engine
 well enough that **LBA1 content could run on the lba2cc engine**. That port is not the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,7 +12,8 @@ format, same Life/Track script model. The long-term prospect is to understand th
 well enough that **LBA1 content could run on the lba2cc engine**. That port is not the
 immediate work; the immediate work is the *understanding* that would make it tractable —
 and which pays off now by telling us where to draw module boundaries (engine/game
-separation, strangler-fig). Architecture is the lever; comprehension is the fulcrum.
+separation, strangler-fig). Architecture is the lever; comprehension is the fulcrum. The
+concrete cost of that port is assessed in [LBA1_PORTING_SURFACE.md](LBA1_PORTING_SURFACE.md).
 
 ## The three axes
 
@@ -52,20 +53,23 @@ that goes deeper. This table is the map-of-maps.
 The single most important seam. The engine runs a fixed main loop; the *game* is Life
 scripts (behaviour AI, dispatched at main-loop step 6, `DoLife`) and Track scripts
 (pathing, step 3, `DoTrack`), plus assets. `GERELIFE`/`GERETRAK`/`FUNC` implement the VM
-and are present in all three Adeline trees. If LBA1 uses the same script model, this
-interface is what lets its content run here. Detailed API spec: *forthcoming —
-ENGINE_GAME_INTERFACE.md (in progress).*
+and are present in all three Adeline trees. LBA1 uses the same VM (confirmed), so this
+interface is what lets its content run here. Detailed API spec:
+**[ENGINE_GAME_INTERFACE.md](ENGINE_GAME_INTERFACE.md)**.
 
-## Gaps — what still needs mapping
+## Gaps — what's mapped, what's left
 
-1. **The engine↔game interface spec** (the script-VM API: opcode catalog, the function
-   tables in `EXTFUNC`/`PTRFUNC`, what the engine exposes to scripts, script-variable
-   storage). *In progress.* This is the keystone for LBA1 portability.
-2. **The LBA1 ↔ LBA2 porting surface** (format and capability deltas: HQR, body/3D model,
-   anim, scene/grid, sprite, palette; render and audio capability gaps). *In progress.*
-3. **The call-graph / data-flow axis** — who mutates the shared-bus offenders, and from
-   where. The fourth axis; not yet mapped. Currently lives only in the code and the
-   codebase-memory graph (which is weak on exactly this — sparse function→function edges).
+1. **The engine↔game interface spec** — *mapped:* [ENGINE_GAME_INTERFACE.md](ENGINE_GAME_INTERFACE.md).
+   The Life/Track bytecode VM: opcode tables, the `switch`-on-cursor dispatch (*not* the
+   `EXTFUNC`/`PTRFUNC` tables — those turned out to be engine-internal / editor tooling),
+   the syscall surface, and script-variable storage. The keystone for LBA1 portability.
+2. **The LBA1 ↔ LBA2 porting surface** — *mapped:* [LBA1_PORTING_SURFACE.md](LBA1_PORTING_SURFACE.md).
+   Per-subsystem compatible/shim/different verdicts. Headline: the engine is a strict
+   superset, so hosting LBA1 is format transcoders + a script opcode-remap + replacing the
+   FLA/MIDI media stack — not re-architecting.
+3. **The call-graph / data-flow axis** — *not yet mapped.* Who mutates the shared-bus
+   offenders, and from where. The fourth axis; lives only in the code and the
+   codebase-memory graph (weak on exactly this — sparse function→function edges).
 
 ## Strangler-fig roadmap (understanding → action, later)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,8 +65,8 @@ interface is what lets its content run here. Detailed API spec:
    the syscall surface, and script-variable storage. The keystone for LBA1 portability.
 2. **The LBA1 ↔ LBA2 porting surface** — *mapped:* [LBA1_PORTING_SURFACE.md](LBA1_PORTING_SURFACE.md).
    Per-subsystem compatible/shim/different verdicts. Headline: the engine is a strict
-   superset, so hosting LBA1 is format transcoders + a script opcode-remap + replacing the
-   FLA/MIDI media stack — not re-architecting.
+   superset, so hosting LBA1 is format transcoders + a script opcode-remap + integrating
+   GPLv2 FLA/MIDI decoders (lba-midi-play, twin-e) — not re-architecting.
 3. **The call-graph / data-flow axis** — *not yet mapped.* Who mutates the shared-bus
    offenders, and from where. The fourth axis; lives only in the code and the
    codebase-memory graph (weak on exactly this — sparse function→function edges).

--- a/docs/ARCHITECTURE_GLOBALS.md
+++ b/docs/ARCHITECTURE_GLOBALS.md
@@ -1,0 +1,277 @@
+# Global variable bounded-context map
+
+> **Status: DRAFT / living document (v0).** A reasoning overlay, not a refactor plan.
+> Domain assignments are provisional and meant to be argued with. Nothing here changes
+> behaviour — the polyrec/projrec equivalence tests freeze the engine, so this map exists
+> to make the implicit *global bus* legible, not to move code.
+
+## Why this exists
+
+The engine communicates almost entirely through ~200 global variables declared in
+`SOURCES/C_EXTERN.H` and defined in `SOURCES/GLOBAL.CPP` (plus a handful defined in
+`KEYBOARD.CPP`, `MESSAGE.CPP`, `OBJECT.CPP`). There is no encapsulation boundary, so a
+function cannot be reasoned about in isolation: to know what `HitObj` does you must know
+`GodMode` gates it, and to change `GodMode` safely you must know everyone who reads it.
+That is a web, not a tree, and webs do not fit in one's head.
+
+This map assigns each global to the domain that *owns* it (writes it, is conceptually
+responsible for it) and flags the domains that merely *read* it. The reads across a
+boundary are the coupling edges. The goal is the first step of a strangler-fig: draw the
+boundaries explicitly *over* the frozen code, the way the platform seam (PR #284–#286)
+wraps SDL without rewriting the renderer. You cannot delete the bus, but you can publish
+its schedule.
+
+## The eight domains
+
+1. **Gameplay / simulation** — entities, AI behaviour, inventory and stats, zones, player physics and control state.
+2. **Rendering** — projection, sort tree, cameras, palettes, shadow, sprite scaling, cinema framing, environment effects.
+3. **World / cube transform** — cube and world coordinate systems, scene/cube origins, transition coordinates. *The busiest coupling axis; likely the first strangler-fig target.*
+4. **Resources / assets** — HQR handles, memory-pool budgets, body/anim/sprite/texture buffers.
+5. **Audio** — sample and music volumes, the ambiance scheduler, stereo.
+6. **Platform / IO** — raw input device state, display mode, timing, file paths, version banners, CD/video.
+7. **UI / text** — menus, dialog and speech presentation, on-screen text buffers, fonts.
+8. **Orchestration / lifecycle** — main-loop and transition flags, scene mode, save/restore state, checksum.
+
+A ninth concern cuts across all of them and is *not* a domain: **persistence**. The block
+under `C_EXTERN.H:302` ("Globales sauvées dans les fichiers de sauvegarde .LBA") marks
+~50 globals as savegame state spanning gameplay, world, audio params, and lifecycle.
+Persistence is an aspect, not a bounded context — worth tracking separately when the
+save format is touched.
+
+## The engine / game / platform lens
+
+A deeper axis cuts *through* these domains: which code is reusable **engine**, which is
+LBA2-specific **game**, which is **platform**. It is validated empirically against the
+sibling LBA1 source (`lba1-classic`) at the module level — see
+[ENGINE_GAME_SEAM.md](ENGINE_GAME_SEAM.md) for the three-way diff and evidence. Short
+version: Rendering, World/cube transform, and Resources are **engine**; Platform/IO is
+**platform**; Gameplay is **game** on an engine substrate; Audio, UI/text, and
+Orchestration are **engine mechanism with game content**. The membrane between engine and
+game is the Life/Track script VM (`GERELIFE`/`GERETRAK`), which is present in all three
+Adeline trees. Prefer strangler-fig facades on engine seams — they pay off for LBA1 too.
+
+## Domains and their globals
+
+Cross-boundary readers are the domains (beyond the owner) that consume the value.
+Array/cluster groups are collapsed to one row. `—` means single-owner / no significant
+cross-read found at v0.
+
+### Gameplay / simulation (~55)
+
+| Global | Role | Cross-boundary readers |
+|---|---|---|
+| `ListObjet[]` | The entity table (all actors) | Rendering, World, UI, Audio |
+| `NbObjets` | Entity count | Rendering |
+| `ListExtra[]`, `ListDart[]` | Projectiles / extras / darts | Rendering |
+| `ListComportement[]`, `PtrComportement` | AI behaviour table + current | Orchestration (save) |
+| `Comportement`, `SaveComportement`, `SaveComportementHero` | Hero behaviour + saved copies | Orchestration |
+| `ListVarCube[]`, `ListVarGame[]` | Scene/game script variables | Rendering, UI, Orchestration |
+| `MagicLevel`, `MagicPoint` | Magic stats | Rendering (gauge), UI |
+| `MagicBall`, `MagicBallType`, `MagicBallCount`, `MagicBallFlags` | Magic-ball state | Rendering |
+| `MagicHitForce[]`, `MagicBallHitForce[]`, `MagicBallSprite[]` | Combat damage tables | Rendering |
+| `Weapon`, `ActionNormal`, `InventoryAction` | Action / weapon mode | UI |
+| `NbGoldPieces`, `NbZlitosPieces`, `NbLittleKeys`, `NbCloverBox` | Inventory counts | UI |
+| `TabInv[]` | Inventory object table | UI |
+| `NbZones`, `ListZone` | Trigger zones | World |
+| `StartYFalling`, `RealFalling`, `StepFalling`, `RealShifting`, `StepShifting` | Falling / shifting physics | World |
+| `PtrZoneClimb`, `FlagClimbing` | Ladder-climb state | — |
+| `LastJoyFlag`, `LastMyJoy`, `LastMyFire`, `Jumping`, `Pushing` | Player control state (gameplay-written, saved) | Platform (source), Orchestration (save) |
+| `NumObjFollow`, `ExtraConque`, `PingouinActif` | Follow / conque / penguin mechanics | — |
+| `ListArdoise[]`, `CurrentArdoise`, `NbArdoise` | Holomap clue slate | UI |
+| `ListBrickTrack`, `NbBrickTrack` | Track-script working data | — |
+| `Bulle`, `SaveBodyHero`, `AnimNumObj`, `APtObj` | Hero body / speech-bubble / anim cursor | Rendering, UI |
+| `FlagReajustPosTwinsen` | Reposition-on-cube-change flag | World |
+
+> **Correction applied (vs the seed taxonomy):** `LastJoyFlag`/`Jumping`/`Pushing`/`LastMyJoy`/`LastMyFire` *look* like Platform input but are written by gameplay logic (`OBJECT.CPP`, `BUGGY.CPP`) off the raw input, and are part of the savegame, so they belong here. Verified by grepping the assignment sites.
+
+### Rendering (~45)
+
+| Global | Role | Cross-boundary readers |
+|---|---|---|
+| `ListTri[]` | Sort tree (painter's order) | — |
+| `PtrPal`, `PtrPalNormal`, `PtrPalCurrent`, `PtrPalEclair`, `PtrPalBlack`, `PtrTransPal` | Active / variant palettes | Resources (writes on load), UI |
+| `PtrXplPalette`, `PtrXplHeader`, `PalettePcx[]` | Explosion / PCX palettes | Resources |
+| `IdxPalette`, `LastIdxPalette` | Current/previous palette index | Resources |
+| `PtrNuances` | Gouraud shading ramp | — |
+| `Shadow`, `ShadowX/Y/Z`, `ShadowCol`, `ShadowLevel` | Drop-shadow state | — |
+| `AllCameras`, `FollowCamera`, `FollowCamBaseDist` | Camera mode | World |
+| `VueCamera`, `FlagCameraForcee`, `AddBetaCam`, `CameraZone`, `DefVueDistance[]`, `DefAlphaCam[]` | Camera view / forced cam | Gameplay |
+| `ScaleFactorSprite`, `SpriteX`, `SpriteY` | Sprite display transform | — |
+| `CinemaMode`, `TimerCinema`, `LastYCinema`, `DebCycleCinema`, `DureeCycleCinema` | Cutscene letterbox framing | Orchestration |
+| `FlagFade`, `FlagPal`, `FadeMenu`, `FlagBlackPal`, `FlagShadeMenu`, `FlagMessageShade` | Palette fade / shade flags | UI |
+| `FlagRain`, `RainEnable`, `FlagWater`, `FlagDrawHorizon`, `DetailLevel` | Environment effects / LOD | — |
+| `DrawZVObjets` | Debug bounding-box draw | — |
+| `ListIncrustDisp[]` | On-screen incrust overlays | UI |
+
+### World / cube transform (~25)
+
+| Global | Role | Cross-boundary readers |
+|---|---|---|
+| `NumCube`, `NewCube` | Current / requested cube id | Gameplay, Rendering, Orchestration |
+| `Island`, `Planet` | Current island / planet | Gameplay, Rendering, Audio |
+| `WorldXCube`, `WorldYCube`, `WorldZCube` | World-space cube origin | Rendering, Gameplay |
+| `CubeStartX/Y/Z`, `StartXCube/Y/Z`, `SceneStartX/Y/Z` | Cube / scene entry origins | Gameplay, Rendering |
+| `NewPosX/Y/Z` | Pending teleport position | Gameplay |
+| `PhantomX`, `PhantomY`, `PhantomIsland` | Death-cube offsets | Gameplay |
+| `XpOrgw`, `YpOrgw` | World origin projected to screen | Rendering |
+| `Nxw/Nyw/Nzw`, `SaveNxw/.../Nzw`, `OldX/OldY/OldZ` | Spatial working / delta scratch | Rendering, Gameplay |
+| `TabAllCube[]` | All-cubes layout table | Resources, Gameplay |
+
+### Resources / assets (~30)
+
+| Global | Role | Cross-boundary readers |
+|---|---|---|
+| `HQR_Anims`, `HQR_Bodys`, `HQR_ObjFix`, `HQR_Samples` | HQR archive handles | Gameplay, Rendering, Audio |
+| `HQRPtrSprite`, `HQRPtrSpriteRaw`, `HQRPtrAnim3DS` | Extra-object HQR handles | Rendering |
+| `PtrZvExtra`, `PtrZvExtraRaw`, `PtrZvAnim3DS` | Extra-object bounding volumes | Rendering, Gameplay |
+| `SpriteMem`, `SpriteRawMem`, `Anim3DSMem`, `SampleMem`, `AnimMem`, `BodyMem`, `ObjFixMem`, `IsleObjMem`, `CubeInfosMem`, `ListDecorsMem`, `MapPGroundMem`, `ListTexDefMem`, `MapSommetYMem`, `MapIntensityMem`, `SCCMem` | Memory-pool budgets | — |
+| `PtrScene`, `PtrSceneMem` | Scene buffer | Gameplay, Rendering |
+| `BufferTexture`, `AnimateTexture`, `BufferAnim` | 3D texture/anim buffers | Rendering |
+| `BufferPof`, `BufferFile3D`, `BufferBrick` | Model / brick load buffers | Rendering |
+| `ListAnim3DS` | 3DS animation list | Rendering |
+| `LbaFont` | Loaded font buffer | UI |
+
+### Audio (~18)
+
+| Global | Role | Cross-boundary readers |
+|---|---|---|
+| `SampleAmbiance[]`, `SampleRepeat[]`, `SampleRnd[]`, `SampleFreq[]`, `SampleVol[]` | Ambiance scheduler config | Gameplay (writes per cube) |
+| `SamplePlayed`, `TimerNextAmbiance`, `SecondEcart`, `SecondMin` | Ambiance scheduling state | Gameplay |
+| `CubeJingle`, `SampleAlwaysMove` | Per-cube jingle / always-on sample | World, Gameplay |
+| `SampleVolume`, `VoiceVolume`, `MasterVolume`, `SamplesEnable` | Mix levels / enable | Platform, Orchestration (save) |
+| `ParmSampleVolume`, `ParmSampleDecalage`, `ParmSampleFrequence` | Saved sample params | Orchestration (save) |
+| `RestartMusic`, `BufSpeak` | Music restart / speech buffer | UI |
+| `ReverseStereo` | Stereo channel swap | Platform |
+
+> The ambiance scheduler is the clearest example of the seed taxonomy being wrong: it is
+> gameplay *scheduling* audio *playback*. Splitting it out names the gameplay↔audio
+> coupling instead of burying it in Platform.
+
+### Platform / IO (~15)
+
+| Global | Role | Cross-boundary readers |
+|---|---|---|
+| `MyKey` | Raw input scancode | Gameplay, UI |
+| `LastInputWasKeyboard` | Last-input-device flag (KEYBOARD.CPP) | UI (save menu) |
+| `VideoFullScreen`, `DisplayFullScreen` | Display mode | Rendering |
+| `TimerProto` | Timing | Orchestration |
+| `GamePathname`, `OldGamePathname`, `PathFla` | Data / video paths | Resources |
+| `FlaFromCD`, `FlagPlayAcf`, `MessageNoCD[]` | CD / video playback | UI |
+| `Version`, `BuildInfo`, `DistribVersion`, `Version_US`, `PlayerName` | Version banners / player id | UI, Orchestration |
+
+### UI / text (~15)
+
+| Global | Role | Cross-boundary readers |
+|---|---|---|
+| `NumObjDial`, `DialNbLine`, `NumObjSpeak`, `FlagSpeak` | Dialog / speech presentation | Gameplay, Audio |
+| `BufText`, `BufOrder` | Dialog text / ordering buffers | — |
+| `GameChoice`, `GameNbChoices`, `GameListChoice[]` | Menu selection state | Orchestration |
+| `GameOptionMenu[]`, `FlagMenuMouse`, `FlecheForcee` | Menu options / cursor | Platform |
+| `NewGameTxt[]`, `PleaseWait[]` | UI strings | — |
+| `String[]`, `Value` | Shared string-format / script scratch | All (cross-cutting) |
+
+### Orchestration / lifecycle (~25)
+
+| Global | Role | Cross-boundary readers |
+|---|---|---|
+| `GameInProgress` | In-game vs menu mode | Gameplay, Rendering, UI |
+| `CubeMode`, `LastCubeMode`, `ModeLabyrinthe` | Interior/exterior/labyrinth scene mode | Rendering, World, Gameplay |
+| `FlagChgCube`, `FlagLoadGame`, `FlagTheEnd` | Transition / load / end triggers | World, Gameplay |
+| `FirstTime`, `FirstLoop`, `FirstSave` | First-iteration guards | — |
+| `SavingEnable`, `NumVersion`, `Checksum` | Save enable / format version / checksum | — |
+| `DemoSlide`, `FlagSlideShow`, `DebugFps` | Demo / debug modes | Rendering |
+| `SnapshotRequested`, `SnapshotName` | Polyrec dev harness | — |
+
+## The shared bus — worst offenders
+
+These are read by three or more domains. They are the heart of why the engine does not
+fit in one's head, and they tell you exactly which axes any module split must negotiate:
+
+| Global | Domains touched | What it really is |
+|---|---|---|
+| `ListObjet[]` | Gameplay, Rendering, World, UI/Audio | The entity table — the single most-shared structure |
+| `NumCube` / `NewCube` | World, Gameplay, Rendering, Orchestration | Which cube we are in / going to |
+| `Island` / `Planet` | World, Gameplay, Rendering, Audio | Which world we are in |
+| `WorldXCube/Y/Z` | World, Rendering, Gameplay | The world-space origin everything projects against |
+| `CubeMode` | Orchestration, Rendering, World, Gameplay | Interior vs exterior — flips the whole render/sim path |
+| `PtrPal` / `PtrPalNormal` | Rendering, Resources, UI | The active palette |
+| `Comportement` | Gameplay, Orchestration, (UI) | The hero's current behaviour |
+| `GameInProgress` | Orchestration, Gameplay, Rendering, UI | In-game vs menu — the mode switch |
+| `String[]` | All | Shared scratch buffer; resists single ownership |
+
+The pattern: the offenders are **coordinates** (cube/island/world origin), **the entity
+table**, **the palette**, and **the mode switches** (in-game vs menu, interior vs
+exterior). Those four clusters are the negotiation surface for any real boundary.
+
+## Dead / vestigial globals
+
+Surfaced while mapping; candidates for a later cleanup pass (verify before removing):
+
+| Global | Observation |
+|---|---|
+| `BodyComportement` | Declared in `C_EXTERN.H:4`; no definition or read site found in `SOURCES`/`LIB386`. |
+| `NbPolyPoints` | Under the `LIB_SVGA` comment (`C_EXTERN.H:175`); no live def/use — likely dead or ASM-only. |
+| `FlagPalettePcx` | Extern-declared (`C_EXTERN.H:119`) but its `GLOBAL.CPP` definition is commented out. |
+
+## Anti-patterns this map makes visible
+
+- **The global-state bus itself.** `C_EXTERN.H` / `GLOBAL.CPP` are a ~200-entry shared
+  blackboard. Every domain boundary above is violated by something reaching across it.
+  This is the root smell; the rest are symptoms.
+- **God object — `T_OBJET`** (`SOURCES/DEFINES.H`) and the `T_OBJ_3D` it wraps
+  (`LIB386/H/OBJECT/AFF_OBJ.H`). One struct carries position, orientation, body/anim,
+  animation frames, bounding box, AI state, and collision. Every system pokes the parts
+  it cares about, so the struct couples gameplay, rendering, world, and collision into a
+  single type — the data-side equivalent of the global bus.
+- **God functions — `AffScene` and `ChangeCube`** (both `SOURCES/OBJECT.CPP`). `AffScene`
+  orchestrates the whole exterior render; `ChangeCube` tears down and rebuilds world,
+  resources, audio, and entity state on every cube transition. Each reaches across every
+  domain in this map. `ChangeCube`'s phases are decomposed in
+  [LIFECYCLES.md](LIFECYCLES.md) — they tour the domains in dependency order, which is the
+  sequence any World/cube facade must preserve.
+
+## How a clean engine would draw these lines
+
+Two reference points, for contrast — not as a refactor mandate:
+
+- **Doom 3 / idTech 4 "no god classes."** id's discipline was that no single type owns
+  everything; subsystems (renderer, sound, game, file system) sit behind narrow
+  interfaces and talk through them, not through shared globals. The equivalent move here
+  is the platform seam already in flight (PR #284–#286): a C-linkage port with a
+  host stub behind it. Generalised, every domain box above wants the same treatment — a
+  facade (`Sort_Insert(...)`, `World_CurrentCube()`) that callers go through instead of
+  touching the globals directly. The facade becomes the contract; the globals become its
+  private state.
+- **ECS, for the simulation layer.** In an entity-component-system the domains above
+  *are* the components, and a system declares which components it reads and writes in its
+  signature. The question this whole document answers by hand — "what global state does
+  this touch?" — becomes mechanical and local. `T_OBJET` is the photographic negative of
+  that: it is every component welded into one struct, on one global array.
+
+The realistic path for a behaviour-faithful port is neither rewrite: it is strangler-fig.
+Pick the busiest boundary — **World / cube transform**, by the offender table above —
+wrap its globals behind a facade without moving them, prove behaviour is unchanged with
+the polyrec/projrec harness, and repeat. This map is the input to choosing which boundary
+to draw first.
+
+## Open questions for the next pass
+
+- Should **persistence** get its own annotation column (savegame yes/no) rather than a
+  prose note? ~50 globals are save state and it cross-cuts every domain.
+- `CubeMode` and `GameInProgress` are mode switches read everywhere — do they belong in
+  Orchestration, or is there a distinct **mode/state-machine** context hiding here?
+- `Nxw/Nyw/Nzw` and `OldX/Y/Z` are spatial scratch shared by World and Rendering — owner
+  is genuinely ambiguous; confirm by usage before trusting the World assignment.
+- Counts are approximate (clusters collapsed to single rows). A future pass could pin an
+  exact owner per individual global if the facade work needs it.
+
+## Related docs
+
+Three orthogonal views of the same engine — read together:
+
+- **This doc** — *structure*: which domain owns which global.
+- **[ENGINE_GAME_SEAM.md](ENGINE_GAME_SEAM.md)** — *layer*: engine vs game vs platform,
+  validated against the LBA1 source.
+- **[LIFECYCLES.md](LIFECYCLES.md)** — *time*: main-loop frame order, `ChangeCube` phases,
+  object/anim/behaviour state machines. The shared-bus offenders above (`ListObjet`,
+  `CubeMode`, `Comportement`) are exactly its lifecycle pivots.

--- a/docs/ENGINE_GAME_INTERFACE.md
+++ b/docs/ENGINE_GAME_INTERFACE.md
@@ -1,0 +1,201 @@
+# The engine/game interface — the Life/Track script VM
+
+> **Status: DRAFT / living document (v0).** Companion to [ENGINE_GAME_SEAM.md](ENGINE_GAME_SEAM.md)
+> and [ARCHITECTURE.md](ARCHITECTURE.md). This documents the membrane between the reusable
+> engine and the game: the bytecode VM that runs the game's behaviour. Truth hierarchy:
+> code > this document.
+
+## Summary
+
+The engine/game membrane is a **per-object bytecode VM** with two cooperating script types:
+
+- **Life** — behaviour / AI. *Decides.* (`SOURCES/GERELIFE.CPP`, `DoLife`)
+- **Track** — movement / pathing. *Executes.* (`SOURCES/GERETRAK.CPP`, `DoTrack`)
+
+Both are hand-rolled `switch`-on-opcode interpreters over a byte cursor. Scripts are
+compiled byte-streams embedded **inline in the per-cube scene file**, pointed to directly
+from each object's struct. The VM's "syscalls" are direct C calls and direct reads/writes
+of engine globals — **there is no isolation layer**. The same VM exists in LBA1; LBA2 is a
+strict superset.
+
+## 1. Two script types, dispatched per object per frame
+
+Both run inside the main loop `MainLoop()` (`SOURCES/PERSO.CPP:437`), in its per-object
+loop (`for i in 0..NbObjets`, `PERSO.CPP:1548`). Order per object:
+
+1. `DoDir(i)` — movement/rotation physics
+2. **Track**: `if (OffsetTrack != -1) DoTrack(i);` (`PERSO.CPP:1593`)
+3. `PtrDoAnim(i)` — advance animation
+4. **Life**: `if (OffsetLife != -1) DoLife(i);` (`PERSO.CPP:1637`)
+
+So **Track runs before Life** each frame; both halt when their program counter is `-1`.
+This is the same membrane LIFECYCLES.md shows as main-loop steps 3 and 6.
+
+- **Life** runs opcodes in a `while` loop *until it hits a yield/terminator*
+  (`LM_RETURN`, `LM_END_COMPORTEMENT`, `LM_SUICIDE`, …). It is decision logic: evaluate
+  conditions, set state, fire dialogue, change cubes, assign Track programs.
+- **Track** is a **coroutine**: opcodes like `TM_GOTO_POINT`, `TM_WAIT_ANIM`,
+  `TM_WAIT_NB_SECOND` rewind the PC and break to yield until next frame; `OffsetTrack`
+  persists across frames.
+
+Life hands a movement program to an object via `LM_SET_TRACK` / `LM_VAR_GAME_TO_TRACK`.
+**Life decides, Track executes.**
+
+## 2. Three-table design and opcode counts
+
+Conditionals are not single opcodes — they are composed from three separate tables
+(`SOURCES/COMMON.H`):
+
+| Table | Kind | Count | Evaluated by |
+|---|---|---|---|
+| `LM_*` | Life **statements** | 155 defined (0–154), ~142 handler cases | the `switch` in `DoLife` |
+| `LF_*` | Life **queries/expressions** | 46 | `DoFuncLife` → result in global `Value` + `TypeAnswer` |
+| `LT_*` | **comparison operators** | 6 | `DoTest` |
+| `TM_*` | Track **statements** | 53 defined, ~50 handler cases | the `switch` in `DoTrack` |
+
+A conditional = one `LF_*` query + one `LT_*` operator + an immediate operand. (Markers
+like `LM_ENDIF`/`LM_DEFAULT`/`LM_NOP`/`LM_REM` have no runtime case — the compiler resolves
+block structure into absolute offset jumps, leaving these as compile-time-only.)
+
+`LM_*` categories: control flow / conditionals; object lifecycle (`LM_KILL_OBJ`,
+`LM_SUICIDE`, life-points, hit, position, collision flags, doors); behaviour
+(`LM_COMPORTEMENT_HERO`, save/restore comportement); Track binding; animation/body/sprite;
+sound; scene/cube/world (`LM_CHANGE_CUBE`, camera, zone toggles, palette, rain, cinema,
+`LM_PLAY_ACF`); variables; dialogue/choice/UI; inventory/economy/progression; effects
+(`LM_IMPACT_*`, `LM_FLOW_*`); game flow (`LM_GAME_OVER`, `LM_THE_END`).
+
+`TM_*` categories: movement/facing; coroutine waits; flow control (`TM_LABEL`/`TM_GOTO`/
+`TM_LOOP`); animation/body/3DS-sprite suite; doors; sound. Life and Track share a
+*vocabulary* (`*_SAMPLE`, `*_ANIM`, `*_BODY`) but use **separate numeric tables and
+handlers** (`LM_SAMPLE`=122 vs `TM_SAMPLE`=14).
+
+## 3. Dispatch mechanism
+
+A classic **threaded-bytecode interpreter** over a global PC pointer `U8 *PtrPrg`
+(`GERELIFE.CPP:8`). No function-pointer table:
+
+```c
+while (flag != -1) {
+    ptrmacro = PtrPrg;
+    switch (*PtrPrg++) {   // read opcode byte, advance PC
+```
+
+Operands are read by post-incrementing the cursor. Jumps reseat it relative to the script
+base: `PtrPrg = ptrobj->PtrLife + *(S16*)PtrPrg`. Conditionals are **two-stage**
+(`GERELIFE.CPP:1066`): `DoFuncLife` evaluates an `LF_*` query into global `Value`; `DoTest`
+applies the `LT_*` operator against an inline immediate; false jumps to the else/endif
+offset, true falls through. Several opcodes are **self-modifying** — `LM_SWIF`/`LM_SNIF`
+(do-once-until-condition-flips) and `LM_ONEIF`/`LM_NEVERIF` (run-once-ever) rewrite their
+own opcode byte in place (`*ptrmacro = LM_SNIF`). Track uses the same pattern on a
+**per-object** cursor (`OffsetTrack`, written back into the struct each yield).
+
+**What `EXTFUNC`/`PTRFUNC` are *not*:** they are not the script dispatch. `PTRFUNC.H` is
+C function-pointer **typedefs** for engine-internal indirection / a build seam
+(`PtrDoAnim`, `PtrGetScreenBrick`, …); `EXTFUNC.CPP`/`FUNC.CPP` are engine helper and
+`LBA_EDITOR` tooling functions, callable from C but **not addressable as script opcodes**.
+Scripts reach engine code only through the hardcoded `case` bodies in
+`DoLife`/`DoTrack`/`DoFuncLife`.
+
+## 4. The VM syscall surface (engine API exposed to scripts)
+
+Each opcode body calls engine C functions directly. Categories:
+
+- **Animation/body**: `InitAnim`, `InitBody`, `SetAnim`, `InitSprite`, `ObjectSetFrame`, `SetComportement`.
+- **Audio**: `HQ_3D_MixSample`, `HQ_MixSample`, `HQ_StopOneSample`, `IsSamplePlaying`, `PlayMusic`.
+- **Dialogue/UI**: `Dial`, `GameAskChoice`, `InitIncrustDisp`, `MenuInventory`, `DoFoundObj`, `EffectPcx`.
+- **Scene/world**: cube change via `NewCube`+`FlagChgCube`, `CheckZoneSce`, `CameraCenter`, `InitGrille`, palette/fade, `PlayAcf`, `DoImpact`, `CreateParticleFlow`.
+- **Geometry/queries**: `Distance2D/3D`, `GetAngle2D` (behind `LF_DISTANCE*`/`LF_ANGLE*`/`LF_CONE_VIEW`), `PosObjetAroundAnother`, `HitObj`, buggy take/leave.
+- **Direct global state**: a large unmediated surface — `MagicLevel`, `MagicPoint`, gold/Zlitos, keys, `Comportement`, `FlagTheEnd`, `CinemaMode`, `FlagRain`, `ListZone[]`, `TabInv[]`, camera globals.
+
+**No sandbox.** The VM has unmediated access to engine globals and arrays, and indices like
+`ListObjet[*PtrPrg++]` are unchecked.
+
+## 5. Script storage and script-visible variables
+
+**Storage:** scripts are not a dedicated resource — they are embedded inline in the
+per-cube scene blob. `LoadScene(numscene)` (`SOURCES/DISKFUNC.CPP:50`) loads the scene from
+`scene.hqr` into `PtrScene`, then walks the blob with a byte cursor, reading for the hero
+and each object a length-prefixed Track stream then a Life stream:
+
+```c
+sizetoload = GET_S16; ptrobj->PtrTrack = PtrSce; PtrSce += sizetoload;  // DISKFUNC.CPP:135
+sizetoload = GET_S16; ptrobj->PtrLife  = PtrSce; PtrSce += sizetoload;  // DISKFUNC.CPP:139
+```
+
+So `PtrLife`/`PtrTrack` (`DEFINES.H:412`) point **directly into the scene buffer**, and
+`OffsetLife`/`OffsetTrack` are the per-object PCs (`-1` = halted). The same blob supplies
+`ListBrickTrack` (the named waypoints `TM_GOTO_POINT`/`LM_POS_POINT` index), zones, and
+patches.
+
+**Script-visible variables** (`GLOBAL.CPP:262`):
+
+- `ListVarCube[80]` (`U8`) — **cube-scoped**, zeroed by `ClearVarsCube()` (`OBJECT.CPP:964`)
+  inside `ClearScene()` on every cube transition. Intra-cube puzzle scratch.
+  (`LF_VAR_CUBE`, `LM_SET/ADD/SUB_VAR_CUBE`.)
+- `ListVarGame[256]` (`S16`) — **game-scoped, persistent** (part of the save file). Many
+  slots are named flags (`FLAG_HOLOMAP`=0, `FLAG_CLOVER`=251, `FLAG_CHAPTER`=253, …,
+  `COMMON.H:228`) and some alias engine systems (setting `FLAG_MONEY` mirrors into
+  `NbGoldPieces`/`NbZlitosPieces`, `GERELIFE.CPP:1320`). (`LF_VAR_GAME`,
+  `LM_SET/ADD/SUB_VAR_GAME`.)
+
+## 6. Title-agnosticism and the LBA1 porting path
+
+**LBA1 uses the same VM.** `lba1-classic/SOURCES/GERELIFE.C` and `GERETRAK.C` are direct
+ancestors: identical `DoLife`/`DoTrack`/`DoFuncLife`/`DoTest` architecture, the same global
+`PtrPrg` cursor, the same `Value`+`TypeAnswer` query/test mechanism, the same control-flow
+family (`LM_IF`/`LM_OR_IF`/`LM_SWIF`/`LM_SNIF`/`LM_ONEIF`/`LM_NEVERIF`/`LM_OFFSET`).
+
+LBA2 is a **strict superset**:
+
+| | LBA1 | LBA2 |
+|---|---|---|
+| Life cases | ~99 | ~142 |
+| `LF_*` queries | ~30 | 46 |
+| Track cases | ~38 | ~50 |
+
+- **Shared core:** control flow, conditionals, `LM_BODY`/`LM_ANIM`/`LM_KILL_OBJ`/
+  `LM_SUICIDE`/`LM_COMPORTEMENT_HERO`/`LM_SET_TRACK`/`LM_MESSAGE`/`LM_SET_DIR`, the whole
+  Track movement/wait/sample family.
+- **LBA1-only / renamed:** `LM_LABEL`, `LM_INIT_PINGOUIN`, `LM_SET_LIFE(_OBJ)`,
+  `LM_SAY_MESSAGE`; and the key rename `LM_SET_FLAG_CUBE/GAME` → `LM_SET_VAR_CUBE/GAME`
+  (LBA1's single-byte flag model became LBA2's `S16` game vars with add/sub).
+- **LBA2-only:** the 3DS-sprite Track suite, `LM_IMPACT_*`/`LM_FLOW_*`, `LM_CINEMA_MODE`,
+  `LM_SWITCH`/`LM_CASE`, holomap/ardoise/buggy/Zlitos opcodes, `LM_ANIM_TEXTURE`, the
+  door/rail/escalator zone toggles — each added LBA2 system bolted on opcodes.
+
+**The conclusion that matters for the LBA1 goal:** the **VM is fully title-agnostic** — a
+generic per-object bytecode interpreter with no LBA2-specific assumptions in its core loop,
+so it is a good reuse target. And a cross-repo opcode diff (see
+[LBA1_PORTING_SURFACE.md](LBA1_PORTING_SURFACE.md) §8) shows the gap is smaller than a
+"not numerically stable" first read suggested: the `LM_*` command tables are **numerically
+identical for opcodes 0–56**. Divergence starts ~57 — a few same-slot renames
+(`LM_SET_FLAG_CUBE`→`LM_SET_VAR_CUBE`, with LBA1's byte flags widened to LBA2's `S16` vars,
+so operand widths must be watched) and a handful of true collisions
+(`LM_ZOOM`(57)→`LM_SHADOW_OBJ`, `LM_PLAY_FLA`(64)→`LM_PLAY_ACF`,
+`LM_PLAY_MIDI`(65)→`LM_ECLAIR`, `LM_INIT_PINGOUIN`(71)→`LM_MEMO_ARDOISE`), several of them
+the FLA/MIDI media opcodes. So LBA1 scripts run on the LBA2 VM after an **opcode-remap
+table** (rewrite the collided/renamed opcodes, redirect FLA/MIDI), plus matching the
+scene-file container — **not** a full transpiler. *The architecture ports trivially; the
+bytecode needs a remap table, not a rewrite.*
+
+## Relation to other docs, and uncertainties
+
+- [IMPACT_SCRIPTS.md](IMPACT_SCRIPTS.md) documents a **separate third** bytecode system
+  (IMPACT/FLOW point-in-space effects); Life reaches it via `LM_IMPACT_*`/`LM_FLOW_*`.
+  [LBA_EDITOR.md](LBA_EDITOR.md) covers `LBA_EDITOR` authoring tooling (confirms
+  EXTFUNC/IMPACT/FLOW are tooling, not script dispatch). Neither covers the Life/Track VM —
+  that is the gap this doc fills. A `docs/SCRIPTS.md` operand spec is the planned next step
+  (Life/Track tooling, issue #181).
+- **Not yet verified:** exact per-opcode operand encodings (cursor pattern and categories
+  confirmed, not an exhaustive operand table); the on-disk scene container beyond the
+  object/zone/track-point walk. The LBA1↔LBA2 opcode-number alignment (0–56 identical,
+  collisions at 57+) *was* diffed — see LBA1_PORTING_SURFACE.md §8 — but the operand
+  widths/order of each shared opcode still want a spot-check.
+
+## Key files
+
+`SOURCES/GERELIFE.CPP` (Life VM), `SOURCES/GERETRAK.CPP` (Track VM), `SOURCES/COMMON.H`
+(`LM_*`/`LF_*`/`LT_*`/`TM_*` constants), `SOURCES/PERSO.CPP:1533` (per-frame dispatch),
+`SOURCES/DISKFUNC.CPP:50` (`LoadScene`), `SOURCES/GLOBAL.CPP:262` + `COMMON.H:463` (var
+arrays), `SOURCES/DEFINES.H:412` (`PtrTrack`/`PtrLife`). LBA1: `lba1-classic/SOURCES/GERELIFE.C`,
+`GERETRAK.C`.

--- a/docs/ENGINE_GAME_SEAM.md
+++ b/docs/ENGINE_GAME_SEAM.md
@@ -8,7 +8,7 @@
 
 ## Why this axis, and why the module level
 
-The engine/game line matters because of a real prospect: `~/code/lba-hacking/lba1-classic`
+The engine/game line matters because of a real prospect: the `lba1-classic` community source
 is the **LBA1 original Adeline source** (Relentless, 1994) — same lineage as this repo,
 same `LIB386/`+`SOURCES/` layout, same HQR format. One day LBA1 content could run on this
 engine. Even before then, LBA1 is useful *now*: it tells us empirically where the

--- a/docs/ENGINE_GAME_SEAM.md
+++ b/docs/ENGINE_GAME_SEAM.md
@@ -1,0 +1,169 @@
+# Engine / game / platform seam
+
+> **Status: DRAFT / living document (v0).** Companion to [ARCHITECTURE_GLOBALS.md](ARCHITECTURE_GLOBALS.md).
+> That doc cuts the LBA2 globals into eight *domains* (a within-game decomposition). This
+> doc cuts along the deeper, orthogonal axis — **engine vs game vs platform** — using the
+> sibling LBA1 source as an empirical oracle. Goal: make visible which code is reusable
+> across titles, so strangler-fig boundaries can be drawn where they pay off twice.
+
+## Why this axis, and why the module level
+
+The engine/game line matters because of a real prospect: `~/code/lba-hacking/lba1-classic`
+is the **LBA1 original Adeline source** (Relentless, 1994) — same lineage as this repo,
+same `LIB386/`+`SOURCES/` layout, same HQR format. One day LBA1 content could run on this
+engine. Even before then, LBA1 is useful *now*: it tells us empirically where the
+engine/game line runs.
+
+The naive way — grep LBA1 for each of the ~200 LBA2 globals — fails: LBA1 is C with
+different identifiers, so per-global name matching is mostly misses. The robust unit is
+the **module**. Modules survive renaming (LBA1 `BUBSORT` → LBA2 `SORT`; LBA1 `HOLOMAP` →
+LBA2 `HOLO*`), and a three-way module diff across the trees separates the layers cleanly.
+
+### The three trees
+
+| Tree | Game | Era | Language |
+|---|---|---|---|
+| `lba1-classic` | LBA1 (Relentless) | 1994 | C + ASM |
+| `lba2-classic` | LBA2 (original Adeline) | 1997 | C++ + ASM |
+| `lba2-classic-community` | LBA2 (this fork) | 1997 + port | C++98 + ASM, SDL3 |
+
+Reproduce the diff with `comm` over the ext-insensitive module stems of each tree's
+`SOURCES/` (and compare `LIB386/` submodule names).
+
+## LIB386 kernel evolution
+
+The engine kernel is recognizable across all three, renamed and consolidated:
+
+| LBA1 | LBA2 / community | Role |
+|---|---|---|
+| `LIB_3D` | `3D` | Projection, rotation, matrices |
+| `LIB_SVGA` | `SVGA` | Rasteriser / framebuffer |
+| `LIB_SYS` | `SYSTEM` | HQR, files, keyboard, mouse, timer |
+| `LIB_MENU` | `MENU` | Menu primitives |
+| `LIB_MIX` / `LIB_SAMP` / `LIB_MIDI` | `ail` / `AIL` | Audio (mixing, samples, music) |
+| `LIB_CD` | (folded into system/audio) | CD audio |
+| — | `ANIM`, `OBJECT`, `pol_work` | LBA2 engine growth (anim interp, object display, polygon fillers) |
+| — | `SNAPSHOT`, `VIDEO_AUDIO_RESAMPLE`, `libsmacker` | Community port infrastructure |
+
+The kernel evolved (more 3D, polygon fillers split out, audio unified behind `ail`) but the
+spine — projection, raster, system/HQR, sound — is continuous.
+
+## SOURCES module layers (the three-way diff)
+
+### Layer 1 — durable engine / framework core (in all three)
+
+`AMBIANCE` `COMMON` `C_EXTERN` `DEFINES` `DISKFUNC` `EXTRA` `FICHE` `FIRE` `FUNC`
+`GAMEMENU` `GERELIFE` `GERETRAK` `GLOBAL` `GRILLE` `INCRUST` `MESSAGE` `OBJECT` `PERSO`
+`VERSION`
+
+These 19 modules survived 1994 → 1997 → 2024. They are the engine-game framework:
+
+| Module(s) | Role | Engine mechanism vs game content |
+|---|---|---|
+| `GERELIFE`, `GERETRAK`, `FUNC` | Life/Track **script VM** and its opcode functions | **The membrane.** Engine interprets; the scripts are game. |
+| `OBJECT`, `PERSO`, `EXTRA`, `FICHE` | Entity / character / projectile / object-data framework | Engine framework; the behaviours and stats are game content. |
+| `GRILLE` | Brick-isometric world / scene render | Engine; the specific scenes are content. |
+| `DISKFUNC` | Resource loading (HQR) | Engine. |
+| `MESSAGE` | Dialog / speech presentation | Engine machinery; the text is content. |
+| `GAMEMENU` | Menu system | Engine machinery; the menu set is content. |
+| `AMBIANCE` | Ambient-audio scheduler | Engine mechanism; the per-cube sample tables are content. |
+| `INCRUST`, `FIRE` | Overlays / fire effect | Engine rendering effects. |
+| `COMMON`, `C_EXTERN`, `DEFINES`, `GLOBAL`, `VERSION` | Types, globals, version scaffolding | Framework scaffolding (the global bus lives here). |
+
+### Layer 2 — LBA2 additions (engine evolution + LBA2 game)
+
+In `lba2-classic` but not `lba1-classic`. Two sub-kinds:
+
+- **Engine evolution:** `SORT` (the sort tree — LBA1 used `BUBSORT`), `POF` (3D model
+  format), `ZV` (bounding volumes), `BEZIER`, `ANIMTEX`, `DEC`/`DEC_XCF` (decor),
+  `EXTFUNC`/`PTRFUNC` (script function tables), `INPUT`/`JOYSTICK`/`KEYB` (input split
+  out), `MEM`, `SAVEGAME`, `CONFIG`, `FLOW`, `PLAYACF` (video), `SCAN`, `VALIDPOS`.
+- **LBA2 game content:** `BUGGY`, `WAGON`, `DART`, `INVENT`, `CHEATCOD`, `COMPORTE`,
+  `HERCULE`, `IMPACT`, `MESSTWIN`, and the holomap (`HOLO`, `HOLOBODY`, `HOLOGLOB`,
+  `HOLOPLAN` — LBA1's single `HOLOMAP` re-grown).
+
+### Layer 3 — community / port additions (in this fork only)
+
+`ASSET_PREFLIGHT` `AUDIO_BALANCE` `BUILD_INFO` `COMPRESS` `CONTROL` `COPY` `CREDITS_PARSE`
+`DEMO_SEED` `DIRECTORIES` `EMBEDDED_CFG_WRITE` `EXIT_SCREEN` `FLOW_A` `FOLLOWCAM_CFG`
+`GAMEMENU_MOUSE` `GRILLE_A` `HERCUL_A` `HQR_NAMES` `IMAGE_LOAD` `INITADEL` `PERFTRACE`
+`PLASMA` `RES_DISCOVERY` `RES_MENU` `RES_PICKER` `RES_SWITCH` `SAVEGAME_LOAD_BOUNDS`
+`SAVENAME_VALIDATION` `TOUCH_INPUT`
+
+Almost entirely **platform / port**: resource discovery (`RES_*`, `DIRECTORIES`,
+`HQR_NAMES`), de-ASM'd primitives (`COPY`, `COMPRESS`, `*_A` C ports of old ASM), the test
+harness (`CONTROL`, `PERFTRACE`), input/IO (`TOUCH_INPUT`, `IMAGE_LOAD`), with a few QoL
+features (`GAMEMENU_MOUSE`, `FOLLOWCAM_CFG`, `AUDIO_BALANCE`, `PLASMA`). The fork has not
+touched the engine core or the game — it has been building the platform layer underneath.
+
+### LBA1-only (modernized away by LBA2)
+
+`ADFLI_A` `BALANCE` `BUBSORT` `CPYMASK` `FLA` `FLIPBOX` `HOLOMAP` `MCGA` `MIXER` `PLAYFLA` —
+old platform tech (`MCGA` display, `FLA`/`PLAYFLA` video, `MIXER`/`BALANCE` audio,
+`BUBSORT`). Confirms the churn between titles was mostly *platform*, not game logic.
+
+## Layer tags on the eight domains
+
+Mapping [ARCHITECTURE_GLOBALS.md](ARCHITECTURE_GLOBALS.md)'s domains onto this axis, with
+the owning module(s) as evidence. Almost every domain is **engine mechanism + game
+content** — the split is rarely a whole domain, it runs *through* each one:
+
+| Domain | Layer | Evidence / note |
+|---|---|---|
+| Gameplay / simulation | **Game** on an engine substrate | `OBJECT`/`PERSO`/`EXTRA` framework is engine (all three); behaviours, inventory, magic, stats are LBA2 content driven by the script VM. |
+| Rendering | **Engine** | `3D`/`SVGA`/`GRILLE`/`INCRUST` in all three; `SORT`/`pol_work` are LBA2 engine evolution. |
+| World / cube transform | **Engine** | `GRILLE` + `DISKFUNC` world model in all three; specific cube/island data is content. |
+| Resources / assets | **Engine** | HQR (`LIB_SYS`→`SYSTEM`) + `DISKFUNC` in all three; the archives are content. |
+| Audio | **Engine** mechanism + game scheduling | `AMBIANCE` in all three; mixing via `ail`; per-cube sample tables are content. |
+| Platform / IO | **Platform** | `SYSTEM`/`SVGA` + the community port layer (`CONTROL`, `RES_*`, `TOUCH_INPUT`). This is the PAL. |
+| UI / text | **Engine** machinery + game content | `MESSAGE`/`GAMEMENU` in all three; the menus, text, holomap are content. |
+| Orchestration / lifecycle | **Engine** framework | Main loop / scene lifecycle / `INITADEL`; the specific game flow is content. |
+
+## What this means for prioritisation
+
+- **The script VM (`GERELIFE`/`GERETRAK`/`FUNC`) is the keystone seam.** It is the literal
+  engine/game interface, present in all three trees. The dynamic proof is in
+  [LIFECYCLES.md](LIFECYCLES.md): the per-frame main loop crosses the membrane at **step 3
+  (`DoTrack`, track scripts)** and **step 6 (`DoLife`, life scripts)** for every object —
+  the engine drives the loop, the game's scripts are invoked. A clean boundary here is what
+  makes the engine title-agnostic — the highest-leverage facade, aligned with the
+  Life/Track tooling thread (#181).
+- **Engine-seam facades pay off twice.** Drawing a facade around an all-three module
+  (World/cube via `GRILLE`+coords, Resources via HQR/`DISKFUNC`) cleans up LBA2 now and is
+  reusable for LBA1 later. Prefer these over facades around Layer-2 game content
+  (`INVENT`, magic ball), which differ per title by definition.
+- **The platform seam is already on this path.** The community layer (Layer 3) is the PAL;
+  PR #284–#286 formalise it. Continuing to push platform concerns into that layer keeps
+  the engine core clean for both titles.
+
+## Caveats
+
+- **Renaming and language.** LBA1 is C; modules and identifiers were renamed and
+  reorganised for LBA2 (`BUBSORT`→`SORT`, `HOLOMAP`→`HOLO*`, `LIB_3D`→`3D`). Module
+  presence is evidence of a *shared concept*, not drop-in compatibility.
+- **Format and capability divergence.** LBA1 used older formats (FLA video, MCGA) and a
+  more limited 3D path. Hosting LBA1 here means bringing its *content* onto this *newer*
+  engine, not merging two equals.
+- **twin-e / TwinEngine** already runs both titles via reimplementation — feasibility is
+  proven. The original-source path is harder but preservation-faithful.
+- Layer tags here are v0 judgments from module evidence; pin per-module before relying on a
+  tag for a specific facade.
+
+## Related docs — the three axes
+
+This map is one of three orthogonal views of the same engine; use them together:
+
+- **[ARCHITECTURE_GLOBALS.md](ARCHITECTURE_GLOBALS.md)** — *structure*: which domain owns
+  which global (the shared-bus offenders).
+- **This doc** — *layer*: engine vs game vs platform (what is reusable across titles).
+- **[LIFECYCLES.md](LIFECYCLES.md)** — *time*: when state is created, mutated, destroyed
+  (main-loop frame order, the `ChangeCube` phases, object/anim/behaviour state machines).
+
+The temporal axis sharpens this one twice over:
+
+- The main-loop frame order shows the engine/game membrane *in motion* — track scripts at
+  step 3, life scripts at step 6, every frame, per object.
+- `ChangeCube`'s six phases are a tour through the domains in dependency order (grid →
+  objects → zones → `CubeMode` → camera). That sequence is the spec a World/cube facade
+  must preserve: it tells you not just *what* the boundary owns but the *order* in which a
+  cube transition crosses it.

--- a/docs/ENGINE_GAME_SEAM.md
+++ b/docs/ENGINE_GAME_SEAM.md
@@ -127,7 +127,8 @@ content** — the split is rarely a whole domain, it runs *through* each one:
   (`DoTrack`, track scripts)** and **step 6 (`DoLife`, life scripts)** for every object —
   the engine drives the loop, the game's scripts are invoked. A clean boundary here is what
   makes the engine title-agnostic — the highest-leverage facade, aligned with the
-  Life/Track tooling thread (#181).
+  Life/Track tooling thread (#181). Full API spec:
+  [ENGINE_GAME_INTERFACE.md](ENGINE_GAME_INTERFACE.md).
 - **Engine-seam facades pay off twice.** Drawing a facade around an all-three module
   (World/cube via `GRILLE`+coords, Resources via HQR/`DISKFUNC`) cleans up LBA2 now and is
   reusable for LBA1 later. Prefer these over facades around Layer-2 game content
@@ -145,7 +146,8 @@ content** — the split is rarely a whole domain, it runs *through* each one:
   more limited 3D path. Hosting LBA1 here means bringing its *content* onto this *newer*
   engine, not merging two equals.
 - **twin-e / TwinEngine** already runs both titles via reimplementation — feasibility is
-  proven. The original-source path is harder but preservation-faithful.
+  proven. The original-source path is harder but preservation-faithful. The concrete
+  per-subsystem porting cost is assessed in [LBA1_PORTING_SURFACE.md](LBA1_PORTING_SURFACE.md).
 - Layer tags here are v0 judgments from module evidence; pin per-module before relying on a
   tag for a specific facade.
 

--- a/docs/LBA1_PORTING_SURFACE.md
+++ b/docs/LBA1_PORTING_SURFACE.md
@@ -143,8 +143,10 @@ opcode-remap table).
 
 **Biggest unknowns — need hands-on verification (a structure survey can't settle these):**
 
-1. **Exact LBA1 body poly-record byte layout** vs LBA2 `STRUC_POLY3` / `T_BODY_HEADER` —
-   byte-diff one real body from each game. Gates models *and* anims.
+1. **LBA1 body per-poly record byte layout.** The *header* is now byte-decoded (see "Body
+   header byte-diff" below) — the transcoder's outer shape is known. What remains is the
+   per-polygon record format inside the polys block (material / vertex-count / colour /
+   normal-index fields). Gates the converter's inner loop and anim group alignment.
 2. **LZS vs LZSS decompressor equivalence** — *substantially verified* (2026-06-04): LBA2's
    `ExpandLZ` decompresses LBA1 method-1 blobs to their exact declared sizes (BODY/SCENE
    samples). A direct byte-diff against LBA1's own `Expand` output would close it fully.
@@ -190,3 +192,25 @@ Ran `scripts/dev/hqr_inspect.py` (the lba2cc HQR reader) against the LBA1 retail
   byte-diff (unknown #1), but the format's front is confirmed.
 - The 134 / 134 / 8715 GRI / BLL / BRK split is real, with matched grid↔block-library counts —
   the three-HQR background packaging from verdict #4.
+
+### Body header byte-diff
+
+Dumped BODY entry 1 from each game (`hqr_inspect.py --dump`) and decoded the headers against
+the two layouts (LBA1 `P_OBJET.ASM`; LBA2 `T_BODY_HEADER`, `AFF_OBJ.H:96`). Both entry-1
+bodies share `YMax`=1240 and a tall narrow footprint — almost certainly both Twinsen, three
+years apart.
+
+| Field | LBA1 | LBA2 |
+|---|---|---|
+| Info / version | `U16` (=3) | `S32` (=272) |
+| Header size | implicit (14 B) | explicit `SizeHeader`=96 + `Dummy` |
+| Bounding box | 6× **s16** (12 B): X[-253,260] Y[0,1240] Z[-153,200] | 6× **S32** (24 B): X[-250,250] Y[0,1240] Z[-250,250] |
+| Element access | **sequential** blocks (polys → lines → spheres) | explicit **count+offset table** (random access) |
+| Sections | polys, lines, spheres | groups, points, normals, normFaces, polys, lines, spheres, **textures** |
+| Compression in BODY.HQR | LZSS (method 1) | **LZMIT** (method 2) |
+
+The **transcoder's outer shape is now known**: widen the 16-bit fields to 32-bit, synthesize
+`SizeHeader` + the count/offset table, and emit groups/normals/textures sections (textures
+empty for LBA1). Remaining for unknown #1: the per-poly record bytes inside the polys block.
+(LBA2's BODY.HQR is LZMIT-compressed — method 2, absent from LBA1 — and the tool decoded it,
+confirming the reader handles both.)

--- a/docs/LBA1_PORTING_SURFACE.md
+++ b/docs/LBA1_PORTING_SURFACE.md
@@ -9,7 +9,7 @@
 
 ## Summary
 
-LBA1 (`~/code/lba-hacking/lba1-classic`, 1994, C+ASM) and this engine (LBA2, 1997 + port)
+LBA1 (the `lba1-classic` community source, 1994, C+ASM) and this engine (LBA2, 1997 + port)
 are the same Adeline codebase one generation apart. That is *why* most content formats line
 up: the divergence is concentrated in **I/O wrappers, the media stack, and rendering
 capability** (and the capability gap runs the helpful direction — LBA2 is a superset). The
@@ -179,7 +179,7 @@ opcode remap + integrating GPLv2 FLA/MIDI decoders** — not in re-architecting 
 ## Verified against LBA1 retail data (2026-06-04)
 
 Ran `scripts/dev/hqr_inspect.py` (the lba2cc HQR reader) against the LBA1 retail archives in
-`../LBA1`. **Every one parsed with the LBA2 tool — the container format is drop-in.**
+a local LBA1 install. **Every one parsed with the LBA2 tool — the container format is drop-in.**
 
 | HQR | Present | Compression | Note |
 |---|---|---|---|

--- a/docs/LBA1_PORTING_SURFACE.md
+++ b/docs/LBA1_PORTING_SURFACE.md
@@ -36,9 +36,9 @@ Same format: `[U32 total]`, a table of U32 offsets, each blob prefixed by
 uses methods 0 (stored) / 1 (LZS); LBA2 (`LIB386/SYSTEM/HQFILE.CPP`, `HQR.H:16`: "0 stored,
 1 LZSS, 2 LZMIT") reads `method <= 2`. The buffered LRU manager (`HQR_Init_Ressource`/
 `HQR_Get`/`HQR_Del_Bloc`) is the same design on both sides. **LBA1 HQRs load on the LBA2
-engine unchanged.** One thing to verify: the `CompressMethod + 1` reindex in
-`HQF_LoadClose` suggests the LZ enum was renumbered — confirm LBA1 method-1 blobs decompress
-byte-identical.
+engine unchanged.** **Verified (2026-06-04)** with `scripts/dev/hqr_inspect.py`: all 14
+LBA1 HQRs read with the LBA2 tool, only methods 0/1 appear (no LZMIT), and LZSS entries
+decompress to their exact declared sizes. See "Verified against LBA1 retail data" below.
 
 ### 2. 3D body / model — needs a transcoder
 
@@ -145,8 +145,9 @@ opcode-remap table).
 
 1. **Exact LBA1 body poly-record byte layout** vs LBA2 `STRUC_POLY3` / `T_BODY_HEADER` —
    byte-diff one real body from each game. Gates models *and* anims.
-2. **LZS vs LZSS decompressor equivalence** — the `CompressMethod + 1` reindex hints at an
-   enum renumber; confirm LBA1 method-1 blobs decompress byte-identical.
+2. **LZS vs LZSS decompressor equivalence** — *substantially verified* (2026-06-04): LBA2's
+   `ExpandLZ` decompresses LBA1 method-1 blobs to their exact declared sizes (BODY/SCENE
+   samples). A direct byte-diff against LBA1's own `Expand` output would close it fully.
 3. **Shared-opcode operand encodings** — opcode numbers 0–56 align; confirm each reads the
    same operand widths/order in both `GERELIFE`/`GERETRAK`.
 4. **Sprite record header** layout (LBA1 `INCRUST.C` vs LBA2 `INCRUST.CPP`).
@@ -156,3 +157,36 @@ opcode-remap table).
 **Net:** the engine is overwhelmingly capable of hosting LBA1 content because it is the same
 codebase one generation on. The work is concentrated in **format transcoders + a script
 opcode remap + replacing the FLA/MIDI media stack** — not in re-architecting any subsystem.
+
+## Verified against LBA1 retail data (2026-06-04)
+
+Ran `scripts/dev/hqr_inspect.py` (the lba2cc HQR reader) against the LBA1 retail archives in
+`../LBA1`. **Every one parsed with the LBA2 tool — the container format is drop-in.**
+
+| HQR | Present | Compression | Note |
+|---|---|---|---|
+| BODY | 132 | LZSS | 3D models |
+| ANIM | 516 | LZSS | animations |
+| FILE3D | 82 | stored | |
+| INVOBJ | 28 | LZSS | inventory objects |
+| SPRITES | 118 | LZSS + stored | |
+| SCENE | 120 | LZSS | script-bearing scene blobs |
+| RESS | 53 | LZSS + stored | palette/font/etc. |
+| TEXT | 140 | LZSS + stored | |
+| SAMPLES | 230 | LZSS + stored | sound effects |
+| MIDI_MI / MIDI_SB | 33 each | LZSS + stored | MIDI music (the media wall) |
+| LBA_GRI | 134 | LZSS | scene grids |
+| LBA_BLL | 134 | LZSS | block libraries |
+| LBA_BRK | 8715 | LZSS + stored | brick atlas |
+
+- **Only methods 0 (stored) and 1 (LZSS) appear — no LZMIT (method 2) anywhere.** LZMIT was
+  an LBA2 addition, so the LBA2 reader is a strict superset for LBA1 data (verdict #1).
+- **The LZSS decompressor round-trips.** BODY entry 1 (csize 4288 → 6858) and SCENE entry 1
+  (3211 → 4247) decompress to their exact declared `SizeFile`. Moves unknown #2 from open to
+  substantially verified.
+- **The body header matches the analysis.** BODY entry 1 begins `Info=0x0003` then a 6×s16 ZV
+  bbox (`-253, 260, 0, 1240, -153, 200`) — a sane object bounding box, exactly the "Info word
+  + 12-byte ZV bbox" layout in verdict #2. The per-poly records below still want a full
+  byte-diff (unknown #1), but the format's front is confirmed.
+- The 134 / 134 / 8715 GRI / BLL / BRK split is real, with matched grid↔block-library counts —
+  the three-HQR background packaging from verdict #4.

--- a/docs/LBA1_PORTING_SURFACE.md
+++ b/docs/LBA1_PORTING_SURFACE.md
@@ -143,10 +143,10 @@ opcode-remap table).
 
 **Biggest unknowns — need hands-on verification (a structure survey can't settle these):**
 
-1. **LBA1 body per-poly record byte layout.** The *header* is now byte-decoded (see "Body
-   header byte-diff" below) — the transcoder's outer shape is known. What remains is the
-   per-polygon record format inside the polys block (material / vertex-count / colour /
-   normal-index fields). Gates the converter's inner loop and anim group alignment.
+1. **LBA1 body per-poly record** — *resolved* (see "Per-poly record" below). Both the header
+   and the polygon-record format are decoded. The remaining body-transcoder work is
+   engineering, not reverse-engineering: n-gon triangulation, type-grouping, index-stride
+   conversion, and face-normal synthesis.
 2. **LZS vs LZSS decompressor equivalence** — *substantially verified* (2026-06-04): LBA2's
    `ExpandLZ` decompresses LBA1 method-1 blobs to their exact declared sizes (BODY/SCENE
    samples). A direct byte-diff against LBA1's own `Expand` output would close it fully.
@@ -211,6 +211,46 @@ years apart.
 
 The **transcoder's outer shape is now known**: widen the 16-bit fields to 32-bit, synthesize
 `SizeHeader` + the count/offset table, and emit groups/normals/textures sections (textures
-empty for LBA1). Remaining for unknown #1: the per-poly record bytes inside the polys block.
-(LBA2's BODY.HQR is LZMIT-compressed — method 2, absent from LBA1 — and the tool decoded it,
+empty for LBA1). (LBA2's BODY.HQR is LZMIT-compressed — method 2, absent from LBA1 — and the tool decoded it,
 confirming the reader handles both.)
+
+### Per-poly record (the transcoder's inner loop)
+
+Decoded LBA1's polygon format from its actual parser (`P_OBJET.ASM:247–368` — the `lods`
+stream *is* the on-disk layout) and LBA2's from `AFF_OBJ.INC` plus a real decode of body 1.
+
+**LBA1 — one flat, material-tagged list, variable-size records:**
+
+```
+count : U16
+per poly:
+  material : U8     # 0..10; >=9 gouraud, >=7 flat, else triste/trame
+  nbpoints : U8     # vertex count — VARIABLE (n-gon)
+  colour   : U16
+  vertices : nbpoints x  pointIndex(U16)                     # flat / triste
+           | nbpoints x [normalIndex(U16), pointIndex(U16)]  # gouraud
+```
+
+Point indices are stored pre-multiplied by the point stride.
+
+**LBA2 — type-grouped, fixed-size records.** Body 1's polys block (off 3320, 281 polys)
+opens with `STRUC_POLY_HEADER{ TypePoly=0x8000, NbPoly=2, OffNextType=32 }`, then two
+`STRUC_POLY4_LIGHT` records — the first decoding cleanly as a quad
+(`P1..P4 = 162,163,164,165  Couleur=0x10c5  Normale=148`). `OffNextType=32` = 8-byte header +
+2×12-byte records. Each type group chains to the next. Record types: `POLY3/4_LIGHT` (12 B),
+`POLY3_TEXTURE` (24 B), `POLY4_TEXTURE` (32 B), plus ENV variants — material is encoded in
+the **type word**, not a per-poly byte.
+
+**The transcoder's inner loop, fully specified (engineering, not RE):**
+
+1. **Triangulate n-gons** — LBA1 polys carry a variable `nbpoints`; LBA2 records are tri or
+   quad only, so polys with >4 vertices must be split.
+2. **Group by type** — LBA1 is a flat material-tagged list; LBA2 needs type-grouped blocks
+   with `STRUC_POLY_HEADER` + `OffNextType` chaining. Map LBA1 material → LBA2 `_LIGHT` type
+   (LBA1 has no textures).
+3. **Convert index stride** — LBA1 point indices are pre-multiplied by the point stride;
+   LBA2 uses plain `P1..Pn` indices.
+4. **Synthesize face normals** — LBA2 has a separate `NormFaces` section + per-record
+   `Normale`; LBA1 carries only per-vertex normals, and only on gouraud polys.
+
+This closes porting unknown #1: the body format is decoded end to end.

--- a/docs/LBA1_PORTING_SURFACE.md
+++ b/docs/LBA1_PORTING_SURFACE.md
@@ -14,7 +14,8 @@ are the same Adeline codebase one generation apart. That is *why* most content f
 up: the divergence is concentrated in **I/O wrappers, the media stack, and rendering
 capability** (and the capability gap runs the helpful direction — LBA2 is a superset). The
 work to host LBA1 is **format transcoders (bodies, scenes) + a script opcode-remap +
-replacing the FLA/MIDI media stack** — not re-architecting any subsystem.
+integrating GPLv2 FLA/MIDI decoders** (both exist upstream — see verdict 7) — not
+re-architecting any subsystem.
 
 ## Per-subsystem verdict
 
@@ -26,7 +27,7 @@ replacing the FLA/MIDI media stack** — not re-architecting any subsystem.
 | 4 | Scene / grid / cube | **Compatible model, packaging shim** | Same brick/block payloads; LBA1 3 HQRs → LBA2 merged container |
 | 5 | Sprites / palettes | **Likely compatible, verify** | Same HQR container; sprite record header needs a byte-diff |
 | 6 | Render capability | **Free win (LBA2 superset)** | Running less-capable content on a more-capable renderer |
-| 7 | Audio + video | **Fundamentally different** | FLA video + MIDI music; LBA2 has neither decoder |
+| 7 | Audio + video | **Solved upstream (GPLv2)** | FLA + MIDI have GPLv2-compatible decoders in sibling LBALab projects |
 | 8 | Script VM (Life/Track) | **Opcode-remap shim** | Same VM; opcodes 0–56 identical, collisions at 57+ |
 
 ### 1. HQR container — compatible as-is
@@ -91,17 +92,29 @@ paths. The only consequence is cosmetic: LBA1 was authored for painter's order a
 so verify LBA1 scenes look right under LBA2's sort tree and resolution scaling (the exterior
 draw-order quirk in the project notes could surface differently).
 
-### 7. Audio + video — fundamentally different (the hard wall)
+### 7. Audio + video — different stack, but solved upstream
 
-- **Video:** LBA1 = **FLA/FLI** (Autodesk-Animator-derived; `FLA.H`, `PLAYFLA.C`). LBA2 =
-  **Smacker** (`libsmacker`, `SMACKER.CPP`, `PLAYACF.CPP`). LBA2 has **no FLA decoder**.
-  LBA1 cutscenes need a new FLA player ported in, or an offline FLA→Smacker transcode.
-- **Audio:** LBA1 = DLL-driver mixer (`MIXER.C`) + separate `LIB_MIDI` and `LIB_SAMP`; uses
-  **MIDI music** (`LM_PLAY_MIDI`). LBA2 = the `AIL/` abstraction (SDL/Miles/null). Sound
-  effects live in HQR on both sides (tractable); **music + cutscenes are not drop-in**.
+Originally flagged as the hard wall — LBA1 uses **FLA/FLI** video (`FLA.H`, `PLAYFLA.C`) and
+**XMIDI music** (`MIXER.C` + `LIB_MIDI`, via `LM_PLAY_MIDI`), while LBA2 uses **Smacker**
+(`libsmacker`, `SMACKER.CPP`) and the `AIL/` audio abstraction with no FLA/MIDI decoder
+in-tree. But both halves have **GPLv2-compatible reference implementations in sibling LBALab
+projects**, and this repo is itself **GPLv2** (`LICENSE`), so they can be adapted/vendored
+directly rather than reverse-engineered:
 
-This is the biggest single chunk of net-new engine work, or it is pushed into an offline
-asset-transcode pipeline.
+- **MIDI** — [lba-midi-play](https://github.com/LBALab/lba-midi-play) (GPL-2.0, C99). The LBA
+  MIDI in `MIDI_MI.HQR` / `MIDI_SB.HQR` is **XMIDI** (Miles Sound System) in the DOS versions,
+  native SMF in the Windows port. Its isolatable `xmidi.c` converts XMIDI→SMF; bundled
+  TinySoundFont + TML synthesize to float32 stereo PCM, routable through this engine's `AIL/`
+  audio path. Drop in the converter + a soft-synth/soundfont and MIDI is solved.
+- **Video** — [twin-e `flamovies.c`](https://github.com/LBALab/twin-e/blob/main/src/flamovies.c)
+  (GPLv2). A full FLA decoder: header (V1.3, 320×200, sample table), opcode dispatch
+  (`processFrame`), RLE key/delta frames (`drawKeyFrame`/`drawDeltaFrame`), palette/fade, and
+  sample playback. It leans on twin-e's screen/sample/file abstractions, so it is *adaptable,
+  not drop-in* — re-target the decode loop at this engine's framebuffer + sample systems.
+
+So the media stack is an **integration job** (wire vendored GPLv2 decoders to the
+framebuffer/audio), not a from-scratch decoder build. The genuinely from-scratch work shifts
+to the **format transcoders** (body, scene), now fully specified above.
 
 ### 8. Script VM — opcode-remap shim
 
@@ -128,18 +141,21 @@ body alignment); brick/block/column world payloads (drop-in; only the multi-HQR 
 is work); render capability (free — LBA2 is a strict superset); script VM model (same engine,
 opcode-remap table).
 
-**Hard (genuine divergence):**
-- **FLA video + MIDI music** — LBA2 has no decoder for either. Largest net-new work, or an
-  offline transcode pipeline. *Dominant effort.*
+**Hard (genuine divergence), now the dominant effort:**
 - **3D body transcoder** — biggest per-asset format conversion (sequential entity stream →
-  offset-table `T_BODY_HEADER`); gates animation alignment.
+  offset-table `T_BODY_HEADER` with type-grouped polys; format fully decoded above); gates
+  animation alignment.
 - **Background repackaging** — three LBA1 HQRs → one LBA2 `T_BKG_HEADER` with synthesized
   per-scene `T_GRI_HEADER`.
+- **FLA video + MIDI music** — *no longer a from-scratch build*: GPLv2-compatible decoders
+  exist upstream (lba-midi-play, twin-e `flamovies.c`) and this repo is GPLv2, so the work is
+  integration against the framebuffer/audio, not reverse-engineering.
 
 ## Dominant effort and biggest unknowns
 
-**Dominant effort:** (1) the FLA/MIDI media wall (port a player or transcode offline), and
-(2) the body/scene transcoders. Everything else is wrapper-level.
+**Dominant effort:** the body/scene **format transcoders** (now fully specified — so it is
+engineering, not RE). The FLA/MIDI media stack, previously the dominant unknown, is downgraded
+to integrating existing GPLv2 decoders. Everything else is wrapper-level.
 
 **Biggest unknowns — need hands-on verification (a structure survey can't settle these):**
 
@@ -158,7 +174,7 @@ opcode-remap table).
 
 **Net:** the engine is overwhelmingly capable of hosting LBA1 content because it is the same
 codebase one generation on. The work is concentrated in **format transcoders + a script
-opcode remap + replacing the FLA/MIDI media stack** — not in re-architecting any subsystem.
+opcode remap + integrating GPLv2 FLA/MIDI decoders** — not in re-architecting any subsystem.
 
 ## Verified against LBA1 retail data (2026-06-04)
 

--- a/docs/LBA1_PORTING_SURFACE.md
+++ b/docs/LBA1_PORTING_SURFACE.md
@@ -1,0 +1,158 @@
+# LBA1 → lba2cc porting surface
+
+> **Status: DRAFT / living document (v0).** Companion to [ENGINE_GAME_SEAM.md](ENGINE_GAME_SEAM.md),
+> [ENGINE_GAME_INTERFACE.md](ENGINE_GAME_INTERFACE.md), and [ARCHITECTURE.md](ARCHITECTURE.md).
+> A structure-level survey of what it would take to host **LBA1 content** on the **lba2cc
+> engine**. Confidence is high on container/struct layout (parsers read on both sides),
+> lower on exact body-record bytes and opcode operands (flagged below). Truth hierarchy:
+> code > this document.
+
+## Summary
+
+LBA1 (`~/code/lba-hacking/lba1-classic`, 1994, C+ASM) and this engine (LBA2, 1997 + port)
+are the same Adeline codebase one generation apart. That is *why* most content formats line
+up: the divergence is concentrated in **I/O wrappers, the media stack, and rendering
+capability** (and the capability gap runs the helpful direction — LBA2 is a superset). The
+work to host LBA1 is **format transcoders (bodies, scenes) + a script opcode-remap +
+replacing the FLA/MIDI media stack** — not re-architecting any subsystem.
+
+## Per-subsystem verdict
+
+| # | Subsystem | Verdict | Why |
+|---|---|---|---|
+| 1 | Resource container (HQR) | **Compatible as-is** | Same format; LBA2 natively reads LBA1's methods 0/1 |
+| 2 | 3D body / model | **Needs transcoder** | Same model, different on-disk encoding; LBA2 superset (textures) |
+| 3 | Animation | **Compatible as-is** | Same frame math/layout; rides on body group alignment |
+| 4 | Scene / grid / cube | **Compatible model, packaging shim** | Same brick/block payloads; LBA1 3 HQRs → LBA2 merged container |
+| 5 | Sprites / palettes | **Likely compatible, verify** | Same HQR container; sprite record header needs a byte-diff |
+| 6 | Render capability | **Free win (LBA2 superset)** | Running less-capable content on a more-capable renderer |
+| 7 | Audio + video | **Fundamentally different** | FLA video + MIDI music; LBA2 has neither decoder |
+| 8 | Script VM (Life/Track) | **Opcode-remap shim** | Same VM; opcodes 0–56 identical, collisions at 57+ |
+
+### 1. HQR container — compatible as-is
+
+Same format: `[U32 total]`, a table of U32 offsets, each blob prefixed by
+`{U32 SizeFile, U32 CompressedSizeFile, U16 CompressMethod}`. LBA1 (`LIB386/LIB_SYS/HQ_RESS.C`)
+uses methods 0 (stored) / 1 (LZS); LBA2 (`LIB386/SYSTEM/HQFILE.CPP`, `HQR.H:16`: "0 stored,
+1 LZSS, 2 LZMIT") reads `method <= 2`. The buffered LRU manager (`HQR_Init_Ressource`/
+`HQR_Get`/`HQR_Del_Bloc`) is the same design on both sides. **LBA1 HQRs load on the LBA2
+engine unchanged.** One thing to verify: the `CompressMethod + 1` reindex in
+`HQF_LoadClose` suggests the LZ enum was renumbered — confirm LBA1 method-1 blobs decompress
+byte-identical.
+
+### 2. 3D body / model — needs a transcoder
+
+Same conceptual model (header + groups + points + normals + polys/lines/spheres), different
+encoding. LBA1 (`P_OBJET.ASM`): `Info` word + 12-byte ZV bbox + sequential blocks (polys,
+lines, spheres); three entity types; flat/gouraud/dither materials; **no textures**. LBA2
+(`AFF_OBJ.H` `T_BODY_HEADER`): an explicit offset/count table
+(`OffGroupes/OffPoints/OffNormales/OffPolys/OffLines/OffSpheres/OffTextures`) plus a full
+textured + z-buffered poly family and quad polys with UVs. LBA2 renders everything LBA1
+bodies contain (flat/gouraud/dither/line/sphere is a subset), so the LBA1 record just needs
+**transcoding** into `T_BODY_HEADER` + separated arrays. This is the dominant per-asset
+model work, and it gates animation (group indices must line up afterward).
+
+### 3. Animation — compatible as-is
+
+The strongest match. Frame math is identical: LBA2 `FRAME.CPP:46`
+`ofsFrame = (nbGroups*8 + 8)*frame + 8` equals LBA1 `P_ANIM.ASM` `SetAnimObjet`. Same header
+`[U16 nbframes][U16 nbGroups]`, same 8-byte per-frame info, same `nbGroups × 8` per-group
+keyframes (`{Type, Alpha, Beta, Gamma}`), same engine primitives (`SetAnimObjet`,
+`SetInterAnimObjet`, `GetNbFramesAnim`). LBA1 anims should drive LBA2's anim engine
+unchanged **provided the body they animate has the same group count/order** — i.e. anim
+compatibility rides on the body transcoder (#2).
+
+### 4. Scene / grid / cube — compatible model, packaging shim
+
+Same brick-isometric world model and algorithms line-for-line: `BufCube/BufMap/TabBlock`,
+`HEADER_BLOCK`, the used-block bitmap, `DecompColonne` column RLE, `LoadUsedBrick`'s
+four-pass brick renumbering. The packaging differs: LBA1 keeps three HQRs (`LBA_GRI`,
+`LBA_BLL`, `LBA_BRK`); LBA2 merges them under `T_BKG_HEADER` (index offsets into one
+container) + per-scene `T_GRI_HEADER {My_Bll, My_Grm, UsedBlock[32]}`, and raised limits
+(`NB_COLON` 28→256, `MAX_BRICK` 150→256) and added GRM overlay objects. A converter
+re-indexes LBA1's three HQRs into LBA2's merged container and synthesizes the headers; the
+brick/block payloads don't change. Medium, mechanical.
+
+### 5. Sprites / palettes — likely compatible, verify
+
+Both store sprites/inventory/font in HQR (`HQRPtrSpriteExtra`, `InventoryObj`), so the
+wrapper is solved. Both are 256-color palette-indexed (768-byte VGA tables). Unknown: the
+per-sprite record header (offset/width/height/clip) byte layout, LBA1 `INCRUST.C` vs LBA2
+`INCRUST.CPP` — same subsystem name, needs a byte-diff. Probable small shim.
+
+### 6. Render capability — free win (LBA2 is a superset)
+
+The one place the asymmetry helps. LBA1: MCGA-first (`MCGA.C`), three body entity types,
+flat/gouraud/dither, **no texture mapping, no z-buffer**, draw order via **bubble-sort
+painter's** (`BUBSORT.C`). LBA2: SVGA, the full `pol_work` filler set (flat, gouraud,
+textured, textured+z-buffer, +fog, sphere, clip), and the dependency-graph **sort tree**
+(`SORT.CPP`). No capability *gap* to fill — LBA1 bodies simply won't exercise LBA2's texture
+paths. The only consequence is cosmetic: LBA1 was authored for painter's order at 320×200,
+so verify LBA1 scenes look right under LBA2's sort tree and resolution scaling (the exterior
+draw-order quirk in the project notes could surface differently).
+
+### 7. Audio + video — fundamentally different (the hard wall)
+
+- **Video:** LBA1 = **FLA/FLI** (Autodesk-Animator-derived; `FLA.H`, `PLAYFLA.C`). LBA2 =
+  **Smacker** (`libsmacker`, `SMACKER.CPP`, `PLAYACF.CPP`). LBA2 has **no FLA decoder**.
+  LBA1 cutscenes need a new FLA player ported in, or an offline FLA→Smacker transcode.
+- **Audio:** LBA1 = DLL-driver mixer (`MIXER.C`) + separate `LIB_MIDI` and `LIB_SAMP`; uses
+  **MIDI music** (`LM_PLAY_MIDI`). LBA2 = the `AIL/` abstraction (SDL/Miles/null). Sound
+  effects live in HQR on both sides (tractable); **music + cutscenes are not drop-in**.
+
+This is the biggest single chunk of net-new engine work, or it is pushed into an offline
+asset-transcode pipeline.
+
+### 8. Script VM — opcode-remap shim
+
+Same VM (see [ENGINE_GAME_INTERFACE.md](ENGINE_GAME_INTERFACE.md)): `*PtrPrg++` dispatch in
+both `GERELIFE` and `GERETRAK`, same condition opcodes (`LF_*`), comparison ops (`LT_*`),
+return widths. The command (`LM_*`) tables are **numerically identical for 0–56**.
+Divergence begins ~57:
+
+- **Renames at the same slot (semantically compatible):** `LM_SET_FLAG_CUBE`(31)→`LM_SET_VAR_CUBE`,
+  `LM_SET_FLAG_GAME`(36)→`LM_SET_VAR_GAME` (and LBA1's byte "flags" became LBA2's `S16`
+  vars — watch operand widths).
+- **True collisions (different command, same byte):** `LM_ZOOM`(57)→`LM_SHADOW_OBJ`,
+  `LM_PLAY_FLA`(64)→`LM_PLAY_ACF`, `LM_PLAY_MIDI`(65)→`LM_ECLAIR`,
+  `LM_INIT_PINGOUIN`(71)→`LM_MEMO_ARDOISE`. LBA2 then extends well past LBA1.
+
+So LBA1 scripts run on the LBA2 VM after an **opcode-remap table** — a contained shim, not a
+transpiler. Notably, the collided opcodes are largely the FLA/MIDI media opcodes, so this
+intersects the subsystem-7 media wall.
+
+## The easy part vs the hard part
+
+**Easy (shared lineage carries it):** HQR container (drop-in); animation (drop-in, rides on
+body alignment); brick/block/column world payloads (drop-in; only the multi-HQR repackaging
+is work); render capability (free — LBA2 is a strict superset); script VM model (same engine,
+opcode-remap table).
+
+**Hard (genuine divergence):**
+- **FLA video + MIDI music** — LBA2 has no decoder for either. Largest net-new work, or an
+  offline transcode pipeline. *Dominant effort.*
+- **3D body transcoder** — biggest per-asset format conversion (sequential entity stream →
+  offset-table `T_BODY_HEADER`); gates animation alignment.
+- **Background repackaging** — three LBA1 HQRs → one LBA2 `T_BKG_HEADER` with synthesized
+  per-scene `T_GRI_HEADER`.
+
+## Dominant effort and biggest unknowns
+
+**Dominant effort:** (1) the FLA/MIDI media wall (port a player or transcode offline), and
+(2) the body/scene transcoders. Everything else is wrapper-level.
+
+**Biggest unknowns — need hands-on verification (a structure survey can't settle these):**
+
+1. **Exact LBA1 body poly-record byte layout** vs LBA2 `STRUC_POLY3` / `T_BODY_HEADER` —
+   byte-diff one real body from each game. Gates models *and* anims.
+2. **LZS vs LZSS decompressor equivalence** — the `CompressMethod + 1` reindex hints at an
+   enum renumber; confirm LBA1 method-1 blobs decompress byte-identical.
+3. **Shared-opcode operand encodings** — opcode numbers 0–56 align; confirm each reads the
+   same operand widths/order in both `GERELIFE`/`GERETRAK`.
+4. **Sprite record header** layout (LBA1 `INCRUST.C` vs LBA2 `INCRUST.CPP`).
+5. **Behavioural fidelity under LBA2's sort tree + SVGA** for content authored against
+   LBA1's MCGA painter's-order at 320×200.
+
+**Net:** the engine is overwhelmingly capable of hosting LBA1 content because it is the same
+codebase one generation on. The work is concentrated in **format transcoders + a script
+opcode remap + replacing the FLA/MIDI media stack** — not in re-architecting any subsystem.

--- a/docs/LIFECYCLES.md
+++ b/docs/LIFECYCLES.md
@@ -109,3 +109,14 @@ Looping animations restart automatically without setting `ANIM_END`.
 - Flags: `ANIM_END`, `NEW_FRAME` in `SOURCES/COMMON.H`
 - Anim engine: `LIB386/ANIM/`
 
+## Related docs
+
+This is the *temporal* view of the engine. Two companion maps give the other axes:
+
+- **[ARCHITECTURE_GLOBALS.md](ARCHITECTURE_GLOBALS.md)** — *structure*: the ~200 globals
+  grouped into eight owning domains, with the shared-bus offenders. The pivots in the
+  state machines above (`ListObjet`, `CubeMode`, `Comportement`) are its worst offenders.
+- **[ENGINE_GAME_SEAM.md](ENGINE_GAME_SEAM.md)** — *layer*: engine vs game vs platform,
+  from a three-way diff against the LBA1 source. The main-loop steps `DoTrack` (3) and
+  `DoLife` (6) are where the engine crosses into the game's Life/Track scripts.
+


### PR DESCRIPTION
## What

A documentation-only corpus that maps the engine's architecture, to give the project a shared reasoning map and a sense of direction. No engine or behaviour changes.

The engine communicates largely through global state, which makes any one part hard to reason about in isolation. These docs make that structure legible — for onboarding, and for deciding where an eventual engine/game separation (strangler-fig, no rewrite) would pay off.

It maps the engine along three orthogonal axes, plus the engine/game interface and a grounded LBA1-hosting study:

- `docs/ARCHITECTURE.md` — index + roadmap; ties the set together and maps each domain to its deeper subsystem doc.
- `docs/ARCHITECTURE_GLOBALS.md` — **structure**: the ~200 globals grouped into 8 owning domains, with the shared-state "bus" offenders called out.
- `docs/ENGINE_GAME_SEAM.md` — **layer**: engine vs game vs platform, established from a three-way module diff across the LBA1 / LBA2-original / community trees.
- `docs/ENGINE_GAME_INTERFACE.md` — the Life/Track script VM that is the engine/game membrane.
- `docs/LIFECYCLES.md` — **time**: now cross-linked to the structural maps (main-loop order, ChangeCube phases).
- `docs/LBA1_PORTING_SURFACE.md` — a per-subsystem assessment of what hosting LBA1 content on this engine would take, with the HQR format and body layout verified against retail data.

## Why include the LBA1 study

The shared Adeline lineage makes "understand the engine well enough that LBA1 could run on it" a natural north-star. It's included as grounded feasibility for directionality — not a commitment, and not new scope. The finding: the engine is largely a superset of LBA1's, so the gap is format transcoders + a small script opcode-remap + reusing existing GPLv2 FLA/MIDI decoders, rather than re-architecting.

## Notes

- All docs are marked living **v0** — meant to be argued with and refined.
- Truth hierarchy in each: **code > the doc**. Some per-global domain assignments are provisional.
- Reproducible: the engine/game module diff is a `comm` over `SOURCES/` stems; the HQR/body verifications use `scripts/dev/hqr_inspect.py`. Anyone can re-run them.

Feedback on direction and any miscategorisations very welcome.