### PR TITLE
feat(boot log): structured, accurate config-bootstrap messages

### DIFF
--- a/SOURCES/INITADEL.C
+++ b/SOURCES/INITADEL.C
@@ -177,25 +177,26 @@ void InitAdeline(S32 argc, char *argv[]) {
 
     // ··········································································
     //  Config File
+    //  First run (or the user deleted it): install a default lba2.cfg — copy the
+    //  one shipped with the game data, or fall back to the built-in template.
+    //  Logged once, after the action, so the boot log states what actually
+    //  happened: Info for the copy, Warn for the no-default-in-game-data fallback.
     GetCfgPath(PathConfigFile, ADELINE_MAX_PATH, CFG_NAME);
     if (!ExistsFileOrDir(PathConfigFile)) {
-        LogPuts("Config file not found! Copying default from assets folder...");
-
         char PathDefaultConfigFile[ADELINE_MAX_PATH];
         GetDefaultCfgPath(PathDefaultConfigFile, ADELINE_MAX_PATH, CFG_NAME);
-        if (!ExistsFileOrDir(PathDefaultConfigFile)) {
-            LogPuts("Default config not in assets folder; writing embedded template...");
-
+        if (ExistsFileOrDir(PathDefaultConfigFile)) {
+            if (!Copy(PathDefaultConfigFile, PathConfigFile)) {
+                BootFatal("Could not copy the configuration file to '%s'.",
+                          PathConfigFile);
+            }
+            Log_Info("Config     created from game-data default");
+        } else {
             if (!WriteEmbeddedDefaultLba2Cfg(PathConfigFile)) {
                 BootFatal("Could not write a default configuration file to '%s'.",
                           PathConfigFile);
             }
-        } else {
-            const bool copyResult = Copy(PathDefaultConfigFile, PathConfigFile);
-            if (!copyResult) {
-                BootFatal("Could not copy the configuration file to '%s'.",
-                          PathConfigFile);
-            }
+            Log_Warn("Config     wrote built-in template (no default in game data)");
         }
     }
 


### PR DESCRIPTION
Follow-up to #297. Tidies the **first-run config install** messages in the boot log.

The config bootstrap ([INITADEL.C](SOURCES/INITADEL.C)) runs when `lba2.cfg` is missing (first launch, or the user deleted it): copy the default shipped with the game data, else write the built-in template, else `BootFatal`. The two progress messages used legacy `LogPuts`, which the shim emits as `REC_RAW` — uncoloured, no severity, in a chatty full-sentence voice that's off from the rest of the boot log.

It also had a real wording bug: the first line *always* said `Config file not found! Copying default from assets folder...` **before** checking whether that default existed — so on the embedded-template path the log claimed a copy it never made, immediately contradicted by `Default config not in assets folder; writing embedded template...`.

## Change
Log **once, after the action**, with the actual outcome and matching severity/voice:

```
Config     created from game-data default            (Info — white)
Config     wrote built-in template (no default ...)  (Warn — yellow)
```

- The embedded fallback is now a `Warn` (shipping without a default config is the unusual case, and it stands out yellow in the terminal/console).
- `BootFatal` still handles the copy/write failures at `Error` (those strings stay descriptive — they go into the GUI error dialog).
- No behavioural change to the install logic; the `if`/`else` is just flipped to read positively (default exists → copy).

## Verification
Exercised both paths live with the user cfg stashed aside:
- retail data (ships `LBA2.CFG`) → `Config     created from game-data default`, uncoloured INFO.
- a cfg-less game dir → `Config     wrote built-in template (no default in game data)`, yellow WARN.

The contradictory double-message is gone. All 21 host tests pass; build + clang-format clean.