### PR TITLE
Experimental (PoC): xBR/EPX brick filtering for the iso HD view

### DIFF
--- a/LIB386/H/SVGA/VIDEO.H
+++ b/LIB386/H/SVGA/VIDEO.H
@@ -48,6 +48,12 @@ void HandleEventsVideo(const void *event);
 typedef void (*PrePresentFn)(U32 *frameBuffer, U32 pitch, U32 width, U32 height, const U8 *palette_rgb);
 void SetPrePresentCallback(PrePresentFn fn);
 
+/** Optional SCENE-level pre-present pass, called BEFORE the pre-present overlay
+ *  (so it sits under the console/touch overlays). Same signature. Used by the
+ *  experimental iso xBR brick compositor to overwrite brick pixels in the
+ *  finished frame with an RGB-filtered layer. */
+void SetScenePresentCallback(PrePresentFn fn);
+
 /** Optional overlay rendered after the main pre-present callback. Used by the
  *  touch virtual gamepad overlay on Android so it draws on top of the console
  *  overlay. Same signature as PrePresentFn. */

--- a/LIB386/SVGA/SDL.CPP
+++ b/LIB386/SVGA/SDL.CPP
@@ -30,6 +30,7 @@ U32 TabOffPhysLine[ADELINE_MAX_Y_RES];
 SDL_Palette *sdlPalette = NULL;
 S32 screenLockCount = 0;
 bool frameDirty = false;
+static PrePresentFn s_scenePresent = NULL;
 static PrePresentFn s_prePresent = NULL;
 static PrePresentFn s_overlayPrePresent = NULL;
 static PresentTimingFn s_presentBegin = NULL;
@@ -237,6 +238,10 @@ void CopyVideoArea(void *dst, const void *src, const U32 tabOffDst[],
     }
 }
 
+void SetScenePresentCallback(PrePresentFn fn) {
+    s_scenePresent = fn;
+}
+
 void SetPrePresentCallback(PrePresentFn fn) {
     s_prePresent = fn;
 }
@@ -308,8 +313,8 @@ static void PresentFrame() {
         }
     }
 
-    if (s_prePresent || s_overlayPrePresent) {
-        /* Build the 256-entry RGB table once; both callbacks take the same. */
+    if (s_scenePresent || s_prePresent || s_overlayPrePresent) {
+        /* Build the 256-entry RGB table once; the callbacks take the same. */
         static U8 paletteRgb[256 * 3];
         for (int i = 0; i < 256; i++) {
             U32 c = paletteLUT[i];
@@ -317,6 +322,8 @@ static void PresentFrame() {
             paletteRgb[i * 3 + 1] = (U8)(c >> 8);
             paletteRgb[i * 3 + 2] = (U8)(c);
         }
+        if (s_scenePresent) /* scene composite first, under the overlays */
+            s_scenePresent((U32 *)stagingPixels, stagingPitch, ModeResX, ModeResY, paletteRgb);
         if (s_prePresent)
             s_prePresent((U32 *)stagingPixels, stagingPitch, ModeResX, ModeResY, paletteRgb);
         if (s_overlayPrePresent)

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -296,6 +296,13 @@ static void cmd_iso(int argc, const char *argv[]) {
     } else if (argc >= 2 && !strcmp(argv[1], "reset")) {
         SetIsoScale(ISO_SCALE_ONE);
         changed = 1;
+    } else if (argc >= 3 && !strcmp(argv[1], "epx")) {
+        extern S32 BrickEpxOn; /* GRILLE.CPP: composed-background brick filter (2x) */
+        BrickEpxOn = (S32)strtol(argv[2], NULL, 0);
+        FirstTime = AFF_ALL_FLIP;
+        Console_Print("iso epx = %d (0 off, 1 EPX-blend, 2 xBR, 3 xBR SSAA; 2x interior only)",
+                      (int)BrickEpxOn);
+        return;
     } else if (argc >= 2 && !strcmp(argv[1], "probe")) {
         /* Compare the per-brick screen delta from the model projector
            (LongProjectPointIso, world coords; 1 brick = SIZE_BRICK_XZ 512 / _Y 256)

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -300,7 +300,7 @@ static void cmd_iso(int argc, const char *argv[]) {
         extern S32 BrickEpxOn; /* GRILLE.CPP: composed-background brick filter (2x) */
         BrickEpxOn = (S32)strtol(argv[2], NULL, 0);
         FirstTime = AFF_ALL_FLIP;
-        Console_Print("iso epx = %d (0 off, 1 EPX-blend, 2 xBR, 3 xBR SSAA; 2x interior only)",
+        Console_Print("iso epx = %d (0 off, 1 EPX-blend, 2 xBR, 3 xBR SSAA; interior, zoom > 1)",
                       (int)BrickEpxOn);
         return;
     } else if (argc >= 2 && !strcmp(argv[1], "probe")) {

--- a/SOURCES/GRILLE.CPP
+++ b/SOURCES/GRILLE.CPP
@@ -777,6 +777,16 @@ void DrawOverBrickCage(S32 xm, S32 ym, S32 zm) {
 /* offset table (4) + Struc_Sprite header (4) + raw pixels (deltaX*deltaY, both
    U8 so <= 255*255). */
 static U8 s_brickRawBank[8 + 256 * 256];
+/* EXPERIMENT (feat/iso-xbr-bricks): composed-background brick filtering.
+   s_brickScratch = bricks composed at native scale (half the 2x view), framing the
+   same region; s_brickRgb = that, edge-filtered to 2x in RGB and aligned to
+   Log/Screen. RGB (not 8-bit) because an interpolating filter makes new colours
+   the palette can't hold, so the composite happens at present time. */
+static U8 *s_brickScratch = NULL;
+static U32 *s_brickRgb = NULL;
+static S32 s_epxW = 0, s_epxH = 0;
+static U32 s_palLut[256]; /* current palette as ARGB (rebuilt each BuildXbrBrickBg) */
+S32 BrickEpxOn = 0;       /* console toggle (iso epx) */
 
 /* Decode one AffGraph-format RLE image (skip/copy/repeat) from any sprite bank
    into s_brickRawBank as raw pixels (colour 0 = transparent), so it can be fed to
@@ -841,13 +851,276 @@ void BlitAnim3DSIso(U8 *buf, S32 index, S32 xs, S32 ys) {
     }
 }
 
+/* Average two ARGB pixels (fast, no overflow). */
+static inline U32 BlendArgb(U32 a, U32 b) {
+    return (((a ^ b) & 0xFEFEFEFEu) >> 1) + (a & b);
+}
+
+/* EXPERIMENT (feat/iso-xbr-bricks): EPX/Scale2x edge rules, but at a detected
+   edge the output subpixel is the *blend* of the centre and the neighbour rather
+   than a hard selection. That anti-aliases the diagonals (real RGB output, new
+   colours), which is the point of going to the RGB present path. The edge test
+   still compares palette indices (equal index == equal colour). Placeholder for
+   real xBR; pluggable. src = 8-bit indices; dst = ARGB at 2x; pal = index->ARGB. */
+static void EpxBlendScale2x(const U8 *src, S32 w, S32 h, U32 *dst, const U32 *pal) {
+    S32 dw = 2 * w;
+    for (S32 y = 0; y < h; y++) {
+        for (S32 x = 0; x < w; x++) {
+            U8 P = src[y * w + x];
+            U8 A = (y > 0) ? src[(y - 1) * w + x] : P;     /* up */
+            U8 B = (x < w - 1) ? src[y * w + x + 1] : P;   /* right */
+            U8 C = (x > 0) ? src[y * w + x - 1] : P;       /* left */
+            U8 D = (y < h - 1) ? src[(y + 1) * w + x] : P; /* down */
+            U32 pP = pal[P];
+            U32 e0 = pP, e1 = pP, e2 = pP, e3 = pP;
+            if (C == A && C != D && A != B)
+                e0 = BlendArgb(pP, pal[A]);
+            if (A == B && A != C && B != D)
+                e1 = BlendArgb(pP, pal[B]);
+            if (D == C && D != B && C != A)
+                e2 = BlendArgb(pP, pal[C]);
+            if (B == D && B != A && D != C)
+                e3 = BlendArgb(pP, pal[D]);
+            dst[(2 * y) * dw + 2 * x] = e0;
+            dst[(2 * y) * dw + 2 * x + 1] = e1;
+            dst[(2 * y + 1) * dw + 2 * x] = e2;
+            dst[(2 * y + 1) * dw + 2 * x + 1] = e3;
+        }
+    }
+}
+
+/* Weighted YUV colour distance (xBR edge metric: luma dominates). */
+static inline int XbrWd(U32 a, U32 b) {
+    int dr = (int)((a >> 16) & 0xFF) - (int)((b >> 16) & 0xFF);
+    int dg = (int)((a >> 8) & 0xFF) - (int)((b >> 8) & 0xFF);
+    int db = (int)(a & 0xFF) - (int)(b & 0xFF);
+    int Y = 299 * dr + 587 * dg + 114 * db;
+    int U = -169 * dr - 331 * dg + 500 * db;
+    int V = 500 * dr - 419 * dg - 81 * db;
+    if (Y < 0)
+        Y = -Y;
+    if (U < 0)
+        U = -U;
+    if (V < 0)
+        V = -V;
+    return (48 * Y + 7 * U + 6 * V) / 1000;
+}
+
+/* Mix two ARGB by integer weights wa:wb. */
+static inline U32 XbrMix(U32 a, U32 b, int wa, int wb) {
+    int t = wa + wb;
+    int r = ((int)((a >> 16) & 0xFF) * wa + (int)((b >> 16) & 0xFF) * wb) / t;
+    int g = ((int)((a >> 8) & 0xFF) * wa + (int)((b >> 8) & 0xFF) * wb) / t;
+    int bl = ((int)(a & 0xFF) * wa + (int)(b & 0xFF) * wb) / t;
+    return 0xFF000000u | ((U32)r << 16) | ((U32)g << 8) | (U32)bl;
+}
+
+static inline void XbrRot90(U32 p[5][5]) {
+    U32 t[5][5];
+    for (int i = 0; i < 5; i++)
+        for (int j = 0; j < 5; j++)
+            t[i][j] = p[4 - j][i];
+    memcpy(p, t, sizeof(t));
+}
+
+/* EXPERIMENT (feat/iso-xbr-bricks): xBR-style 2x. For each of the 4 output
+   corners (via 4x 90-degree rotation of the neighbourhood), a 5x5 weighted edge
+   detection decides whether a diagonal line cuts the corner; if so the corner
+   subpixel blends toward the line colour, anti-aliasing the staircase. The 5x5
+   context (vs EPX's 3x3) suppresses over-filling on noisy textures. Written from
+   the published xBR edge metric, not ported from any implementation. */
+static void XbrCornersFromP(U32 p[5][5], U32 out[2][2]) {
+    for (int rot = 0; rot < 4; rot++) {
+        U32 E = p[2][2], F = p[2][3], H = p[3][2], I = p[3][3];
+        U32 C = p[1][3], G = p[3][1], B = p[1][2], D = p[2][1];
+        U32 F4 = p[2][4], H5 = p[4][2], I4 = p[3][4], I5 = p[4][3];
+        int left = XbrWd(E, C) + XbrWd(E, G) + XbrWd(I, F4) + XbrWd(I, H5) + 4 * XbrWd(F, H);
+        int right = XbrWd(F, B) + XbrWd(F, I4) + XbrWd(H, D) + XbrWd(H, I5) + 4 * XbrWd(E, I);
+        U32 res = E;
+        if (left < right) {
+            U32 px = (XbrWd(E, F) <= XbrWd(E, H)) ? F : H;
+            res = XbrMix(px, E, 3, 1); /* corner mostly the line colour, slight AA */
+        }
+        if (rot == 0)
+            out[1][1] = res; /* SE */
+        else if (rot == 1)
+            out[1][0] = res; /* SW */
+        else if (rot == 2)
+            out[0][0] = res; /* NW */
+        else
+            out[0][1] = res; /* NE */
+        if (rot < 3)
+            XbrRot90(p);
+    }
+}
+
+static void XbrScale2x(const U8 *src, S32 w, S32 h, U32 *dst, const U32 *pal) {
+    S32 dw = 2 * w;
+    for (S32 y = 0; y < h; y++) {
+        for (S32 x = 0; x < w; x++) {
+            U32 p[5][5];
+            for (int dy = -2; dy <= 2; dy++) {
+                int sy = y + dy;
+                sy = sy < 0 ? 0 : (sy >= h ? h - 1 : sy);
+                for (int dx = -2; dx <= 2; dx++) {
+                    int sx = x + dx;
+                    sx = sx < 0 ? 0 : (sx >= w ? w - 1 : sx);
+                    p[dy + 2][dx + 2] = pal[src[sy * w + sx]];
+                }
+            }
+            U32 out[2][2];
+            XbrCornersFromP(p, out);
+            dst[(2 * y) * dw + 2 * x] = out[0][0];
+            dst[(2 * y) * dw + 2 * x + 1] = out[0][1];
+            dst[(2 * y + 1) * dw + 2 * x] = out[1][0];
+            dst[(2 * y + 1) * dw + 2 * x + 1] = out[1][1];
+        }
+    }
+}
+
+/* RGB-input xBR 2x (same core), used for the second supersample pass. */
+static void XbrScale2xRgb(const U32 *src, S32 w, S32 h, U32 *dst) {
+    S32 dw = 2 * w;
+    for (S32 y = 0; y < h; y++) {
+        for (S32 x = 0; x < w; x++) {
+            U32 p[5][5];
+            for (int dy = -2; dy <= 2; dy++) {
+                int sy = y + dy;
+                sy = sy < 0 ? 0 : (sy >= h ? h - 1 : sy);
+                for (int dx = -2; dx <= 2; dx++) {
+                    int sx = x + dx;
+                    sx = sx < 0 ? 0 : (sx >= w ? w - 1 : sx);
+                    p[dy + 2][dx + 2] = src[sy * w + sx];
+                }
+            }
+            U32 out[2][2];
+            XbrCornersFromP(p, out);
+            dst[(2 * y) * dw + 2 * x] = out[0][0];
+            dst[(2 * y) * dw + 2 * x + 1] = out[0][1];
+            dst[(2 * y + 1) * dw + 2 * x] = out[1][0];
+            dst[(2 * y + 1) * dw + 2 * x + 1] = out[1][1];
+        }
+    }
+}
+
+/* Box-downscale 2x: average each 2x2 of an ARGB image (sw x sh) into (sw/2 x sh/2). */
+static void BoxDown2x(const U32 *src, S32 sw, S32 sh, U32 *dst) {
+    S32 dw = sw / 2, dh = sh / 2;
+    for (S32 j = 0; j < dh; j++) {
+        const U32 *r0 = src + (size_t)(2 * j) * sw;
+        const U32 *r1 = src + (size_t)(2 * j + 1) * sw;
+        for (S32 i = 0; i < dw; i++) {
+            U32 a = r0[2 * i], b = r0[2 * i + 1], c = r1[2 * i], d = r1[2 * i + 1];
+            int rr = (((a >> 16) & 0xFF) + ((b >> 16) & 0xFF) + ((c >> 16) & 0xFF) + ((d >> 16) & 0xFF)) / 4;
+            int gg = (((a >> 8) & 0xFF) + ((b >> 8) & 0xFF) + ((c >> 8) & 0xFF) + ((d >> 8) & 0xFF)) / 4;
+            int bb = ((a & 0xFF) + (b & 0xFF) + (c & 0xFF) + (d & 0xFF)) / 4;
+            dst[(size_t)j * dw + i] = 0xFF000000u | ((U32)rr << 16) | ((U32)gg << 8) | (U32)bb;
+        }
+    }
+}
+
 static void BlitBrickIso(S32 numbrick, S32 xs, S32 ys) {
     if (IsoScale == ISO_SCALE_ONE) {
         AffGraph(numbrick, xs, ys, BufferBrick);
     } else {
         DecodeBrickToRaw(numbrick);
-        /* ScaleSprite factors are 16.16; IsoScale is 8.8 (ISO_SCALE_ONE=256). */
+        /* ScaleSprite factors are 16.16; IsoScale is 8.8 (ISO_SCALE_ONE=256).
+           This nearest stretch also serves as the brick mask source for the
+           composed-background EPX path (see EpxCompositeToLog). */
         ScaleSprite(0, xs, ys, IsoScale << 8, IsoScale << 8, s_brickRawBank);
+    }
+}
+
+/* EXPERIMENT: build the seam-free 2x RGB brick layer. Instead of a second
+   AffGrille pass (which corrupts shared render state -> moving objects render
+   black), recover the native composed bricks by 2x-downscaling the cached scale-2
+   brick background (Screen is the nearest-doubled native bricks, so Screen[2i,2j]
+   == native[i,j]), then EPX-blend that *composed* image back to 2x (no per-tile
+   transparent borders -> no seams). Aligned to Screen/Log, so no offset. 2x only. */
+void BuildEpxBrickBg(void) {
+    if (IsoScale != 2 * ISO_SCALE_ONE)
+        return;
+    S32 W = (S32)ModeDesiredX, H = (S32)ModeDesiredY;
+    S32 nw = W / 2, nh = H / 2;
+    if (s_epxW != W || s_epxH != H) {
+        free(s_brickScratch);
+        free(s_brickRgb);
+        s_brickScratch = (U8 *)malloc((size_t)nw * nh);
+        s_brickRgb = (U32 *)malloc((size_t)W * H * sizeof(U32));
+        s_epxW = W;
+        s_epxH = H;
+    }
+    if (!s_brickScratch || !s_brickRgb)
+        return;
+
+    /* 2x-downscale the cached brick background to recover the native composed bricks */
+    U8 *S = (U8 *)Screen;
+    for (S32 j = 0; j < nh; j++) {
+        U32 srow = TabOffLine[2 * j];
+        U8 *drow = s_brickScratch + (size_t)j * nw;
+        for (S32 i = 0; i < nw; i++)
+            drow[i] = S[srow + 2 * i];
+    }
+
+    /* current palette -> ARGB, then edge-filter the composed bricks to 2x RGB.
+       BrickEpxOn: 1 = EPX-blend (cheap), 2 = xBR, 3 = xBR supersampled (SSAA). */
+    for (S32 i = 0; i < 256; i++)
+        s_palLut[i] =
+            ((U32)0xFF << 24) | ((U32)PtrPal[i * 3] << 16) | ((U32)PtrPal[i * 3 + 1] << 8) | (U32)PtrPal[i * 3 + 2];
+    if (BrickEpxOn == 3) {
+        /* SSAA: native -> xBR 2x -> xBR 4x -> box-average down to 2x. The extra
+           sub-pixel resolution lets the shallow 2:1 iso diagonals resolve smoothly. */
+        static U32 *s_buf2x = NULL, *s_buf4x = NULL;
+        static S32 s_ssW = 0, s_ssH = 0;
+        if (s_ssW != W || s_ssH != H) {
+            free(s_buf2x);
+            free(s_buf4x);
+            s_buf2x = (U32 *)malloc((size_t)W * H * sizeof(U32));
+            s_buf4x = (U32 *)malloc((size_t)(2 * W) * (2 * H) * sizeof(U32));
+            s_ssW = W;
+            s_ssH = H;
+        }
+        if (s_buf2x && s_buf4x) {
+            XbrScale2x(s_brickScratch, nw, nh, s_buf2x, s_palLut); /* 8-bit -> 2x RGB (WxH) */
+            XbrScale2xRgb(s_buf2x, W, H, s_buf4x);                 /* 2x -> 4x RGB (2Wx2H) */
+            BoxDown2x(s_buf4x, 2 * W, 2 * H, s_brickRgb);          /* 4x -> 2x averaged */
+        } else {
+            XbrScale2x(s_brickScratch, nw, nh, s_brickRgb, s_palLut); /* OOM fallback */
+        }
+    } else if (BrickEpxOn == 2) {
+        XbrScale2x(s_brickScratch, nw, nh, s_brickRgb, s_palLut);
+    } else {
+        EpxBlendScale2x(s_brickScratch, nw, nh, s_brickRgb, s_palLut);
+    }
+}
+
+/* Scene-present callback (runs after Log->ARGB, before the UI overlays): paint the
+   finished frame from the iso brick layer + the game palette. Brick pixels (where
+   Log==Screen, the nearest brick draw with no model on top) take the RGB-filtered
+   composed background; model pixels are re-converted from Log through PtrPal (the
+   SDL paletteLUT misses the 216-255 range some objects use, so they would otherwise
+   present black). The layer is aligned to Screen/Log, so there is no offset. */
+void IsoXbrPresent(U32 *frame, U32 pitch, U32 width, U32 height, const U8 *pal_rgb) {
+    (void)pal_rgb;
+    if (!BrickEpxOn || IsoScale != 2 * ISO_SCALE_ONE || !s_brickRgb)
+        return;
+    S32 W = (S32)ModeDesiredX, H = (S32)ModeDesiredY;
+    if ((U32)W != width || (U32)H != height)
+        return; /* present buffer size mismatch; skip */
+    U8 *L = (U8 *)Log, *S = (U8 *)Screen;
+    for (S32 y = 0; y < H; y++) {
+        U32 lrow = TabOffLine[y];
+        U32 erow = (U32)y * (U32)W;
+        U32 *frow = (U32 *)((U8 *)frame + (U32)y * pitch);
+        for (S32 x = 0; x < W; x++) {
+            U32 idx = lrow + (U32)x;
+            if (L[idx] != S[idx])
+                frow[x] = s_palLut[L[idx]]; /* model: re-convert via PtrPal (the SDL
+                                              paletteLUT misses the 216-255 range, so
+                                              objects using it would present black) */
+            else
+                frow[x] = s_brickRgb[erow + (U32)x]; /* brick: filtered RGB (aligned) */
+        }
     }
 }
 

--- a/SOURCES/GRILLE.CPP
+++ b/SOURCES/GRILLE.CPP
@@ -784,7 +784,6 @@ static U8 s_brickRawBank[8 + 256 * 256];
    the palette can't hold, so the composite happens at present time. */
 static U8 *s_brickScratch = NULL;
 static U32 *s_brickRgb = NULL;
-static S32 s_epxW = 0, s_epxH = 0;
 static U32 s_palLut[256]; /* current palette as ARGB (rebuilt each BuildXbrBrickBg) */
 S32 BrickEpxOn = 0;       /* console toggle (iso epx) */
 
@@ -1019,6 +1018,34 @@ static void BoxDown2x(const U32 *src, S32 sw, S32 sh, U32 *dst) {
     }
 }
 
+/* Bilinear resample an ARGB image (sw x sh) to (dw x dh). Maps corner to corner. */
+static void BilinearResample(const U32 *src, S32 sw, S32 sh, U32 *dst, S32 dw, S32 dh) {
+    for (S32 y = 0; y < dh; y++) {
+        S32 fy = (dh > 1) ? (S32)(((S64)y * (sh - 1) * 256) / (dh - 1)) : 0;
+        S32 sy = fy >> 8, wy = fy & 255;
+        S32 sy1 = (sy + 1 < sh) ? sy + 1 : sy;
+        const U32 *r0 = src + (size_t)sy * sw;
+        const U32 *r1 = src + (size_t)sy1 * sw;
+        U32 *drow = dst + (size_t)y * dw;
+        for (S32 x = 0; x < dw; x++) {
+            S32 fx = (dw > 1) ? (S32)(((S64)x * (sw - 1) * 256) / (dw - 1)) : 0;
+            S32 sx = fx >> 8, wx = fx & 255;
+            S32 sx1 = (sx + 1 < sw) ? sx + 1 : sx;
+            U32 a = r0[sx], b = r0[sx1], c = r1[sx], d = r1[sx1];
+            int rt = (((int)((a >> 16) & 0xFF) * (256 - wx)) + ((int)((b >> 16) & 0xFF) * wx)) >> 8;
+            int rb = (((int)((c >> 16) & 0xFF) * (256 - wx)) + ((int)((d >> 16) & 0xFF) * wx)) >> 8;
+            int gt = (((int)((a >> 8) & 0xFF) * (256 - wx)) + ((int)((b >> 8) & 0xFF) * wx)) >> 8;
+            int gb = (((int)((c >> 8) & 0xFF) * (256 - wx)) + ((int)((d >> 8) & 0xFF) * wx)) >> 8;
+            int bt = (((int)(a & 0xFF) * (256 - wx)) + ((int)(b & 0xFF) * wx)) >> 8;
+            int bb = (((int)(c & 0xFF) * (256 - wx)) + ((int)(d & 0xFF) * wx)) >> 8;
+            int r = (rt * (256 - wy) + rb * wy) >> 8;
+            int g = (gt * (256 - wy) + gb * wy) >> 8;
+            int bl = (bt * (256 - wy) + bb * wy) >> 8;
+            drow[x] = 0xFF000000u | ((U32)r << 16) | ((U32)g << 8) | (U32)bl;
+        }
+    }
+}
+
 static void BlitBrickIso(S32 numbrick, S32 xs, S32 ys) {
     if (IsoScale == ISO_SCALE_ONE) {
         AffGraph(numbrick, xs, ys, BufferBrick);
@@ -1031,67 +1058,94 @@ static void BlitBrickIso(S32 numbrick, S32 xs, S32 ys) {
     }
 }
 
-/* EXPERIMENT: build the seam-free 2x RGB brick layer. Instead of a second
-   AffGrille pass (which corrupts shared render state -> moving objects render
-   black), recover the native composed bricks by 2x-downscaling the cached scale-2
-   brick background (Screen is the nearest-doubled native bricks, so Screen[2i,2j]
-   == native[i,j]), then EPX-blend that *composed* image back to 2x (no per-tile
-   transparent borders -> no seams). Aligned to Screen/Log, so no offset. 2x only. */
+/* EXPERIMENT: build the seam-free RGB brick layer for any zoom > 1. Instead of a
+   second AffGrille pass (which corrupts shared render state -> moving objects
+   render black), recover the native composed bricks by downscaling the zoomed
+   brick background by the zoom factor (Screen holds it nearest-stretched, so
+   Screen[i*zoom] == native[i]), edge-filter that *composed* image to 2x native (no
+   per-tile transparent borders -> no seams), then bilinear-resample the 2x-native
+   layer to the display. At zoom == 2 the 2x-native layer already is the display, so
+   the resample is skipped and the filter writes straight into the composite buffer. */
 void BuildEpxBrickBg(void) {
-    if (IsoScale != 2 * ISO_SCALE_ONE)
-        return;
+    if (IsoScale <= ISO_SCALE_ONE)
+        return; /* only when zoomed in */
     S32 W = (S32)ModeDesiredX, H = (S32)ModeDesiredY;
-    S32 nw = W / 2, nh = H / 2;
-    if (s_epxW != W || s_epxH != H) {
+    /* native = the un-zoomed brick resolution the current zoom stretched from */
+    S32 nw = (S32)(((S64)W * ISO_SCALE_ONE) / IsoScale);
+    S32 nh = (S32)(((S64)H * ISO_SCALE_ONE) / IsoScale);
+    if (nw < 1)
+        nw = 1;
+    if (nh < 1)
+        nh = 1;
+    S32 lw = 2 * nw, lh = 2 * nh; /* the filter outputs 2x native */
+
+    static U32 *s_layer2x = NULL;
+    static S32 s_bnw = 0, s_bnh = 0, s_bW = 0, s_bH = 0;
+    if (s_bnw != nw || s_bnh != nh || s_bW != W || s_bH != H) {
         free(s_brickScratch);
         free(s_brickRgb);
+        free(s_layer2x);
         s_brickScratch = (U8 *)malloc((size_t)nw * nh);
         s_brickRgb = (U32 *)malloc((size_t)W * H * sizeof(U32));
-        s_epxW = W;
-        s_epxH = H;
+        s_layer2x = (U32 *)malloc((size_t)lw * lh * sizeof(U32));
+        s_bnw = nw;
+        s_bnh = nh;
+        s_bW = W;
+        s_bH = H;
     }
-    if (!s_brickScratch || !s_brickRgb)
+    if (!s_brickScratch || !s_brickRgb || !s_layer2x)
         return;
 
-    /* 2x-downscale the cached brick background to recover the native composed bricks */
+    /* recover the native composed bricks (downscale the zoomed Screen by the zoom) */
     U8 *S = (U8 *)Screen;
     for (S32 j = 0; j < nh; j++) {
-        U32 srow = TabOffLine[2 * j];
+        S32 sj = (S32)(((S64)j * IsoScale) / ISO_SCALE_ONE);
+        if (sj >= H)
+            sj = H - 1;
+        U32 srow = TabOffLine[sj];
         U8 *drow = s_brickScratch + (size_t)j * nw;
-        for (S32 i = 0; i < nw; i++)
-            drow[i] = S[srow + 2 * i];
+        for (S32 i = 0; i < nw; i++) {
+            S32 si = (S32)(((S64)i * IsoScale) / ISO_SCALE_ONE);
+            if (si >= W)
+                si = W - 1;
+            drow[i] = S[srow + (U32)si];
+        }
     }
 
-    /* current palette -> ARGB, then edge-filter the composed bricks to 2x RGB.
+    /* current palette -> ARGB, then edge-filter to 2x native.
        BrickEpxOn: 1 = EPX-blend (cheap), 2 = xBR, 3 = xBR supersampled (SSAA). */
     for (S32 i = 0; i < 256; i++)
         s_palLut[i] =
             ((U32)0xFF << 24) | ((U32)PtrPal[i * 3] << 16) | ((U32)PtrPal[i * 3 + 1] << 8) | (U32)PtrPal[i * 3 + 2];
+
+    /* when the 2x-native layer already matches the display (zoom == 2) filter
+       straight into the composite buffer, else into the scratch layer + resample */
+    U32 *dst = (lw == W && lh == H) ? s_brickRgb : s_layer2x;
     if (BrickEpxOn == 3) {
-        /* SSAA: native -> xBR 2x -> xBR 4x -> box-average down to 2x. The extra
-           sub-pixel resolution lets the shallow 2:1 iso diagonals resolve smoothly. */
-        static U32 *s_buf2x = NULL, *s_buf4x = NULL;
-        static S32 s_ssW = 0, s_ssH = 0;
-        if (s_ssW != W || s_ssH != H) {
-            free(s_buf2x);
+        /* SSAA: native -> xBR 2x -> xBR 4x -> box-average down to 2x native. */
+        static U32 *s_buf4x = NULL;
+        static S32 s_s4w = 0, s_s4h = 0;
+        if (s_s4w != lw || s_s4h != lh) {
             free(s_buf4x);
-            s_buf2x = (U32 *)malloc((size_t)W * H * sizeof(U32));
-            s_buf4x = (U32 *)malloc((size_t)(2 * W) * (2 * H) * sizeof(U32));
-            s_ssW = W;
-            s_ssH = H;
+            s_buf4x = (U32 *)malloc((size_t)(2 * lw) * (2 * lh) * sizeof(U32));
+            s_s4w = lw;
+            s_s4h = lh;
         }
-        if (s_buf2x && s_buf4x) {
-            XbrScale2x(s_brickScratch, nw, nh, s_buf2x, s_palLut); /* 8-bit -> 2x RGB (WxH) */
-            XbrScale2xRgb(s_buf2x, W, H, s_buf4x);                 /* 2x -> 4x RGB (2Wx2H) */
-            BoxDown2x(s_buf4x, 2 * W, 2 * H, s_brickRgb);          /* 4x -> 2x averaged */
+        if (s_buf4x) {
+            XbrScale2x(s_brickScratch, nw, nh, dst, s_palLut); /* 8-bit -> 2x native */
+            XbrScale2xRgb(dst, lw, lh, s_buf4x);               /* 2x -> 4x native */
+            BoxDown2x(s_buf4x, 2 * lw, 2 * lh, dst);           /* 4x -> 2x averaged */
         } else {
-            XbrScale2x(s_brickScratch, nw, nh, s_brickRgb, s_palLut); /* OOM fallback */
+            XbrScale2x(s_brickScratch, nw, nh, dst, s_palLut); /* OOM fallback */
         }
     } else if (BrickEpxOn == 2) {
-        XbrScale2x(s_brickScratch, nw, nh, s_brickRgb, s_palLut);
+        XbrScale2x(s_brickScratch, nw, nh, dst, s_palLut);
     } else {
-        EpxBlendScale2x(s_brickScratch, nw, nh, s_brickRgb, s_palLut);
+        EpxBlendScale2x(s_brickScratch, nw, nh, dst, s_palLut);
     }
+
+    if (dst != s_brickRgb)
+        BilinearResample(s_layer2x, lw, lh, s_brickRgb, W, H);
 }
 
 /* Scene-present callback (runs after Log->ARGB, before the UI overlays): paint the
@@ -1102,7 +1156,7 @@ void BuildEpxBrickBg(void) {
    present black). The layer is aligned to Screen/Log, so there is no offset. */
 void IsoXbrPresent(U32 *frame, U32 pitch, U32 width, U32 height, const U8 *pal_rgb) {
     (void)pal_rgb;
-    if (!BrickEpxOn || IsoScale != 2 * ISO_SCALE_ONE || !s_brickRgb)
+    if (!BrickEpxOn || IsoScale <= ISO_SCALE_ONE || !s_brickRgb)
         return;
     S32 W = (S32)ModeDesiredX, H = (S32)ModeDesiredY;
     if ((U32)W != width || (U32)H != height)

--- a/SOURCES/GRILLE.H
+++ b/SOURCES/GRILLE.H
@@ -105,6 +105,13 @@ extern void DrawOverBrickCage(S32 xm, S32 ym, S32 zm);
 extern void BlitAnim3DSIso(U8 *buf, S32 index, S32 xs, S32 ys);
 
 //-------------------------------------------------------------------
+/* EXPERIMENT (feat/iso-xbr-bricks): composed-background brick filtering (RGB). */
+extern S32 BrickEpxOn;
+extern void BuildEpxBrickBg(void); /* build the 2x RGB brick layer (full redraw) */
+extern void IsoXbrPresent(U32 *frame, U32 pitch, U32 width, U32 height,
+                          const U8 *pal_rgb); /* scene-present composite callback */
+
+//-------------------------------------------------------------------
 extern void AffBrickBlock(S32 block, S32 brick, S16 x, S16 y, S16 z);
 
 //-------------------------------------------------------------------

--- a/SOURCES/OBJECT.CPP
+++ b/SOURCES/OBJECT.CPP
@@ -6226,6 +6226,18 @@ startaffscene:
         }
     }
 
+    /* EXPERIMENT (feat/iso-xbr-bricks): rebuild the 2x RGB brick layer from the
+       composed background. The composite over the crisp HD models happens at
+       present time (IsoXbrPresent), since the RGB-filtered bricks can't live in
+       the 8-bit Log. Only on a FULL redraw: the native AffGrille pass touches
+       shared render globals, so running it every frame corrupts the per-frame
+       object draw (moving objects render black). The brick layer is a cached
+       background anyway, re-laid only on full redraws. 2x interior only. */
+    if (BrickEpxOn && CubeMode == CUBE_INTERIEUR &&
+        (flagflip == AFF_ALL_FLIP || flagflip == AFF_ALL_NO_FLIP)) {
+        BuildEpxBrickBg();
+    }
+
 #ifdef ENABLE_POLY_RECORDING
     // Polygon call recording — stop recording and write file
     if (polyrec_pending_name[0]) {

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2512,6 +2512,10 @@ int main(int argc, char *argv[]) {
     SetEventFilter(Console_FeedEvent);
     SetPrePresentCallback(Console_PrePresent);
 
+    /* EXPERIMENT (feat/iso-xbr-bricks): scene-level present pass that overwrites
+       brick pixels with the RGB-filtered composed background, under the console. */
+    SetScenePresentCallback(IsoXbrPresent);
+
     /* Touch virtual gamepad (Android / mobile). Init before Perftrace so
        timing callbacks nest correctly. No-op on non-Android builds. */
     TouchOverlay_Init();

--- a/docs/ISO_XBR_FILTERING.md
+++ b/docs/ISO_XBR_FILTERING.md
@@ -1,0 +1,130 @@
+# Iso brick filtering (xBR / EPX): experiment notes
+
+Experimental. Off by default. Branch `feat/iso-xbr-bricks`, built on the iso
+view-scale foundation (see [ISO_SCALE_FINDINGS.md](ISO_SCALE_FINDINGS.md)). This
+note records how it works and what was tried, so the work can be picked up later.
+
+## What it does
+
+At an iso zoom (`iso scale > 1`) the brick background is blocky: the tiles are
+nearest-stretched. This filters that background with an edge-directed upscaler
+(EPX-blend or xBR) and composites the result over the unscaled, crisp 3D models,
+so the floor/walls smooth out while the characters and objects stay sharp.
+
+Console toggle (interior only):
+
+```
+iso scale 2     # zoom first (the filter keys off the zoom)
+iso epx 0       # off (nearest bricks)
+iso epx 1       # EPX-blend (cheap, mild)
+iso epx 2       # xBR (edge-directed)
+iso epx 3       # xBR supersampled (SSAA, smoothest)
+```
+
+## Pipeline
+
+The filter runs as a scene-level present callback, not in the engine draw path:
+
+1. **Recover the native bricks.** `Screen` holds the brick background already
+   drawn at the zoom (nearest-stretched), so downscaling it by the zoom factor
+   recovers the original native-resolution composed bricks. This avoids a second
+   `AffGrille` pass, which corrupts shared render state and makes the moving
+   objects draw black.
+2. **Filter** the recovered native image back up to 2x native with EPX-blend or
+   xBR (the *composed* image, so there are no per-tile transparent borders and
+   therefore no seams between tiles), then bilinear-resample that 2x-native layer
+   to the display. At zoom == 2 the 2x-native layer already is the display, so the
+   resample is skipped and the filter writes straight into the composite buffer
+   (zoom 2 stays bit-identical to the original 2x-only path).
+3. **Composite at present time** (`IsoXbrPresent`, a new `SetScenePresentCallback`
+   slot that runs under the console/touch overlays). For each finished-frame
+   pixel: where `Log == Screen` it is a brick (no model on top) and takes the
+   filtered RGB layer; otherwise it is a model pixel and is re-converted from
+   `Log` through `PtrPal`.
+
+The composite is at present time (not in `Log`) because an interpolating filter
+makes new colours the 8-bit palette cannot hold, so the layer is RGB.
+
+## The palette gotcha (important)
+
+Going RGB-at-present exposed a real, pre-existing engine quirk that will bite
+anything else that does the same.
+
+The SDL present palette (`paletteLUT` in `LIB386/SVGA/SDL.CPP`) is **missing the
+216-255 range** in iso scenes: those entries are black, while the game palette
+`PtrPal` holds the real colours (a shading ramp plus specials, e.g. index 246 =
+`(87,87,255)`, the ghost's blue). The screen palette only updates via
+`PaletteSync(...)` and the high range simply is not pushed in these scenes.
+
+Consequence: any object using a high-range index presents **black** even though
+it is correct in `Log`. Screenshots hide this entirely because `SavePNG` uses
+`PtrPal` directly, not `paletteLUT`. That is why the bricks looked fine but the
+ghost and Twinsen went black, and why headless `--screenshot` could not see it.
+
+Fix in the composite: re-convert **model** pixels from `Log` through `PtrPal`
+(built into `s_palLut`) instead of leaving the stale `paletteLUT` value, so the
+whole iso view presents from the authoritative palette.
+
+## Diagnosing present-time effects headlessly
+
+`--screenshot` saves `Log` (8-bit, pre-composite), so it cannot see a present-time
+composite. The dummy video driver *does* run the present path, so a temporary PPM
+dump of the staging buffer inside the present callback works for headless A/B (the
+staging dump can be flaky though, so treat it as advisory and confirm live). The
+palette diff that found the bug compared the callback's `pal_rgb` argument (the SDL
+palette) against `PtrPal` directly.
+
+## Optimisation (preserved on `feat/iso-xbr-optimized`)
+
+The proof-of-concept rebuilds the layer on every full redraw. That was slow at the
+higher filter levels, so a perf pass was done and then set aside (re-optimise once
+the design settles). It lives on branch **`feat/iso-xbr-optimized`** (commits
+`441cf265`, `b574930b`, `ce64f987` on top of this one) and covers:
+
+- **Skip-when-unchanged.** The layer is a pure function of `Screen` + dims + mode;
+  hash those and reuse the cached layer otherwise. Idle scenes rebuild zero times.
+- **Luma-only edge distance.** Bricks are low-chroma, so dropping U/V from the xBR
+  metric costs nothing visible and cuts the hot path (~40 calls/pixel) to a third.
+- **Threaded filter.** Each thread owns a disjoint band of output rows (read-only
+  source, disjoint writes, no locks), via `SDL_CreateThread` like `AIL/SDL/STREAM`.
+  Race-free and deterministic.
+- **LRU layer cache.** Keep the last N built layers keyed by the `Screen`+mode
+  hash, so snapping back to an already-built camera view is a cache hit (no
+  rebuild). The camera snaps between fixed iso views, so revisits are common.
+- **Rebuild-cost log** on cache miss, to measure the filter cost against the
+  game's own camera-transition delay.
+
+Measured rebuild cost at 1280x960 (one camera view), before and after:
+
+| mode | before | after (wall) |
+|------|--------|--------------|
+| 1 EPX-blend | 10 ms | 11 ms |
+| 2 xBR | 311 ms | 61 ms |
+| 3 xBR SSAA | 1470 ms | 189 ms |
+
+Memory: ~5 MB per built layer; SSAA adds ~25 MB of shared scratch. The LRU cache
+multiplies the layer cost by its slot count (lazy, grows only with views visited).
+
+To resume the optimisation: `git cherry-pick 441cf265 b574930b ce64f987` (or rebase
+that branch) once the scale generalisation below is settled.
+
+## Findings / gotchas worth keeping
+
+- The bricks turned out to be **brick decor**, not objects, so they live in
+  `Screen` and the downscale-recovery sees them. Moving entities (Twinsen, the
+  ghost) are `Log != Screen` and stay crisp.
+- The camera **snaps** between fixed views with its own transition delay, so the
+  filter rebuild lands inside an existing pause rather than adding a new hitch.
+  Walking within a room does not re-lay bricks (verified: one build over 300 idle
+  ticks), so steady state is just the composite.
+- xBR and its YUV edge metric here are written from the published algorithm, not
+  ported, so there is no licensing entanglement.
+
+## Known limits / future
+
+- SSAA is the smoothest but heaviest; the per-cut cost is hidden in the camera
+  transition but is the first thing to profile if cuts feel slow.
+- The brick layer detail is capped at 2x of native, so very high zoom stretches it
+  (a deeper supersample or per-scale filter level would address that).
+- An async rebuild (present nearest immediately, swap the filtered layer in a few
+  frames later) would fully decouple the filter from the camera-cut feel.

--- a/docs/ISO_XBR_FILTERING.md
+++ b/docs/ISO_XBR_FILTERING.md
@@ -105,8 +105,11 @@ Measured rebuild cost at 1280x960 (one camera view), before and after:
 Memory: ~5 MB per built layer; SSAA adds ~25 MB of shared scratch. The LRU cache
 multiplies the layer cost by its slot count (lazy, grows only with views visited).
 
-To resume the optimisation: `git cherry-pick 441cf265 b574930b ce64f987` (or rebase
-that branch) once the scale generalisation below is settled.
+To resume the optimisation: the luma metric and the threaded filter (`XbrWd`,
+`XbrRows`/`XbrParallel`) are independent of the build function and cherry-pick
+cleanly. The skip-gate, LRU cache, and rebuild log live inside `BuildEpxBrickBg`,
+which the scale generalisation rewrote, so those need re-applying by hand on top of
+the generalised build (keep the LRU key = hash of Screen + mode + the native dims).
 
 ## Findings / gotchas worth keeping
 


### PR DESCRIPTION
**Status: experimental PoC, Draft, not for merge.** Stacked on #314 (the iso view-scale foundation); the base will retarget to main if/when that lands. Sharing it so the approach and one engine finding are on record.

## What it is

At an iso zoom (`iso scale > 1`, from #314) the brick background is nearest-stretched and blocky. This filters that background with an edge-directed upscaler and composites it over the unscaled, crisp 3D models, so the floor and walls smooth out while characters and objects stay sharp.

Console toggle (interior, zoom > 1):

```
iso scale 2     # zoom first
iso epx 0       # off (nearest bricks)
iso epx 1       # EPX-blend (cheap, mild)
iso epx 2       # xBR (edge-directed)
iso epx 3       # xBR supersampled (SSAA, smoothest)
```

## How it works

- Recover the native bricks by downscaling the zoomed `Screen` by the zoom factor (no second `AffGrille` pass, which corrupts shared render state and makes moving objects draw black).
- Filter to 2x native, then bilinear-resample to the display, so it works at any zoom > 1 (zoom 2 stays bit-identical to the direct path).
- Composite at present time, via a new scene-level present callback that runs under the console/touch overlays: brick pixels (where `Log == Screen`) take the filtered RGB layer; model pixels are re-converted from `Log` through `PtrPal`.

xBR and its YUV edge metric here are written from the published algorithm, not ported.

## One finding worth recording

Going RGB-at-present surfaced a pre-existing engine quirk: the SDL present palette misses the 216-255 range in iso scenes (those entries are black, while `PtrPal` holds the real colours, e.g. the translucent ghost's blue). Anything using that range presents black even though it is correct in `Log`, and `--screenshot` hides it entirely because it saves `PtrPal`-converted `Log`. The composite works around it by re-converting model pixels through `PtrPal`. Full write-up in `docs/ISO_XBR_FILTERING.md`.

## Scope and status

- Experimental, off by default, interior + zoom > 1 only.
- This branch is intentionally **unoptimised** (per-camera-cut rebuild is slow). The perf work (skip-when-unchanged gate, luma-only metric, threaded filter, LRU layer cache: xBR 311 -> 61 ms, SSAA 1470 -> 189 ms at 1280x960) is preserved on `feat/iso-xbr-optimized` and documented for re-applying once the design settles.
- The camera snaps between fixed views with its own transition delay, so the rebuild lands inside an existing pause; steady-state is just the composite.

Not proposing this for merge.
