### PR TITLE
chore(log): drop em-dashes from console-bound strings + harden CreateLog include

### DIFF
--- a/SOURCES/INITADEL.C
+++ b/SOURCES/INITADEL.C
@@ -292,7 +292,7 @@ void InitAdeline(S32 argc, char *argv[]) {
                bypass the SDL dummy driver's nanosleep pacing (~58% of sys time
                in projection_demo); a player whose audio device fails just
                loses sound instead of being unable to launch the game. */
-            Log_Warn("Audio      none — running silently");
+            Log_Warn("Audio      none - running silently");
         } else {
             Log_Info("Audio      44100 Hz stereo");
         }

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -14,6 +14,7 @@
 #include "PERFTRACE.H"
 #include "TOUCH_INPUT.H"
 #include <SYSTEM/LOG.H>
+#include <SYSTEM/LOGPRINT.H> /* CreateLog (boot log brought up in main) */
 #include "ASSET_PREFLIGHT.H"
 #include <SYSTEM/EVENTS.H>
 #include <SVGA/VIDEO.H>

--- a/SOURCES/RES_SWITCH.CPP
+++ b/SOURCES/RES_SWITCH.CPP
@@ -307,7 +307,7 @@ const char *Res_SwitchAllowedReason(void) {
     /* Refuse mid-cinematic: the Smacker decoder owns the framebuffer and
        partial state would be lost. */
     if (FlagPlayAcf)
-        return "Not now: a cinematic is playing — wait for it to finish.";
+        return "Not now: a cinematic is playing - wait for it to finish.";
     /* Refuse before the first scene loads. PtrInitGrille has nothing to
        reload, and the engine isn't in a steady main-loop state yet. */
     if (PtrScene == NULL || NumCube < 0)


### PR DESCRIPTION
Two small follow-ups to the boot-log work (#297–#300).

## Drop em-dashes from console-bound strings
The in-engine F12 console renders the CP437 bitmap font, which has no em-dash glyph, so a `—` in any string that reaches it shows as garbage / `?`. A tree-wide sweep found two such strings (the rest of the `—`s in the tree are comments or real UTF-8 native-dialog message boxes, which are fine):
- [INITADEL.C](SOURCES/INITADEL.C) — `Audio      none — running silently` (boot log).
- [RES_SWITCH.CPP](SOURCES/RES_SWITCH.CPP) — the mid-cinematic resolution-switch refusal reason, printed to the console via `Console_Print` in the `resolution` command handler.

Both now use a plain ASCII `-`. Keeping the strings ASCII is simpler and the right altitude — we control these strings, so there's no need to teach the CP437 renderer to fold em-dashes. (I started down the "map em-dash → '-' in `utf8_to_cp437`" path and backed it out: the renderer shouldn't carry special cases for characters we just shouldn't be emitting.)

## Harden the CreateLog include
#300 added a `CreateLog` call to `main()`, but `PERSO.CPP` only had that declaration transitively (`C_EXTERN.H → … → LOGPRINT.H`, ~4 deep). Added a direct `#include <SYSTEM/LOGPRINT.H>` so the dependency is explicit.

## Verified
No logged em-dashes remain (grep over all `Log_*`/`Console_Print` calls); build + clang-format clean; all 21 host tests pass.