### PR TITLE
fix(log): set Windows console to UTF-8 so the boot banner renders

### DIFF
--- a/LIB386/SYSTEM/LOG.CPP
+++ b/LIB386/SYSTEM/LOG.CPP
@@ -210,6 +210,12 @@ int terminal_enabled(void) {
         return 0;
     if (!SetConsoleMode(h, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING))
         return 0;
+    /* The console's output codepage defaults to the legacy OEM page (CP437 in
+     * US locales), which renders our UTF-8 bytes as mojibake: the banner's "·"
+     * separator (U+00B7 = 0xC2 0xB7) shows up as "┬╖", and accented paths fare
+     * no better. Switch the console to UTF-8 so what we write is read back
+     * correctly. Best-effort: colour still works if this fails. */
+    SetConsoleOutputCP(CP_UTF8);
 #endif
     return 1;
 }


### PR DESCRIPTION
## Problem

On Windows the boot banner renders the `·` separator as `┬╖`:

```
LBA2 Classic Community 0.11.0-dev ┬╖ Windows x86_64 ┬╖ 6 cores ┬╖ 64 GB RAM
```

The banner ([INITADEL.C](SOURCES/INITADEL.C)) uses a UTF-8 `·` (U+00B7 = bytes `0xC2 0xB7`). The terminal sink writes those raw bytes to `stderr`, but the Windows console output codepage defaults to the legacy OEM page (CP437 in US locales), where `0xC2` is `┬` and `0xB7` is `╖`. The in-engine F12 console already folds Unicode to CP437, and `adeline.log` is read as UTF-8, so only the Windows terminal was affected.

`terminal_enabled()` already enables ANSI VT processing on Windows but never set the output codepage, so colour worked and encoding didn't.

## Fix

Add `SetConsoleOutputCP(CP_UTF8)` next to the existing VT-enable in `terminal_enabled()`. It's best-effort (colour still works if it fails) and only runs when `stderr` is a real console, so redirected output is untouched. This also fixes the `Assets:`/`Saves:`/`Config:` path lines, which would mojibake the same way for a non-ASCII Windows username.

## Testing

clang-format clean; Linux build recompiles and links. The `_WIN32` branch can't be exercised on the Linux dev box (no cross-toolchain), so Windows CI / a Windows run is the real check. The two added lines use only standard `<windows.h>` symbols already included by the file.