### PR TITLE
refactor(boot log): structure boot-time diagnostics + start the log before discovery

### DIFF
--- a/LIB386/SYSTEM/DEFFILE.CPP
+++ b/LIB386/SYSTEM/DEFFILE.CPP
@@ -119,7 +119,7 @@ S32 DefFileBufferInit(char *file, void *buffer, S32 maxsize) {
        corruption that never self-heals. Discarding it (treat as empty) makes
        the next write regenerate a clean file from defaults. */
     if (buffersize > 0 && memchr(buffer, 0, (size_t)buffersize) != NULL) {
-        Log_Warn("DefFileBufferInit: config has embedded NULs (corrupt) — discarding");
+        Log_Warn("DefFileBufferInit: config has embedded NULs (corrupt) - discarding");
         buffersize = 0;
     }
 

--- a/LIB386/SYSTEM/DEFFILE.CPP
+++ b/LIB386/SYSTEM/DEFFILE.CPP
@@ -1,6 +1,6 @@
 //══════════════════════════════════════════════════════════════════════════
 #include <SYSTEM/ADELINE.H>
-#include <SYSTEM/LOGPRINT.H>
+#include <SYSTEM/LOG.H>
 #include <SYSTEM/FILES.H>
 #include <SYSTEM/LOADSAVE.H>
 #include <SYSTEM/ITOA.H>
@@ -102,12 +102,12 @@ S32 DefFileBufferInit(char *file, void *buffer, S32 maxsize) {
     OrgPtrDef = NULL;
 
     if (!buffer) {
-        LogPuts("Error: Trying to use DefFileBufferInit with a NULL pointer");
+        Log_Error("DefFileBufferInit: NULL buffer pointer");
         return FALSE;
     }
 
     if (buffersize >= maxsize - 3) {
-        LogPuts("Error: Buffer too small in DefFileBufferInit");
+        Log_Error("DefFileBufferInit: buffer too small");
         return FALSE;
     }
 
@@ -119,7 +119,7 @@ S32 DefFileBufferInit(char *file, void *buffer, S32 maxsize) {
        corruption that never self-heals. Discarding it (treat as empty) makes
        the next write regenerate a clean file from defaults. */
     if (buffersize > 0 && memchr(buffer, 0, (size_t)buffersize) != NULL) {
-        LogPuts("Warning: DefFileBufferInit found embedded NULs (corrupt) - discarding");
+        Log_Warn("DefFileBufferInit: config has embedded NULs (corrupt) — discarding");
         buffersize = 0;
     }
 

--- a/LIB386/SYSTEM/EVENTS.CPP
+++ b/LIB386/SYSTEM/EVENTS.CPP
@@ -2,7 +2,7 @@
 
 #include <SVGA/VIDEO.H>
 #include <SYSTEM/KEYBOARD.H>
-#include <SYSTEM/LOGPRINT.H>
+#include <SYSTEM/LOG.H>
 #include <SYSTEM/MOUSE.H>
 #include <SYSTEM/TIMER.H>
 #include <SYSTEM/WINDOW.H>
@@ -41,11 +41,7 @@ bool InitEvents() {
     assert(eventSystemInitialized == false);
 
     if (!SDL_InitSubSystem(SDL_INIT_EVENTS)) {
-        const char *errorMsg = SDL_GetError();
-        LogPrintf("Error: Unable to initialize SDL Events subsystem.\n"
-                  "\tSDL Message: %s\n",
-                  errorMsg);
-
+        Log_Error("Event system init failed: %s", SDL_GetError());
         eventSystemInitialized = false;
         return false;
     }

--- a/SOURCES/DIRECTORIES.CPP
+++ b/SOURCES/DIRECTORIES.CPP
@@ -404,12 +404,17 @@ void GetResPath(char *outPath, U16 pathMaxSize, const char *resFilename) {
     DiscoverEndingAndAppend(outPath, pathMaxSize, directoriesResDir, resFilename);
 }
 
+void GetLogPathInDir(char *outPath, U16 pathMaxSize, const char *userDir,
+                     const char *logFilename) {
+    assert((outPath != NULL) && (pathMaxSize > 0));
+    assert(userDir != NULL);
+
+    DiscoverEndingAndAppend(outPath, pathMaxSize, userDir, logFilename);
+}
+
 void GetLogPath(char *outPath, U16 pathMaxSize, const char *logFilename) {
     assert(directoriesInitialized);
-    assert((outPath != NULL) && (pathMaxSize > 0));
-
-    DiscoverEndingAndAppend(outPath, pathMaxSize, directoriesUserDir,
-                            logFilename);
+    GetLogPathInDir(outPath, pathMaxSize, directoriesUserDir, logFilename);
 }
 
 // =============================================================================

--- a/SOURCES/DIRECTORIES.H
+++ b/SOURCES/DIRECTORIES.H
@@ -36,6 +36,10 @@ void GetVoicePath(char *outPath, U16 pathMaxSize, const char *voiceFilename,
 void GetMoviePath(char *outPath, U16 pathMaxSize, const char *movieFilename);
 void GetResPath(char *outPath, U16 pathMaxSize, const char *resFilename);
 void GetLogPath(char *outPath, U16 pathMaxSize, const char *logFilename);
+/// Like GetLogPath but takes the user dir explicitly, so it works before
+/// InitDirectories (the boot log starts before game-data discovery resolves).
+void GetLogPathInDir(char *outPath, U16 pathMaxSize, const char *userDir,
+                     const char *logFilename);
 
 // =============================================================================
 #ifdef __cplusplus

--- a/SOURCES/INITADEL.C
+++ b/SOURCES/INITADEL.C
@@ -125,20 +125,15 @@ void InitAdeline(S32 argc, char *argv[]) {
         GetResPath(resFolderPath, ADELINE_MAX_PATH, NULL);
         GetSavePath(saveFolderPath, ADELINE_MAX_PATH, NULL);
         GetCfgPath(cfgFilePath, ADELINE_MAX_PATH, CFG_NAME);
-
         GetLogPath(logFilePath, ADELINE_MAX_PATH, LOG_NAME);
-        CreateLog(logFilePath);
 
-        /* Structured boot log (docs/BOOT_LOG_PLAN.md). The file sink reuses
-           adeline.log — CreateLog above truncated it for this launch, the sink
-           appends; both it and the legacy LogPrintf sites share the one file.
-           The terminal sink colours stderr when launched from a real TTY. The
-           console sink mirrors records into the in-engine F12 overlay. */
-        Log_Init();
-        Log_AddSink(Log_MakeFileSink(logFilePath, LOG_DEBUG));
-        Log_AddSink(Log_MakeTerminalSink(LOG_DEBUG));
+        /* The structured log + file/terminal sinks are already up: main() starts
+           them before game-data discovery so the discovery/picker diagnostics are
+           captured (docs/BOOT_LOG_PLAN.md). Add the in-engine F12 console sink now
+           — it has no surface until we're past early boot, so it joins here rather
+           than at Log_Init. The file sink reuses adeline.log (CreateLog truncated
+           it for this launch); both it and the legacy LogPrintf sites share it. */
         Log_AddSink(Log_MakeConsoleBufferSink(ConsoleLogLine));
-        atexit(Log_Shutdown);
 
         /* Boot identity + key paths up top, so a pasted log is self-describing. */
         Log_Banner("%s · %s %s · %d cores · %d GB RAM", APPNAME, LOG_PLATFORM_NAME,

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2419,6 +2419,24 @@ int main(int argc, char *argv[]) {
 
         GetDefaultUserDir(userFolderPath);
 
+        /* Bring the structured log up here — BEFORE game-data discovery and the
+           folder picker — so their diagnostics reach adeline.log and the terminal,
+           not just stderr. The "can't find game data" path is exactly when a
+           persisted log matters most, and it used to be invisible there because
+           CreateLog/Log_Init ran later, inside InitAdeline. The log file lives in
+           the user dir (known now, independent of where the game data is). Use
+           GetLogPathInDir rather than GetLogPath, which needs InitDirectories — and
+           that needs the game dir we haven't resolved yet; it derives the same path
+           from the user dir alone. The console-buffer sink joins later in
+           InitAdeline: there's no F12 overlay this early. */
+        char logFilePath[ADELINE_MAX_PATH] = "";
+        GetLogPathInDir(logFilePath, ADELINE_MAX_PATH, userFolderPath, LOG_NAME);
+        CreateLog(logFilePath);
+        Log_Init();
+        Log_AddSink(Log_MakeFileSink(logFilePath, LOG_DEBUG));
+        Log_AddSink(Log_MakeTerminalSink(LOG_DEBUG));
+        atexit(Log_Shutdown);
+
         if (!ResolveGameDataDir(resFolderPath, ADELINE_MAX_PATH, &argc, argv)) {
             /* Auto-discovery exhausted. Last fallback before exit: in a
              * windowed environment, prompt the user with a folder dialog

--- a/SOURCES/RES_DISCOVERY.CPP
+++ b/SOURCES/RES_DISCOVERY.CPP
@@ -7,7 +7,6 @@
 #include <SYSTEM/FILES.H>
 #include <SYSTEM/LIMITS.H>
 #include <SYSTEM/LOG.H>
-#include <SYSTEM/LOGPRINT.H>
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_filesystem.h>
@@ -106,10 +105,10 @@ void LogFailure(const char tried[][ADELINE_MAX_PATH], int triedCount) {
     Log_Error("No valid game data directory (need lba2.hqr). Tried %d path(s).",
               triedCount);
     for (int i = 0; i < triedCount; i++) {
-        LogPrintf("  - %s\n", tried[i]);
+        Log_Error("  - %s", tried[i]);
     }
-    LogPuts("Hints: set LBA2_GAME_DIR to your install folder, or use --game-dir <path>.");
-    LogPuts("See docs/GAME_DATA.md. Retail game files are not included in this repository.");
+    Log_Error("Hints: set LBA2_GAME_DIR to your install folder, or use --game-dir <path>.");
+    Log_Error("See docs/GAME_DATA.md. Retail game files are not included in this repository.");
 }
 
 void StripGameDirArgs(int *argc, char **argv) {
@@ -317,7 +316,7 @@ bool WritePersistedGameDir(const char *path) {
 
     FILE *fp = fopen(filePath, "w");
     if (fp == NULL) {
-        LogPrintf("RES_DISCOVERY: could not write %s\n", filePath);
+        Log_Warn("RES_DISCOVERY: could not write %s", filePath);
         return false;
     }
 
@@ -354,8 +353,8 @@ bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv) {
      * still win above (user passing both is asking for "use this path,
      * but if it's bad show the picker"). */
     if (forcePicker) {
-        LogPuts("RES_DISCOVERY: --pick-game-dir set; skipping persisted "
-                "and auto-discovery probes.");
+        Log_Info("RES_DISCOVERY: --pick-game-dir set; skipping persisted "
+                 "and auto-discovery probes.");
         return false;
     }
 
@@ -376,9 +375,9 @@ bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv) {
         if (NormalizeAndTry(persisted, outDir, outMax, tried, &triedCount)) {
             return true;
         }
-        LogPrintf("RES_DISCOVERY: saved game-data path %s no longer "
-                  "valid, re-prompting via picker\n",
-                  persisted);
+        Log_Warn("RES_DISCOVERY: saved game-data path %s no longer "
+                 "valid, re-prompting via picker",
+                 persisted);
     }
 
     /* SDL_Init must be done by the caller before SDL_GetBasePath / cwd helpers

--- a/SOURCES/RES_PICKER.CPP
+++ b/SOURCES/RES_PICKER.CPP
@@ -4,7 +4,7 @@
 #include "DIRECTORIES.H"
 
 #include "SYSTEM/LIMITS.H"
-#include "SYSTEM/LOGPRINT.H"
+#include "SYSTEM/LOG.H"
 
 #include <SDL3/SDL.h>
 
@@ -45,13 +45,12 @@ void SDLCALL OnFolderChosen(void *userdata, const char *const *filelist,
      * platform-specific quirks (trailing newlines, empty-string-on-cancel,
      * etc.) are visible in the log when something goes wrong. */
     if (filelist == NULL) {
-        LogPrintf("RES_PICKER: callback filelist=NULL, error: %s\n",
-                  SDL_GetError());
+        Log_Warn("RES_PICKER: callback filelist=NULL, error: %s", SDL_GetError());
     } else if (filelist[0] == NULL) {
-        LogPuts("RES_PICKER: callback filelist[0]=NULL (cancel)");
+        Log_Debug("RES_PICKER: callback filelist[0]=NULL (cancel)");
     } else {
-        LogPrintf("RES_PICKER: callback filelist[0]='%s' (len=%zu)\n",
-                  filelist[0], strlen(filelist[0]));
+        Log_Debug("RES_PICKER: callback filelist[0]='%s' (len=%zu)", filelist[0],
+                  strlen(filelist[0]));
     }
 
     if (filelist == NULL) {
@@ -157,8 +156,8 @@ extern "C" bool PromptForResDir(char *outPath, U16 outMax) {
      * portal, --headless build, etc.), there's no way to show a dialog
      * and we fall back to the caller's exit. */
     if (!SDL_InitSubSystem(SDL_INIT_VIDEO)) {
-        LogPrintf("RES_PICKER: SDL_INIT_VIDEO failed (%s); skipping picker\n",
-                  SDL_GetError());
+        Log_Warn("RES_PICKER: SDL_INIT_VIDEO failed (%s); skipping picker",
+                 SDL_GetError());
         return false;
     }
 
@@ -166,7 +165,7 @@ extern "C" bool PromptForResDir(char *outPath, U16 outMax) {
      * folder picker pops up unannounced and feels like the app is
      * confused. The message-box-then-picker pattern matches what other
      * cross-platform games do for first-launch data discovery. */
-    LogPuts("RES_PICKER: showing 'data not found' message + folder picker...");
+    Log_Info("RES_PICKER: showing 'data not found' message + folder picker...");
     ShowDiscoveryFailedMessage();
 
     /* Default location for the picker. Home is the universal "user
@@ -197,10 +196,10 @@ extern "C" bool PromptForResDir(char *outPath, U16 outMax) {
                  * (the "data not found" box already explained what was
                  * needed; this one explains why the picker couldn't help
                  * and what to do instead). */
-                LogPuts("RES_PICKER: dialog backend unavailable");
+                Log_Warn("RES_PICKER: dialog backend unavailable");
                 ShowDialogUnavailableMessage();
             } else {
-                LogPuts("RES_PICKER: cancelled");
+                Log_Info("RES_PICKER: cancelled");
             }
             return false;
         }
@@ -223,13 +222,13 @@ extern "C" bool PromptForResDir(char *outPath, U16 outMax) {
          * not a special validation path; it's the same probe with a
          * different input source. */
         if (IsValidResourceDir(state.chosen)) {
-            LogPrintf("RES_PICKER: picked %s\n", state.chosen);
+            Log_Info("RES_PICKER: picked %s", state.chosen);
             strncpy(outPath, state.chosen, outMax - 1);
             outPath[outMax - 1] = '\0';
             return true;
         }
 
-        LogPrintf("RES_PICKER: invalid (%s) — re-prompting\n", state.chosen);
+        Log_Warn("RES_PICKER: invalid (%s) — re-prompting", state.chosen);
         ShowInvalidPickMessage();
         /* Loop: show picker again. */
     }

--- a/SOURCES/RES_PICKER.CPP
+++ b/SOURCES/RES_PICKER.CPP
@@ -228,7 +228,7 @@ extern "C" bool PromptForResDir(char *outPath, U16 outMax) {
             return true;
         }
 
-        Log_Warn("RES_PICKER: invalid (%s) — re-prompting", state.chosen);
+        Log_Warn("RES_PICKER: invalid (%s) - re-prompting", state.chosen);
         ShowInvalidPickMessage();
         /* Loop: show picker again. */
     }


### PR DESCRIPTION
Continues the boot-log cleanup from a full sweep of everything that can log between process entry and `Ready`. Three sequential commits (each builds + passes the 21 host tests independently).

### (a) `boot log: structure the InitEvents / DefFile diagnostics`
Two subsystem lines fired during boot as legacy `LogPuts`/`LogPrintf` (verbatim `REC_RAW`, no severity, uncoloured):
- [EVENTS.CPP](LIB386/SYSTEM/EVENTS.CPP) `InitEvents` failure → `Log_Error`
- [DEFFILE.CPP](LIB386/SYSTEM/DEFFILE.CPP) NULL-buffer / buffer-too-small → `Log_Error`; embedded-NUL corruption (can fire on a corrupt `lba2.cfg`) → `Log_Warn`

The `Error:`/`Warning:` text prefixes are dropped — severity carries that now. Both files swap `LOGPRINT.H` → `SYSTEM/LOG.H`.

### (b) `boot log: structure the game-data discovery / picker diagnostics`
[RES_DISCOVERY.CPP](SOURCES/RES_DISCOVERY.CPP) and [RES_PICKER.CPP](SOURCES/RES_PICKER.CPP) logged their boot diagnostics through `LogPrintf`/`LogPuts`. Converted to the structured log with sensible levels: the "no valid game data" fatal block (tried paths + hints) → `Log_Error`; recoverable problems (persist-write failure, stale path, picker backend issues, invalid pick) → `Log_Warn`; flow milestones (showing picker, picked, cancelled) → `Log_Info`; verbose callback traces → `Log_Debug`. Both files swap `LOGPRINT.H` → `SYSTEM/LOG.H`.

### (c) `boot log: start the log before game-data discovery`
The file/terminal sinks were created inside `InitAdeline` — *after* discovery, the picker, and `InitDirectories`. So everything in that early window only reached **stderr**, never `adeline.log`; the "can't find game data" path (the reason the picker exists) was invisible in the log file. Moved `CreateLog` + `Log_Init` + the file/terminal sinks into `main()`, right after the user dir is known and **before** `ResolveGameDataDir`. A new `GetLogPathInDir` derives the log path from the user dir alone (which is independent of the game-data location); `GetLogPath` now delegates to it. `InitAdeline` keeps the banner and just adds the F12 console sink (no overlay exists that early). `atexit(Log_Shutdown)` keeps the same LIFO order vs `TheEndInfo`.

## Verification
- All 21 host tests pass after each commit; build + clang-format clean.
- (c) confirmed live: `--pick-game-dir` + an invalid video driver now writes the `RES_DISCOVERY`/`RES_PICKER` lines into `adeline.log` (`[INFO]`/`[WARN]`) — previously stderr-only. A separate failing-`InitWindow` boot showed the banner + error in both `adeline.log` and the pty (red). A normal boot's log is unchanged.

Scope notes: the early-`SDL_Init` failure line and the `[control]` arg-validation `fprintf`s genuinely precede SDL/log setup and are left on stderr; the audio/video stack already logs only on failure. Dead `InitSmacker` block left alone.