### PR TITLE
Experimental (PoC): screen-space view zoom

### DIFF
--- a/LIB386/H/SVGA/SCREEN.H
+++ b/LIB386/H/SVGA/SCREEN.H
@@ -22,6 +22,16 @@ void EndScreen();
 // --- Interface ---------------------------------------------------------------
 bool CreateScreenMemory(U32 resX, U32 resY);
 
+// --- Screen-space view zoom --------------------------------------------------
+// Magnify a centred sub-region of the finished frame at present time (pure
+// image-space; the render pipeline is untouched). Fixed-point: ZOOM_ONE is 1.0,
+// 512 is 2x. At ZOOM_ONE the present is bit-identical to no zoom. This is a
+// dev/experimental zoom: it magnifies pixels (no extra detail) and scales the
+// whole frame including the UI.
+#define ZOOM_ONE 256
+extern S32 ScreenZoom;
+void SetScreenZoom(S32 zoom);
+
 // -----------------------------------------------------------------------------
 #define CopyScreen(src, dst) FastCopy(dst, src, ModeDesiredX *ModeDesiredY)
 

--- a/LIB386/SVGA/SDL.CPP
+++ b/LIB386/SVGA/SDL.CPP
@@ -288,6 +288,16 @@ static void CommitPresentTarget(void * /*pixels*/, U32 /*pitch*/) {
 }
 #endif
 
+S32 ScreenZoom = ZOOM_ONE;
+
+void SetScreenZoom(S32 zoom) {
+    if (zoom < ZOOM_ONE)
+        zoom = ZOOM_ONE; /* zoom in only; no minify */
+    if (zoom > 16 * ZOOM_ONE)
+        zoom = 16 * ZOOM_ONE;
+    ScreenZoom = zoom;
+}
+
 static void PresentFrame() {
     assert(sdlPalette != NULL);
     assert(Log != NULL);
@@ -300,11 +310,38 @@ static void PresentFrame() {
 
     U8 *logMem = (U8 *)Log;
 
-    for (U32 y = 0; y < ModeDesiredY; ++y) {
-        U8 *srcRow = logMem + y * ModeDesiredX;
-        U32 *dstRow = (U32 *)((U8 *)stagingPixels + y * stagingPitch);
-        for (U32 x = 0; x < ModeDesiredX; ++x) {
-            dstRow[x] = paletteLUT[srcRow[x]];
+    if (ScreenZoom == ZOOM_ONE) {
+        for (U32 y = 0; y < ModeDesiredY; ++y) {
+            U8 *srcRow = logMem + y * ModeDesiredX;
+            U32 *dstRow = (U32 *)((U8 *)stagingPixels + y * stagingPitch);
+            for (U32 x = 0; x < ModeDesiredX; ++x) {
+                dstRow[x] = paletteLUT[srcRow[x]];
+            }
+        }
+    } else {
+        /* Nearest-neighbour magnify of a centred sub-region of Log to fill the
+           frame. srcW/srcH is the window sampled (smaller = more zoom); stepX/Y
+           are 16.16 source-pixels per destination pixel. */
+        U32 W = ModeDesiredX, H = ModeDesiredY;
+        U32 srcW = (U32)((U64)W * ZOOM_ONE / (U32)ScreenZoom);
+        U32 srcH = (U32)((U64)H * ZOOM_ONE / (U32)ScreenZoom);
+        if (srcW < 1)
+            srcW = 1;
+        if (srcH < 1)
+            srcH = 1;
+        U32 srcX0 = (W - srcW) / 2;
+        U32 srcY0 = (H - srcH) / 2;
+        U32 stepX = (srcW << 16) / W;
+        U32 stepY = (srcH << 16) / H;
+        for (U32 y = 0; y < H; ++y) {
+            U32 srcY = srcY0 + ((y * stepY) >> 16);
+            U8 *srcRow = logMem + srcY * W;
+            U32 *dstRow = (U32 *)((U8 *)stagingPixels + y * stagingPitch);
+            U32 accX = srcX0 << 16;
+            for (U32 x = 0; x < W; ++x) {
+                dstRow[x] = paletteLUT[srcRow[accX >> 16]];
+                accX += stepX;
+            }
         }
     }
 

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -1459,6 +1459,21 @@ static void cmd_perftrace(int argc, const char *argv[]) {
     Console_Print("perftrace: unknown subcommand '%s'", sub);
 }
 
+static void cmd_zoom(int argc, const char *argv[]) {
+    if (argc >= 2 && !strcmp(argv[1], "reset")) {
+        SetScreenZoom(ZOOM_ONE);
+    } else if (argc >= 2) {
+        double f = atof(argv[1]);
+        if (f < 1.0) {
+            Console_Print("zoom: factor must be >= 1.0");
+            return;
+        }
+        SetScreenZoom((S32)(f * ZOOM_ONE + 0.5));
+    }
+    Console_Print("zoom = %.3f (screen-space magnify of the presented frame, UI included)",
+                  (double)ScreenZoom / ZOOM_ONE);
+}
+
 static void cmd_resolution(int argc, const char *argv[]) {
     /* Cap intentionally generous so cap-overflow can't silently truncate the
        advanced list as it grows over time. */
@@ -1625,6 +1640,12 @@ void Console_RegisterAll(void) {
                               "No args lists recommended modes; <n> picks by index; WxH is arbitrary "
                               "(W%8==0, range 320x200..1920x1024); native snaps to the current display; "
                               "--all expands the list with advanced modes. See docs/RUNTIME_RESOLUTION.md.");
+
+    Console_RegisterCommandEx("zoom", cmd_zoom, "Screen-space view zoom (dev/experimental)",
+                              "zoom <factor> | zoom reset",
+                              "1.0 = no zoom (bit-identical). Magnifies a centred region of the finished "
+                              "frame at present time; cheap and smooth, but pixels are upscaled (no extra "
+                              "detail) and the whole frame including the UI zooms.");
 
     Console_RegisterCommandEx("vsync", cmd_vsync,
                               "Toggle vertical sync (no args = show state)",


### PR DESCRIPTION
**Status: experimental PoC, Draft, not for merge.** A cheap screen-space view zoom, kept as the simpler alternative to the per-element projection scaling in #314.

## What it is

A `zoom` console command that magnifies a centered sub-region of the finished frame when it is uploaded to the display (`PresentFrame`). The render pipeline is untouched; this is about 40 lines in the present path plus the command.

```
zoom 2       # magnify 2x
zoom 1.5
zoom reset   # back to 1.0
zoom         # print current
```

`ZOOM_ONE` (1.0) is bit-identical to no zoom (gated to the original present loop), so the default path and the shipped game are unaffected.

## How it compares to #314

This is the "sample the buffer" approach. It is far simpler than #314 and gives smooth fractional zoom, but it upscales pixels: **no extra model detail and no silhouette-shimmer fix**, and it magnifies the whole frame including the UI. It does not deliver HD models; that is what #314's per-element foundation is for. The two are kept as separate, independent experiments.

## Known limitations (inherent to screen-space)

- Pixels are nearest-neighbour upscaled (blocky).
- The whole frame zooms, including the UI/HUD and menus.
- Centered on the framebuffer centre, not the hero (the iso follow keeps the hero roughly centred, so it reads fine in practice).

Keeping the UI fixed would mean compositing it as a separate layer at native scale (or, for full-screen menus, simply forcing `zoom = 1.0` while they are open). That UI-as-separate-layer step is also required by the HD/SSAA path, so it is shared work, not throwaway.

## Verification

The sampling math is verified offline (centered magnify, no out-of-bounds, fractional factors fine, 1.0 = full frame); build and format are clean. It is not visible in `--screenshot` captures, which save the pre-zoom `Log` buffer, so it was checked in the live window.
