### PR TITLE
fix(harness): screenshot captures Log (the presented buffer), not Screen

### DIFF
--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -615,7 +615,10 @@ static void control_dump_state(const char *path) {
 }
 
 static void control_screenshot(const char *path) {
-    SavePNG((char *)path, Screen, (S32)ModeDesiredX, (S32)ModeDesiredY, PtrPal);
+    /* Capture Log, the presented buffer (SDL PresentFrame uploads Log). Screen is
+       a secondary buffer that only holds the clean brick background, so it misses
+       the per-frame 3D models and the foreground-brick re-blit. */
+    SavePNG((char *)path, Log, (S32)ModeDesiredX, (S32)ModeDesiredY, PtrPal);
 }
 
 /* The capture half of finalize: dump/screenshot only, no exit. Shared by the tick-budget

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -809,12 +809,15 @@ restartloop:
 
         CheckSavePcx(); // F9: Sauve Screen
 
-        /* Console screenshot (PNG): requested without overlay; perform here where we have Screen + PtrPal. */
+        /* Console screenshot (PNG): performed here where Log + PtrPal are valid.
+           Capture Log, the presented buffer (SDL PresentFrame uploads Log); Screen
+           is the clean-background secondary and misses the per-frame 3D models and
+           the foreground-brick re-blit. */
         {
             char shotPath[ADELINE_MAX_PATH];
             int is_png = 0;
             if (Console_HasPendingScreenshot(shotPath, sizeof(shotPath), &is_png) && is_png) {
-                SavePNG(shotPath, Screen, ModeDesiredX, ModeDesiredY, PtrPal);
+                SavePNG(shotPath, Log, ModeDesiredX, ModeDesiredY, PtrPal);
                 Console_ClearPendingScreenshot();
             }
         }


### PR DESCRIPTION
## What

The `--screenshot` harness flag and the `screenshot` console command now capture
`Log` (the buffer SDL presents) instead of `Screen`.

## Why

`PresentFrame` (SVGA/SDL.CPP) uploads `Log` to the display, so `Log` is the real
composited frame. `Screen` is a secondary buffer holding only the clean brick
background (the source for the `CopyMask` foreground re-blit and `BackupScreen`).
It misses the per-frame 3D models and the foreground-brick re-blit, so 3D
character models did not appear in captures at all.

The Dial / menu / UI captures (MESSAGE.CPP, GAMEMENU.CPP) already use `Log`; this
aligns the general screenshot with them and with what is actually on screen.

## Test

Captured an interior scene headless before and after: 3D character models are
absent in the old `Screen` capture and present in the new `Log` capture. Builds
clean; the change is two `SavePNG` buffer arguments.
