### PR TITLE
fix(voice): guard installed voice files from deletion + warn on incomplete vox

### DIFF
--- a/SOURCES/ASSET_PREFLIGHT.CPP
+++ b/SOURCES/ASSET_PREFLIGHT.CPP
@@ -10,6 +10,7 @@
 #include <SYSTEM/LIMITS.H>
 
 #include <stddef.h> /* NULL */
+#include <stdio.h>  /* snprintf */
 
 /* Internals in an anonymous namespace for internal linkage — the house
  * new-infrastructure style (see SOURCES/RES_PICKER.CPP). */
@@ -93,6 +94,31 @@ extern "C" int AssetPreflight(void) {
     if (!dirExists(path)) {
         Log_Warn("optional asset missing: vox/ (no voices)");
         ++missingOpt;
+    } else {
+        /* vox/ exists, but a bare subtree check misses an incomplete copy.
+           Each installed language has <lang>GAM.VOX (menu/common voices) plus
+           the per-scene banks <lang>000.VOX ... A GAM-only language plays menu
+           voices but goes silent for in-game dialogue, so warn per incomplete
+           language. Prefixes mirror ListLanguage in MESSAGE.CPP; "gam"/"000"
+           are case-resolved on disk by GetVoicePath (DiscoverEndingAndAppend). */
+        static const char *const kVoiceLangs[] = {"EN_", "FR_", "DE_",
+                                                  "SP_", "IT_", "PO_"};
+        const int nLang = (int)(sizeof kVoiceLangs / sizeof kVoiceLangs[0]);
+        for (i = 0; i < nLang; ++i) {
+            char voxName[64];
+            snprintf(voxName, sizeof voxName, "%sgam.VOX", kVoiceLangs[i]);
+            GetVoicePath(path, ADELINE_MAX_PATH, voxName, false);
+            if (!fileExists(path))
+                continue; /* language not installed */
+            snprintf(voxName, sizeof voxName, "%s000.VOX", kVoiceLangs[i]);
+            GetVoicePath(path, ADELINE_MAX_PATH, voxName, false);
+            if (!fileExists(path)) {
+                Log_Warn("voice data incomplete: %s per-scene banks missing "
+                         "(<lang>000.VOX ...) -- in-game dialogue will be silent",
+                         kVoiceLangs[i]);
+                ++missingOpt;
+            }
+        }
     }
 
     if (missingReq == 0 && missingOpt == 0)

--- a/SOURCES/DIRECTORIES.CPP
+++ b/SOURCES/DIRECTORIES.CPP
@@ -148,6 +148,17 @@ bool IsValidResourceDir(const char *path) {
     return Discover(NULL, 0, path, FILE_VALID_RES_DIR);
 }
 
+bool Directories_IsUnderResDir(const char *path) {
+    // Every Get*Path under the resource tree is built by appending to
+    // directoriesResDir, so a prefix match identifies installed game data.
+    // A false positive only ever *spares* a file from deletion (the safe
+    // direction), so the simple prefix test is deliberate.
+    if (path == NULL || directoriesResDir[0] == '\0') {
+        return false;
+    }
+    return strncmp(path, directoriesResDir, strlen(directoriesResDir)) == 0;
+}
+
 // --- Initialization ----------------------------------------------------------
 void InitDirectories(const char *userDir, const char *resDir,
                      const char *cfgDir, const char *CDPrefix,

--- a/SOURCES/DIRECTORIES.H
+++ b/SOURCES/DIRECTORIES.H
@@ -20,6 +20,10 @@ void GetDefaultResDir(char *outDir);     ///< Path for game resources
 /// True if \p path is a directory containing lba2.hqr (case-discovered).
 bool IsValidResourceDir(const char *path);
 
+/// True if \p path lives under the resolved resource (game-data) directory.
+/// Lets cleanup spare installed assets and only remove transient copies.
+bool Directories_IsUnderResDir(const char *path);
+
 void GetDefaultCfgPath(char *outPath, U16 pathMaxSize, const char *cfgFilename);
 
 void GetCfgPath(char *outPath, U16 pathMaxSize, const char *cfgFilename);

--- a/SOURCES/MESSAGE.CPP
+++ b/SOURCES/MESSAGE.CPP
@@ -469,6 +469,13 @@ void ClearVoiceFile() {
     pt = TabFileOnHD;
 
     for (i = 0; i < NbFileOnHD; i++, pt++) {
+        /* Never delete installed game-data voice files: only genuine CD->HD
+           temp copies are transient. Guards the player's assets even if
+           FlagKeepVoice somehow ends up 0 (e.g. a hand-edited/corrupt cfg).
+           On an HD install every voice file lives under the resource dir, so
+           this path effectively never deletes -- the intended invariant. */
+        if (Directories_IsUnderResDir(pt->NameHD))
+            continue;
         if (FileSize(pt->NameHD)) //  On ne sait jamais,
             Delete(pt->NameHD);   // un bug est si vite arrive :-o
     }


### PR DESCRIPTION
Two robustness fixes around per-language voice data, prompted by debugging an in-game voice outage that turned out to be a `vox/` copy missing its per-scene banks (only the `*_GAM.VOX` common voices were present).

## 1. Don't delete installed voice files
`ClearVoiceFile()` deletes every file it registered in `TabFileOnHD` whenever `FlagKeepVoice` is 0 — and `InitVoiceFile` registers *all* `.VOX` files it scans in the resource dir, not just transient CD→HD temp copies. So a hand-edited or corrupt cfg that flips the flag (or the `static FlagKeepVoice = 0` init firing before `InitLanguage`) could silently wipe the player's installed voice files.

Guard the delete loop with a new `Directories_IsUnderResDir()`: files under the resolved resource (game-data) directory are installed assets and are never deleted — only genuine transient copies are. On an HD install every voice file lives under the resource dir, so the loop effectively never deletes, which is the intended invariant. (A false-positive prefix match only ever *spares* a file — the safe direction.)

## 2. Preflight warns on incomplete voice data
The asset preflight only checked that `vox/` *exists*, so a copy holding just `<lang>_GAM.VOX` (and none of the per-scene `<lang>000.VOX …` banks) passed silently while in-game dialogue played mute. Deepen the check to warn per installed language whose per-scene banks are missing — this would have pointed straight at the problem at boot.

## Testing
- Host suite green (`make test`, 20/20).
- Preflight stays silent on complete data (`Assets     all present`).
- Against a `vox/` with only `EN_GAM.VOX`, preflight emits: `voice data incomplete: EN_ per-scene banks missing (<lang>000.VOX ...) -- in-game dialogue will be silent`.
- Build + clang-format clean.