### PR TITLE
feat(boot/console): colour the bookends and console, fix the · separator

### DIFF
--- a/LIB386/H/SYSTEM/LOG.H
+++ b/LIB386/H/SYSTEM/LOG.H
@@ -22,10 +22,23 @@ typedef enum {
 
 typedef struct LogSink LogSink; /* opaque handle */
 
-/* A formatted, ready-to-print line (no trailing newline). The console buffer
- * sink calls one of these for each record — the engine passes an adapter over
- * Console_Print, keeping this core free of any SOURCES dependency. */
-typedef void (*LogLineFn)(const char *line);
+/* The kind of line reaching the console sink, so its adapter can colour
+ * structural lines (the Log_Banner bookends, section headers) distinctly from
+ * ordinary text. NORMAL lines are coloured by severity; BANNER/SECTION get the
+ * structural accent (cyan, matching the terminal sink). */
+typedef enum {
+    LOG_LINE_NORMAL = 0,
+    LOG_LINE_BANNER,
+    LOG_LINE_SECTION
+} LogLineKind;
+
+/* A formatted, ready-to-print line (no trailing newline) plus its severity and
+ * kind. The console buffer sink calls one of these for each record — the engine
+ * passes an adapter over Console_Print, keeping this core free of any SOURCES
+ * dependency. Severity/kind are handed across so the adapter can colour the line
+ * (the console shows level/structure as colour, not a text tag); the core stays
+ * palette-agnostic. */
+typedef void (*LogLineFn)(const char *line, LogSeverity sev, LogLineKind kind);
 
 /* Install the fan-out (no-op under LBA_LOG_NO_SDL) and reset the sink registry.
  * Shutdown flushes and closes sinks and uninstalls the fan-out. */
@@ -42,6 +55,11 @@ void Log_Error(const char *fmt, ...);
  * For framing/banner output (e.g. the boot header). Admitted at INFO level for
  * per-sink filtering. */
 void Log_Raw(const char *fmt, ...);
+
+/* Banner line — verbatim like Log_Raw, but the terminal sink tints it cyan (the
+ * section-header colour). For the boot log's bookend lines: the identity header
+ * and the "Ready" closer. File and console sinks print it plain. INFO level. */
+void Log_Banner(const char *fmt, ...);
 
 /* Section markers — sinks render the header in their own idiom (the file sink
  * uses "==== Title ===="). EndSection has no file-sink output; it exists for

--- a/LIB386/SYSTEM/LOG.CPP
+++ b/LIB386/SYSTEM/LOG.CPP
@@ -24,6 +24,7 @@
 #define LBA_CAT_SECTION (SDL_LOG_CATEGORY_CUSTOM + 1)
 #define LBA_CAT_SECTION_END (SDL_LOG_CATEGORY_CUSTOM + 2)
 #define LBA_CAT_RAW (SDL_LOG_CATEGORY_CUSTOM + 3)
+#define LBA_CAT_BANNER (SDL_LOG_CATEGORY_CUSTOM + 4)
 #endif
 
 #define LOG_MSG_MAX 1024
@@ -38,7 +39,8 @@ namespace {
 enum { REC_NORMAL = 0,
        REC_SECTION_BEGIN = 1,
        REC_SECTION_END = 2,
-       REC_RAW = 3 };
+       REC_RAW = 3,
+       REC_BANNER = 4 };
 
 typedef void (*SinkWriteFn)(LogSink *sink, LogSeverity sev, int kind,
                             const char *msg);
@@ -106,8 +108,8 @@ void file_sink_write(LogSink *s, LogSeverity sev, int kind, const char *msg) {
         fprintf(s->fp, "==== %s ====\n", msg);
     else if (kind == REC_SECTION_END)
         ; /* no closer in the file */
-    else if (kind == REC_RAW)
-        fprintf(s->fp, "%s\n", msg);
+    else if (kind == REC_RAW || kind == REC_BANNER)
+        fprintf(s->fp, "%s\n", msg); /* banner is colour-only; file stays plain */
     else
         fprintf(s->fp, "[%s] %s\n", severity_tag(sev), msg);
     fflush(s->fp);
@@ -142,6 +144,8 @@ void term_sink_write(LogSink *s, LogSeverity sev, int kind, const char *msg) {
         for (int i = 0; i < LOG_TERM_WIDTH; ++i)
             fputc('-', out);
         fputs("\033[0m\n", out);
+    } else if (kind == REC_BANNER) {
+        fprintf(out, "\033[36m%s\033[0m\n", msg); /* cyan, like section rules */
     } else if (kind == REC_RAW) {
         fprintf(out, "%s\n", msg);
     } else {
@@ -154,7 +158,10 @@ void term_sink_write(LogSink *s, LogSeverity sev, int kind, const char *msg) {
  * NO_COLOR is set), so redirected output never gets ANSI escapes. */
 void noop_write(LogSink *, LogSeverity, int, const char *) {}
 
-/* --- Console buffer sink: monochrome text into the in-engine scrollback ---- */
+/* --- Console buffer sink: text into the in-engine scrollback ---------------
+ * Severity is conveyed to the engine adapter (it colours the line), so unlike
+ * the file sink there is no "[INFO]"/"[WARN]" text tag — the message goes
+ * through verbatim and the colour carries the level. */
 
 void console_sink_write(LogSink *s, LogSeverity sev, int kind, const char *msg) {
     if (!s->line_fn)
@@ -171,13 +178,16 @@ void console_sink_write(LogSink *s, LogSeverity sev, int kind, const char *msg) 
     if (kind == REC_SECTION_END)
         return; /* no closer line in the console */
     char line[LOG_MSG_MAX];
-    if (kind == REC_SECTION_BEGIN)
+    LogLineKind lkind = LOG_LINE_NORMAL;
+    if (kind == REC_SECTION_BEGIN) {
         (void)snprintf(line, sizeof line, "== %s ==", msg);
-    else if (kind == REC_RAW)
+        lkind = LOG_LINE_SECTION;
+    } else { /* REC_NORMAL / REC_RAW / REC_BANNER: verbatim, colour carries level */
         (void)snprintf(line, sizeof line, "%s", msg);
-    else
-        (void)snprintf(line, sizeof line, "[%s] %s", severity_tag(sev), msg);
-    s->line_fn(line);
+        if (kind == REC_BANNER)
+            lkind = LOG_LINE_BANNER;
+    }
+    s->line_fn(line, sev, lkind);
 }
 
 int terminal_enabled(void) {
@@ -258,6 +268,8 @@ int sdl_category_to_kind(int category) {
         return REC_SECTION_END;
     if (category == LBA_CAT_RAW)
         return REC_RAW;
+    if (category == LBA_CAT_BANNER)
+        return REC_BANNER;
     return REC_NORMAL;
 }
 
@@ -268,6 +280,8 @@ int kind_to_sdl_category(int kind) {
         return LBA_CAT_SECTION_END;
     if (kind == REC_RAW)
         return LBA_CAT_RAW;
+    if (kind == REC_BANNER)
+        return LBA_CAT_BANNER;
     return LBA_CAT_LOG;
 }
 
@@ -292,7 +306,7 @@ void log_fallback_write(LogSeverity sev, int kind, const char *msg) {
         return;
     if (kind == REC_SECTION_BEGIN)
         fprintf(stderr, "==== %s ====\n", msg);
-    else if (kind == REC_RAW)
+    else if (kind == REC_RAW || kind == REC_BANNER)
         fprintf(stderr, "%s\n", msg);
     else
         fprintf(stderr, "[%s] %s\n", severity_tag(sev), msg);
@@ -341,6 +355,7 @@ void Log_Init(void) {
     SDL_SetLogPriority(LBA_CAT_SECTION, SDL_LOG_PRIORITY_DEBUG);
     SDL_SetLogPriority(LBA_CAT_SECTION_END, SDL_LOG_PRIORITY_DEBUG);
     SDL_SetLogPriority(LBA_CAT_RAW, SDL_LOG_PRIORITY_DEBUG);
+    SDL_SetLogPriority(LBA_CAT_BANNER, SDL_LOG_PRIORITY_DEBUG);
     SDL_SetLogOutputFunction(sdl_output, 0);
 #endif
 }
@@ -395,6 +410,15 @@ void Log_Raw(const char *fmt, ...) {
     (void)vsnprintf(buf, sizeof buf, fmt, ap);
     va_end(ap);
     emit_formatted(LOG_INFO, REC_RAW, buf);
+}
+
+void Log_Banner(const char *fmt, ...) {
+    char buf[LOG_MSG_MAX];
+    va_list ap;
+    va_start(ap, fmt);
+    (void)vsnprintf(buf, sizeof buf, fmt, ap);
+    va_end(ap);
+    emit_formatted(LOG_INFO, REC_BANNER, buf);
 }
 
 void Log_BeginSection(const char *title) {

--- a/SOURCES/CONSOLE/CONSOLE.CPP
+++ b/SOURCES/CONSOLE/CONSOLE.CPP
@@ -52,6 +52,7 @@ static int s_cmd_count = 0;
 static struct cvar_entry s_cvars[CONSOLE_MAX_CVARS];
 static int s_cvar_count = 0;
 static char s_scrollback[CONSOLE_SCROLLBACK_LINES][CONSOLE_LINE_MAX];
+static U8 s_scrollback_col[CONSOLE_SCROLLBACK_LINES]; /* per-line ink (CONSOLE_COL_*) */
 static int s_scrollback_count = 0;
 static int s_scrollback_head = 0; /* next write position */
 static char s_input_line[CONSOLE_INPUT_MAX];
@@ -193,30 +194,27 @@ void Console_Close(void) {
 }
 
 /* Push one line to scrollback (no wrap). */
-static void scrollback_push_one(const char *line);
+static void scrollback_push_one(const char *line, U8 colour);
 
-static void scrollback_push(const char *line) {
-    scrollback_push_one(line);
-}
-
-static void scrollback_push_one(const char *line) {
+static void scrollback_push_one(const char *line, U8 colour) {
     size_t n = strlen(line);
     if (n >= CONSOLE_LINE_MAX)
         n = CONSOLE_LINE_MAX - 1;
     memcpy(s_scrollback[s_scrollback_head], line, n);
     s_scrollback[s_scrollback_head][n] = '\0';
+    s_scrollback_col[s_scrollback_head] = colour;
     s_scrollback_head = (s_scrollback_head + 1) % CONSOLE_SCROLLBACK_LINES;
     if (s_scrollback_count < CONSOLE_SCROLLBACK_LINES)
         s_scrollback_count++;
 }
 
 /* Break long lines at CONSOLE_WRAP_WIDTH (at space when possible) and push each. */
-static void scrollback_push_wrapped(const char *line) {
+static void scrollback_push_wrapped(const char *line, U8 colour) {
     size_t len = strlen(line);
     if (len == 0)
         return;
     if (len <= (size_t)CONSOLE_WRAP_WIDTH) {
-        scrollback_push_one(line);
+        scrollback_push_one(line, colour);
         return;
     }
     char seg[CONSOLE_LINE_MAX];
@@ -226,7 +224,7 @@ static void scrollback_push_wrapped(const char *line) {
         if (remain <= (size_t)CONSOLE_WRAP_WIDTH) {
             memcpy(seg, p, remain);
             seg[remain] = '\0';
-            scrollback_push_one(seg);
+            scrollback_push_one(seg, colour);
             break;
         }
         size_t take = CONSOLE_WRAP_WIDTH;
@@ -240,10 +238,31 @@ static void scrollback_push_wrapped(const char *line) {
         size_t n = (size_t)(br - p);
         memcpy(seg, p, n);
         seg[n] = '\0';
-        scrollback_push_one(seg);
+        scrollback_push_one(seg, colour);
         p = br;
         while (p < line + len && (*p == ' ' || *p == '\t'))
             p++;
+    }
+}
+
+/* Split buf on '\n' so callers can pass multi-line strings naturally (matches
+ * printf intuition: '\n' means "advance to a new line"). Empty segments — from
+ * leading, trailing, or repeated '\n' — are skipped (no spurious blank lines).
+ * The sink-for-tests sees exactly what gets pushed to the scrollback. */
+static void console_push_multiline(char *buf, U8 colour) {
+    char *p = buf;
+    while (*p) {
+        char *nl = strchr(p, '\n');
+        if (nl)
+            *nl = '\0';
+        if (*p) {
+            scrollback_push_wrapped(p, colour);
+            if (s_line_sink_for_tests)
+                s_line_sink_for_tests(p);
+        }
+        if (!nl)
+            break;
+        p = nl + 1;
     }
 }
 
@@ -254,27 +273,17 @@ void Console_Print(const char *fmt, ...) {
     vsnprintf(buf, CONSOLE_LINE_MAX, fmt, ap);
     va_end(ap);
     buf[CONSOLE_LINE_MAX - 1] = '\0';
+    console_push_multiline(buf, CONSOLE_COL_DEFAULT);
+}
 
-    /* Split on '\n' so callers can pass multi-line strings naturally
-     * (matches printf intuition: '\n' in the format means "advance to
-     * a new line"). Empty segments — from leading, trailing, or
-     * repeated '\n' — are skipped, matching the behavior console
-     * users expect (no spurious blank lines). The sink-for-tests
-     * sees exactly what gets pushed to the scrollback. */
-    char *p = buf;
-    while (*p) {
-        char *nl = strchr(p, '\n');
-        if (nl)
-            *nl = '\0';
-        if (*p) {
-            scrollback_push_wrapped(p);
-            if (s_line_sink_for_tests)
-                s_line_sink_for_tests(p);
-        }
-        if (!nl)
-            break;
-        p = nl + 1;
-    }
+void Console_PrintColored(int colour, const char *fmt, ...) {
+    char buf[CONSOLE_LINE_MAX];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(buf, CONSOLE_LINE_MAX, fmt, ap);
+    va_end(ap);
+    buf[CONSOLE_LINE_MAX - 1] = '\0';
+    console_push_multiline(buf, (U8)colour);
 }
 
 void Console_SetLineSinkForTests(Console_LineSinkFn sink) {
@@ -363,6 +372,166 @@ void Console_Update(void) {
     }
 }
 
+/* Map a Unicode codepoint to its CP437 byte (the AffStringToBuffer font), or 0
+ * if CP437 has no glyph for it. Covers the printable Latin-1 range — enough for
+ * the boot log's "·" separator and accented language names (Français, Español)
+ * and any Western-European text a command might print. */
+static unsigned char cp_to_cp437(unsigned int cp) {
+    switch (cp) {
+    case 0x00B7:
+        return 0xFA; /* · middle dot (the title separator) */
+    case 0x00B0:
+        return 0xF8; /* ° */
+    case 0x00A1:
+        return 0xAD; /* ¡ */
+    case 0x00BF:
+        return 0xA8; /* ¿ */
+    case 0x00AB:
+        return 0xAE; /* « */
+    case 0x00BB:
+        return 0xAF; /* » */
+    case 0x00A3:
+        return 0x9C; /* £ */
+    case 0x00C7:
+        return 0x80; /* Ç */
+    case 0x00FC:
+        return 0x81; /* ü */
+    case 0x00E9:
+        return 0x82; /* é */
+    case 0x00E2:
+        return 0x83; /* â */
+    case 0x00E4:
+        return 0x84; /* ä */
+    case 0x00E0:
+        return 0x85; /* à */
+    case 0x00E5:
+        return 0x86; /* å */
+    case 0x00E7:
+        return 0x87; /* ç (Français) */
+    case 0x00EA:
+        return 0x88; /* ê */
+    case 0x00EB:
+        return 0x89; /* ë */
+    case 0x00E8:
+        return 0x8A; /* è */
+    case 0x00EF:
+        return 0x8B; /* ï */
+    case 0x00EE:
+        return 0x8C; /* î */
+    case 0x00EC:
+        return 0x8D; /* ì */
+    case 0x00C4:
+        return 0x8E; /* Ä */
+    case 0x00C5:
+        return 0x8F; /* Å */
+    case 0x00C9:
+        return 0x90; /* É */
+    case 0x00E6:
+        return 0x91; /* æ */
+    case 0x00C6:
+        return 0x92; /* Æ */
+    case 0x00F4:
+        return 0x93; /* ô */
+    case 0x00F6:
+        return 0x94; /* ö */
+    case 0x00F2:
+        return 0x95; /* ò */
+    case 0x00FB:
+        return 0x96; /* û */
+    case 0x00F9:
+        return 0x97; /* ù */
+    case 0x00FF:
+        return 0x98; /* ÿ */
+    case 0x00D6:
+        return 0x99; /* Ö */
+    case 0x00DC:
+        return 0x9A; /* Ü */
+    case 0x00E1:
+        return 0xA0; /* á */
+    case 0x00ED:
+        return 0xA1; /* í */
+    case 0x00F3:
+        return 0xA2; /* ó */
+    case 0x00FA:
+        return 0xA3; /* ú */
+    case 0x00F1:
+        return 0xA4; /* ñ (Español) */
+    case 0x00D1:
+        return 0xA5; /* Ñ */
+    case 0x00DF:
+        return 0xE1; /* ß */
+    default:
+        return 0;
+    }
+}
+
+/* Fold a UTF-8 string into the CP437 bytes the font draws. ASCII passes through;
+ * mapped Latin-1 chars become their CP437 byte; anything unmapped becomes '?'.
+ * Runs at draw time only — the stored scrollback stays UTF-8 so
+ * Console_GetScrollback / --dump-state remain valid UTF-8. */
+static void utf8_to_cp437(const char *src, char *dst, size_t dstsz) {
+    size_t o = 0;
+    const unsigned char *s = (const unsigned char *)src;
+    while (*s && o + 1 < dstsz) {
+        unsigned char c = *s;
+        if (c < 0x80) { /* ASCII */
+            dst[o++] = (char)c;
+            s++;
+            continue;
+        }
+        unsigned int cp = 0;
+        if ((c & 0xE0) == 0xC0 && (s[1] & 0xC0) == 0x80) {
+            cp = ((unsigned int)(c & 0x1F) << 6) | (s[1] & 0x3F);
+            s += 2;
+        } else if ((c & 0xF0) == 0xE0 && (s[1] & 0xC0) == 0x80 && (s[2] & 0xC0) == 0x80) {
+            s += 3; /* 3-byte: outside CP437's reach */
+            dst[o++] = '?';
+            continue;
+        } else {
+            s++; /* stray continuation / invalid byte */
+            dst[o++] = '?';
+            continue;
+        }
+        unsigned char mapped = cp_to_cp437(cp);
+        dst[o++] = mapped ? (char)mapped : '?';
+    }
+    dst[o] = '\0';
+}
+
+/* Palette-independent RGB for the reserved console inks (see CONSOLE_COL_*). Any
+ * other ink is drawn from the scene palette by the compositor; only these
+ * reserved values resolve here, so "warn is yellow" / "banner is cyan" holds in
+ * every scene. */
+static void console_fixed_rgb(U8 idx, U8 *r, U8 *g, U8 *b) {
+    switch (idx) {
+    case CONSOLE_COL_BANNER:
+        *r = 90;
+        *g = 215;
+        *b = 220;
+        break; /* cyan (matches the terminal sink's bookend colour) */
+    case CONSOLE_COL_DEBUG:
+        *r = 130;
+        *g = 130;
+        *b = 130;
+        break; /* dim grey */
+    case CONSOLE_COL_WARN:
+        *r = 235;
+        *g = 205;
+        *b = 50;
+        break; /* yellow */
+    case CONSOLE_COL_ERROR:
+        *r = 235;
+        *g = 70;
+        *b = 60;
+        break; /* red */
+    default:
+        *r = 255;
+        *g = 255;
+        *b = 255;
+        break;
+    }
+}
+
 /** Draw scrollback + input line into s_console_buf (call when open and buffer ready). */
 static void Console_Draw(void) {
     int i, y, start, n;
@@ -404,8 +573,10 @@ static void Console_Draw(void) {
 
         for (i = 0; i < drawLines; i++) {
             int idx = (start + i) % CONSOLE_SCROLLBACK_LINES;
-            AffStringToBuffer(s_console_buf, s_console_w, 8, y,
-                              s_scrollback[idx], CONSOLE_TEXT_COLOUR);
+            char rendered[CONSOLE_LINE_MAX];
+            utf8_to_cp437(s_scrollback[idx], rendered, sizeof rendered);
+            AffStringToBuffer(s_console_buf, s_console_w, 8, y, rendered,
+                              s_scrollback_col[idx]);
             y += CONSOLE_LINE_HEIGHT;
         }
 
@@ -418,7 +589,9 @@ static void Console_Draw(void) {
     {
         char prompt[CONSOLE_INPUT_MAX + 8];
         snprintf(prompt, sizeof(prompt), "]> %s_", s_input_line);
-        AffStringToBuffer(s_console_buf, s_console_w, 8, y, prompt, CONSOLE_TEXT_COLOUR);
+        char rendered[CONSOLE_INPUT_MAX + 8];
+        utf8_to_cp437(prompt, rendered, sizeof rendered);
+        AffStringToBuffer(s_console_buf, s_console_w, 8, y, rendered, CONSOLE_TEXT_COLOUR);
     }
 }
 
@@ -487,6 +660,9 @@ void Console_PrePresent(U32 *frameBuffer, U32 pitch, U32 width, U32 height, cons
                 r = (U8)((br * 3) / 5);
                 g = (U8)((bg * 3) / 5);
                 b = (U8)((bb * 3) / 5);
+            } else if (idx >= CONSOLE_COL_BANNER && idx <= CONSOLE_COL_ERROR) {
+                /* Reserved console inks (banner/severity): fixed RGB. */
+                console_fixed_rgb(idx, &r, &g, &b);
             } else {
                 /* Text: solid colour from current palette. */
                 const U8 *c = palette_rgb + (idx * 3);
@@ -572,7 +748,7 @@ static void Console_SubmitLine(void) {
     if (s_input_len <= 0)
         return;
     s_input_line[s_input_len] = '\0';
-    scrollback_push(s_input_line);
+    scrollback_push_one(s_input_line, CONSOLE_COL_DEFAULT);
     /* Add to history */
     if (s_history_count < CONSOLE_HISTORY_SIZE) {
         strncpy(s_history[s_history_count], s_input_line, CONSOLE_LINE_MAX - 1);

--- a/SOURCES/CONSOLE/CONSOLE.H
+++ b/SOURCES/CONSOLE/CONSOLE.H
@@ -24,6 +24,20 @@ void Console_Close(void);
 void Console_Update(void);
 void Console_Print(const char *fmt, ...);
 
+/* Console text colours for Console_PrintColored. DEFAULT is a palette index
+ * (the scene's white, as plain Console_Print uses); the rest are
+ * palette-independent fixed-RGB inks resolved in the compositor, so "warn is
+ * yellow" / "banner is cyan" holds in every scene regardless of the loaded
+ * palette. BANNER matches the terminal sink's cyan for the boot bookends. */
+#define CONSOLE_COL_DEFAULT 15
+#define CONSOLE_COL_BANNER 250
+#define CONSOLE_COL_DEBUG 251
+#define CONSOLE_COL_WARN 252
+#define CONSOLE_COL_ERROR 253
+
+/** Like Console_Print, but draws the line in the given CONSOLE_COL_* colour. */
+void Console_PrintColored(int colour, const char *fmt, ...);
+
 /** Called from video layer pre-present callback. Overlays console onto ARGB frameBuffer if open. */
 void Console_PrePresent(U32 *frameBuffer, U32 pitch, U32 width, U32 height, const U8 *palette_rgb);
 

--- a/SOURCES/INITADEL.C
+++ b/SOURCES/INITADEL.C
@@ -88,19 +88,43 @@ atexit(SafeErrorMallocMsg);
 // ··········································································
 
 /* Adapter handed to the console buffer sink so the log core (now in LIB386)
-   stays free of any dependency on CONSOLE (SOURCES). */
-static void ConsoleLogLine(const char *line) { Console_Print("%s", line); }
+   stays free of any dependency on CONSOLE (SOURCES). Maps the line's kind and
+   severity to a console colour — the in-engine console shows level/structure as
+   colour, not a text tag. Banner/section lines get the cyan structural accent
+   (matching the terminal sink's bookends); ordinary lines colour by severity. */
+static void ConsoleLogLine(const char *line, LogSeverity sev, LogLineKind kind) {
+    int colour = CONSOLE_COL_DEFAULT;
+    if (kind == LOG_LINE_BANNER || kind == LOG_LINE_SECTION) {
+        colour = CONSOLE_COL_BANNER;
+    } else {
+        switch (sev) {
+        case LOG_DEBUG:
+            colour = CONSOLE_COL_DEBUG;
+            break;
+        case LOG_WARN:
+            colour = CONSOLE_COL_WARN;
+            break;
+        case LOG_ERROR:
+            colour = CONSOLE_COL_ERROR;
+            break;
+        case LOG_INFO:
+            colour = CONSOLE_COL_DEFAULT;
+            break;
+        }
+    }
+    Console_PrintColored(colour, "%s", line);
+}
 
 void InitAdeline(S32 argc, char *argv[]) {
     {
         char resFolderPath[ADELINE_MAX_PATH] = "";
         char saveFolderPath[ADELINE_MAX_PATH] = "";
-        char cfgFolderPath[ADELINE_MAX_PATH] = "";
+        char cfgFilePath[ADELINE_MAX_PATH] = "";
         char logFilePath[ADELINE_MAX_PATH] = "";
 
         GetResPath(resFolderPath, ADELINE_MAX_PATH, NULL);
         GetSavePath(saveFolderPath, ADELINE_MAX_PATH, NULL);
-        GetCfgPath(cfgFolderPath, ADELINE_MAX_PATH, NULL);
+        GetCfgPath(cfgFilePath, ADELINE_MAX_PATH, CFG_NAME);
 
         GetLogPath(logFilePath, ADELINE_MAX_PATH, LOG_NAME);
         CreateLog(logFilePath);
@@ -117,13 +141,13 @@ void InitAdeline(S32 argc, char *argv[]) {
         atexit(Log_Shutdown);
 
         /* Boot identity + key paths up top, so a pasted log is self-describing. */
-        Log_Raw("%s · %s %s · %d cores · %d GB RAM", APPNAME, LOG_PLATFORM_NAME,
-                LOG_ARCH_NAME, SDL_GetNumLogicalCPUCores(),
-                (SDL_GetSystemRAM() + 512) / 1024);
+        Log_Banner("%s · %s %s · %d cores · %d GB RAM", APPNAME, LOG_PLATFORM_NAME,
+                   LOG_ARCH_NAME, SDL_GetNumLogicalCPUCores(),
+                   (SDL_GetSystemRAM() + 512) / 1024);
         Log_Raw("Built %s %s", __DATE__, __TIME__);
         Log_Raw("Assets: %s", resFolderPath);
         Log_Raw("Saves:  %s", saveFolderPath);
-        Log_Raw("Config: %s", cfgFolderPath);
+        Log_Raw("Config: %s", cfgFilePath);
         Log_Raw("Log:    %s", logFilePath);
         Log_Raw("");
     }

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2548,7 +2548,7 @@ int main(int argc, char *argv[]) {
        video, window). The intro banners/logos that follow are a timed slideshow,
        deliberately not included. */
     Log_Raw("");
-    Log_Raw("======== Ready in %.2fs ========", (double)subsystemsMs / 1000.0);
+    Log_Banner("======== Ready in %.2fs ========", (double)subsystemsMs / 1000.0);
 
     BufText = (U8 *)SmartMalloc(BIG_FILE_DIA);
     if (!BufText)

--- a/docs/BOOT_LOG_PLAN.md
+++ b/docs/BOOT_LOG_PLAN.md
@@ -387,6 +387,32 @@ Decisions:
 - Per-subsystem sections dropped from boot; the section primitive
   (`Log_BeginSection`/`EndSection`, terminal `------`) stays as a latent,
   tested capability (unused for now).
+- **Bookend lines tinted.** The identity header and the `Ready` closer use a new
+  `Log_Banner()` primitive (record kind `REC_BANNER`, fifth SDL category) that
+  the terminal sink draws in cyan — the section-header colour. File and console
+  sinks print it verbatim (the tint is the terminal sink's alone; `adeline.log`
+  is unchanged), so the contract "call sites never know which sinks exist" holds
+  — no ANSI is baked into the call site. The middle path lines stay plain
+  `Log_Raw`.
+- **`Config` shows the file, not the folder.** Like the `Log:` line, it now
+  resolves with `CFG_NAME` (`Config: …/lba2.cfg`). `Assets`/`Saves` stay
+  directories (they hold many files); `Config`/`Log` are single named files.
+- **Console is now colour-coded (supersedes the "monochrome v1" of decisions 2,
+  6 and Phase 2).** The console sink drops the `[INFO]`/`[WARN]`/`[ERROR]` text
+  tag and conveys the level as colour instead: `LogLineFn` carries the
+  `LogSeverity`, the engine adapter (`ConsoleLogLine`) maps it to a
+  `CONSOLE_COL_*` ink, and `Console_PrintColored` stores a per-line colour. The
+  severity inks are **palette-independent fixed RGB** resolved in the
+  compositor (scene palettes are arbitrary, so "warn is yellow" can't rely on a
+  palette index); default/info stays on the scene's palette-white, so existing
+  text is unchanged. The log core stays palette-agnostic — it passes severity,
+  not colours. `LogLineFn` also carries a `LogLineKind` so the adapter tints the
+  **banner bookends and section headers cyan** in the console too, matching the
+  terminal sink's structural colour (banner/section → cyan, normal → severity).
+- **Console renders CP437; boot text is UTF-8.** `AffStringToBuffer` is a CP437
+  bitmap font, so the `·` separator (and accented language names like
+  `Français`/`Español`) is folded UTF-8 → CP437 at draw time. Stored scrollback
+  stays UTF-8, so `Console_GetScrollback` / `--dump-state` remain valid UTF-8.
 - **Accurate `Display` line.** Fullscreen is config-driven and applied late
   (`ReadConfigFile` -> `SetWindowFullscreen`, inside `InitProgram` — *after*
   `InitAdeline`), so reading the mode in `InitAdeline` always said "windowed".

--- a/tests/console/CMakeLists.txt
+++ b/tests/console/CMakeLists.txt
@@ -1,12 +1,17 @@
 add_executable(test_console_state test_console_state.cpp)
 add_executable(test_console_commands test_console_commands.cpp)
 add_executable(test_console_give test_console_give.cpp)
+add_executable(test_console_render test_console_render.cpp)
 
 target_include_directories(test_console_state PRIVATE
     ${CMAKE_SOURCE_DIR}/SOURCES
     ${CMAKE_SOURCE_DIR}/LIB386/H
 )
 target_include_directories(test_console_commands PRIVATE
+    ${CMAKE_SOURCE_DIR}/SOURCES
+    ${CMAKE_SOURCE_DIR}/LIB386/H
+)
+target_include_directories(test_console_render PRIVATE
     ${CMAKE_SOURCE_DIR}/SOURCES
     ${CMAKE_SOURCE_DIR}/LIB386/H
 )
@@ -22,15 +27,19 @@ target_compile_definitions(test_console_give PRIVATE
 target_link_libraries(test_console_state PRIVATE console)
 target_link_libraries(test_console_commands PRIVATE console)
 target_link_libraries(test_console_give PRIVATE console)
+target_link_libraries(test_console_render PRIVATE console)
 
 set_target_properties(test_console_state PROPERTIES CXX_STANDARD 11)
 set_target_properties(test_console_commands PROPERTIES CXX_STANDARD 11)
 set_target_properties(test_console_give PROPERTIES CXX_STANDARD 11)
+set_target_properties(test_console_render PROPERTIES CXX_STANDARD 11)
 
 add_test(NAME test_console_state COMMAND test_console_state)
 add_test(NAME test_console_commands COMMAND test_console_commands)
 add_test(NAME test_console_give COMMAND test_console_give)
+add_test(NAME test_console_render COMMAND test_console_render)
 
 register_host_test(test_console_state)
 register_host_test(test_console_commands)
 register_host_test(test_console_give)
+register_host_test(test_console_render)

--- a/tests/console/test_console_render.cpp
+++ b/tests/console/test_console_render.cpp
@@ -1,0 +1,114 @@
+/* Host test for the console render path (docs/BOOT_LOG_PLAN.md boot-log shape):
+ * per-line severity colour and UTF-8 -> CP437 transliteration.
+ *
+ * The real renderer (AffStringToBuffer) is replaced by a recording stub that
+ * captures the (string, ink) passed for each drawn line. Console_PrePresent
+ * runs Console_Draw against a small fake framebuffer + palette, so we assert:
+ *   - the ink matches the line's CONSOLE_COL_* colour (severity as colour), and
+ *   - the drawn bytes are CP437 (the "·" separator folded to 0xFA, "ç"/"ñ"
+ *     to their CP437 bytes), never the raw UTF-8 lead/continuation bytes. */
+#include "CONSOLE/CONSOLE.H"
+
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+struct DrawCall {
+    std::string str;
+    U8 ink;
+};
+static std::vector<DrawCall> g_draws;
+
+extern "C" void AffStringToBuffer(U8 *dst, U32 pitch, S32 x, S32 y, const char *str, U8 ink) {
+    (void)dst;
+    (void)pitch;
+    (void)x;
+    (void)y;
+    DrawCall d;
+    d.str = str ? str : "";
+    d.ink = ink;
+    g_draws.push_back(d);
+}
+
+/* Link stubs (the console lib references these; the render path doesn't use them). */
+void Console_RegisterAll(void) {}
+int TryExecuteCheatByName(const char *name) {
+    (void)name;
+    return 0;
+}
+
+/* Find the recorded draw for the line containing needle. */
+static const DrawCall *draw_with(const char *needle) {
+    for (size_t i = 0; i < g_draws.size(); i++)
+        if (g_draws[i].str.find(needle) != std::string::npos)
+            return &g_draws[i];
+    return 0;
+}
+
+static bool contains_byte(const std::string &s, unsigned char b) {
+    return s.find((char)b) != std::string::npos;
+}
+
+static int g_failures = 0;
+#define CHECK(cond)                                          \
+    do {                                                     \
+        if (!(cond)) {                                       \
+            printf("FAIL: %s (line %d)\n", #cond, __LINE__); \
+            g_failures++;                                    \
+        }                                                    \
+    } while (0)
+
+int main(void) {
+    /* Open the console and push a representative mix of lines. */
+    Console_Toggle();
+    Console_Print("info-line");                           /* default colour */
+    Console_PrintColored(CONSOLE_COL_DEBUG, "dbg-line");  /* grey */
+    Console_PrintColored(CONSOLE_COL_WARN, "warn-line");  /* yellow */
+    Console_PrintColored(CONSOLE_COL_ERROR, "err-line");  /* red */
+    Console_PrintColored(CONSOLE_COL_BANNER, "bnr-line"); /* cyan bookend */
+    Console_Print("LBA2 \xC2\xB7 x86_64");                /* UTF-8 middle dot */
+    Console_Print("Fran\xC3\xA7"
+                  "ais Espa\xC3\xB1ol"); /* ç (U+00E7), ñ (U+00F1) */
+
+    /* Drive the render path against a small fake ARGB framebuffer + palette. */
+    const U32 W = 320, H = 200;
+    std::vector<U32> fb(W * H, 0);
+    std::vector<U8> pal(256 * 3, 0);
+    Console_PrePresent(fb.data(), W * sizeof(U32), W, H, pal.data());
+
+    /* Severity/structure is rendered as the line's ink, not a text tag. */
+    const DrawCall *info = draw_with("info-line");
+    const DrawCall *dbg = draw_with("dbg-line");
+    const DrawCall *warn = draw_with("warn-line");
+    const DrawCall *err = draw_with("err-line");
+    const DrawCall *bnr = draw_with("bnr-line");
+    CHECK(info && info->ink == CONSOLE_COL_DEFAULT);
+    CHECK(dbg && dbg->ink == CONSOLE_COL_DEBUG);
+    CHECK(warn && warn->ink == CONSOLE_COL_WARN);
+    CHECK(err && err->ink == CONSOLE_COL_ERROR);
+    CHECK(bnr && bnr->ink == CONSOLE_COL_BANNER);
+
+    /* The "·" reaches the font as CP437 0xFA, never the UTF-8 bytes 0xC2/0xB7. */
+    const DrawCall *dot = draw_with("LBA2 ");
+    CHECK(dot != 0);
+    if (dot) {
+        CHECK(contains_byte(dot->str, 0xFA));  /* CP437 middle dot */
+        CHECK(!contains_byte(dot->str, 0xC2)); /* no UTF-8 lead byte */
+        CHECK(!contains_byte(dot->str, 0xB7)); /* no UTF-8 continuation byte */
+    }
+
+    /* Accented language names fold to their CP437 bytes (ç=0x87, ñ=0xA4). */
+    const DrawCall *lang = draw_with("Fran");
+    CHECK(lang != 0);
+    if (lang) {
+        CHECK(contains_byte(lang->str, 0x87));  /* ç */
+        CHECK(contains_byte(lang->str, 0xA4));  /* ñ */
+        CHECK(!contains_byte(lang->str, 0xC3)); /* no UTF-8 lead byte */
+    }
+
+    if (g_failures == 0)
+        printf("test_console_render: OK\n");
+    return g_failures != 0;
+}

--- a/tests/logging/test_log.cpp
+++ b/tests/logging/test_log.cpp
@@ -17,11 +17,41 @@
  * Log_MakeConsoleBufferSink) — capture the lines so the sink's rendering and
  * filtering can be asserted without linking the real console module. */
 static char g_console_capture[4096];
-static void record_console_line(const char *line) {
+/* Per-call (line, severity, kind) record so tests can assert what the console
+ * needs to colour the line — the console renders level/structure as colour, so
+ * the sink passes severity + kind instead of a "[INFO]" text tag. */
+struct ConsoleCall {
+    char line[256];
+    LogSeverity sev;
+    LogLineKind kind;
+};
+static struct ConsoleCall g_console_calls[128];
+static int g_console_call_count;
+static void record_console_line(const char *line, LogSeverity sev, LogLineKind kind) {
+    if (g_console_call_count < 128) {
+        snprintf(g_console_calls[g_console_call_count].line, 256, "%s", line);
+        g_console_calls[g_console_call_count].sev = sev;
+        g_console_calls[g_console_call_count].kind = kind;
+        g_console_call_count++;
+    }
     size_t used = strlen(g_console_capture);
     snprintf(g_console_capture + used, sizeof g_console_capture - used, "%s\n", line);
 }
-static void console_capture_reset(void) { g_console_capture[0] = '\0'; }
+static void console_capture_reset(void) {
+    g_console_capture[0] = '\0';
+    g_console_call_count = 0;
+}
+static const struct ConsoleCall *console_call_of(const char *needle) {
+    for (int i = 0; i < g_console_call_count; i++)
+        if (strstr(g_console_calls[i].line, needle))
+            return &g_console_calls[i];
+    return 0;
+}
+/* Severity recorded for the first captured line containing needle, or -1. */
+static int console_sev_of(const char *needle) {
+    const struct ConsoleCall *c = console_call_of(needle);
+    return c ? (int)c->sev : -1;
+}
 
 static void slurp(const char *path, char *out, int max) {
     FILE *f = fopen(path, "r");
@@ -93,6 +123,21 @@ static void test_section_header(void) {
     remove(TMP);
 }
 
+/* Log_Banner is verbatim to the file sink — the cyan tint is the terminal
+ * sink's doing alone, so the on-disk text is identical to a raw line. */
+static void test_banner_verbatim_to_file(void) {
+    remove(TMP);
+    Log_Init();
+    Log_AddSink(Log_MakeFileSink(TMP, LOG_DEBUG));
+    Log_Banner("======== Ready in %.2fs ========", 0.73);
+    Log_Shutdown();
+
+    char buf[4096];
+    slurp(TMP, buf, sizeof buf);
+    ASSERT_TRUE(strcmp(buf, "======== Ready in 0.73s ========\n") == 0);
+    remove(TMP);
+}
+
 /* The C++ ScopedSection RAII helper opens a section on construction. */
 static void test_scoped_section(void) {
     remove(TMP);
@@ -111,9 +156,11 @@ static void test_scoped_section(void) {
     remove(TMP);
 }
 
-/* Console buffer sink: monochrome text into the scrollback, INFO default,
- * raw verbatim, runtime severity change. (Thread gating is SDL-only and
- * compiled out under LBA_LOG_NO_SDL, so the sink always writes here.) */
+/* Console buffer sink: text into the scrollback with NO severity text tag (the
+ * console renders the level as colour), INFO default, raw/banner verbatim,
+ * section idiom, runtime severity change. The severity still rides along to the
+ * printer — asserted via console_sev_of. (Thread gating is SDL-only and compiled
+ * out under LBA_LOG_NO_SDL, so the sink always writes here.) */
 static void test_console_sink(void) {
     console_capture_reset();
     Log_Init();
@@ -122,18 +169,31 @@ static void test_console_sink(void) {
     Log_AddSink(s);
     ASSERT_TRUE(Log_GetConsoleSeverity() == LOG_INFO);
 
-    /* Default INFO: DEBUG dropped, INFO/WARN tagged, raw verbatim, section idiom. */
+    /* Default INFO: DEBUG dropped; INFO/WARN/raw/banner all verbatim (no tag);
+     * section idiom; severity conveyed out-of-band for the colour. */
     Log_Debug("dbg-line");
     Log_Info("info-line");
     Log_Warn("warn-line");
     Log_Raw("raw-line");
+    Log_Banner("banner-line");
     Log_BeginSection("Boot");
     ASSERT_TRUE(strstr(g_console_capture, "dbg-line") == NULL);
-    ASSERT_TRUE(strstr(g_console_capture, "[INFO] info-line") != NULL);
-    ASSERT_TRUE(strstr(g_console_capture, "[WARN] warn-line") != NULL);
+    ASSERT_TRUE(strstr(g_console_capture, "info-line") != NULL);
+    ASSERT_TRUE(strstr(g_console_capture, "warn-line") != NULL);
     ASSERT_TRUE(strstr(g_console_capture, "raw-line") != NULL);
-    ASSERT_TRUE(strstr(g_console_capture, "[INFO] raw-line") == NULL); /* verbatim */
+    ASSERT_TRUE(strstr(g_console_capture, "banner-line") != NULL);
     ASSERT_TRUE(strstr(g_console_capture, "== Boot ==") != NULL);
+    /* No severity text tag reaches the console — colour replaces it. */
+    ASSERT_TRUE(strstr(g_console_capture, "[INFO]") == NULL);
+    ASSERT_TRUE(strstr(g_console_capture, "[WARN]") == NULL);
+    /* …but the severity is handed to the printer so it can pick the colour. */
+    ASSERT_TRUE(console_sev_of("info-line") == LOG_INFO);
+    ASSERT_TRUE(console_sev_of("warn-line") == LOG_WARN);
+    /* Kind is handed across too, so the adapter can tint banners/sections cyan. */
+    ASSERT_TRUE(console_call_of("info-line")->kind == LOG_LINE_NORMAL);
+    ASSERT_TRUE(console_call_of("banner-line")->kind == LOG_LINE_BANNER);
+    ASSERT_TRUE(console_call_of("raw-line")->kind == LOG_LINE_NORMAL);
+    ASSERT_TRUE(console_call_of("== Boot ==")->kind == LOG_LINE_SECTION);
 
     /* loglevel raise to WARN now drops INFO. */
     console_capture_reset();
@@ -142,7 +202,8 @@ static void test_console_sink(void) {
     Log_Info("info-after");
     Log_Error("err-after");
     ASSERT_TRUE(strstr(g_console_capture, "info-after") == NULL);
-    ASSERT_TRUE(strstr(g_console_capture, "[ERROR] err-after") != NULL);
+    ASSERT_TRUE(strstr(g_console_capture, "err-after") != NULL);
+    ASSERT_TRUE(console_sev_of("err-after") == LOG_ERROR);
 
     Log_Shutdown();
 }
@@ -163,9 +224,11 @@ static void test_fanout_to_all_sinks(void) {
 
     char buf[4096];
     slurp(TMP, buf, sizeof buf);
-    /* WARN reached both sinks from a single emit. */
+    /* WARN reached both sinks from a single emit. The file keeps its text tag;
+     * the console drops it (colour carries the level) but gets the message. */
     ASSERT_TRUE(strstr(buf, "[WARN] fan-7") != NULL);
-    ASSERT_TRUE(strstr(g_console_capture, "[WARN] fan-7") != NULL);
+    ASSERT_TRUE(strstr(g_console_capture, "fan-7") != NULL);
+    ASSERT_TRUE(console_sev_of("fan-7") == LOG_WARN);
     /* Per-sink filtering holds inside the fan-out: DEBUG to file, not console. */
     ASSERT_TRUE(strstr(buf, "[DEBUG] dbg-only") != NULL);
     ASSERT_TRUE(strstr(g_console_capture, "dbg-only") == NULL);
@@ -319,6 +382,7 @@ int main(void) {
     RUN_TEST(test_severity_prefixes);
     RUN_TEST(test_min_severity_filter);
     RUN_TEST(test_section_header);
+    RUN_TEST(test_banner_verbatim_to_file);
     RUN_TEST(test_scoped_section);
     RUN_TEST(test_console_sink);
     RUN_TEST(test_fanout_to_all_sinks);

--- a/tests/logging/test_log_spine.cpp
+++ b/tests/logging/test_log_spine.cpp
@@ -44,6 +44,7 @@ static void test_spine_roundtrip(void) {
     Log_Warn("warn");
     Log_Error("err");
     Log_Raw("raw-line");
+    Log_Banner("banner-line");
     Log_BeginSection("Sect");
     Log_EndSection();
     Log_Shutdown();
@@ -55,6 +56,8 @@ static void test_spine_roundtrip(void) {
     ASSERT_TRUE(strstr(buf, "[WARN] warn") != NULL);
     ASSERT_TRUE(strstr(buf, "[ERROR] err") != NULL);
     ASSERT_TRUE(strstr(buf, "raw-line") != NULL);
+    ASSERT_TRUE(strstr(buf, "banner-line") != NULL);        /* LBA_CAT_BANNER round-trip */
+    ASSERT_TRUE(strstr(buf, "[INFO] banner-line") == NULL); /* verbatim, no tag */
     ASSERT_TRUE(strstr(buf, "==== Sect ====") != NULL);
     remove(TMP);
 }


### PR DESCRIPTION
Polishes the boot log's presentation. Three things, all cosmetic/UX — no behavioural change to what's logged or to `adeline.log`.

## Terminal
- The identity header (`LBA2 Classic Community … · Linux x86_64 · …`) and the `======== Ready in Xs ========` closer are now **cyan**, matching the section-header colour. They ride a new `Log_Banner()` primitive (a `REC_BANNER` record kind + SDL category); the file and console sinks print banners verbatim, so the tint is the terminal sink's alone and no ANSI is baked into the call sites.
- The `Config:` line now resolves the **file** (`…/lba2.cfg`), like the `Log:` line, instead of just the directory. `Assets`/`Saves` stay directories (they hold many files); `Config`/`Log` are single named files.

## In-engine console
- Dropped the `[INFO]`/`[WARN]`/`[ERROR]` text tags — the level is shown as **colour** instead. `LogLineFn` now carries the severity and a `LogLineKind`, so the engine-side adapter colours ordinary lines by severity (info white, debug grey, warn yellow, error red) and tints the **banner bookends and section headers cyan**, mirroring the terminal's structural colour. The reserved inks are palette-independent fixed RGB resolved in the compositor, so the colours hold across arbitrary scene palettes; the log core stays palette-agnostic (it passes severity/kind, not colours).
- The console font is **CP437**, so UTF-8 text is folded to CP437 at draw time. The `·` separator was rendering as two box-drawing glyphs; it (and accented language names like `Français`/`Español`) now render correctly. Stored scrollback stays UTF-8, so `Console_GetScrollback` / `--dump-state` remain valid UTF-8.

## Tests
- `tests/logging/test_log.cpp` / `test_log_spine.cpp`: the banner record kind round-trips; the console sink drops tags while conveying severity **and** kind.
- New `tests/console/test_console_render.cpp`: drives the real render path through a recording `AffStringToBuffer` stub and asserts per-line ink (severity/banner → colour) and the UTF-8→CP437 folding (`·`→0xFA, `ç`→0x87, `ñ`→0xA4).
- All 21 host tests pass; full engine build clean; clang-format clean.

Verified end-to-end on retail data: a pty boot shows the cyan bookends, `--dump-state` shows the console scrollback untagged and as valid UTF-8, and `adeline.log` is byte-identical to before (no escapes).

See `docs/BOOT_LOG_PLAN.md` for the design notes (supersedes the earlier "console is monochrome in v1" decision).