### PR TITLE
feat(iso): runtime IsoScale knob for the isometric interior view

### DIFF
--- a/LIB386/3D/CAMERA.CPP
+++ b/LIB386/3D/CAMERA.CPP
@@ -48,6 +48,8 @@ S32 TypeProj = TYPE_3D;
 float FRatioX = 0.0f;
 float FRatioY = 0.0f;
 
+S32 IsoScale = ISO_SCALE_ONE;
+
 U64 MMX_DEMI = (8192LL << 32) | 8192LL;
 U64 MMX_DEMI2 = (4096LL << 32) | 4096LL;
 
@@ -125,6 +127,15 @@ void SetFollowCamera(S32 targetx, S32 targety, S32 targetz, S32 alpha, S32 beta,
         CameraY = Y0;
         CameraZ = Z0;
     }
+}
+
+void SetIsoScale(S32 scale) {
+    // Clamp to a sane zoom range (1/16x .. 16x). ISO_SCALE_ONE is 1.0.
+    if (scale < ISO_SCALE_ONE / 16)
+        scale = ISO_SCALE_ONE / 16;
+    if (scale > ISO_SCALE_ONE * 16)
+        scale = ISO_SCALE_ONE * 16;
+    IsoScale = scale;
 }
 
 // =============================================================================

--- a/LIB386/3D/LPROJISO.CPP
+++ b/LIB386/3D/LPROJISO.CPP
@@ -24,11 +24,16 @@ S32 LongProjectPointIso(S32 x, S32 y, S32 z) {
     y = y - tmpy;
     z = z * 3;
 
-    x = x >> 6; // /64 IsoScale
+    // Apply the runtime iso view scale. At the default ISO_SCALE_ONE this is
+    // (v * 2^SHIFT) >> (n + SHIFT) == v >> n, bit-for-bit the original /64 and
+    // /256 shifts; the long long intermediate keeps the scaled path from
+    // overflowing. The screen centre is added after the scale, so zoom is
+    // about XCentre/YCentre (the camera/hero point).
+    x = (S32)(((long long)x * IsoScale) >> (6 + ISO_SCALE_SHIFT)); // /64 IsoScale
     x = x + XCentre;
     z = z - y;
 
-    z = z >> 8; // /256 IsoScale
+    z = (S32)(((long long)z * IsoScale) >> (8 + ISO_SCALE_SHIFT)); // /256 IsoScale
     z = z + YCentre + 1;
 
     Xp = x;

--- a/LIB386/3D/PRLIISO.CPP
+++ b/LIB386/3D/PRLIISO.CPP
@@ -35,8 +35,12 @@ void ProjectListIso(TYPE_PT *Dst, TYPE_VT16 *Src, S32 NbPt, S32 OrgX,
 		   preserve byte-for-byte behavior. */
         memcpy(&v->Z, &sortZ, sizeof(sortZ));
 
-        S32 newX = XCentre + (((x - z) * 3) >> 6);              // IsoScale
-        S32 newY = YCentre + 1 + (((x + z) * 6 - y * 15) >> 8); // IsoScale
+        // IsoScale: same runtime view scale as LongProjectPointIso. At the
+        // default ISO_SCALE_ONE the multiply/shift cancels to the original
+        // `>> 6` / `>> 8`, so test_prliiso stays bit-exact against the ASM.
+        S32 newX = XCentre + (S32)(((long long)((x - z) * 3) * IsoScale) >> (6 + ISO_SCALE_SHIFT));
+        S32 newY = YCentre + 1 +
+                   (S32)(((long long)((x + z) * 6 - y * 15) * IsoScale) >> (8 + ISO_SCALE_SHIFT));
 
         if (newX > 32767 || newX < -32767 || newY > 32767 || newY < -32767) {
             TYPE_PT *p = &Dst[i];

--- a/LIB386/H/3D/CAMERA.H
+++ b/LIB386/H/3D/CAMERA.H
@@ -42,6 +42,15 @@ extern S32 TypeProj;
 extern float FRatioX;
 extern float FRatioY;
 
+/* Runtime isometric view scale (fixed-point, ISO_SCALE_ONE == 1.0). Multiplies the
+   iso projection of models (LongProjectPointIso) and brick positions (Map2Screen)
+   so an interior view can be zoomed or supersampled without touching world state.
+   At the default ISO_SCALE_ONE the projection is bit-for-bit identical to the
+   original, so the faithful path and the ASM equivalence tests are unaffected. */
+#define ISO_SCALE_SHIFT 8
+#define ISO_SCALE_ONE (1 << ISO_SCALE_SHIFT)
+extern S32 IsoScale;
+
 extern U64 MMX_DEMI;
 extern U64 MMX_DEMI2;
 
@@ -52,6 +61,7 @@ void SetAngleCamera(S32 alpha, S32 beta, S32 gamma);
 void SetPosCamera(S32 x, S32 y, S32 z);
 void SetFollowCamera(S32 targetx, S32 targety, S32 targetz, S32 alpha, S32 beta,
                      S32 gamma, S32 camzoom);
+void SetIsoScale(S32 scale);
 
 // =============================================================================
 #ifdef __cplusplus

--- a/LIB386/OBJECT/AFF_OBJ.CPP
+++ b/LIB386/OBJECT/AFF_OBJ.CPP
@@ -1058,6 +1058,11 @@ S32 Sphere(U32 typePoly, void *poly) {
     if (TypeProj != TYPE_3D) {
         radius += radius + (radius << 5);
         radius >>= 9;
+        // Scale the sphere radius by the iso view scale so spheres (hands, joints,
+        // heads) grow with the zoom like the polygon body does. The point centre
+        // already scales via ProjectListIso; without this the radii stay fixed and
+        // spheres appear to shrink relative to the body. Bit-exact at ISO_SCALE_ONE.
+        radius = (S32)(((long long)radius * IsoScale) >> ISO_SCALE_SHIFT);
         radius = ~radius;
     } else {
         // @@Radius_Proj:
@@ -1113,6 +1118,11 @@ S32 Sphere_Transp(U32 typePoly, void *poly) {
     if (TypeProj != TYPE_3D) {
         radius += radius + (radius << 5);
         radius >>= 9;
+        // Scale the sphere radius by the iso view scale so spheres (hands, joints,
+        // heads) grow with the zoom like the polygon body does. The point centre
+        // already scales via ProjectListIso; without this the radii stay fixed and
+        // spheres appear to shrink relative to the body. Bit-exact at ISO_SCALE_ONE.
+        radius = (S32)(((long long)radius * IsoScale) >> ISO_SCALE_SHIFT);
         radius = ~radius;
     } else {
         S16 z = Obj_ListRotatedPoints[sphere->P1].Z;

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -17,6 +17,7 @@
 #include "../INVENT.H"
 #include "../RES_SWITCH.H"
 #include "../PERFTRACE.H"
+#include <3D/CAMERA.H>
 #include <SYSTEM/LOG.H>
 #include <SYSTEM/FILES.H>
 #include <SYSTEM/STRING.H>
@@ -276,6 +277,37 @@ static void cmd_screenshot(int argc, const char *argv[]) {
     GetShootPath(path, ADELINE_MAX_PATH, filename);
     Console_RequestScreenshot(path, 1); /* 1 = PNG via SavePNG in game */
     Console_Print("Screenshot (no console): %s", path);
+}
+
+/* iso scale <factor> | iso reset: dev/experimental zoom of the isometric
+   interior projection. Sets the global IsoScale (models + brick positions).
+   1.0 is the original. Brick tiles are not stretched yet, so factors > 1 show
+   gaps between floor bricks; see docs/ISO_SCALE.md. */
+static void cmd_iso(int argc, const char *argv[]) {
+    int changed = 0;
+    if (argc >= 3 && !strcmp(argv[1], "scale")) {
+        double f = atof(argv[2]);
+        if (f <= 0.0) {
+            Console_Print("iso scale: factor must be > 0");
+            return;
+        }
+        SetIsoScale((S32)(f * ISO_SCALE_ONE + 0.5));
+        changed = 1;
+    } else if (argc >= 2 && !strcmp(argv[1], "reset")) {
+        SetIsoScale(ISO_SCALE_ONE);
+        changed = 1;
+    } else if (argc >= 2) {
+        Console_Print("Usage: iso scale <factor> | iso reset");
+        return;
+    }
+    /* The brick floor is a cached background, re-laid only on a full redraw
+       (RefreshGrille runs in AffScene's AFF_ALL_* path, not the per-frame
+       AFF_OBJETS_* path). Force one so bricks pick up the new scale instead of
+       only the per-frame 3D objects. */
+    if (changed)
+        FirstTime = AFF_ALL_FLIP;
+    Console_Print("iso scale = %.3f (raw %d/%d)", (double)IsoScale / ISO_SCALE_ONE,
+                  (int)IsoScale, (int)ISO_SCALE_ONE);
 }
 
 /* ui <surface> <path> — open a UI modal in headless-harness mode, capture a
@@ -1619,6 +1651,10 @@ void Console_RegisterAll(void) {
                               "headless captures of UI state.");
     Console_RegisterCommandEx("savebug", cmd_savebug, "Save current game to bugs dir (optional name)", "savebug [name]",
                               "Requires in-game loaded cube (not during video); writes bugs/<name>.lba.");
+    Console_RegisterCommandEx("iso", cmd_iso, "Scale the iso interior view (dev/experimental zoom)",
+                              "iso scale <factor> | iso reset",
+                              "1.0 = original (bit-exact). Scales models + brick positions; brick tiles "
+                              "do not stretch yet, so factors > 1 leave gaps. See docs/ISO_SCALE.md.");
     Console_RegisterCommandEx("resolution", cmd_resolution,
                               "Switch render resolution at runtime (no args = list)",
                               "resolution [<n> | WxH | native | --all]",

--- a/SOURCES/GRILLE.CPP
+++ b/SOURCES/GRILLE.CPP
@@ -2,6 +2,7 @@
 #include "DIRECTORIES.H"
 
 #include <3D/PROJREC.H>
+#include <3D/CAMERA.H>
 #include <SVGA/SCREEN.H>
 
 /*══════════════════════════════════════════════════════════════════════════*
@@ -1422,8 +1423,17 @@ void DecompColonne(U8 *pts, U8 *ptd) {
 // iso grid stays centred at any render-space size; at 640×480 this is
 // the original (288, 226). See docs/WIDESCREEN.md Phase 2.
 void Map2Screen(S32 x, S32 y, S32 z) {
-    XScreen = 24 * (x - z) + ((S32)ModeDesiredX / 2 - 32);
-    YScreen = 12 * (z + x) - 15 * y + ((S32)ModeDesiredY / 2 - 14);
+    // Brick screen position, scaled by the runtime iso view scale so the floor
+    // grid tracks the models (LongProjectPointIso uses the same IsoScale). At the
+    // default ISO_SCALE_ONE the multiply/shift cancels and this is bit-for-bit the
+    // original `24*(x-z)` / `12*(z+x)-15*y`. Only the iso offset scales; the screen
+    // anchor (ModeDesiredX/2 ...) does not, so zoom stays centred on the view.
+    // Note: the brick *tile* is still blitted at native size by AffBrickBlock, so
+    // scales > 1 leave gaps between tiles. See docs/ISO_SCALE.md.
+    XScreen = (S32)(((long long)(24 * (x - z)) * IsoScale) >> ISO_SCALE_SHIFT) +
+              ((S32)ModeDesiredX / 2 - 32);
+    YScreen = (S32)(((long long)(12 * (z + x) - 15 * y) * IsoScale) >> ISO_SCALE_SHIFT) +
+              ((S32)ModeDesiredY / 2 - 14);
     Projrec_Map2Screen(x, y, z, XScreen, YScreen);
 }
 

--- a/docs/ISO_SCALE.md
+++ b/docs/ISO_SCALE.md
@@ -1,0 +1,141 @@
+# Iso view scale
+
+A runtime scale for the isometric interior projection. It multiplies how large the
+iso world is drawn on screen without touching world state, camera position, or game
+logic. The default is 1.0, where the projection is bit-for-bit identical to the
+original, so the faithful path and the ASM equivalence tests are unaffected.
+
+This is the shared primitive behind three planned features. The difference between
+them is only whether you also change the render buffer size:
+
+- **scale only** gives a dynamic zoom (the framing changes, the model gets larger or
+  smaller).
+- **scale and buffer together, then downsample** gives supersampled anti-aliasing
+  (same framing, more pixels, which removes the silhouette shimmer that the original
+  integer rasterizer produces on slowly moving characters).
+- **scale and buffer together at a high-resolution display** gives HD fidelity (same
+  framing, more pixels on the model).
+
+Only the first (a dev/experimental zoom) is wired up today. The rest are roadmap.
+
+## What it touches
+
+The iso projection has no scale argument of its own (`SetIsoProjection` takes only a
+centre), so the scale lives in a single global, `IsoScale`, applied everywhere the
+iso world is sized for the screen:
+
+- Object geometry: `ProjectListIso` ([PRLIISO.CPP](../LIB386/3D/PRLIISO.CPP)), the
+  batched vertex projector that draws character and object bodies.
+- Single points: `LongProjectPointIso` ([LPROJISO.CPP](../LIB386/3D/LPROJISO.CPP)),
+  used for object anchors, shadows, and bounding boxes.
+- Brick floor and walls: `Map2Screen` ([GRILLE.CPP](../SOURCES/GRILLE.CPP)).
+- Sphere primitives: the radius in `Sphere` / `Sphere_Transp`
+  ([AFF_OBJ.CPP](../LIB386/OBJECT/AFF_OBJ.CPP)). Spheres (hands, joints, heads) carry
+  a separate radius scalar, not just a projected centre. The first three places only
+  move the centre, so without this the radii stay fixed and spheres appear to shrink
+  as the body grows.
+
+All four must scale by the same factor or the model comes apart (bodies detach from
+the floor, hands shrink). The point projectors share the same visual scale in
+different coordinate units (one brick step is 512 world units), so scaling all of
+them by `IsoScale` keeps the model coherent.
+
+`IsoScale` is fixed-point: `ISO_SCALE_ONE` (256) is 1.0, so 512 is 2.0 and 128 is 0.5.
+At `ISO_SCALE_ONE` the multiply and shift cancel exactly (`(v * 256) >> (n + 8) == v >> n`),
+which is why the default path is bit-exact. The constant and the global are declared in
+[CAMERA.H](../LIB386/H/3D/CAMERA.H); set it through `SetIsoScale()`, which clamps to a
+1/16x to 16x range.
+
+Only iso interior scenes are affected. Exterior island scenes use the perspective
+projection (`LongProjectPoint3D`, with its own `FRatioX` focal), so `IsoScale` is a
+no-op there.
+
+## Lineage
+
+This restores a capability the LBA1 engine had and LBA2 dropped. In LBA1,
+`SetIsoProjection` took a third `scale` argument that set a global `IsoScale` (the iso
+projection divided by it; gameplay passed `SIZE_BRICK_XZ` = 512). LBA2 removed the
+parameter and hardcoded the scale (the `/512` here is that value baked in), so this is
+re-adding a knob the original engine evolution removed, not inventing a new one. Two
+deliberate differences from LBA1:
+
+- It lives in a separate global, not a third `SetIsoProjection` argument. Re-adding the
+  argument would diverge from LBA2's original 2-argument ASM and break the
+  `test_proj` equivalence test, so the scale is kept out of that signature.
+- LBA1's `IsoScale` was a divisor (larger = smaller image). This one is a fixed-point
+  multiplier (`ISO_SCALE_ONE` = 1.0, larger = zoom in), because the reimplemented iso
+  formula uses shifts rather than a divide.
+
+## Trying it
+
+In the console:
+
+```
+iso scale 2      # zoom the iso interior to 2x
+iso scale 1.5
+iso reset        # back to 1.0
+iso              # print the current scale
+```
+
+Headless, for before and after captures (the screenshot path used during development):
+
+```
+lba2cc --game-dir <data> --load "<save>" --no-audio --fixed-dt 16 \
+       --exec "iso scale 2" --tick 40 --screenshot out_2x.png --exit
+```
+
+Load an interior save (for example the game-start save, Twinsen's house) to see an
+effect; an exterior save will not change.
+
+## Known limitation: bricks do not stretch yet
+
+Bricks are fixed-resolution sprite tiles, blitted at native size by `AffBrickBlock`
+(via `AffGraph`), and the brick pipeline keys off a hardcoded 24px grid (clipping,
+the `(XScreen+24)/24` column bucketing, the `DrawOverBrick` re-blit). `Map2Screen`
+scales the brick *positions*, so the floor layout stays correct, but the tiles are
+still drawn at their original size. At scales above 1.0 this leaves gaps between
+floor bricks; below 1.0 the tiles overlap.
+
+So today the scale is coherent for geometry (characters stay on the floor) but the
+brick environment cannot gain detail beyond its source art. This is expected and is
+the next thing to solve before the zoom is presentable.
+
+The brick floor is also a cached background: it is re-laid only on a full redraw
+(`RefreshGrille` runs in `AffScene`'s `AFF_ALL_*` path, not the per-frame
+`AFF_OBJETS_*` path). So changing the scale mid-scene re-scales only the per-frame
+3D objects until a redraw happens. The `iso` console command forces one
+(`FirstTime = AFF_ALL_FLIP`) so the floor re-lays at the new scale immediately. A
+future dynamic zoom that changes the scale every frame would have to re-lay the
+bricks every frame, which is one more reason the render-at-scale-and-sample approach
+(which sidesteps brick re-lay entirely) is the likely path for smooth zoom.
+
+## Roadmap
+
+1. **Brick scaling strategy.** Either stretch the brick blit (and rework the 24px
+   grid assumptions), or render the iso scene at a fixed higher scale and sample the
+   buffer for intermediate zoom (which avoids fractional geometry and the brick-grid
+   surgery, at the cost of capping maximum sharpness). The second path is the likely
+   choice for smooth dynamic zoom.
+2. **Dynamic zoom.** Drive `IsoScale` over time and integrate with the iso follow
+   camera so the view stays centred as the visible window shrinks. Zoom is a pure
+   view transform: collision is world-space (`WorldColBrick`) and is not affected,
+   which is what keeps it safe for determinism.
+3. **Supersampling for the silhouette shimmer.** Render the scene to a buffer scaled
+   by S with `IsoScale` scaled by S, then box-downsample to the display. The
+   downsample is what removes the flicker (it anti-aliases the edges). The UI is
+   4:3 display-anchored and must be composited at display resolution after the
+   downsample, not supersampled with the scene.
+
+## Constraints
+
+- The default (1.0) must stay bit-exact. The three projectors are covered by ASM
+  equivalence tests ([tests/3D/test_lprojiso.cpp](../tests/3D/test_lprojiso.cpp),
+  [tests/3D/test_prliiso.cpp](../tests/3D/test_prliiso.cpp),
+  [tests/test_grille.cpp](../tests/test_grille.cpp)); any change here keeps scale 1.0
+  matching the original ASM.
+- Non-default scales change projected coordinates, so they change projection-record
+  hashes and are not a faithful-path mode. Keep the scale at 1.0 for regression runs.
+- The console command is a dev knob. There is no keybinding or persisted setting yet,
+  and opening a menu after setting a scale may inherit it (the menus also use the iso
+  projection). Scoping the scale to the gameplay view is part of wiring up a real
+  zoom feature.

--- a/docs/WIDESCREEN.md
+++ b/docs/WIDESCREEN.md
@@ -302,3 +302,5 @@ LBA2_BIN=build-wide/SOURCES/lba2cc \
 | 6 — regression | Not started |
 
 Foundation already in place: PR #134 (`RESOLUTION_X` / `RESOLUTION_Y` constants, and most render-space literals routed through them).
+
+The HD and zoom side of Phase 5 starts with a runtime iso view scale (`IsoScale`), the shared primitive for dynamic zoom, supersampled anti-aliasing, and HD model fidelity in interior scenes. See [ISO_SCALE.md](ISO_SCALE.md).


### PR DESCRIPTION
## What

Adds a runtime scale for the isometric interior projection, `IsoScale`. It is the
shared primitive for dynamic zoom, supersampled anti-aliasing, and HD interior
fidelity. The default is 1.0, where the projection is bit-for-bit identical to the
original.

For now it is driven by a dev console verb: `iso scale <factor>` / `iso reset`, also
usable headless via `--exec`.

## Why

The iso projection had no scale parameter (`SetIsoProjection` takes only a centre), so
raising the resolution revealed more room instead of putting more pixels on models.
This is the lever that decouples render resolution from framing.

It also restores a capability the LBA1 engine had: LBA1's `SetIsoProjection` took a
`scale` argument that set a global `IsoScale`; LBA2 dropped the parameter and hardcoded
the value (the `/512` in the iso path is that value baked in). See
[docs/ISO_SCALE.md](docs/ISO_SCALE.md) for the lineage and the design rationale. It is
kept as a separate global rather than re-adding the third argument, because the
2-argument `SetIsoProjection` must stay bit-exact against the original ASM.

## How

A single fixed-point `IsoScale` global, applied at every iso scale site so the model
scales coherently:

- `ProjectListIso` (object/character geometry)
- `LongProjectPointIso` (single points: anchors, shadows, bounding boxes)
- `Map2Screen` (brick positions)
- the sphere radius in `Sphere` / `Sphere_Transp` (hands, joints, heads carry a
  separate radius scalar, not just a projected centre)

At the default `ISO_SCALE_ONE` the multiply and shift cancel exactly
(`(v * 256) >> (n + 8) == v >> n`), so the faithful path is unchanged.

## Testing

- ASM equivalence at identity: `test_lprojiso`, `test_prliiso`, `test_grille` and
  `test_aff_obj` all pass, so the changed functions stay bit-for-bit against the
  original ASM at scale 1.0.
- Host test suite green.
- Verified in-game: models, bricks and sphere primitives all scale together.

## Known limitation

Bricks are fixed-size sprite tiles, so `Map2Screen` scales their positions but the
tiles are still blitted at native size, leaving gaps between floor bricks at scales
above 1.0. Documented in [docs/ISO_SCALE.md](docs/ISO_SCALE.md); the next step is the
brick scaling strategy (render-at-scale-and-sample), which also unlocks smooth dynamic
zoom.
