### PR TITLE
fix: pin the FPS counter to the bottom corner at any resolution

### DIFF
--- a/SOURCES/OBJECT.CPP
+++ b/SOURCES/OBJECT.CPP
@@ -5307,7 +5307,11 @@ void AffNbFps(void) {
         UnsetClipWindow();
 
         CoulText(LBAWHITE, 0);
-        GraphPrintf(FALSE, 0, 472, "%d ", NbFramePerSecond);
+        // Pin to the bottom-left corner at any render height. The glyph cell is
+        // 8 px tall (GraphPrintf), so ModeDesiredY - 8 sits flush with the
+        // bottom edge; the original hardcoded 472 only matched 480-tall modes
+        // and floated mid-screen at taller resolutions.
+        GraphPrintf(FALSE, 0, ModeDesiredY - 8, "%d ", NbFramePerSecond);
 
         RestoreClipWindow();
         UnsetClip();


### PR DESCRIPTION
## Summary

The on-screen FPS counter (`AffNbFps`, shown via the `fps` console verb or the SPEED cheat) was drawn at a hardcoded `y = 472`. That is the bottom edge only at 480-tall render modes; at taller resolutions it floated mid-screen. Derive the row from the render height so it stays in the bottom-left corner at any resolution.

## Change

`GraphPrintf(FALSE, 0, 472, ...)` becomes `GraphPrintf(FALSE, 0, ModeDesiredY - 8, ...)`. The glyph cell is 8 px tall, so `ModeDesiredY - 8` sits flush with the bottom edge. `x = 0` already pinned the left edge, so the counter stays bottom-left.

## Verified

The present path uploads `Log` but `--screenshot` reads `Screen`, so I confirmed the draw position by instrumentation rather than a screenshot:

| Resolution | y | passes clip | sits at |
|---|---|---|---|
| 640x480 | 472 | yes | bottom (unchanged) |
| 640x720 | 712 | yes | bottom |
| 1280x1024 | 1016 | yes | bottom |

Build clean; all 23 host tests pass; clang-format clean.