### PR TITLE
Experimental: scalable iso interior view (HD/SSAA foundation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ tests/SNAPSHOT/fixtures/*.raw
 android/build/
 android/apk/
 android/local.properties
+
+# local dev screenshot captures
+.frames-tmp/

--- a/LIB386/3D/CAMERA.CPP
+++ b/LIB386/3D/CAMERA.CPP
@@ -48,6 +48,8 @@ S32 TypeProj = TYPE_3D;
 float FRatioX = 0.0f;
 float FRatioY = 0.0f;
 
+S32 IsoScale = ISO_SCALE_ONE;
+
 U64 MMX_DEMI = (8192LL << 32) | 8192LL;
 U64 MMX_DEMI2 = (4096LL << 32) | 4096LL;
 
@@ -125,6 +127,15 @@ void SetFollowCamera(S32 targetx, S32 targety, S32 targetz, S32 alpha, S32 beta,
         CameraY = Y0;
         CameraZ = Z0;
     }
+}
+
+void SetIsoScale(S32 scale) {
+    // Clamp to a sane zoom range (1/16x .. 16x). ISO_SCALE_ONE is 1.0.
+    if (scale < ISO_SCALE_ONE / 16)
+        scale = ISO_SCALE_ONE / 16;
+    if (scale > ISO_SCALE_ONE * 16)
+        scale = ISO_SCALE_ONE * 16;
+    IsoScale = scale;
 }
 
 // =============================================================================

--- a/LIB386/3D/LPROJISO.CPP
+++ b/LIB386/3D/LPROJISO.CPP
@@ -24,11 +24,16 @@ S32 LongProjectPointIso(S32 x, S32 y, S32 z) {
     y = y - tmpy;
     z = z * 3;
 
-    x = x >> 6; // /64 IsoScale
+    // Apply the runtime iso view scale. At the default ISO_SCALE_ONE this is
+    // (v * 2^SHIFT) >> (n + SHIFT) == v >> n, bit-for-bit the original /64 and
+    // /256 shifts; the long long intermediate keeps the scaled path from
+    // overflowing. The screen centre is added after the scale, so zoom is
+    // about XCentre/YCentre (the camera/hero point).
+    x = (S32)(((long long)x * IsoScale) >> (6 + ISO_SCALE_SHIFT)); // /64 IsoScale
     x = x + XCentre;
     z = z - y;
 
-    z = z >> 8; // /256 IsoScale
+    z = (S32)(((long long)z * IsoScale) >> (8 + ISO_SCALE_SHIFT)); // /256 IsoScale
     z = z + YCentre + 1;
 
     Xp = x;

--- a/LIB386/3D/PRLIISO.CPP
+++ b/LIB386/3D/PRLIISO.CPP
@@ -35,8 +35,12 @@ void ProjectListIso(TYPE_PT *Dst, TYPE_VT16 *Src, S32 NbPt, S32 OrgX,
 		   preserve byte-for-byte behavior. */
         memcpy(&v->Z, &sortZ, sizeof(sortZ));
 
-        S32 newX = XCentre + (((x - z) * 3) >> 6);              // IsoScale
-        S32 newY = YCentre + 1 + (((x + z) * 6 - y * 15) >> 8); // IsoScale
+        // IsoScale: same runtime view scale as LongProjectPointIso. At the
+        // default ISO_SCALE_ONE the multiply/shift cancels to the original
+        // `>> 6` / `>> 8`, so test_prliiso stays bit-exact against the ASM.
+        S32 newX = XCentre + (S32)(((long long)((x - z) * 3) * IsoScale) >> (6 + ISO_SCALE_SHIFT));
+        S32 newY = YCentre + 1 +
+                   (S32)(((long long)((x + z) * 6 - y * 15) * IsoScale) >> (8 + ISO_SCALE_SHIFT));
 
         if (newX > 32767 || newX < -32767 || newY > 32767 || newY < -32767) {
             TYPE_PT *p = &Dst[i];

--- a/LIB386/H/3D/CAMERA.H
+++ b/LIB386/H/3D/CAMERA.H
@@ -42,6 +42,15 @@ extern S32 TypeProj;
 extern float FRatioX;
 extern float FRatioY;
 
+/* Runtime isometric view scale (fixed-point, ISO_SCALE_ONE == 1.0). Multiplies the
+   iso projection of models (LongProjectPointIso) and brick positions (Map2Screen)
+   so an interior view can be zoomed or supersampled without touching world state.
+   At the default ISO_SCALE_ONE the projection is bit-for-bit identical to the
+   original, so the faithful path and the ASM equivalence tests are unaffected. */
+#define ISO_SCALE_SHIFT 8
+#define ISO_SCALE_ONE (1 << ISO_SCALE_SHIFT)
+extern S32 IsoScale;
+
 extern U64 MMX_DEMI;
 extern U64 MMX_DEMI2;
 
@@ -52,6 +61,7 @@ void SetAngleCamera(S32 alpha, S32 beta, S32 gamma);
 void SetPosCamera(S32 x, S32 y, S32 z);
 void SetFollowCamera(S32 targetx, S32 targety, S32 targetz, S32 alpha, S32 beta,
                      S32 gamma, S32 camzoom);
+void SetIsoScale(S32 scale);
 
 // =============================================================================
 #ifdef __cplusplus

--- a/LIB386/H/3D/CAMERA.H
+++ b/LIB386/H/3D/CAMERA.H
@@ -51,6 +51,13 @@ extern float FRatioY;
 #define ISO_SCALE_ONE (1 << ISO_SCALE_SHIFT)
 extern S32 IsoScale;
 
+/* Scale a native iso pixel constant by the runtime view scale. At ISO_SCALE_ONE
+   this is the identity (n*256/256 == n) for any n, so the faithful path is
+   unchanged. Use it for every screen-pixel dimension in the iso path (clip
+   bounds, brick column granularity, sprite offsets) so they all move with one
+   factor instead of each carrying its own scaling. See docs/ISO_SPACE_AUDIT.md. */
+#define ISO_PX(n) ((S32)(((long long)(n) * IsoScale) / ISO_SCALE_ONE))
+
 extern U64 MMX_DEMI;
 extern U64 MMX_DEMI2;
 

--- a/LIB386/OBJECT/AFF_OBJ.CPP
+++ b/LIB386/OBJECT/AFF_OBJ.CPP
@@ -1058,6 +1058,11 @@ S32 Sphere(U32 typePoly, void *poly) {
     if (TypeProj != TYPE_3D) {
         radius += radius + (radius << 5);
         radius >>= 9;
+        // Scale the sphere radius by the iso view scale so spheres (hands, joints,
+        // heads) grow with the zoom like the polygon body does. The point centre
+        // already scales via ProjectListIso; without this the radii stay fixed and
+        // spheres appear to shrink relative to the body. Bit-exact at ISO_SCALE_ONE.
+        radius = (S32)(((long long)radius * IsoScale) >> ISO_SCALE_SHIFT);
         radius = ~radius;
     } else {
         // @@Radius_Proj:
@@ -1113,6 +1118,11 @@ S32 Sphere_Transp(U32 typePoly, void *poly) {
     if (TypeProj != TYPE_3D) {
         radius += radius + (radius << 5);
         radius >>= 9;
+        // Scale the sphere radius by the iso view scale so spheres (hands, joints,
+        // heads) grow with the zoom like the polygon body does. The point centre
+        // already scales via ProjectListIso; without this the radii stay fixed and
+        // spheres appear to shrink relative to the body. Bit-exact at ISO_SCALE_ONE.
+        radius = (S32)(((long long)radius * IsoScale) >> ISO_SCALE_SHIFT);
         radius = ~radius;
     } else {
         S16 z = Obj_ListRotatedPoints[sphere->P1].Z;

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -17,6 +17,7 @@
 #include "../INVENT.H"
 #include "../RES_SWITCH.H"
 #include "../PERFTRACE.H"
+#include <3D/CAMERA.H>
 #include <SYSTEM/LOG.H>
 #include <SYSTEM/FILES.H>
 #include <SYSTEM/STRING.H>
@@ -276,6 +277,37 @@ static void cmd_screenshot(int argc, const char *argv[]) {
     GetShootPath(path, ADELINE_MAX_PATH, filename);
     Console_RequestScreenshot(path, 1); /* 1 = PNG via SavePNG in game */
     Console_Print("Screenshot (no console): %s", path);
+}
+
+/* iso scale <factor> | iso reset: dev/experimental zoom of the isometric
+   interior projection. Sets the global IsoScale (models + brick positions).
+   1.0 is the original. Brick tiles are not stretched yet, so factors > 1 show
+   gaps between floor bricks; see docs/ISO_SCALE.md. */
+static void cmd_iso(int argc, const char *argv[]) {
+    int changed = 0;
+    if (argc >= 3 && !strcmp(argv[1], "scale")) {
+        double f = atof(argv[2]);
+        if (f <= 0.0) {
+            Console_Print("iso scale: factor must be > 0");
+            return;
+        }
+        SetIsoScale((S32)(f * ISO_SCALE_ONE + 0.5));
+        changed = 1;
+    } else if (argc >= 2 && !strcmp(argv[1], "reset")) {
+        SetIsoScale(ISO_SCALE_ONE);
+        changed = 1;
+    } else if (argc >= 2) {
+        Console_Print("Usage: iso scale <factor> | iso reset");
+        return;
+    }
+    /* The brick floor is a cached background, re-laid only on a full redraw
+       (RefreshGrille runs in AffScene's AFF_ALL_* path, not the per-frame
+       AFF_OBJETS_* path). Force one so bricks pick up the new scale instead of
+       only the per-frame 3D objects. */
+    if (changed)
+        FirstTime = AFF_ALL_FLIP;
+    Console_Print("iso scale = %.3f (raw %d/%d)", (double)IsoScale / ISO_SCALE_ONE,
+                  (int)IsoScale, (int)ISO_SCALE_ONE);
 }
 
 /* ui <surface> <path> — open a UI modal in headless-harness mode, capture a
@@ -1619,6 +1651,10 @@ void Console_RegisterAll(void) {
                               "headless captures of UI state.");
     Console_RegisterCommandEx("savebug", cmd_savebug, "Save current game to bugs dir (optional name)", "savebug [name]",
                               "Requires in-game loaded cube (not during video); writes bugs/<name>.lba.");
+    Console_RegisterCommandEx("iso", cmd_iso, "Scale the iso interior view (dev/experimental zoom)",
+                              "iso scale <factor> | iso reset",
+                              "1.0 = original (bit-exact). Scales models + brick positions; brick tiles "
+                              "do not stretch yet, so factors > 1 leave gaps. See docs/ISO_SCALE.md.");
     Console_RegisterCommandEx("resolution", cmd_resolution,
                               "Switch render resolution at runtime (no args = list)",
                               "resolution [<n> | WxH | native | --all]",

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -296,16 +296,51 @@ static void cmd_iso(int argc, const char *argv[]) {
     } else if (argc >= 2 && !strcmp(argv[1], "reset")) {
         SetIsoScale(ISO_SCALE_ONE);
         changed = 1;
+    } else if (argc >= 2 && !strcmp(argv[1], "probe")) {
+        /* Compare the per-brick screen delta from the model projector
+           (LongProjectPointIso, world coords; 1 brick = SIZE_BRICK_XZ 512 / _Y 256)
+           vs the brick projector (Map2Screen, brick-unit coords). Deltas should
+           match if models and bricks scale identically. */
+        extern S32 LongProjectPointIso(S32, S32, S32);
+        extern void Map2Screen(S32, S32, S32);
+        extern S32 Xp, Yp, XScreen, YScreen;
+        LongProjectPointIso(0, 0, 0);
+        S32 mx0 = Xp, my0 = Yp;
+        LongProjectPointIso(512, 0, 0);
+        S32 mXdx = Xp - mx0, mXdy = Yp - my0; /* +1 brick world X */
+        LongProjectPointIso(0, 256, 0);
+        S32 mYdx = Xp - mx0, mYdy = Yp - my0; /* +1 brick world Y (height) */
+        Map2Screen(0, 0, 0);
+        S32 bx0 = XScreen, by0 = YScreen;
+        Map2Screen(1, 0, 0);
+        S32 bXdx = XScreen - bx0, bXdy = YScreen - by0; /* +1 brick X */
+        Map2Screen(0, 1, 0);
+        S32 bYdx = XScreen - bx0, bYdy = YScreen - by0; /* +1 brick Y (height) */
+        Console_Print("iso probe IsoScale=%d", (int)IsoScale);
+        Console_Print("  origin(world0)  model=(%d,%d)  brick=(%d,%d)  diff=(%d,%d)", mx0, my0, bx0, by0,
+                      mx0 - bx0, my0 - by0);
+        Console_Print("  per-brick-X  model=(%d,%d)  brick=(%d,%d)", mXdx, mXdy, bXdx, bXdy);
+        Console_Print("  per-brick-Y  model=(%d,%d)  brick=(%d,%d)", mYdx, mYdy, bYdx, bYdy);
+        return;
     } else if (argc >= 2) {
-        Console_Print("Usage: iso scale <factor> | iso reset");
+        Console_Print("Usage: iso scale <factor> | iso reset | iso probe");
         return;
     }
-    /* The brick floor is a cached background, re-laid only on a full redraw
-       (RefreshGrille runs in AffScene's AFF_ALL_* path, not the per-frame
-       AFF_OBJETS_* path). Force one so bricks pick up the new scale instead of
-       only the per-frame 3D objects. */
-    if (changed)
+    if (changed) {
+        /* Re-apply the iso projection centre for the new scale so the object grid
+           zooms about the same pivot as the brick grid (mirrors Init3DView;
+           Init3DView is only re-run on cube change, not on a scale change).
+           Interior (iso) only; exterior uses the perspective projection where
+           IsoScale is a no-op. */
+        extern void SetIsoProjection(S32, S32);
+        if (CubeMode == CUBE_INTERIEUR)
+            SetIsoProjection((S32)ModeDesiredX / 2 - 32 + ISO_PX(23),
+                             (S32)ModeDesiredY / 2 - 15 + ISO_PX(15));
+        /* The brick floor is a cached background, re-laid only on a full redraw
+           (RefreshGrille runs in AffScene's AFF_ALL_* path). Force one so bricks
+           and the new centre take effect, not just the per-frame 3D objects. */
         FirstTime = AFF_ALL_FLIP;
+    }
     Console_Print("iso scale = %.3f (raw %d/%d)", (double)IsoScale / ISO_SCALE_ONE,
                   (int)IsoScale, (int)ISO_SCALE_ONE);
 }
@@ -1652,9 +1687,10 @@ void Console_RegisterAll(void) {
     Console_RegisterCommandEx("savebug", cmd_savebug, "Save current game to bugs dir (optional name)", "savebug [name]",
                               "Requires in-game loaded cube (not during video); writes bugs/<name>.lba.");
     Console_RegisterCommandEx("iso", cmd_iso, "Scale the iso interior view (dev/experimental zoom)",
-                              "iso scale <factor> | iso reset",
-                              "1.0 = original (bit-exact). Scales models + brick positions; brick tiles "
-                              "do not stretch yet, so factors > 1 leave gaps. See docs/ISO_SCALE.md.");
+                              "iso scale <factor> | iso reset | iso probe",
+                              "1.0 = original (bit-exact). Scales the whole interior view (bricks, models, "
+                              "sprites, particles). 'probe' prints the projector deltas. See "
+                              "docs/ISO_SCALE_FINDINGS.md.");
     Console_RegisterCommandEx("resolution", cmd_resolution,
                               "Switch render resolution at runtime (no args = list)",
                               "resolution [<n> | WxH | native | --all]",

--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -615,7 +615,10 @@ static void control_dump_state(const char *path) {
 }
 
 static void control_screenshot(const char *path) {
-    SavePNG((char *)path, Screen, (S32)ModeDesiredX, (S32)ModeDesiredY, PtrPal);
+    /* Capture Log, the presented buffer (SDL PresentFrame uploads Log). Screen is
+       a secondary buffer that only holds the clean brick background, so it misses
+       the per-frame 3D models and the foreground-brick re-blit. */
+    SavePNG((char *)path, Log, (S32)ModeDesiredX, (S32)ModeDesiredY, PtrPal);
 }
 
 /* The capture half of finalize: dump/screenshot only, no exit. Shared by the tick-budget

--- a/SOURCES/FLOW.CPP
+++ b/SOURCES/FLOW.CPP
@@ -424,6 +424,37 @@ U32 CreateExtraParticleFlow(S32 type, S32 owner, S32 num, S32 num2,
     return (TRUE);
 }
 
+/* Particle dot at the iso view scale. BoxFlow draws a fixed 2x2 block and is
+   ASM-equivalence tested, so it is left untouched; under zoom the dot must grow
+   with the cloud or the effect thins out as the dot spread doubles. Native
+   BoxFlow at ISO_SCALE_ONE (bit-exact).
+   BoxFlow anchors the 2x2 at the top-left (centre at x+0.5,y+0.5), so the scaled
+   NxN block is offset by (n-2)/2 to keep that same centre, otherwise the dot
+   grows down-right and the whole cloud drifts off its true position at zoom. */
+static void BoxFlowIso(S32 x, S32 y, S32 coul) {
+    if (IsoScale == ISO_SCALE_ONE) {
+        BoxFlow(x, y, coul);
+        return;
+    }
+    S32 n = ISO_PX(2);     /* the native dot is 2x2 */
+    S32 off = (n - 2) / 2; /* re-centre the grown dot on the native centre */
+    S32 ox = x - off;
+    S32 oy = y - off;
+    U8 *L = (U8 *)Log;
+    for (S32 dy = 0; dy < n; dy++) {
+        S32 py = oy + dy;
+        if (py < ClipYMin || py >= ClipYMax)
+            continue;
+        S32 base = TabOffLine[py] + ox;
+        for (S32 dx = 0; dx < n; dx++) {
+            S32 px = ox + dx;
+            if (px < ClipXMin || px >= ClipXMax)
+                continue;
+            L[base + dx] = (U8)coul;
+        }
+    }
+}
+
 //▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
 S32 AffParticleFlow(S_PART_FLOW *ptrf) {
     S32 n;
@@ -445,7 +476,7 @@ S32 AffParticleFlow(S_PART_FLOW *ptrf) {
                     Plot(Xp, Yp, ptrd->Couleur);
                 else
 #endif
-                    BoxFlow(Xp, Yp, ptrd->Couleur);
+                    BoxFlowIso(Xp, Yp, ptrd->Couleur);
 
                 if (Xp < ScreenXMin)
                     ScreenXMin = Xp;

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -1,4 +1,5 @@
 #include "C_EXTERN.H"
+#include <3D/CAMERA.H> /* ISO_PX (iso view scale) */
 #include "CONFIG.H"
 #include "DIRECTORIES.H"
 #include "INPUT.H"
@@ -717,13 +718,15 @@ static void CycleVoiceLanguage(S32 step) {
 /*──────────────────────────────────────────────────────────────────────────*/
 
 void Init3DView(void) {
-    // Iso projection centre = framebuffer centre - 9px horizontal shim. The -9 is
-    // an iso-grid offset that pairs with Map2Screen's -32 origin shim (see
-    // GRILLE.CPP::Map2Screen) — the two iso sites must move together to keep
-    // interior scene composition coherent. Routing through ModeDesiredX/Y so
-    // iso scenes stay centred at any render-space size; at 640x480 this is the
-    // original (311, 240). See docs/WIDESCREEN.md Phase 2.
-    SetIsoProjection((S32)ModeDesiredX / 2 - 9, (S32)ModeDesiredY / 2);
+    // Iso projection centre. The -9 (X) / +0 (Y) object shims pair with
+    // Map2Screen's -32 (X) / -14 (Y) brick shims (see GRILLE.CPP::Map2Screen).
+    // Both grids must zoom about the SAME pivot or objects drift off the bricks
+    // under IsoScale > 1: the object pivot is 23px (X) / 15px (Y) from the brick
+    // pivot, and that offset has to scale. So derive the centre from the brick
+    // pivot plus the scaled object-vs-brick offset. At ISO_SCALE_ONE this is the
+    // original (ModeDesiredX/2 - 9, ModeDesiredY/2). See docs/ISO_SPACE_AUDIT.md.
+    SetIsoProjection((S32)ModeDesiredX / 2 - 32 + ISO_PX(23),
+                     (S32)ModeDesiredY / 2 - 15 + ISO_PX(15));
     SetPosCamera(0, 0, 0);
     SetAngleCamera(0, 0, 0);
     SetLightVector(AlphaLight, BetaLight, 0);

--- a/SOURCES/GRILLE.CPP
+++ b/SOURCES/GRILLE.CPP
@@ -2,6 +2,7 @@
 #include "DIRECTORIES.H"
 
 #include <3D/PROJREC.H>
+#include <3D/CAMERA.H>
 #include <SVGA/SCREEN.H>
 
 /*══════════════════════════════════════════════════════════════════════════*
@@ -1422,8 +1423,17 @@ void DecompColonne(U8 *pts, U8 *ptd) {
 // iso grid stays centred at any render-space size; at 640×480 this is
 // the original (288, 226). See docs/WIDESCREEN.md Phase 2.
 void Map2Screen(S32 x, S32 y, S32 z) {
-    XScreen = 24 * (x - z) + ((S32)ModeDesiredX / 2 - 32);
-    YScreen = 12 * (z + x) - 15 * y + ((S32)ModeDesiredY / 2 - 14);
+    // Brick screen position, scaled by the runtime iso view scale so the floor
+    // grid tracks the models (LongProjectPointIso uses the same IsoScale). At the
+    // default ISO_SCALE_ONE the multiply/shift cancels and this is bit-for-bit the
+    // original `24*(x-z)` / `12*(z+x)-15*y`. Only the iso offset scales; the screen
+    // anchor (ModeDesiredX/2 ...) does not, so zoom stays centred on the view.
+    // Note: the brick *tile* is still blitted at native size by AffBrickBlock, so
+    // scales > 1 leave gaps between tiles. See docs/ISO_SCALE.md.
+    XScreen = (S32)(((long long)(24 * (x - z)) * IsoScale) >> ISO_SCALE_SHIFT) +
+              ((S32)ModeDesiredX / 2 - 32);
+    YScreen = (S32)(((long long)(12 * (z + x) - 15 * y) * IsoScale) >> ISO_SCALE_SHIFT) +
+              ((S32)ModeDesiredY / 2 - 14);
     Projrec_Map2Screen(x, y, z, XScreen, YScreen);
 }
 

--- a/SOURCES/GRILLE.CPP
+++ b/SOURCES/GRILLE.CPP
@@ -596,6 +596,26 @@ void InitBufferCube() {
  *══════════════════════════════════════════════════════════════════════════*/
 /*──────────────────────────────────────────────────────────────────────────*/
 
+/* Does a stored foreground brick vertically overlap the current object clip
+   window?  At ISO_SCALE_ONE this is the original `Ys + 38 > ClipYMin && Ys <=
+   ClipYMax` (bit-exact: top=Ys, bottom=Ys+38). Under zoom the single 38px height
+   approximation under-reaches for tall/spread wall bricks, so foreground bricks
+   fail the test and never re-blit over the object (it shows through the wall).
+   Use the brick's actual scaled extent instead: top = Ys + HotY*scale,
+   bottom = top + DeltaY*scale, from the brick header. */
+static int BrickOverlapsClipY(const T_COLONB *b) {
+    S32 top, bot;
+    if (IsoScale == ISO_SCALE_ONE) {
+        top = b->Ys;
+        bot = b->Ys + 38;
+    } else {
+        U8 *data = (U8 *)BufferBrick + ((U32 *)BufferBrick)[b->Brick];
+        top = b->Ys + ISO_PX((S8)data[3]); /* HotY (signed) */
+        bot = top + ISO_PX(data[1]);       /* DeltaY */
+    }
+    return bot > ClipYMin AND top <= ClipYMax;
+}
+
 void DrawOverBrick(S32 xm, S32 ym, S32 zm) {
     register T_COLONB *ptrlbc;
     S32 col, i;
@@ -631,8 +651,7 @@ void DrawOverBrick(S32 xm, S32 ym, S32 zm) {
 
         for (i = 0; i < NbBrickColon[col]; i++) {
             /* bricks devant */
-            if (ptrlbc->Ys + ISO_PX(38) > ClipYMin
-                                              AND ptrlbc->Ys <= ClipYMax) {
+            if (BrickOverlapsClipY(ptrlbc)) {
                 recouvre = FALSE;
 
                 // essai correction bugs escaliers
@@ -688,8 +707,7 @@ void DrawOverBrick3(S32 xm, S32 ym, S32 zm, S32 ymax) {
 
         for (i = 0; i < NbBrickColon[col]; i++, ptrlbc++) {
             /* bricks devant */
-            if (ptrlbc->Ys + ISO_PX(38) > ClipYMin
-                                              AND ptrlbc->Ys <= ClipYMax) {
+            if (BrickOverlapsClipY(ptrlbc)) {
                 if (ptrlbc->Ym > ymax) {
                     if ((ptrlbc->Zm >= zm)
                             OR(ptrlbc->Xm >= xm)) {
@@ -730,8 +748,7 @@ void DrawOverBrickCage(S32 xm, S32 ym, S32 zm) {
 
         for (i = 0; i < NbBrickColon[col]; i++, ptrlbc++) {
             /* bricks devant */
-            if (ptrlbc->Ys + ISO_PX(38) > ClipYMin
-                                              AND ptrlbc->Ys <= ClipYMax) {
+            if (BrickOverlapsClipY(ptrlbc)) {
                 if (ptrlbc->Ym > 0 // diff ici avec DrawOverBrick3
                                  AND ptrlbc->Ym >= ym) {
                     if ((ptrlbc->Zm == zm)
@@ -761,11 +778,16 @@ void DrawOverBrickCage(S32 xm, S32 ym, S32 zm) {
    U8 so <= 255*255). */
 static U8 s_brickRawBank[8 + 256 * 256];
 
-static void DecodeBrickToRaw(S32 numbrick) {
-    U8 *data = (U8 *)BufferBrick + ((U32 *)BufferBrick)[numbrick];
+/* Decode one AffGraph-format RLE image (skip/copy/repeat) from any sprite bank
+   into s_brickRawBank as raw pixels (colour 0 = transparent), so it can be fed to
+   ScaleSprite. The bank layout is a U32 offset table followed by per-image data
+   {deltaX, deltaY, hotX, hotY, rows...}, shared by bricks (BufferBrick) and the
+   anim-3DS sprite objects (doors etc.), both of which AffGraph draws. */
+static void DecodeRLEToRaw(const U8 *buf, S32 index) {
+    const U8 *data = buf + ((const U32 *)buf)[index];
     U8 deltaX = data[0];
     U8 deltaY = data[1];
-    U8 *g = data + 4;
+    const U8 *g = data + 4;
 
     ((U32 *)s_brickRawBank)[0] = 4; /* sprite 0 starts right after the offset */
     s_brickRawBank[4] = deltaX;
@@ -801,6 +823,24 @@ static void DecodeBrickToRaw(S32 numbrick) {
     }
 }
 
+static void DecodeBrickToRaw(S32 numbrick) {
+    DecodeRLEToRaw((const U8 *)BufferBrick, numbrick);
+}
+
+/* Draw an anim-3DS sprite image (a SPRITE_3D object such as a door) scaled to the
+   iso view. At ISO_SCALE_ONE this is the original native AffGraph blit, bit-exact.
+   Under zoom the RLE image is decoded to raw and stretched with ScaleSprite so the
+   sprite tracks the scaled scene instead of staying native-size (audit group D). */
+void BlitAnim3DSIso(U8 *buf, S32 index, S32 xs, S32 ys) {
+    if (IsoScale == ISO_SCALE_ONE) {
+        AffGraph(index, xs, ys, buf);
+    } else {
+        DecodeRLEToRaw(buf, index);
+        /* ScaleSprite factors are 16.16; IsoScale is 8.8 (ISO_SCALE_ONE=256). */
+        ScaleSprite(0, xs, ys, IsoScale << 8, IsoScale << 8, s_brickRawBank);
+    }
+}
+
 static void BlitBrickIso(S32 numbrick, S32 xs, S32 ys) {
     if (IsoScale == ISO_SCALE_ONE) {
         AffGraph(numbrick, xs, ys, BufferBrick);
@@ -818,11 +858,51 @@ static void BlitBrickIso(S32 numbrick, S32 xs, S32 ys) {
    initial draw uses, so the foreground brick lands exactly where it was drawn.
    ScaleSprite skips colour-0 pixels, giving the same transparent-edge result as
    the mask. */
+/* Scaled re-blit of a foreground brick over an object. Mirrors CopyMask: copy
+   the *composited* Screen background (where overlapping bricks already resolved
+   front-to-back) into Log, masked by the brick silhouette. Re-drawing the single
+   raw brick (BlitBrickIso) instead loses that compositing and paints the wrong
+   tile where bricks overlap. The decoded brick's non-zero pixels are the
+   silhouette; Screen already holds the brick at the scaled position, so the copy
+   is 1:1 at the scaled footprint. */
+static void ScaledReBlitFromScreen(S32 numbrick, S32 xs, S32 ys) {
+    DecodeBrickToRaw(numbrick);
+    U8 deltaX = s_brickRawBank[4];
+    U8 deltaY = s_brickRawBank[5];
+    S32 left = xs + ISO_PX((S8)s_brickRawBank[6]); /* HotX */
+    S32 top = ys + ISO_PX((S8)s_brickRawBank[7]);  /* HotY */
+    S32 sW = ISO_PX(deltaX);
+    S32 sH = ISO_PX(deltaY);
+    U8 *raw = s_brickRawBank + 8;
+    U8 *L = (U8 *)Log;
+    U8 *S = (U8 *)Screen;
+    for (S32 dy = 0; dy < sH; dy++) {
+        S32 py = top + dy;
+        if (py < ClipYMin || py > ClipYMax)
+            continue;
+        S32 sr = ((S32)dy * ISO_SCALE_ONE) / IsoScale;
+        if (sr >= deltaY)
+            sr = deltaY - 1;
+        U8 *rrow = raw + sr * deltaX;
+        S32 base = TabOffLine[py];
+        for (S32 dx = 0; dx < sW; dx++) {
+            S32 px = left + dx;
+            if (px < ClipXMin || px > ClipXMax)
+                continue;
+            S32 sc = ((S32)dx * ISO_SCALE_ONE) / IsoScale;
+            if (sc >= deltaX)
+                sc = deltaX - 1;
+            if (rrow[sc]) /* brick silhouette */
+                L[base + px] = S[base + px];
+        }
+    }
+}
+
 static void ReBlitBrickIso(S32 numbrick, S32 xs, S32 ys) {
     if (IsoScale == ISO_SCALE_ONE) {
         CopyMask(numbrick, xs, ys, BufferMaskBrick, Screen);
     } else {
-        BlitBrickIso(numbrick, xs, ys);
+        ScaledReBlitFromScreen(numbrick, xs, ys);
     }
 }
 

--- a/SOURCES/GRILLE.CPP
+++ b/SOURCES/GRILLE.CPP
@@ -68,6 +68,12 @@ PTR_U8 TabBlock = 0;
 PTR_U8 BufferBrick = 0;
 
 extern S32 Nxw, Nyw, Nzw;
+
+/* Iso view scale (zoom) brick blit + re-blit; defined below, forward-declared so
+   the DrawOverBrick* re-blit (above their definition) can use them. */
+static void BlitBrickIso(S32 numbrick, S32 xs, S32 ys);
+static void ReBlitBrickIso(S32 numbrick, S32 xs, S32 ys);
+
 //void	ReajustPos( U8 col ) ;
 /*--------------------------------------------------------------------------*/
 typedef struct
@@ -611,18 +617,22 @@ void DrawOverBrick(S32 xm, S32 ym, S32 zm) {
     // overlap the actor, CopyMask paints offscreen of the actor (same
     // wasted-CPU pattern the 640 build was already doing). See
     // WIDESCREEN_HARDCODED_DIMS_AUDIT.md.
-    startcol = (ClipXMin + 24) / 24 - 2;
+    // Iso zoom: scale the column granularity with the view. ISO_PX(24) is the
+    // scaled half-brick column width, so the native -2 back-scan (one full brick
+    // of columns) stays correct at any scale. ISO_PX is identity at 1.0.
+    S32 isoCol = ISO_PX(24);
+    startcol = (ClipXMin + isoCol) / isoCol - 2;
     if (startcol < 0)
         startcol = 0;
-    endcol = (ClipXMax + 24) / 24;
+    endcol = (ClipXMax + isoCol) / isoCol;
 
     for (col = startcol; col <= endcol; col++) {
         ptrlbc = &ListBrickColon[col][0];
 
         for (i = 0; i < NbBrickColon[col]; i++) {
             /* bricks devant */
-            if (ptrlbc->Ys + 38 > ClipYMin
-                                      AND ptrlbc->Ys <= ClipYMax) {
+            if (ptrlbc->Ys + ISO_PX(38) > ClipYMin
+                                              AND ptrlbc->Ys <= ClipYMax) {
                 recouvre = FALSE;
 
                 // essai correction bugs escaliers
@@ -652,7 +662,7 @@ void DrawOverBrick(S32 xm, S32 ym, S32 zm) {
                                    1
                                        //				AND WorldColBrick(xw+SIZE_BRICK_XZ,yw,zw)==1 ) )
                                        AND WorldColBrick(xw + SIZE_BRICK_XZ, yw, zw) >= 1)) {
-                        CopyMask(ptrlbc->Brick, ptrlbc->Xs, ptrlbc->Ys, BufferMaskBrick, Screen);
+                        ReBlitBrickIso(ptrlbc->Brick, ptrlbc->Xs, ptrlbc->Ys);
                     }
                 }
             }
@@ -669,30 +679,31 @@ void DrawOverBrick3(S32 xm, S32 ym, S32 zm, S32 ymax) {
     S32 col, i;
     S32 startcol, endcol;
 
-    startcol = (ClipXMin + 24) / 24 - 1;
-    endcol = (ClipXMax + 24) / 24;
+    S32 isoCol = ISO_PX(24); // scaled half-brick column width
+    startcol = (ClipXMin + isoCol) / isoCol - 1;
+    endcol = (ClipXMax + isoCol) / isoCol;
 
     for (col = startcol; col <= endcol; col++) {
         ptrlbc = &ListBrickColon[col][0];
 
         for (i = 0; i < NbBrickColon[col]; i++, ptrlbc++) {
             /* bricks devant */
-            if (ptrlbc->Ys + 38 > ClipYMin
-                                      AND ptrlbc->Ys <= ClipYMax) {
+            if (ptrlbc->Ys + ISO_PX(38) > ClipYMin
+                                              AND ptrlbc->Ys <= ClipYMax) {
                 if (ptrlbc->Ym > ymax) {
                     if ((ptrlbc->Zm >= zm)
                             OR(ptrlbc->Xm >= xm)) {
-                        CopyMask(ptrlbc->Brick, ptrlbc->Xs, ptrlbc->Ys, BufferMaskBrick, Screen);
+                        ReBlitBrickIso(ptrlbc->Brick, ptrlbc->Xs, ptrlbc->Ys);
                     }
                 } else if (ptrlbc->Ym >= ym) {
                     if ((ptrlbc->Zm == zm)
                             AND(ptrlbc->Xm == xm)) {
-                        CopyMask(ptrlbc->Brick, ptrlbc->Xs, ptrlbc->Ys, BufferMaskBrick, Screen);
+                        ReBlitBrickIso(ptrlbc->Brick, ptrlbc->Xs, ptrlbc->Ys);
                     }
 
                     if ((ptrlbc->Zm > zm)
                             OR(ptrlbc->Xm > xm)) {
-                        CopyMask(ptrlbc->Brick, ptrlbc->Xs, ptrlbc->Ys, BufferMaskBrick, Screen);
+                        ReBlitBrickIso(ptrlbc->Brick, ptrlbc->Xs, ptrlbc->Ys);
                     }
                 }
             }
@@ -710,26 +721,27 @@ void DrawOverBrickCage(S32 xm, S32 ym, S32 zm) {
     S32 col, i;
     S32 startcol, endcol;
 
-    startcol = (ClipXMin + 24) / 24 - 1;
-    endcol = (ClipXMax + 24) / 24;
+    S32 isoCol = ISO_PX(24); // scaled half-brick column width
+    startcol = (ClipXMin + isoCol) / isoCol - 1;
+    endcol = (ClipXMax + isoCol) / isoCol;
 
     for (col = startcol; col <= endcol; col++) {
         ptrlbc = &ListBrickColon[col][0];
 
         for (i = 0; i < NbBrickColon[col]; i++, ptrlbc++) {
             /* bricks devant */
-            if (ptrlbc->Ys + 38 > ClipYMin
-                                      AND ptrlbc->Ys <= ClipYMax) {
+            if (ptrlbc->Ys + ISO_PX(38) > ClipYMin
+                                              AND ptrlbc->Ys <= ClipYMax) {
                 if (ptrlbc->Ym > 0 // diff ici avec DrawOverBrick3
                                  AND ptrlbc->Ym >= ym) {
                     if ((ptrlbc->Zm == zm)
                             AND(ptrlbc->Xm == xm)) {
-                        CopyMask(ptrlbc->Brick, ptrlbc->Xs, ptrlbc->Ys, BufferMaskBrick, Screen);
+                        ReBlitBrickIso(ptrlbc->Brick, ptrlbc->Xs, ptrlbc->Ys);
                     }
 
                     if ((ptrlbc->Zm > zm)
                             OR(ptrlbc->Xm > xm)) {
-                        CopyMask(ptrlbc->Brick, ptrlbc->Xs, ptrlbc->Ys, BufferMaskBrick, Screen);
+                        ReBlitBrickIso(ptrlbc->Brick, ptrlbc->Xs, ptrlbc->Ys);
                     }
                 }
             }
@@ -799,6 +811,21 @@ static void BlitBrickIso(S32 numbrick, S32 xs, S32 ys) {
     }
 }
 
+/* Re-blit a foreground brick over a moving object.  At ISO_SCALE_ONE the
+   original CopyMask restores the brick pixels from the (clean) Screen copy into
+   Log, bit-for-bit.  Under zoom that mask blit would paint the tile at native
+   size; instead re-draw the scaled tile with BlitBrickIso, the same path the
+   initial draw uses, so the foreground brick lands exactly where it was drawn.
+   ScaleSprite skips colour-0 pixels, giving the same transparent-edge result as
+   the mask. */
+static void ReBlitBrickIso(S32 numbrick, S32 xs, S32 ys) {
+    if (IsoScale == ISO_SCALE_ONE) {
+        CopyMask(numbrick, xs, ys, BufferMaskBrick, Screen);
+    } else {
+        BlitBrickIso(numbrick, xs, ys);
+    }
+}
+
 /*--------------------------------------------------------------------------*/
 
 void AffBrickBlock(S32 block, S32 brick, S16 x, S16 y, S16 z) {
@@ -827,19 +854,24 @@ void AffBrickBlock(S32 block, S32 brick, S16 x, S16 y, S16 z) {
         // (ModeDesiredX/2 - 32) % 24 == 0 (4:3 / 640: 288 = 12*24). At wider widths
         // the iso origin offset slides off that multiple and the rejected bricks
         // start having visible content. See WIDESCREEN_HARDCODED_DIMS_AUDIT.md.
-        if (XScreen >= -47 AND XScreen < (S32)ModeDesiredX AND YScreen >= -38 AND YScreen < (S32)ModeDesiredY) {
+        // Clip bounds are native brick pixel dimensions (47 = full brick width-1,
+        // 38 = brick height), scaled with the iso view via ISO_PX so wider tiles
+        // at zoom are not wrongly rejected at the screen edges.
+        if (XScreen >= -ISO_PX(47) AND XScreen < (S32)ModeDesiredX AND YScreen >= -ISO_PX(38) AND
+                                                                                      YScreen < (S32)ModeDesiredY) {
             BlitBrickIso(numbrick - 1, XScreen, YScreen);
 
-            // ListBrickColon is indexed by `col = (XScreen+24)/24`, which goes
-            // negative below -24 and would corrupt the array. Bricks in the
-            // newly-painted [-47,-24) strip aren't bucketed for DrawOverBrick
-            // re-blits — acceptable, they sit on the leftmost pixel column and
-            // their visible pixels are already painted by AffGraph above.
-            if (XScreen < -24) {
+            // ListBrickColon is indexed by `col = (XScreen + isoCol)/isoCol`,
+            // which goes negative below -isoCol and would corrupt the array.
+            // Bricks in the newly-painted [-ISO_PX(47), -isoCol) strip aren't
+            // bucketed for DrawOverBrick re-blits; acceptable, they sit on the
+            // leftmost pixel column and were already painted above.
+            S32 isoCol = ISO_PX(24); /* scaled half-brick column width (48/2 intercalée) */
+            if (XScreen < -isoCol) {
                 return;
             }
 
-            col = (XScreen + 24) / 24; /* 48 / 2 colonne intercalée */
+            col = (XScreen + isoCol) / isoCol;
 
             nb = NbBrickColon[col];
 
@@ -918,8 +950,10 @@ void AffBrickBlockColon(S32 block, S32 brick, S16 x, S16 y, S16 z) {
     if (numbrick AND numbrick != ForbidenBrick) {
         Map2Screen(x - StartXCube, y - StartYCube, z - StartZCube);
 
-        if (XScreen >= -24 AND XScreen < (S32)ModeDesiredX AND YScreen >= -38 AND YScreen < (S32)ModeDesiredY) {
-            col = (XScreen + 24) / 24; /* 48 / 2 colonne intercalée */
+        if (XScreen >= -ISO_PX(24) AND XScreen < (S32)ModeDesiredX AND YScreen >= -ISO_PX(38) AND
+                                                                                      YScreen < (S32)ModeDesiredY) {
+            S32 isoCol = ISO_PX(24); /* scaled half-brick column width */
+            col = (XScreen + isoCol) / isoCol;
 
             nb = NbBrickColon[col];
 
@@ -1000,7 +1034,8 @@ void AffBrickBlockOnly(S32 block, S32 brick, S16 x, S16 y, S16 z) {
     if (numbrick AND numbrick != ForbidenBrick) {
         Map2Screen(x - StartXCube, y - StartYCube, z - StartZCube);
 
-        if (XScreen >= -24 AND XScreen < (S32)ModeDesiredX AND YScreen >= -38 AND YScreen < (S32)ModeDesiredY) {
+        if (XScreen >= -ISO_PX(24) AND XScreen < (S32)ModeDesiredX AND YScreen >= -ISO_PX(38) AND
+                                                                                      YScreen < (S32)ModeDesiredY) {
             BlitBrickIso(numbrick - 1, XScreen, YScreen);
         }
     }

--- a/SOURCES/GRILLE.CPP
+++ b/SOURCES/GRILLE.CPP
@@ -3,6 +3,8 @@
 
 #include <3D/PROJREC.H>
 #include <3D/CAMERA.H>
+#include <SVGA/SCALESPI.H>
+#include <SVGA/GRAPH.H>
 #include <SVGA/SCREEN.H>
 
 /*══════════════════════════════════════════════════════════════════════════*
@@ -736,6 +738,68 @@ void DrawOverBrickCage(S32 xm, S32 ym, S32 zm) {
 }
 
 /*--------------------------------------------------------------------------*/
+/* Iso view scale (zoom) brick blit.  Bricks are RLE-compressed tiles drawn at
+   native size by AffGraph; under IsoScale > 1 the grid spacing (Map2Screen)
+   grows but the tiles would not, leaving gaps.  When the scale is not 1.0 we
+   decode the brick RLE into a raw Struc_Sprite buffer and let ScaleSprite (the
+   engine's tested scaled-sprite blitter, which needs raw pixels) draw it at the
+   matching factor.  At ISO_SCALE_ONE we stay on AffGraph, bit-for-bit. */
+
+/* offset table (4) + Struc_Sprite header (4) + raw pixels (deltaX*deltaY, both
+   U8 so <= 255*255). */
+static U8 s_brickRawBank[8 + 256 * 256];
+
+static void DecodeBrickToRaw(S32 numbrick) {
+    U8 *data = (U8 *)BufferBrick + ((U32 *)BufferBrick)[numbrick];
+    U8 deltaX = data[0];
+    U8 deltaY = data[1];
+    U8 *g = data + 4;
+
+    ((U32 *)s_brickRawBank)[0] = 4; /* sprite 0 starts right after the offset */
+    s_brickRawBank[4] = deltaX;
+    s_brickRawBank[5] = deltaY;
+    s_brickRawBank[6] = data[2]; /* hotX */
+    s_brickRawBank[7] = data[3]; /* hotY */
+
+    U8 *raw = s_brickRawBank + 8;
+    memset(raw, 0, (size_t)deltaX * deltaY); /* colour 0 = transparent */
+
+    for (S32 line = 0; line < deltaY; line++) {
+        U8 nbBlock = *g++;
+        U8 *row = raw + (S32)line * deltaX;
+        S32 xpix = 0;
+        for (S32 b = 0; b < nbBlock; b++) {
+            U8 control = *g;
+            U8 opCode = control >> 6;
+            S32 counter = (control & 0x3F) + 1; /* all runs are +1, as in AffGraph */
+            if (opCode == 0) {                  /* skip (transparent) */
+                g++;
+                xpix += counter;
+            } else if (opCode == 1) { /* copy literal pixels */
+                g++;
+                while (counter-- > 0)
+                    row[xpix++] = *g++;
+            } else { /* repeat one colour */
+                U8 color = g[1];
+                g += 2;
+                while (counter-- > 0)
+                    row[xpix++] = color;
+            }
+        }
+    }
+}
+
+static void BlitBrickIso(S32 numbrick, S32 xs, S32 ys) {
+    if (IsoScale == ISO_SCALE_ONE) {
+        AffGraph(numbrick, xs, ys, BufferBrick);
+    } else {
+        DecodeBrickToRaw(numbrick);
+        /* ScaleSprite factors are 16.16; IsoScale is 8.8 (ISO_SCALE_ONE=256). */
+        ScaleSprite(0, xs, ys, IsoScale << 8, IsoScale << 8, s_brickRawBank);
+    }
+}
+
+/*--------------------------------------------------------------------------*/
 
 void AffBrickBlock(S32 block, S32 brick, S16 x, S16 y, S16 z) {
     U8 *adr;
@@ -764,7 +828,7 @@ void AffBrickBlock(S32 block, S32 brick, S16 x, S16 y, S16 z) {
         // the iso origin offset slides off that multiple and the rejected bricks
         // start having visible content. See WIDESCREEN_HARDCODED_DIMS_AUDIT.md.
         if (XScreen >= -47 AND XScreen < (S32)ModeDesiredX AND YScreen >= -38 AND YScreen < (S32)ModeDesiredY) {
-            AffGraph(numbrick - 1, XScreen, YScreen, BufferBrick);
+            BlitBrickIso(numbrick - 1, XScreen, YScreen);
 
             // ListBrickColon is indexed by `col = (XScreen+24)/24`, which goes
             // negative below -24 and would corrupt the array. Bricks in the
@@ -937,7 +1001,7 @@ void AffBrickBlockOnly(S32 block, S32 brick, S16 x, S16 y, S16 z) {
         Map2Screen(x - StartXCube, y - StartYCube, z - StartZCube);
 
         if (XScreen >= -24 AND XScreen < (S32)ModeDesiredX AND YScreen >= -38 AND YScreen < (S32)ModeDesiredY) {
-            AffGraph(numbrick - 1, XScreen, YScreen, BufferBrick);
+            BlitBrickIso(numbrick - 1, XScreen, YScreen);
         }
     }
 }

--- a/SOURCES/GRILLE.H
+++ b/SOURCES/GRILLE.H
@@ -100,6 +100,11 @@ extern void DrawOverBrick3(S32 xm, S32 ym, S32 zm, S32 ymax);
 extern void DrawOverBrickCage(S32 xm, S32 ym, S32 zm);
 
 //-------------------------------------------------------------------
+/* Draw an anim-3DS sprite image (SPRITE_3D object, e.g. a door) at the iso view
+   scale; native AffGraph at ISO_SCALE_ONE, ScaleSprite-stretched under zoom. */
+extern void BlitAnim3DSIso(U8 *buf, S32 index, S32 xs, S32 ys);
+
+//-------------------------------------------------------------------
 extern void AffBrickBlock(S32 block, S32 brick, S16 x, S16 y, S16 z);
 
 //-------------------------------------------------------------------

--- a/SOURCES/OBJECT.CPP
+++ b/SOURCES/OBJECT.CPP
@@ -4827,6 +4827,25 @@ void AfficheShadow(T_SORT *pt, S32 beta) {
     }
 }
 
+/* Draw a TYPE_OBJ_SPRITE image (e.g. a door) at the iso view scale. PtrAffGraph
+   draws goodie sprites (>=100) native via AffGraph and raw sprites (<100) via
+   ScaleSprite at ScaleFactorSprite; under iso zoom both must scale by IsoScale or
+   the sprite stays native-size while the scene grows. Delegates to PtrAffGraph at
+   ISO_SCALE_ONE so the faithful path is bit-exact. Only called from the gameplay
+   scene draw. PtrAffGraph itself is left untouched for the HUD/inventory/menus. */
+static void BlitSpriteIso(S32 sprite, S32 xp, S32 yp) {
+    if (IsoScale == ISO_SCALE_ONE) {
+        PtrAffGraph(xp, yp, sprite);
+        return;
+    }
+    if (sprite >= 100) {
+        BlitAnim3DSIso((U8 *)HQR_Get(HQRPtrSprite, sprite), 0, xp, yp);
+    } else {
+        S32 sf = (S32)(((long long)ScaleFactorSprite * IsoScale) / ISO_SCALE_ONE);
+        ScaleSprite(0, xp, yp, sf, sf, (U8 *)HQR_Get(HQRPtrSpriteRaw, sprite));
+    }
+}
+
 //▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
 /*──────────────────────────────────────────────────────────────────────────*/
 S32 AffOneObject(T_SORT *pt) {
@@ -5022,20 +5041,29 @@ S32 AffOneObject(T_SORT *pt) {
                          ptrobj->Obj.Y,
                          ptrobj->Obj.Z, num);
 
+        /* Sprite objects (doors etc.) are blitted native by PtrAffGraph, so under
+           iso zoom they stay native-size while the scene grows. Scale the hotspot
+           offset (PtrProjectSprite added it natively as SpriteX-Xp) and clip and
+           blit by IsoScale. Done at the gameplay call site, not in PtrAffGraph,
+           because that is shared with the HUD/inventory/menus (must not zoom).
+           Identity at ISO_SCALE_ONE. */
+        SpriteX = Xp + ISO_PX(SpriteX - Xp);
+        SpriteY = Yp + ISO_PX(SpriteY - Yp);
+
         if (ptrobj->Flags & SPRITE_CLIP) {
-            SetClip(ptrobj->Info + XpOrgw, ptrobj->Info1 + YpOrgw,
-                    ptrobj->Info2 + XpOrgw, ptrobj->Info3 + YpOrgw);
+            SetClip(ISO_PX(ptrobj->Info) + XpOrgw, ISO_PX(ptrobj->Info1) + YpOrgw,
+                    ISO_PX(ptrobj->Info2) + XpOrgw, ISO_PX(ptrobj->Info3) + YpOrgw);
 
             // A remplacer par une fonction de preClipping des
             // sprites
             if (ClipXMin <= ClipXMax
                                 AND ClipYMin <= ClipYMax) {
-                PtrAffGraph(SpriteX, SpriteY, num);
+                BlitSpriteIso(num, SpriteX, SpriteY);
                 UnsetClip();
                 SetClip(ScreenXMin, ScreenYMin, ScreenXMax, ScreenYMax);
             }
         } else {
-            PtrAffGraph(SpriteX, SpriteY, num);
+            BlitSpriteIso(num, SpriteX, SpriteY);
             SetClip(ScreenXMin, ScreenYMin, ScreenXMax, ScreenYMax);
         }
 
@@ -5116,21 +5144,25 @@ S32 AffOneObject(T_SORT *pt) {
 
         ScaleFactorSprite = DEF_SCALE_FACTOR;
 
-        SpriteX = Xp + PtrZvAnim3DS[num * 8 + 0];
-        SpriteY = Yp + PtrZvAnim3DS[num * 8 + 1];
+        /* anim-3DS sprite objects (doors etc.) are blitted native by AffGraph, so
+           under iso zoom they must be scaled too or they stay native-size while
+           the scene grows. Scale the ZV hotspot offset, the SPRITE_CLIP window,
+           and the blit by IsoScale (all identity at ISO_SCALE_ONE). */
+        SpriteX = Xp + ISO_PX(PtrZvAnim3DS[num * 8 + 0]);
+        SpriteY = Yp + ISO_PX(PtrZvAnim3DS[num * 8 + 1]);
 
         if (ptrobj->Flags & SPRITE_CLIP) {
-            SetClip(ptrobj->Info + XpOrgw, ptrobj->Info1 + YpOrgw,
-                    ptrobj->Info2 + XpOrgw, ptrobj->Info3 + YpOrgw);
+            SetClip(ISO_PX(ptrobj->Info) + XpOrgw, ISO_PX(ptrobj->Info1) + YpOrgw,
+                    ISO_PX(ptrobj->Info2) + XpOrgw, ISO_PX(ptrobj->Info3) + YpOrgw);
 
             // A remplacer par une fonction de preClipping des
             // sprites
             if (ClipXMin <= ClipXMax
                                 AND ClipYMin <= ClipYMax) {
-                AffGraph(0, SpriteX, SpriteY, GetPtrAnim3DS(num));
+                BlitAnim3DSIso(GetPtrAnim3DS(num), 0, SpriteX, SpriteY);
             }
         } else {
-            AffGraph(0, SpriteX, SpriteY, GetPtrAnim3DS(num));
+            BlitAnim3DSIso(GetPtrAnim3DS(num), 0, SpriteX, SpriteY);
             SetClip(ScreenXMin, ScreenYMin, ScreenXMax, ScreenYMax);
         }
 
@@ -5188,11 +5220,21 @@ S32 AffOneObject(T_SORT *pt) {
             AffSpecial(numobj);
         } else // sprite
         {
-            SpriteX = Xp + PtrZvExtraRaw[num * 8 + 0]; // Add Hot Spot
-            SpriteY = Yp + PtrZvExtraRaw[num * 8 + 1];
+            SpriteX = Xp + ISO_PX(PtrZvExtraRaw[num * 8 + 0]); // Add Hot Spot
+            SpriteY = Yp + ISO_PX(PtrZvExtraRaw[num * 8 + 1]);
 
             // Toujours des sprites Raw
             CalculeScaleFactorSprite(ptrextra->PosX, ptrextra->PosY, ptrextra->PosZ, ptrextra->Scale);
+
+            /* Extras with a fixed scale (Scale==-1, e.g. the magic ball and item
+               drops) get DEF_SCALE_FACTOR from CalculeScaleFactorSprite, which
+               ignores the iso view scale; multiply it by IsoScale so they zoom
+               with the scene. The projection-derived branch (Scale>=0) already
+               scales (it measures through the scaled iso projection) so it must
+               NOT be multiplied or it would double-scale. Identity at scale 1. */
+            if (CubeMode == CUBE_INTERIEUR AND ptrextra->Scale == -1)
+                ScaleFactorSprite =
+                    (S32)(((long long)ScaleFactorSprite * IsoScale) / ISO_SCALE_ONE);
 
             if (ptrextra->Flags & EXTRA_TRANSPARENT) {
                 ScaleSpriteTransp(0, SpriteX, SpriteY,

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -809,12 +809,15 @@ restartloop:
 
         CheckSavePcx(); // F9: Sauve Screen
 
-        /* Console screenshot (PNG): requested without overlay; perform here where we have Screen + PtrPal. */
+        /* Console screenshot (PNG): performed here where Log + PtrPal are valid.
+           Capture Log, the presented buffer (SDL PresentFrame uploads Log); Screen
+           is the clean-background secondary and misses the per-frame 3D models and
+           the foreground-brick re-blit. */
         {
             char shotPath[ADELINE_MAX_PATH];
             int is_png = 0;
             if (Console_HasPendingScreenshot(shotPath, sizeof(shotPath), &is_png) && is_png) {
-                SavePNG(shotPath, Screen, ModeDesiredX, ModeDesiredY, PtrPal);
+                SavePNG(shotPath, Log, ModeDesiredX, ModeDesiredY, PtrPal);
                 Console_ClearPendingScreenshot();
             }
         }

--- a/docs/ISO_SCALE.md
+++ b/docs/ISO_SCALE.md
@@ -1,0 +1,141 @@
+# Iso view scale
+
+A runtime scale for the isometric interior projection. It multiplies how large the
+iso world is drawn on screen without touching world state, camera position, or game
+logic. The default is 1.0, where the projection is bit-for-bit identical to the
+original, so the faithful path and the ASM equivalence tests are unaffected.
+
+This is the shared primitive behind three planned features. The difference between
+them is only whether you also change the render buffer size:
+
+- **scale only** gives a dynamic zoom (the framing changes, the model gets larger or
+  smaller).
+- **scale and buffer together, then downsample** gives supersampled anti-aliasing
+  (same framing, more pixels, which removes the silhouette shimmer that the original
+  integer rasterizer produces on slowly moving characters).
+- **scale and buffer together at a high-resolution display** gives HD fidelity (same
+  framing, more pixels on the model).
+
+Only the first (a dev/experimental zoom) is wired up today. The rest are roadmap.
+
+## What it touches
+
+The iso projection has no scale argument of its own (`SetIsoProjection` takes only a
+centre), so the scale lives in a single global, `IsoScale`, applied everywhere the
+iso world is sized for the screen:
+
+- Object geometry: `ProjectListIso` ([PRLIISO.CPP](../LIB386/3D/PRLIISO.CPP)), the
+  batched vertex projector that draws character and object bodies.
+- Single points: `LongProjectPointIso` ([LPROJISO.CPP](../LIB386/3D/LPROJISO.CPP)),
+  used for object anchors, shadows, and bounding boxes.
+- Brick floor and walls: `Map2Screen` ([GRILLE.CPP](../SOURCES/GRILLE.CPP)).
+- Sphere primitives: the radius in `Sphere` / `Sphere_Transp`
+  ([AFF_OBJ.CPP](../LIB386/OBJECT/AFF_OBJ.CPP)). Spheres (hands, joints, heads) carry
+  a separate radius scalar, not just a projected centre. The first three places only
+  move the centre, so without this the radii stay fixed and spheres appear to shrink
+  as the body grows.
+
+All four must scale by the same factor or the model comes apart (bodies detach from
+the floor, hands shrink). The point projectors share the same visual scale in
+different coordinate units (one brick step is 512 world units), so scaling all of
+them by `IsoScale` keeps the model coherent.
+
+`IsoScale` is fixed-point: `ISO_SCALE_ONE` (256) is 1.0, so 512 is 2.0 and 128 is 0.5.
+At `ISO_SCALE_ONE` the multiply and shift cancel exactly (`(v * 256) >> (n + 8) == v >> n`),
+which is why the default path is bit-exact. The constant and the global are declared in
+[CAMERA.H](../LIB386/H/3D/CAMERA.H); set it through `SetIsoScale()`, which clamps to a
+1/16x to 16x range.
+
+Only iso interior scenes are affected. Exterior island scenes use the perspective
+projection (`LongProjectPoint3D`, with its own `FRatioX` focal), so `IsoScale` is a
+no-op there.
+
+## Lineage
+
+This restores a capability the LBA1 engine had and LBA2 dropped. In LBA1,
+`SetIsoProjection` took a third `scale` argument that set a global `IsoScale` (the iso
+projection divided by it; gameplay passed `SIZE_BRICK_XZ` = 512). LBA2 removed the
+parameter and hardcoded the scale (the `/512` here is that value baked in), so this is
+re-adding a knob the original engine evolution removed, not inventing a new one. Two
+deliberate differences from LBA1:
+
+- It lives in a separate global, not a third `SetIsoProjection` argument. Re-adding the
+  argument would diverge from LBA2's original 2-argument ASM and break the
+  `test_proj` equivalence test, so the scale is kept out of that signature.
+- LBA1's `IsoScale` was a divisor (larger = smaller image). This one is a fixed-point
+  multiplier (`ISO_SCALE_ONE` = 1.0, larger = zoom in), because the reimplemented iso
+  formula uses shifts rather than a divide.
+
+## Trying it
+
+In the console:
+
+```
+iso scale 2      # zoom the iso interior to 2x
+iso scale 1.5
+iso reset        # back to 1.0
+iso              # print the current scale
+```
+
+Headless, for before and after captures (the screenshot path used during development):
+
+```
+lba2cc --game-dir <data> --load "<save>" --no-audio --fixed-dt 16 \
+       --exec "iso scale 2" --tick 40 --screenshot out_2x.png --exit
+```
+
+Load an interior save (for example the game-start save, Twinsen's house) to see an
+effect; an exterior save will not change.
+
+## Known limitation: bricks do not stretch yet
+
+Bricks are fixed-resolution sprite tiles, blitted at native size by `AffBrickBlock`
+(via `AffGraph`), and the brick pipeline keys off a hardcoded 24px grid (clipping,
+the `(XScreen+24)/24` column bucketing, the `DrawOverBrick` re-blit). `Map2Screen`
+scales the brick *positions*, so the floor layout stays correct, but the tiles are
+still drawn at their original size. At scales above 1.0 this leaves gaps between
+floor bricks; below 1.0 the tiles overlap.
+
+So today the scale is coherent for geometry (characters stay on the floor) but the
+brick environment cannot gain detail beyond its source art. This is expected and is
+the next thing to solve before the zoom is presentable.
+
+The brick floor is also a cached background: it is re-laid only on a full redraw
+(`RefreshGrille` runs in `AffScene`'s `AFF_ALL_*` path, not the per-frame
+`AFF_OBJETS_*` path). So changing the scale mid-scene re-scales only the per-frame
+3D objects until a redraw happens. The `iso` console command forces one
+(`FirstTime = AFF_ALL_FLIP`) so the floor re-lays at the new scale immediately. A
+future dynamic zoom that changes the scale every frame would have to re-lay the
+bricks every frame, which is one more reason the render-at-scale-and-sample approach
+(which sidesteps brick re-lay entirely) is the likely path for smooth zoom.
+
+## Roadmap
+
+1. **Brick scaling strategy.** Either stretch the brick blit (and rework the 24px
+   grid assumptions), or render the iso scene at a fixed higher scale and sample the
+   buffer for intermediate zoom (which avoids fractional geometry and the brick-grid
+   surgery, at the cost of capping maximum sharpness). The second path is the likely
+   choice for smooth dynamic zoom.
+2. **Dynamic zoom.** Drive `IsoScale` over time and integrate with the iso follow
+   camera so the view stays centred as the visible window shrinks. Zoom is a pure
+   view transform: collision is world-space (`WorldColBrick`) and is not affected,
+   which is what keeps it safe for determinism.
+3. **Supersampling for the silhouette shimmer.** Render the scene to a buffer scaled
+   by S with `IsoScale` scaled by S, then box-downsample to the display. The
+   downsample is what removes the flicker (it anti-aliases the edges). The UI is
+   4:3 display-anchored and must be composited at display resolution after the
+   downsample, not supersampled with the scene.
+
+## Constraints
+
+- The default (1.0) must stay bit-exact. The three projectors are covered by ASM
+  equivalence tests ([tests/3D/test_lprojiso.cpp](../tests/3D/test_lprojiso.cpp),
+  [tests/3D/test_prliiso.cpp](../tests/3D/test_prliiso.cpp),
+  [tests/test_grille.cpp](../tests/test_grille.cpp)); any change here keeps scale 1.0
+  matching the original ASM.
+- Non-default scales change projected coordinates, so they change projection-record
+  hashes and are not a faithful-path mode. Keep the scale at 1.0 for regression runs.
+- The console command is a dev knob. There is no keybinding or persisted setting yet,
+  and opening a menu after setting a scale may inherit it (the menus also use the iso
+  projection). Scoping the scale to the gameplay view is part of wiring up a real
+  zoom feature.

--- a/docs/ISO_SCALE_FINDINGS.md
+++ b/docs/ISO_SCALE_FINDINGS.md
@@ -1,0 +1,163 @@
+# Iso view scale: implementation findings
+
+Notes from making the whole isometric interior view scale by a runtime factor
+(`iso scale 2` in the console). This is a record of what the work taught us about
+the interior render pipeline, not a description of a finished feature. Treat it as
+exploratory: the knob is a dev tool, and whether any of it ships is undecided.
+
+For the underlying primitive (the `IsoScale` global, `ISO_PX`, lineage to LBA1)
+see [ISO_SCALE.md](ISO_SCALE.md). For the pre-implementation survey of hardcoded
+iso-space pixel assumptions see ISO_SPACE_AUDIT.md. This doc is the
+post-implementation companion: what actually broke, why, and how each piece was
+fixed and checked.
+
+## Status
+
+- Experimental dev knob only. `iso scale <f>` / `iso reset` in the console. Not
+  keybound, not persisted, not integrated with the follow camera.
+- Bit-exact at scale 1.0. Every change below collapses to the original code when
+  `IsoScale == ISO_SCALE_ONE` (the `ISO_PX(n)` macro is the identity there), so the
+  faithful path and the ASM equivalence tests are untouched.
+- Coherent at a static scale: at `iso scale 2` the floor, walls, characters,
+  doors, items, and particles all grow together and stay aligned.
+- Not done: smooth dynamic zoom (driving the scale per frame and keeping the view
+  centred), supersampling, an HD render buffer, scoping the scale away from the
+  UI, and any performance work. See "What it would take to ship".
+
+## The main lesson: an interior scene is drawn by several independent render classes
+
+The single biggest finding is that there is no one "draw the iso scene" path to
+scale. An interior frame is assembled from separate subsystems, each with its own
+projection, its own sizing, and its own anchor convention. Scaling the view means
+finding and scaling every one of them, and they do not share code. Missing one
+leaves that class native-size while everything else grows, which is how each gap
+was discovered (the model floated off the floor, the door looked open, the fan was
+tiny, the item drops did not grow).
+
+| Class | What it draws | Path | How it is scaled | Checked with |
+| --- | --- | --- | --- | --- |
+| Bricks | Floor, walls, architecture | `Map2Screen` + `AffGraph`/`ScaleSprite` ([GRILLE.CPP](../SOURCES/GRILLE.CPP)) | `Map2Screen` positions via `ISO_PX`; `BlitBrickIso` decodes the RLE tile and `ScaleSprite`s it under zoom (native `AffGraph` at 1.0) | static captures |
+| Foreground re-blit | Repaints foreground bricks over moving objects | `DrawOverBrick` to `CopyMask` / `ScaledReBlitFromScreen` ([GRILLE.CPP](../SOURCES/GRILLE.CPP)) | copy the composited `Screen` masked by the brick silhouette, at the scaled footprint | door-behind-railing scene |
+| 3D models | Characters, dart and projectile bodies, impact effects | `ProjectListIso` / `LongProjectPointIso` ([PRLIISO.CPP](../LIB386/3D/PRLIISO.CPP), [LPROJISO.CPP](../LIB386/3D/LPROJISO.CPP)) | `IsoScale` inside the projectors, plus sphere radius in `Sphere`/`Sphere_Transp` | user-confirmed, projector probe |
+| `TYPE_OBJ_ANIM_3DS` sprites | Fans, vents, animated sprite decor | `AffGraph` via `BlitAnim3DSIso` ([OBJECT.CPP](../SOURCES/OBJECT.CPP), [GRILLE.CPP](../SOURCES/GRILLE.CPP)) | decode the RLE sprite, `ScaleSprite` it; `ISO_PX` on the ZV hotspot | EM2.LBA fan, isolation diff |
+| `TYPE_OBJ_SPRITE` sprites | Doors, goodie sprites | `PtrAffGraph` via `BlitSpriteIso` ([OBJECT.CPP](../SOURCES/OBJECT.CPP)) | scaled only at the gameplay call site; `ISO_PX` on hotspot and the `SPRITE_CLIP` window | current.lba door, isolation diff |
+| `TYPE_EXTRA` sprites | Magic ball, item drops, flowers, effects | `CalculeScaleFactorSprite` + `ScaleSprite` ([OBJECT.CPP](../SOURCES/OBJECT.CPP), [EXTFUNC.CPP](../SOURCES/EXTFUNC.CPP)) | `ISO_PX` on hotspot; multiply `ScaleFactorSprite` by `IsoScale` only on the fixed-scale branch | Francos.LBA flowers, isolation diff |
+| Particle flows | Fountains, fire, magic streams | `BoxFlow` dots via `BoxFlowIso` ([FLOW.CPP](../SOURCES/FLOW.CPP)) | scale the dot size to `ISO_PX(2)` and re-centre it | Dark Monk.LBA stream, isolation diff |
+
+A separate placement fix sits underneath all of this (below).
+
+## Two projection insights
+
+**The pivot has to scale, not just the step.** A projector maps the world to the
+screen as `origin + step * worldOffset`. The per-brick step already scaled
+correctly once `LongProjectPointIso` and `Map2Screen` were scaled (a probe showed
+both moving 24px per brick at 1.0 and 48px at 2.0). But the two grids zoom about
+different fixed points: the object grid pivots at the camera point (`ModeDesiredX/2
+- 9`) and the brick grid at the cube corner (`ModeDesiredX/2 - 32`), a 23px gap in
+X and 15px in Y. Those offsets did not scale, so objects and bricks drifted apart
+by about 23px per scale step (the "model is a bit off the tile" symptom). The fix
+derives the iso centre from the brick pivot plus the scaled object-to-brick offset
+in `Init3DView`, re-applied on a scale change ([GAMEMENU.CPP](../SOURCES/GAMEMENU.CPP),
+[CONSOLE_CMD.CPP](../SOURCES/CONSOLE/CONSOLE_CMD.CPP)). At 1.0 it equals the
+original `(ModeDesiredX/2 - 9, ModeDesiredY/2)`.
+
+**Projection-derived sizes scale for free.** `CalculeScaleFactorSprite` sizes a
+sprite by projecting two points 1000 world units apart and measuring the screen
+gap. Because that measurement goes through the now-scaled `LongProjectPoint`, any
+sprite using it (the `Scale > 0` branch: many effects) already grows with the zoom.
+Only the fixed branch (`CubeMode == CUBE_INTERIEUR && Scale == -1`, which returns a
+constant `DEF_SCALE_FACTOR`) needed an explicit multiply. The corollary bites: you
+must not multiply the projection-derived branch as well, or it double-scales to 4x
+at 2x.
+
+## Bugs found and fixes
+
+1. **Screenshots captured `Screen`, not `Log`.** `Log` is the buffer presented to
+   the display; `Screen` is a clean background copy used for re-blits. The
+   screenshot path saved `Screen`, so 3D models never appeared in captures. This
+   silently invalidated headless validation for most of the session. Fixed
+   (separate change, PR #313): capture `Log`. Lesson: confirm the capture path
+   shows what the display shows before trusting any A/B.
+
+2. **The scaled re-blit re-drew a single brick instead of copying the composite.**
+   The original `CopyMask` copies the composited `Screen` (where overlapping bricks
+   already resolved front to back) over a moving object. The first scaled version
+   re-drew one decoded brick, which loses the compositing, so where bricks overlap
+   the wrong tile showed through. `ScaledReBlitFromScreen` mirrors `CopyMask`: copy
+   `Screen` masked by the brick silhouette, at the scaled footprint.
+
+3. **Object-to-brick placement drift.** The pivot issue above.
+
+4. **Three sprite paths blit native.** Doors, fans, and extras are three different
+   subsystems, none of which used the model projector, so each stayed native size.
+   The door path (`PtrAffGraph`) is shared with the HUD, inventory, and menus, so
+   the fix is at the gameplay call site only, never in the shared primitive.
+
+5. **Particle dots: fixed size and off-centre growth.** Each dot is a fixed 2x2
+   block (`BoxFlow`). With only the positions scaled, the cloud spread doubled
+   while dots stayed 2x2, so effects thinned out. Scaling the dot to `ISO_PX(2)`
+   fixes the size; because `BoxFlow` anchors the block at its top-left, the grown
+   dot also has to be offset by `(n-2)/2` to keep its centre on the particle, or
+   the whole cloud creeps down-right at zoom.
+
+## Methodology and gotchas
+
+- **The harness mutates the save you load.** `--load <save> --tick N` autosaves to
+  the live slot (`current.lba`, `autosave.lba`) as ticks advance, so the file you
+  loaded changes between runs and A/B diffs show whole-frame differences that are
+  really the game state advancing. Work from a copy: `cp current.lba /tmp/x.lba`
+  and load that. Autosave still writes the real slot, leaving the copy stable.
+- **Finding a scene with a given render class.** The `cube N` console verb warps
+  within the current island; named saves in the save dir cover other locations.
+  Concretely: EM2.LBA has a `SPRITE_3D` fan, current.lba (Twinsen's house) has a
+  `TYPE_OBJ_SPRITE` door, Francos.LBA has `Scale == -1` flower extras, Dark Monk.LBA
+  has particle flows. Island 0 (the house) has no anim sprites at all, which is why
+  the first door search came up empty.
+- **Isolation diff to verify a fix.** For each class, capture the scene with the
+  fix and again with the scaled branch forced back to native, then diff. A non-zero
+  diff localised to the object proves the fix is what changed it (and nothing
+  else); a zero diff means the class is not present in that scene, not that the fix
+  works. Force-native via a temporary `if (1)` on the scale-1 gate.
+- **ASM-tested primitives stay untouched; scale at the call site.** `BoxFlow`
+  (FLOW_A), `Map2Screen`, `LongProjectPointIso`, and `ProjectListIso` are covered
+  by ASM equivalence tests. Where the primitive is shared or tested, add a scaled
+  wrapper used only by the gameplay caller (`BoxFlowIso`, `BlitSpriteIso`) rather
+  than editing the primitive.
+- **The bit-exact-at-1.0 invariant is the safety net.** Every wrapper gates to the
+  original call at `IsoScale == ISO_SCALE_ONE`, and every offset uses `ISO_PX`,
+  which is the identity at 1.0. That is what keeps the default path and the tests
+  unaffected, and it makes "did the default change" a one-line check (diff a
+  scale-1 capture against a known good one).
+
+## What is verified, and what is not
+
+Verified by static capture and isolation diff: bricks, the foreground re-blit, 3D
+model scaling, the fan, the door, item-style extras (flowers), particle dot size
+and centring, and the placement pivot (via the projector probe).
+
+Not verified, because they are transient and cannot be triggered headlessly: the
+magic ball in flight, an item dropping, a door opening and closing (the
+`SPRITE_CLIP` sliding window is scaled but the animation was not driven), and live
+particle bursts. These need an in-game pass at `iso scale 2`.
+
+## What it would take to ship
+
+- **Scope the scale to the gameplay view.** `IsoScale` is a global. The sprite
+  fixes are at gameplay call sites so the HUD and inventory are safe today, but if a
+  menu re-uses the iso projection while a scale is set, it would inherit it. A real
+  feature would save and restore the scale around UI, or carry it as view state
+  rather than a global.
+- **Dynamic zoom.** Drive `IsoScale` over time and keep the iso follow camera
+  centred as the visible window shrinks. The brick floor is a cached background
+  re-laid only on a full redraw, so per-frame zoom re-lays bricks every frame; the
+  render-at-scale-and-sample approach sidesteps that and is the likely path.
+- **Fractional and below-1.0 scales.** Everything here was exercised at integer
+  scales (2x, 3x). Nearest-neighbour tile and dot scaling will look blocky, and
+  odd `ISO_PX` results introduce sub-pixel centring error. Smooth zoom probably
+  wants the sample-the-buffer approach rather than per-element fractional scaling.
+- **Performance.** Untested. Decoding and `ScaleSprite`-ing bricks and sprites per
+  frame is more work than the native blit; the cached-background design assumes the
+  floor is laid once.
+- **Determinism.** A non-1.0 scale changes projected coordinates, so it changes
+  projection-record hashes. It is a view transform (collision is world-space and
+  unaffected), but it is not a faithful-path mode. Keep regression runs at 1.0.

--- a/docs/WIDESCREEN.md
+++ b/docs/WIDESCREEN.md
@@ -302,3 +302,5 @@ LBA2_BIN=build-wide/SOURCES/lba2cc \
 | 6 — regression | Not started |
 
 Foundation already in place: PR #134 (`RESOLUTION_X` / `RESOLUTION_Y` constants, and most render-space literals routed through them).
+
+The HD and zoom side of Phase 5 starts with a runtime iso view scale (`IsoScale`), the shared primitive for dynamic zoom, supersampled anti-aliasing, and HD model fidelity in interior scenes. See [ISO_SCALE.md](ISO_SCALE.md).


### PR DESCRIPTION
**Status: experimental, Draft, not for merge.** This is the per-element foundation for HD interior models, kept as a reviewable record of the work and the findings. It supersedes #311 (the `IsoScale` primitive alone; this branch contains that commit plus everything built on it).

Default behaviour is unchanged: at `IsoScale = 1.0` every change is bit-exact, and the scale is a dev-only console knob (`iso scale <f>` / `iso reset` / `iso probe`). So it is safe in the tree, but it does not ship a user-facing feature on its own.

## What this is

HD interior models means rendering the iso scene at a higher scale (and, for SSAA, downsampling). That only renders correctly if every part of an interior frame honors the scale. An interior frame turns out to be drawn by about seven independent render classes that share no code, so this makes each one scale with `IsoScale`:

- Bricks (floor and walls) and the foreground brick re-blit over moving objects
- 3D models (characters, projectile bodies, impact effects)
- anim-3DS sprites (fans, vents)
- `TYPE_OBJ_SPRITE` sprites (doors)
- `TYPE_EXTRA` sprites (magic ball, item drops, effects)
- Particle-flow dots
- The object-to-brick projection pivot, so models stay aligned on the tile

## What is done vs not

Done and verified by static capture and per-class isolation diff: all seven classes scale coherently at a static scale, bit-exact at 1.0.

Not done: the S-times render buffer plus downsample pass (the actual HD/SSAA step), camera integration for smooth dynamic zoom, scoping the scale away from the UI, fractional scales, and any performance work. Not yet verified in-game for transient effects (magic ball in flight, item drop, door open and close, live particle bursts).

## Notes

- Full writeup of the render-class map, the bugs and fixes, and the verification method is in `docs/ISO_SCALE_FINDINGS.md`.
- Includes the screenshot-captures-Log fix (#313) as an ancestor commit; it rebases out cleanly if #313 lands first.
- The ASM-equivalence tests pin scale 1.0; keep regression runs at 1.0.
