### PR TITLE
chore: no em-dashes in code string literals

### DIFF
--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2198,7 +2198,7 @@ LBA_NORETURN void BootFatal(const char *fmt, ...) {
     char msg[ADELINE_MAX_PATH + 640];
     snprintf(msg, sizeof msg, "%s\n\nThe game can't start.\nDetails: %s", reason,
              logPath);
-    ShowFatalErrorDialog("LBA2 — cannot start", msg);
+    ShowFatalErrorDialog("LBA2: cannot start", msg);
 
     exit(EXIT_FAILURE);
 }
@@ -2304,7 +2304,7 @@ void TheEndInfo() {
         snprintf(msg, sizeof msg,
                  "%s\n\n%s\n\nThe game can't continue.\nDetails: %s", headline,
                  End_Error ? End_Error : "", logPath);
-        ShowFatalErrorDialog("LBA2 — cannot start", msg);
+        ShowFatalErrorDialog("LBA2: cannot start", msg);
     }
 
     WriteConfigFile();

--- a/SOURCES/RES_PICKER.CPP
+++ b/SOURCES/RES_PICKER.CPP
@@ -87,8 +87,8 @@ void ShowInvalidPickMessage(void) {
         "Game data not found",
         "This folder doesn't contain lba2.hqr.\n\n"
         "Please pick the folder containing your retail Little Big "
-        "Adventure 2 install — the one with lba2.hqr, music/, video/, "
-        "vox/, etc.",
+        "Adventure 2 install (the one with lba2.hqr, music/, video/, "
+        "vox/, etc.).",
         NULL);
 }
 
@@ -120,8 +120,8 @@ void ShowDiscoveryFailedMessage(void) {
         "Game data folder not found",
         "Little Big Adventure 2 retail game data wasn't found in any of "
         "the usual places.\n\n"
-        "Please pick the folder containing your LBA2 install — the one "
-        "with lba2.hqr, music/, video/, vox/, etc.\n\n"
+        "Please pick the folder containing your LBA2 install (the one "
+        "with lba2.hqr, music/, video/, vox/, etc.).\n\n"
         "Your choice will be remembered for future launches.",
         NULL);
 }
@@ -140,7 +140,7 @@ void ShowDialogUnavailableMessage(void) {
         "    sudo apt install zenity\n"
         "    (or: pacman -S zenity / dnf install zenity)\n\n"
         "For native-styled dialogs on KDE / GNOME / Hyprland, install\n"
-        "the matching xdg-desktop-portal package — see docs/GAME_DATA.md\n"
+        "the matching xdg-desktop-portal package. See docs/GAME_DATA.md\n"
         "section 'Picker backends per environment'.\n\n"
         "Or skip the picker entirely: launch from a terminal with\n"
         "    lba2cc --game-dir /path/to/your/lba2/install\n"


### PR DESCRIPTION
Removes the last em-dashes from code string literals, so there are none left anywhere in code (comments aside, which are fine per the request).

A tree-wide scan found five, all in native SDL message-box text:
- [PERSO.CPP](SOURCES/PERSO.CPP) fatal-dialog title (x2): the dash becomes a colon (`"LBA2: cannot start"`).
- [RES_PICKER.CPP](SOURCES/RES_PICKER.CPP) picker messages (x3): the two install-location asides are parenthesised; the docs-pointer aside becomes a second sentence.

These are real UTF-8 dialogs, so they always rendered fine; this is a style call, not a render fix (the CP437-console-bound ones were already handled in #300/#301). I phrased the dashes out with colons, parens, and sentence splits rather than swapping in a hyphen, since a spaced hyphen used as a connective is the same reflex.

Build + clang-format clean; 21 host tests pass. The repo's `check-emdash` commit hook passes (it caught my first commit message for quoting the old strings, which is exactly its job).