### PR TITLE
fix: FollowCamera no longer re-renders the full terrain every idle frame

### DIFF
--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -1804,9 +1804,18 @@ restartloop:
                                 if (dynamicDiv < FOLLOW_CAM_ROT_DIVISOR / 3)
                                     dynamicDiv = FOLLOW_CAM_ROT_DIVISOR / 3;
                                 S32 step = diff / dynamicDiv;
-                                if (step > 0 AND step < FOLLOW_CAM_ROT_MIN_STEP)
-                                    step = FOLLOW_CAM_ROT_MIN_STEP;
-                                if (step<0 AND step> - FOLLOW_CAM_ROT_MIN_STEP)
+                                // Clamp to a minimum magnitude toward the target. Integer
+                                // division truncates to 0 whenever |diff| < dynamicDiv (e.g.
+                                // diff -13 / div 36 = 0), and diff is still past the snap
+                                // threshold here, so without this the camera neither steps
+                                // nor snaps: BetaCam sticks ~threshold..dynamicDiv units off
+                                // target forever, the dirty check keeps firing, and the
+                                // exterior re-renders the full terrain (AFF_ALL_FLIP) every
+                                // idle frame. Handle step == 0 too, not just the < MIN_STEP
+                                // cases, so the camera always closes the gap and settles.
+                                if (step >= 0 AND step < FOLLOW_CAM_ROT_MIN_STEP)
+                                    step = (diff > 0) ? FOLLOW_CAM_ROT_MIN_STEP : -FOLLOW_CAM_ROT_MIN_STEP;
+                                else if (step<0 AND step> - FOLLOW_CAM_ROT_MIN_STEP)
                                     step = -FOLLOW_CAM_ROT_MIN_STEP;
                                 BetaCam = (BetaCam + step) & 4095;
                             } else {


### PR DESCRIPTION
## Summary

With Auto camera (FollowCamera) on, the exterior re-rendered the entire terrain (`AFF_ALL_FLIP`) on every frame even with the hero standing still, pinning exterior FPS near the vsync ceiling (~45 fps, render-bound). Turning Auto camera off jumped to 200+ fps. This fixes the root cause so an idle FollowCamera settles and drops to the cheap object-only redraw.

## Root cause

The follow-camera rotation lerp in `PERSO.CPP` converges `BetaCam` toward the target angle:

```c
S32 step = diff / dynamicDiv;                 // integer division
if (step > 0 && step < MIN_STEP)  step = MIN_STEP;
if (step < 0 && step > -MIN_STEP) step = -MIN_STEP;
BetaCam = (BetaCam + step) & 4095;
```

`diff / dynamicDiv` truncates to 0 whenever `|diff| < dynamicDiv` (e.g. -13 / 36 = 0). The two clamps only cover `step > 0` and `step < 0`, so a step of 0 falls through unchanged. And `|diff|` there is still past the snap threshold, so the snap-to-target branch does not run either. So `BetaCam` sticks ~13 units off target indefinitely (measured standing still: `BetaCam` 1876 vs target 1863).

That keeps the camera dirty-check firing every frame, which forces `FirstTime = AFF_ALL_FLIP` (full terrain rebuild) on every frame, idle or not. The "when the hero is idle, all work is skipped entirely" comment was the intent; the dead zone broke it.

## Fix

Force a minimum step toward the target when the division rounds below `MIN_STEP` (including the 0 case), so the camera always closes the gap and reaches the snap zone. Once settled, the dirty-check goes quiet and the exterior uses the cheap object-only redraw.

## Measured (headless, vsync off, Desert Island, hero idle)

|  | scene / frame | FPS |
|---|---|---|
| FollowCamera on, before | ~22 ms | ~45 |
| FollowCamera off (classic) | ~4.3 ms | ~228 |
| FollowCamera on, after | ~4.5 ms | ~221 |

## Notes

- Moving behaviour is unchanged: when the hero moves, `diff` is large and `step` was already non-zero, so this only affects the final settling.
- Does not touch the projection corpus baselines (those run the default classic camera, FollowCamera off). All 23 host tests pass; clang-format clean.
- Related: the `AddBetaCam` pan-drift logic uses the same `step = drift / divisor` + clamp pattern, so it can leave a small residual offset, but it only runs while moving so it does not cause the idle-redraw waste. Left as-is.