### PR TITLE
fix(config): discard NUL-corrupted cfg on load so corruption self-heals

### DIFF
--- a/LIB386/SYSTEM/DEFFILE.CPP
+++ b/LIB386/SYSTEM/DEFFILE.CPP
@@ -113,6 +113,16 @@ S32 DefFileBufferInit(char *file, void *buffer, S32 maxsize) {
 
     Load(file, buffer);
 
+    /* Reject a blob with embedded NUL bytes as corrupt. A partial or garbage
+       write (e.g. a process killed mid-rewrite) injects NULs, and the in-place
+       load-modify-rewrite below would propagate them on every save -- sticky
+       corruption that never self-heals. Discarding it (treat as empty) makes
+       the next write regenerate a clean file from defaults. */
+    if (buffersize > 0 && memchr(buffer, 0, (size_t)buffersize) != NULL) {
+        LogPuts("Warning: DefFileBufferInit found embedded NULs (corrupt) - discarding");
+        buffersize = 0;
+    }
+
     // Re-entry from DefFileBufferWriteString passes the module-static FileName
     // back in as `file`, which aliases the strcpy destination. Self-copy is UB
     // (ASan: strcpy-param-overlap); skip the copy when source and dest alias.

--- a/tests/deffile/test_deffile_latin1.cpp
+++ b/tests/deffile/test_deffile_latin1.cpp
@@ -175,6 +175,33 @@ int main() {
         CHECK(std::strcmp(target, "hello") == 0);
     }
 
+    // ── Test 5: a NUL-corrupted cfg is discarded and self-heals on write ────
+    // A partial/garbage write injects NUL bytes mid-file (the real-world repro:
+    // a process killed mid-rewrite left ~1.5 KB of NULs after the first key).
+    // The in-place load-modify-rewrite would otherwise propagate those NULs on
+    // every save — sticky corruption that never recovers. DefFileBufferInit
+    // must treat such a blob as empty so the next write regenerates a clean,
+    // NUL-free file from defaults.
+    {
+        std::string corrupt = "FlagDisplayText: ON\r\n";
+        corrupt.append(2000, '\0'); // garbage NUL block
+        corrupt += "VoiceVolume: 112\r\n";
+        WriteFile(path, corrupt);
+
+        std::vector<char> buffer(8192, 0);
+        CHECK(DefFileBufferInit(path, &buffer[0], (S32)buffer.size()) == TRUE);
+
+        // Corrupt blob discarded -> every key reads as absent (caller defaults).
+        CHECK(DefFileBufferReadString("FlagDisplayText") == NULL);
+        CHECK(DefFileBufferReadString("VoiceVolume") == NULL);
+
+        // Next write produces a clean, NUL-free file carrying the new value.
+        CHECK(DefFileBufferWriteString("VoiceVolume", "100") == TRUE);
+        const std::string healed = ReadFile(path);
+        CHECK(healed.find('\0') == std::string::npos);
+        CHECK(healed.find("VoiceVolume: 100") != std::string::npos);
+    }
+
     std::remove(path);
     return 0;
 }


### PR DESCRIPTION
## Background
While debugging an in-game voice outage, the Linux `lba2.cfg` was found corrupted: a ~1.5 KB block of NUL bytes wedged after the first key. It stayed corrupt across launches and only a manual delete fixed it.

## Root cause
`DefFileBuffer` loads a `.cfg`/`.def` into a buffer and rewrites it **in place, one key at a time** (`DefFileBufferWriteString`: `OpenWrite` truncate → write buffer → reload, ~20× per `WriteConfigFile`). Once the file picks up embedded NUL bytes — e.g. a write interrupted mid-flush — the load-modify-rewrite copies them back on every save. The corruption is **sticky**: it never self-heals, because each rewrite faithfully reproduces the NULs already in the buffer. `ReadBufferString` skips NULs as control chars, so the parser doesn't notice.

## Fix
In `DefFileBufferInit`, treat a blob containing embedded NUL bytes as corrupt and discard it (read as empty). Every key then falls back to its default and the next write regenerates a clean, NUL-free file. Settings reset once, but the config heals instead of staying broken forever.

## Testing
- New `tests/deffile` case: a NUL-laced cfg reads as absent keys, and the next write produces a clean (NUL-free) file. **A/B-verified**: aborts without the guard (`CHECK ...ReadString("FlagDisplayText") == NULL`), passes with it.
- Host suite green (20/20); build + clang-format clean.

## Follow-up (not in this PR)
The other half — making the writer **atomic** (temp-file + rename) so an interrupted write can't inject NULs in the first place — needs a `rename` file primitive the platform layer doesn't expose yet. Tracked separately; the self-heal above makes any such injection non-fatal in the meantime.