### PR TITLE
docs(lba1): plan for hosting LBA1 on the lba2cc engine

### DIFF
--- a/docs/LBA1_PORTING_SURFACE.md
+++ b/docs/LBA1_PORTING_SURFACE.md
@@ -124,6 +124,18 @@ to the **format transcoders** (body, scene), now fully specified above.
 
 ### 8. Script VM — opcode-remap shim
 
+> **Correction (2026-06-17, `[verified-from-code]` via `scripts/dev/lba1_script_remap.py`; see
+> `LBA1_PORT_PLAN.md` §6.4):** the claim below that the `LM_*` tables are "numerically identical
+> for 0–56" is **wrong**. Diffing `lba1-classic/SOURCES/COMMON.H` against this repo's: of LBA1's
+> 101 Life ops, 68 are identical-slot, 2 are FLAG->VAR renames (31, 36), and 30 collide, with
+> collisions **inside 0..56**: `LM_LABEL`(10)->`LM_PALETTE`, `LM_SET_LIFE`(21)->`LM_SET_CAMERA`,
+> `LM_SET_LIFE_OBJ`(22)->`LM_CAMERA_CENTER`. A by-name remap covers 71/101; the rest need a manual
+> alias (e.g. `LM_LABEL`->`LM_COMPORTEMENT`) or a handler (media ops, fades, proj). The
+> control-flow + flag spine still aligns by number, so the VM mechanism transcodes; and the
+> byte-vs-S16 flag-width seam (verified: LBA1 `RET_BYTE`/1-byte SET vs LBA2 `RET_S16`/2-byte SET,
+> with absolute jumps to recompute) is real. Net: still a contained shim, but a genuine per-op
+> remap table with operand-width rewriting, not a near-identity map.
+
 Same VM (see [ENGINE_GAME_INTERFACE.md](ENGINE_GAME_INTERFACE.md)): `*PtrPrg++` dispatch in
 both `GERELIFE` and `GERETRAK`, same condition opcodes (`LF_*`), comparison ops (`LT_*`),
 return widths. The command (`LM_*`) tables are **numerically identical for 0–56**.

--- a/docs/LBA1_PORT_PLAN.md
+++ b/docs/LBA1_PORT_PLAN.md
@@ -1,0 +1,580 @@
+# Hosting LBA1 on the lba2cc engine: paths, cost, and feasibility spikes
+
+**Status:** Research + plan. A proposal awaiting go/no-go on the §7 decisions. The §6.2 body
+transcoder spike (`scripts/dev/lba1_body_probe.py`) passes: the LBA1 body is decoded and
+validated on retail bytes and its geometry transcoded to a valid LBA2 body; the on-engine
+render (face-normal synthesis + a load/snapshot harness) is the remaining sub-step. The §6.4
+script spike (`scripts/dev/lba1_script_remap.py`) also passes: the quest's set/test/branch
+transcodes across the byte-to-S16 flag-width seam, and it corrected the opcode-alignment claim
+in `LBA1_PORTING_SURFACE.md` §8. The §6.5 background spike (`scripts/dev/lba1_bkg_repack.py`)
+passes too: LBA1's 3 background HQRs re-index into LBA2's merged container by offset arithmetic.
+The §6.6 audio spike (`scripts/dev/lba1_voc_probe.py`) confirms LBA1 VOC audio is drop-in through
+lba2cc's existing VOC decoder (one-line gate widening needed for 4 `0x01`-prefixed voice entries).
+This is the **plan**; the per-subsystem **cost survey** it builds on is
+[LBA1_PORTING_SURFACE.md](LBA1_PORTING_SURFACE.md), and the **north-star** it serves is
+[ARCHITECTURE.md](ARCHITECTURE.md) ("one engine, two games").
+
+**Scope:** Decide *how* to bring LBA1 to this groundwork, cost the candidate paths against
+each other, and de-risk the recommended path with cheap spikes. Three end-states were
+considered (§2). The recommendation is **Path B (host LBA1 content on the lba2cc engine),
+built in-repo and game-id-gated, with extraction to a separate repo deferred**.
+
+**Evidence tags:** `[verified-from-code]` (read the exact lines, in this repo, the
+`lba1-classic` tree, or the `twin-e` tree), `[verified-from-docs]` (checked against another
+doc here), `[verified-from-data]` (checked against local LBA1/LBA2 retail HQRs), `[assumed]`
+(inference / estimate), `[design]` (a design choice, not a code finding). `path:line`
+citations are against the trees at audit time.
+
+---
+
+## 0. Decision-ready summary
+
+- **The cheap path is also the documented one.** The lba2cc engine is a strict superset of
+  LBA1's (`LBA1_PORTING_SURFACE.md`): same HQR, same Life/Track VM, same brick-iso world,
+  same anim math. Hosting LBA1 is **format transcoders (body, scene) + a script opcode-remap
+  + GPLv2 FLA/MIDI integration**, not re-architecting. Path B reuses the *actual* engine
+  (SDL3, rasteriser, tests, CI, multiplatform); Paths A and C re-pay or re-package that work.
+- **LBA1's quest is data, not C.** `[verified-from-code]` Progression lives in Life-script
+  bytecode + three flag arrays (`ListFlagGame[255]`, `ListFlagCube[80]`,
+  `ListFlagInventory[28]` in `lba1-classic/SOURCES/GLOBAL.C`), mutated by VM opcodes
+  (`LM_SET_FLAG_GAME`, `LM_INC_CHAPTER`, `LM_CHANGE_CUBE`, `LM_FOUND_OBJECT`,
+  `LM_SET_HOLO_POS`) and branched on by `LF_FLAG_GAME`/`LF_CHAPTER`/`LF_USE_INVENTORY`. The
+  whole quest rides inside `SCENE.HQR` once the VM runs LBA1 bytecode. **Only two hardcoded
+  story "rustines"** exist: the intro (`PERSO.C:213-248`, `NewCube==0 && Chapitre==0`) and
+  one redirect (`OBJECT.C:369-372`, `NewCube==4 → 118 if ListFlagGame[30]`). This is what
+  makes Path B small, and it puts the opcode-remap (and flag *width*) at the centre.
+- **The PAL is independent.** `[verified-from-docs]` B/C reuse SDL3 as it ships; the headless
+  determinism harness they test against (`Control_*` + fixed-dt) **already exists today**, pre-
+  PAL ([PLATFORM_PAL_PLAN.md](PLATFORM_PAL_PLAN.md) §0). PAL only matters for a *non-SDL* LBA1
+  host, the same §5.1 story as for LBA2. Do them in either order; neither blocks the other.
+- **The menu is the same engine in both trees, so "agnostic menu" is a facade, not a
+  rewrite.** `[verified-from-code]` Both define menus as a `U16` array
+  `[selected, nb_entries, y_center, dia_num, (type, text_id)*]` driven by a generic
+  `DoGameMenu()` returning the selected text-id; both use the template→build→drive flow and a
+  plasma background. The divergence is *data* (entry text-ids, inventory grid size, behaviour
+  set). See §5.
+- **The LBA1 source of truth is `../lba1-classic`; `twin-e` is only a helper.**
+  `[verified-from-code]` The canonical LBA1 behaviour and on-disk formats are the original
+  Adeline source (`lba1-classic`: opcode numbering in `SOURCES/COMMON.H`, the body parser
+  `LIB386/LIB_3D/P_OBJET.ASM`, etc.). `twin-e` is a pure-LBA1 GPLv2 *reimplementation* used as
+  a secondary, more-readable cross-check: named opcode tables (`twin-e/src/script.life.c:1511+`,
+  `script.move.c:539+`), all 255 flags named (`twin-e/docs/GameFlags.md`), a standalone
+  XMIDI→MIDI converter, and the FLA decoder. The opcode-remap table is `lba1-classic`'s
+  numbering diffed against lba2cc's, with twin-e's names as a legend; where the two disagree,
+  `lba1-classic` wins. See §6.3.
+- **Assets stay native on disk; the `GameProfile` adapts them in-engine.** `[design]` Not offline
+  asset conversion but a game-id-selected loader layer that reads each game's native format and
+  builds the engine's shared in-memory structures at load (§7 decision 9). Engine init is
+  game-neutral and brings up all capabilities (incl. MIDI + FLA); the `GameProfile` only routes
+  usage, so games can even be toggled at runtime (§5). The media stack is the user's own GPLv2
+  projects vendored behind AIL (§6.7).
+
+**Bottom line:** Proceed on **Path B**, in-repo and gated behind a new game-id, with the
+agnostic-menu/shell extraction and any separate-repo packaging (Path C) deferred until LBA1
+content actually loads. Start with the §6 spikes; they touch zero LBA2 code paths.
+
+---
+
+## 1. The two trees today `[verified-from-code]` `[verified-from-data]`
+
+| | `lba2-classic-community` (the groundwork) | `lba1-classic` (the target) |
+|---|---|---|
+| Game / era | LBA2, 1997 + community port | LBA1 (Relentless), 1994 |
+| Platform | SDL3; Linux/macOS/Windows/Android | **DOS only** (DOS4GW/DPMI, VESA/MCGA), OpenWatcom 2 + JWasm → `LBAD.EXE`/`LBADC.EXE` |
+| Language | C++98, much ASM ported to C++ | C90; **~59% still ASM** (`LIB_SVGA`, `LIB_3D` entirely ASM) |
+| Infra | host + ASM-equiv + Docker tests, CI tiers, ~50 docs, debug console, headless `Control_*` harness w/ fixed-dt, ABI/64-bit, perftrace, polyrec | no `tests/`, no `docs/` folder, no SDL, no 64-bit, release-only CI |
+| Shared lineage | HQR, Life/Track VM (`GERELIFE`/`GERETRAK`), `P_OBJET`/`P_ANIM`, `GRILLE`, `INCRUST`: same Adeline DNA one generation apart | |
+
+Both games' retail data is available locally for verification (`../LBA/` = LBA1,
+`../LBA2-GOG/` + `../LBA2/Common/` = LBA2) `[verified-from-data]`.
+
+**Reference projects.** Per-repo provenance and role (all `github.com/LBALab/*` except `flade`):
+
+| Project | URL | Role |
+|---|---|---|
+| `lba1-classic` | `github.com/LBALab/lba1-classic` | LBA1 original Adeline source: **source of truth** for LBA1 formats/behaviour |
+| `lba2-classic-community` | `github.com/LBALab/lba2-classic-community` | this repo: the host engine |
+| `twin-e` | `github.com/LBALab/twin-e` | GPLv2 LBA1 reimplementation: **readable helper/legend** (LBA1-only), never authoritative |
+| `lba2remake` | `github.com/LBALab/lba2remake` | TS reimplementation of **both** games: **bilingual reference** (per-game opcode/operand tables); evidence for §8 |
+| `lba-midi-play` | `github.com/LBALab/lba-midi-play` | XMIDI→SMF + TSF synth: **vendored** for the AIL MIDI backend (§6.7 Track A) |
+| `cueplay` | `github.com/LBALab/cueplay` | BIN/CUE + ISO9660 reader: **reference** for the disc-image resource source (§6.7) |
+| `flade` | `github.com/noctonca/flade` | FLA player (+ opcodes, MIDI, ISO9660): **vendored** for FLA video (§6.7 Track B) + disc-image source |
+
+Precedence: `lba1-classic` and `lba2-classic-community` are canonical; the reimplementations
+(`twin-e`, `lba2remake`) and media tools are helpers/vendored code, never overriding the original
+source where they differ.
+
+**Scope boundary, Time Commando.** Whether this generalises to other Adeline titles: Time Commando
+(1996, between LBA1 and LBA2) shares the **engine substrate** (HQR, LZSS/LZMIT, the 3D libs; its
+XCF cinematic codec is even in-tree as `DEC_XCF`, decodable by `scripts/dev/acf_decode.py`), so its
+*data* is readable today. But TC is a **different game** (pre-rendered XCF backdrop + a live 3D
+actor in a `Recouvre` window + a scripted rail camera + STAGE/RUN levels), not the brick-iso +
+Life/Track world LBA1 and LBA2 share. Hosting TC would mean building a TC *game layer* on the
+shared substrate, not a content port. The realistic north-star is **one engine substrate, two LBA
+games**; the `GameProfile` could host a third title, but each non-LBA game needs its own game
+layer. TC's value here is as the SDK Rosetta stone (the dual-path format seams were verified across
+LBA1/TC/LBA2; see `ENGINE_GAME_SEAM.md` / `TIME_COMMANDO.md`).
+
+---
+
+## 2. The three paths, costed
+
+Effort is order-of-magnitude (one experienced engineer), for *comparison*, not scheduling.
+
+| | **Path A: native LBA1** | **Path B: LBA1 on lba2cc** | **Path C: hybrid repo** |
+|---|---|---|---|
+| Reuses | lba2cc's *patterns* | lba2cc's *actual engine* | lba2cc's engine, vendored |
+| Builds | DOS→SDL3 for LBA1, port ~53 graphics/3D ASM files, ABI/64-bit, then graft on infra | body/scene transcoders + opcode-remap + GPLv2 FLA/MIDI + a game-id content layer | B's engineering, packaged as a forked repo vendoring the engine |
+| `lba1-classic` is | the codebase you port | a reference oracle | a reference oracle |
+| End artifact | faithful standalone **LBA1 engine** | **lba2cc that also runs LBA1** | a distinct `lba1-classic-community` riding the shared engine |
+| Rough total | ~12–24+ person-months | **~3–6 person-months** | B + ~1–2 mo topology; **+6–12 mo** if the clean two-game seam is built |
+| Relative to B | ~4–6× | 1× | ~1.3× (light) … ~3×+ (clean seam) |
+| Head start banked | low (patterns only) | **high** (body format decoded, HQR/LZSS verified, opcode collisions mapped, twin-e as legend) | high (same as B) |
+| Fidelity | authentic LBA1 | LBA1 *on the LBA2 engine* (verify sort-tree vs painter's, SVGA vs MCGA) | same caveat as B |
+
+**Per-subsystem reuse** (✅ reuse ≈0 · 🟢 small · 🟡 medium · 🔴 large):
+
+| Subsystem | A | B | C |
+|---|---|---|---|
+| Platform (window/video-out/input/timing) | 🔴 new SDL3 layer for LBA1 | ✅ reuse | ✅ |
+| Software rasteriser (`LIB_SVGA`+`LIB_3D`, ~53 ASM) | 🔴 port to C++ | ✅ `pol_work` (LBA1 is a subset) | ✅ |
+| HQR container | 🟢 ABI cleanup | ✅ drop-in (`[verified-from-data]`) | ✅ |
+| 3D body format | ✅ keep LBA1's | 🟡 transcoder (format decoded; §6) | 🟡 |
+| Animation | ✅ keep | 🟢 drop-in once groups align | 🟢 |
+| Scene/grid/cube | ✅ keep | 🟡 repackaging shim (3 HQR → merged) | 🟡 |
+| Sprites/palettes | ✅ keep | 🟢 byte-diff + small shim | 🟢 |
+| Script VM (Life/Track) | 🟢 keep + ABI | 🟡 **opcode-remap + flag width** | 🟡 |
+| Audio samples | 🔴 rewrite DMA/GUS/SB | ✅ existing VOC path (1-line gate widening; §6.6) | ✅ |
+| MIDI music | 🔴 rewrite | 🟡 new AIL MIDI backend (vendor `lba-midi-play`; §6.7) | 🟡 |
+| Video (FLA) | 🟡 vendor twin-e `flamovies.c` | 🟡 FLA driver (vendor `flade`; writes `Log`; §6.7) | 🟡 |
+| Save/load | 🟡 fix + modernise | 🟡 LBA1 save layout in engine | 🟡 |
+| Build / ABI / 64-bit | 🔴 replace OpenWatcom/DOS4GW | ✅ reuse | ✅ |
+| Two-games plumbing (game-id, menu/HUD/holomap/save) | ✅ N/A | 🟡 new (§5) | 🟡–🔴 plus seam work |
+| Tests / CI / docs / console / headless | 🟡 re-instantiate patterns; **no LBA1 equiv-oracle** | ✅ inherit; add LBA1 cases | ✅ inherit + repo CI |
+| Repo & upstream-sync | 🟢 standalone | ✅ in-repo | 🟡 vendor + sync burden |
+
+**Why not A:** it re-pays the entire lba2cc port on an older, more ASM-laden codebase, and has
+**no equivalence oracle**. lba2cc's confidence comes from ASM↔C++ tests against the original;
+a fresh native port that also de-ASMs the rasteriser has nothing to diff against but "looks
+right." Only choose A for a purist standalone LBA1 *engine*.
+
+**Why B over C first:** the engine/game facades that would make C clean are *understood but
+not built* (`ENGINE_GAME_SEAM.md`, `ARCHITECTURE.md` defer them). C still has to touch the
+same shared-core points B does (body loader, VM operand widths, flag storage), but across a
+repo boundary, with the LBA2 regression tests in the *other* repo. So C-first can *raise* the
+"break LBA2" risk while adding an engine-sync burden. Build B in-repo, prove content runs,
+*then* decide whether to extract to C.
+
+---
+
+## 3. Will Path B break LBA2? `[design]` `[verified-from-docs]`
+
+The fear is legitimate; the design neutralises most of it **in-repo**:
+
+- B's work is overwhelmingly **additive and game-id-gated**: new transcoders, a remap table
+  selected by game-id, an LBA1 content layer. The shared engine core stays behaviour-identical
+  for LBA2, and lba2cc already has the harness to prove it: **polyrec byte-for-byte, fixed-dt
+  determinism, ASM-equivalence**.
+- The engine was **already built multi-title-aware.** `ENGINE_GAME_SEAM.md` (SDK-timeline)
+  lists dual-path seams it carries today: **LZSS+LZMIT**, **VOC+WAV**, **16-bit vs 32-bit body
+  coords**, XCF/Smacker. Adding LBA1 paths follows an existing pattern.
+- The narrow shared-code touch points to guard with tests: the **body loader** (16↔32-bit,
+  *already* dual-path), **VM operand widths**, **flag-storage width**.
+
+So the regression guard is the test harness, and it is strongest when everything is in one
+repo, which is the core argument for B-first over C-first (§2).
+
+---
+
+## 4. PAL dependency `[verified-from-docs]`
+
+None. B/C run on today's SDL3 engine. The headless, deterministic, screenshot-comparable
+execution the spikes need (`Control_*` harness + fixed-dt virtual clock + `SNAPSHOT`) **ships
+today**, pre-PAL ([PLATFORM_PAL_PLAN.md](PLATFORM_PAL_PLAN.md) §0). The PAL becomes relevant
+only for a non-SDL LBA1 host (libretro/GameCube): the §5.1 story shared with LBA2. The two
+efforts are synergistic (both isolate the platform/IO/media layer where the LBA1↔LBA2
+divergence concentrates) but not coupled; the only interaction is mild merge coordination if
+the PAL present-path PR and the LBA1 FLA work land together, and FLA writes the engine's
+existing `Log` framebuffer the way Smacker does, so even that misses the PAL seam.
+
+---
+
+## 5. The agnostic menu + engine shell + game-id `[verified-from-code]` `[design]`
+
+The two menus are **the same Adeline menu engine, one generation apart**:
+
+| | LBA1 (`lba1-classic/SOURCES/GAMEMENU.C`) | LBA2 (`SOURCES/GAMEMENU.CPP`) |
+|---|---|---|
+| Menu data | `U16` array `[sel, nb, ycenter, dia, (type,text_id)*]` | identical format (`MENU.md`, `:82-86`) |
+| Driver | `DoGameMenu()` → selected text-id | `DoGameMenu()` → text-id or `1000` (ESC) |
+| Build flow | `GameMainMenu[]` filtered | `RealGameMainMenu`→`BuildGameMainMenu`→`GameMainMenu` |
+| Main entries | New/Continue/Options/Quit (text 20–23) | Resume/New/Load/Save/Options/Quit (text 70–75) |
+| Background | plasma/fire | plasma/fire ("a hallmark of LBA1 and LBA2 menus") |
+
+So "make `GAMEMENU` agnostic" is **formalising a seam already latent in both codebases**: a
+facade, not a rewrite (~20–30% of `GAMEMENU.CPP` surface, low risk if menu-nav + screenshot
+tests cover it). The design, three layers:
+
+1. **Menu VM (already agnostic, both trees):** `DoGameMenu`/`DrawGameMenu`/slider types/save
+   picker/plasma. Keep its behaviour byte-identical.
+2. **Port/engine options (shared, belong to neither game):** volume, language, display
+   (resolution/vsync/fullscreen), gamepad config, follow-camera, audio balance. These live in
+   LBA2's `GAMEMENU.CPP` today but are *port* options, shared across both games.
+3. **Per-game content descriptor (the only game-specific part):** main-menu entry table +
+   text-id base + save schema, selected by **game-id**.
+
+**Scope the agnostic work to the start/load/save/options *shell***: that is where "they look
+the same" is genuinely true and the risk is lowest. The **in-world HUD** diverges more and
+stays per-game (riding shared draw primitives): inventory (LBA1 4×4=16 vs LBA2 7×5=35),
+behaviour selector (LBA1 CTRL+arrows overlay vs **none in LBA2's menu UI**), holomap (LBA1's
+single `HOLOMAP.C` vs LBA2's four `HOLO*` modules).
+
+**The keystone is a game-id, which does not exist yet** `[verified-from-code]`:
+`RES_DISCOVERY` only knows `lba2.hqr`; `DistribVersion` is publisher-logo only; `Version` is a
+build string. A `GameId`/`GameProfile` is foundational: it is the **one dispatch point** that
+selects the per-game **native-format asset loaders/resolvers** (the in-engine adaptation of §7
+decision 9: body loader, background grid/block/brick resolver, sprite/palette reader, script VM
+mode), plus the opcode-remap table, asset-name map, menu descriptor, and save schema. So
+"reading LBA1 assets unmodified" is not a separate mechanism: it *is* the `GameProfile` choosing
+LBA1 loaders. The retail files stay native on disk; only the in-memory structures are shared. **The game-select menu is its natural first
+consumer and belongs to the boot shell, not either game:** boot → `RES_DISCOVERY` finds data →
+if both an LBA1 marker (`lba.hqr`/`ress.hqr`) and `lba2.hqr` are present, show a 2-entry
+chooser on the existing `DoGameMenu`; single-game installs auto-select (today's LBA2 UX
+preserved); `--game lba1` forces it. This reframes the work as **"an Adeline engine shell that
+discovers data, picks a GameProfile, and runs"**: the north-star at the boot/UX layer.
+
+**Engine init is game-neutral; the `GameProfile` is a runtime-swappable routing object.**
+`[design]` Capabilities come up once, unconditionally, at engine init: SDL, the full AIL audio
+stack (samples, streams, CD, *and* MIDI), the video decoders (Smacker + FLA), the framebuffer,
+input. The `GameProfile` does not gate capability *init*; it routes *usage* (which loaders, opcode
+table, menu, save schema, and which music/video driver a game drives). So the MIDI synth and FLA
+decoder initialise regardless of the active game, and switching games at runtime is a **soft
+reset** (tear down game state, reload that game's data, swap the active `GameProfile`), not an
+engine re-init. The constraint: keep all game-specific state behind the `GameProfile` and out of
+the one-time init path, so the engine hosts either title and can toggle between them at runtime.
+
+**Sequencing:** the feasibility spike (§6) needs *no menu*. Introduce the `GameProfile` scaffold
+with the first real LBA1-loading PR; do the shell extraction + game-select UI *after* LBA1
+content loads, when there are **two concrete menu content sets** to extract from (principled
+refactoring, not premature abstraction, the strangler-fig pattern the docs already prescribe).
+
+---
+
+## 6. Feasibility spikes (de-risk B; touch zero LBA2 code)
+
+All spikes lean on groundwork already landed (the `Control_*` harness + `SNAPSHOT`) and run
+against local retail data, so they double as proof of how additive B is. **All four spikes below
+have passed** (§6.2 body, §6.4 script, §6.5 background, §6.6 audio); the media stack (§6.7) is
+planned, not spiked.
+
+**Offline vs production (decision 9, §7):** the spike tools transcode/repack *offline* in Python
+to validate the format mappings cheaply. That is **not** the recommended production approach,
+which is **in-engine adaptation**: a game-id-gated loader layer that reads each game's native
+on-disk assets and builds the engine's in-memory structures at load, leaving the retail files
+untouched (the same way the engine already consumes LBA2 data). So treat these tools as the
+validated mapping reference + test oracles, not an asset-conversion pipeline.
+
+**Spike ladder, in order:**
+
+1. **Body transcoder (the dominant unknown).** Transcode one LBA1 body → `T_BODY_HEADER`, load
+   on lba2cc, render headless, eyeball. *Transcode + standalone render done (§6.2); on-engine
+   render pending.*
+2. **Opcode-remap + flag-width (the quest linchpin).** Run one LBA1 `SCENE.HQR` script blob on
+   the lba2cc VM through a remap table + an LBA1 flag-storage shim; confirm a
+   `set flag → test flag → branch` executes. This is where the byte-vs-`S16` subtlety bites.
+3. **Scene repackaging.** Re-index LBA1's three background HQRs (`LBA_GRI/BLL/BRK`) into one
+   `T_BKG` + synthesized `T_GRI_HEADER`; render one cube.
+4. *(optional)* **VOC sample.** Confirm an LBA1 `SAMPLES.HQR` VOC plays through lba2cc's
+   existing VOC path.
+
+Spikes 1–3 reach **"one LBA1 scene renders and one script branch runs on the lba2cc engine"**,
+the minimal end-to-end proof that B is real (~2–4 weeks).
+
+### 6.1 Body format, decoded for the spike `[verified-from-code]` `[verified-from-data]`
+
+LBA1 body stream (`lba1-classic/LIB386/LIB_3D/P_OBJET.ASM:211-248`, `AffObjet`): `Infos` (U16)
+→ ZV bbox (12 B = 6×`s16`) → `U16` zone-info size + that many bytes → point/normal/group cloud
+(consumed by `RotateNuage`/`AnimNuage`) → `U16` nb polys + poly records → lines → spheres.
+Per-poly records and the n-gon/material encoding are specified in
+[LBA1_PORTING_SURFACE.md](LBA1_PORTING_SURFACE.md) (§ "Per-poly record").
+
+LBA2 target (`LIB386/H/OBJECT/AFF_OBJ.H:96-122`, `T_BODY_HEADER`, 96 B): `S32 Info`,
+`S16 SizeHeader`/`Dummy`, 6×`S32` bbox, then count/offset pairs for
+groups/points/normals/normFaces/polys/lines/spheres/textures. Transcode = widen 16→32-bit,
+synthesize `SizeHeader`=96 + the offset table, type-group the polys, triangulate n-gons,
+convert the pre-multiplied index stride, synthesize face normals; textures empty for LBA1.
+
+The spike tool reads LBA1 and LBA2 bodies with the **same** HQR/LZSS reader (`hqr_inspect.py`),
+validates the LBA1 header against the known retail values (`Info=0x0003`, bbox
+`-253,260,0,1240,-153,200` for body 1), decodes the full LBA2 `T_BODY_HEADER`, and emits a
+first-cut transcoded header, pinpointing the remaining inner-loop (the nuage+poly walk) as the
+next work. Run results are recorded in §6.2.
+
+### 6.2 Spike 1 result: body transcoder on retail bytes `[verified-from-data]`
+
+`scripts/dev/lba1_body_probe.py` against local retail data (`../LBA/BODY.HQR`,
+`../LBA2-GOG/BODY.HQR`), entry 1 (Twinsen). **SPIKE PASS.** The full LBA1 body is decoded and
+its geometry transcoded to a structurally valid LBA2 `T_BODY_HEADER`; the LBA1 decode is
+checked by independent invariants, not by eyeballing.
+
+LBA1 body 1: 6858 B LZSS; `Info=0x0003` (**animated**); **180 points, 19 groups, 135 normals,
+230 polys (210 tri, 20 quad), 21 lines, 5 spheres**; section offsets
+`points@26 groups@1108 normals@1832 polys@2914 lines@6644 spheres@6814 end@6856`.
+
+LBA1 decode validation (all PASS), each an independent invariant against the source-of-truth
+layout (`P_OBJET.ASM` / `P_ANIM.ASM`):
+
+- **parse consumed the body** (6856/6858; 2 trailing pad bytes `AffObjet` never reads).
+- **header matches the documented retail values** (`Info=0x0003`, bbox per
+  `LBA1_PORTING_SURFACE.md`).
+- **all point indices in `[0,180)`** after dividing out the `SIZE_LIST_POINT`=6 pre-multiplier.
+- **`sum(group[+18]) == nbNormals` (135)** validates the 38-byte group decode against
+  `ComputeAnimNormal` (which reads per-group normal counts from group offset 18).
+- **a group word sums to `nbPoints` (offset 2)** recovers the per-group point count, so
+  point/group **skinning is reconstructed, not guessed**.
+
+(The bbox-equals-points check is N/A here: animated bodies store group-local points, so the
+header ZV is the assembled-model box, not the raw point extent.)
+
+Transcode to LBA2: emitted 5768 B; the 230 LBA1 polys triangulate and type-group into LBA2
+`_LIGHT` records across 4 type-groups; per-group skinning applied; anim bit translated
+(`INFO_ANIM`=2 to `MASK_OBJECT_ANIMATED`=`0x100`). Emitted-body validation (all PASS):
+`SizeHeader==96`, section offsets monotonic and in-bounds, every emitted poly index `< nbPoints`.
+
+**What this proves:** the LBA1 body format is decoded end to end and validated on retail bytes
+against the original Adeline source, and its geometry transcodes into a well-formed LBA2 body.
+**What remains before an on-engine render (flagged stubs, not faked):** synthesize per-poly
+face normals + the `NormFaces` section (LBA2 body 1 has `NormFaces=8`); fine material to
+LBA2-type mapping (dither/trame/env); the normal `range` field; the group parent index. Then
+load the body on the engine and snapshot it headless via the `Control_*` / `SNAPSHOT` harness
+(the remaining, separate sub-step of spike 1).
+
+**Standalone visual check (`scripts/dev/lba1_body_render.py`).** A dependency-free software
+rasteriser (stdlib `zlib` only, no engine build) renders decoded geometry to PNG. Scanning the
+whole archive: **all 132 LBA1 bodies parse cleanly** (`static=0 animated=132 unparsed=0`), so
+the decoder is validated across the entire retail set, not just body 1. Every body is animated
+(points group-local), so a bind-pose assembly through the bone hierarchy is needed.
+
+The full 38-byte group is decoded from `RotateGroupe` / `RotList`: `+0` start(x6), `+2` nbPoints,
+`+4` pivot(x6), `+6` parent(x38, -1=root), `+8` type, `+10/12/14` angles, `+18` nbNormal, `+20` a
+3x3 Q14 matrix. The body's per-group angles are all 0 (rest), so the engine's
+`RotMat`+`RotList` reduce to translation, and bind-pose assembly is
+`assembled[i] = rawPoint[i] + assembled[pivot]` (parents first). With that, **body 1 renders as
+an unmistakable Twinsen** (head, torso, arms, legs), and the **assembled bounding box reproduces
+the header ZV** (`Y[0,1238]` vs `[0,1240]`), an independent correctness check on top of the
+visual one; body 51 reads as a coherent multi-part craft, body 80 as a faceted disc. Per-frame
+limb poses come from `ANIM.HQR` (a separate concern, not needed to validate body geometry).
+
+**What remains of spike 1:** the on-engine render (face-normal synthesis + a load/snapshot
+harness). The format reverse-engineering (decode, skeleton, transcode) is closed.
+
+### 6.3 `twin-e` as a secondary helper `[verified-from-code]`
+
+The LBA1 source of truth is `../lba1-classic` (the original Adeline source). `twin-e` (GPLv2,
+pure-LBA1 *reimplementation*, `../twin-e`) is a more-readable cross-check, not code to copy and
+not authoritative where it disagrees with `lba1-classic`:
+
+| Need | twin-e artifact | Use |
+|---|---|---|
+| LBA1 Life opcodes | `src/script.life.c:1511+` (named dispatch 0x00–0x69) | LBA1 side of the remap table (§ spike 2) |
+| LBA1 Move opcodes | `src/script.move.c:539+` | Track-VM remap |
+| Conditions / operators | `src/script.life.c:71-112` | operand semantics |
+| All 255 game flags named | `docs/GameFlags.md` | quest/flag mapping + save schema |
+| LBA1 save layout | `src/gamestate.h` (`gameFlags[256]`, `inventoryFlags[28]`, `holomap_flags[150]`) | save-format shim |
+| XMIDI→MIDI | `src/utils/xmidi.c` (standalone, from ScummVM/Exult) | MIDI integration |
+| FLA decoder | `src/flamovies.c` + `docs/FLA.md` | FLA integration (also twin-e is the GPLv2 source cited in `LBA1_PORTING_SURFACE.md` §7) |
+
+Critically twin-e models **only** LBA1, and it is a reimplementation: where it and
+`lba1-classic` differ, **`lba1-classic` is authoritative**. The remap table is `lba1-classic`'s
+opcode numbering (`SOURCES/COMMON.H`) diffed against lba2cc's; twin-e's named tables and flag
+list are a human-readable legend over those numbers, and the LBA2 numbers come from this repo.
+
+### 6.4 Spike 2 result: opcode remap + flag-width on real source `[verified-from-code]`
+
+`scripts/dev/lba1_script_remap.py` parses both `COMMON.H` opcode tables (LBA1
+`../lba1-classic/SOURCES/COMMON.H` as source of truth; LBA2 this repo) and exercises a
+`set flag -> if flag==v -> branch` transcode on a mini Life-VM. **SPIKE PASS**, plus a
+correction to the surface doc.
+
+The flag-width linchpin works. From the engines' own `GERELIFE`: LBA1 `LF_FLAG_GAME` reads a
+`UBYTE` (`TypeAnswer=RET_BYTE`, 1-byte compare) and `LM_SET_FLAG_GAME` writes 1 byte; LBA2
+`LF_VAR_GAME` reads an `S16` (`RET_S16`, 2-byte compare) and `LM_SET_VAR_GAME` writes 2. Because
+`LM_IF` jumps are absolute 2-byte offsets, widening operands shifts every jump. The transcoder
+remaps opcodes, widens the flag/var operands (byte to S16), and recomputes the jump offsets; the
+LBA1 script (20 B) and its transcode (24 B) then branch **identically** on the mini-VM for both
+the true and false paths (`v6=42` / `v6=99`).
+
+**FINDING (corrects `LBA1_PORTING_SURFACE.md` §8):** the `LM_` tables do **not** align 0..56.
+Verified on real source: of LBA1's 101 Life ops, 68 are identical-slot, 2 are FLAG->VAR renames
+(31, 36), and 30 collide, **including inside 0..56**: `LM_LABEL`(10)->`LM_PALETTE`,
+`LM_SET_LIFE`(21)->`LM_SET_CAMERA`, `LM_SET_LIFE_OBJ`(22)->`LM_CAMERA_CENTER`. So divergence is
+interspersed, not "begins at 57". A by-name remap (name match + the FLAG->VAR rename) covers
+71/101 automatically; the rest need a manual alias (e.g. `LM_LABEL`->`LM_COMPORTEMENT`, which
+shared LBA1's handler) or a real handler (media `LM_PLAY_FLA`/`LM_PLAY_MIDI`/`LM_PLAY_CD_TRACK`,
+the fades, `LM_PROJ_ISO/3D`). The control-flow + flag spine still aligns by number (`END`=0,
+`IF`=12, `ELSE`=15, `ENDIF`=16, `BODY`=17, `COMPORTEMENT`=32, `SET_*_GAME`=36), which is why the
+quest mechanism transcodes.
+
+**What this means:** the opcode-remap is still a contained shim, but a real per-op table with
+operand-width rewriting and a handful of handlers, not the near-identity the surface doc implied.
+The quest-is-data thesis holds: progression rides the VM, and the VM's set/test/branch crosses
+the flag-width seam cleanly. **Remaining:** a full operand-table transcoder (every opcode's
+operand layout) plus the media-op handlers, then a real `SCENE.HQR` Life script run end to end.
+
+### 6.5 Spike 3 result: background repackaging on real data `[verified-from-data]`
+
+`scripts/dev/lba1_bkg_repack.py`. **SPIKE PASS** (confirms verdict #4, scene/grid/cube, on real
+data from both games).
+
+LBA2's `LBA_BKG.HQR` (18101 entries) decodes as the documented 4-partition merged container via
+the `T_BKG_HEADER` at entry 0: `Gri_Start=1, Grm_Start=149, Bll_Start=179, Brk_Start=197,
+Max_Brk=17903` (grids | GRMs | block-libs | bricks, ascending and in-bounds). A sample grid's
+`T_GRI_HEADER` reads `My_Bll=0, My_Grm=0, UsedBlock` popcount 82/256, and its block library
+resolves at `Bll_Start+My_Bll=179`, inside the BLL partition.
+
+LBA1 keeps the three HQRs separate with matched counts (`LBA_GRI`=134 grids, `LBA_BLL`=134
+block-libs, `LBA_BRK`=8715 bricks). The re-index into one container is offset arithmetic:
+synthesized `T_BKG_HEADER` `Gri_Start=0, Grm_Start=134, Bll_Start=134, Brk_Start=268,
+Max_Brk=8715` (8983 entries total), with a per-grid `T_GRI_HEADER` whose `My_Bll` = the grid
+index (LBA1 pairs grid N with style N 1:1, whereas LBA2 shares 18 styles across 148 grids; the
+1:1 mapping is still valid since the engine resolves `Bll_Start+My_Bll`). The arithmetic and a
+sample grid resolution validate.
+
+**Production note (see §7 decision 9):** this spike repacks *offline* to validate the mapping,
+but the preferred end-state is **in-engine adaptation**, not a converted asset. A per-game
+resource resolver routes grid/block/brick lookups to LBA1's three HQRs and computes `UsedBlock`
+at load, exactly as LBA1's own `LoadUsedBrick` already does (LBA1 computes the bitmap; only LBA2
+stores it in `T_GRI_HEADER`). That keeps the retail assets untouched and is closer to LBA1's
+real behavior than repacking. Either way the brick/block/column payloads are unchanged.
+
+### 6.6 Spike 4 result: VOC audio is (near) drop-in `[verified-from-data]` `[verified-from-code]`
+
+`scripts/dev/lba1_voc_probe.py`. **SPIKE PASS.** lba2cc's `PlaySample`
+(`LIB386/AIL/SDL/SAMPLE.CPP`) already decodes Creative Voice (`ParseVocIfPresent`), a path the
+community port added for LBA2's own VOX voices. LBA1's audio is the same format, so it rides the
+existing AIL path with no new decoder.
+
+- **SFX** (`SAMPLES.HQR`, 230 entries): 230/230 are VOC, 8-bit PCM, `C`-prefixed, rates ~4 to
+  17 kHz (mostly 11111 Hz). Fully drop-in.
+- **Voices** (`VOX/EN_000`, 191 entries): 191/191 are VOC, 8-bit PCM, 11111 Hz; 187 are
+  `0x00`-prefixed (which `ParseVocIfPresent` accepts) and **4 are `0x01`-prefixed** (entries
+  39/47/82/83).
+
+**FINDING:** lba2cc's VOC magic gate (`SAMPLE.CPP:103`, `buffer[0] in {C,W,0x00}`) rejects the 4
+`0x01`-prefixed voice entries, even though they are valid VOC (the `reative Voice File` magic
+matches at offset 1). The fix is **one line**: accept any first byte (the offset-1 magic is the
+real signature) or add `0x01`. With that, LBA1 audio (SFX + voices) is fully drop-in via the
+`GameProfile`'s sample loader, and the widening is also a small robustness improvement for the
+existing LBA2 voice path. (MIDI music is separate: it is the one new audio capability, planned
+in §6.7.)
+
+### 6.7 Media stack plan (verdict #7): MIDI + FLA + CD via AIL `[verified-from-code]` `[design]`
+
+Not a spike: a re-implementation plan, since the user's own GPLv2 projects supply the
+implementations (`../lba-midi-play` MIDI; `../flade` FLA + its sample/MIDI cues + an ISO9660
+reader; `../cueplay` CD audio from BIN/CUE images). All vendor cleanly into GPLv2 lba2cc (`xmidi.c`
+GPLv2, TSF MIT, TML zlib, `fla.c` GPLv2; share one copy of `xmidi`/`tsf`/`tml`).
+
+**The LBA1 sound driver is "the LBA2 stack + MIDI".** The AIL stack already covers nearly all of it:
+
+| Capability | lba2cc today | LBA1 need | Work |
+|---|---|---|---|
+| SFX / voices | `PlaySample` (WAV / VOC) | VOC | none (§6.6) + the 1-line VOC gate fix |
+| CD music | `PlayCD` reads extracted `TrackNN.wav` | track numbers (`PlayCdTrack(8/9)`, jingles) | drop-in if extracted (Steam); add a disc-image source for raw GOG (below) |
+| MIDI music | **stub** (`InitMidiDriver` returns TRUE; LBA2 unused) | `MIDI_MI.HQR`, 33 tracks | **the one real new audio capability** |
+| Video | Smacker (`PlayAcf`) | FLA | **new FLA video driver** |
+
+**Track A, MIDI (the one new capability).** Vendor the synth core once into AIL (`xmidi.c`
+XMIDI->SMF + `tsf.h` + `tml.h`; make the converter reentrant). Render-then-stream (as `flade`
+does): convert -> TML parse -> `tsf_render` to a PCM buffer -> play via the existing AIL SDL stream
+path (`STREAM.CPP`). Extend `MIDI.H` with `PlayMidi/StopMidi/SetMidiVolume`. **Init the MIDI driver
+unconditionally** (an engine capability, not per-game, see §5).
+
+**Track B, FLA video.** Vendor `flade`'s SDL-free decoder (`fla.c`/`voc.c`/`util.h`); it emits a
+320x200 8-bit paletted frame + 256-colour palette, the `Log` framebuffer's native form. Add
+`PlayFla()` mirroring `PlayAcf()` (loop `fla_step`, blit to `Log`, `set_palette`, pace by fps,
+ESC-skip). Route FLA cues to AIL: `OP_PLAY_SAMPLE`/`OP_STOP_SAMPLE` -> `PlaySample` (VOC); `OP_INFO`
+MIDI triggers -> Track A. Both decoders init; the **`GameProfile` selects the active video driver**
+(LBA1 `PlayFla`, LBA2 `PlayAcf`) and music source.
+
+**Disc-image resource source (orthogonal, useful for raw GOG).** `flade`'s ISO9660 reader and
+`cueplay`'s BIN/CUE parser (audio tracks are raw 16-bit/44.1k PCM in 2352-byte sectors, the same
+layout `scripts/dev/iso_bin.py` already reads for data) can back a **resource-source driver** that
+reads HQRs *and* CD tracks straight from a `.bin/.cue/.gog` image, no pre-extraction. This is
+**orthogonal to the `GameProfile`**: the GameProfile picks per-game loaders; the resource-source
+layer picks where bytes come from (a data directory, today's path, or a disc image). It lets
+`PlayCD` and HQR loads work off a raw GOG disc without the user extracting tracks first.
+
+**Soundfont (decided):** bundle one small, license-clean, good-quality GM soundfont and let the
+user supply their own (config/CLI override). `flade`'s ~9 KB flute SF2 covers the FLA cutscene
+MIDI; the in-game soundtrack (`MIDI_MI.HQR`) wants a small GM bank. Sourcing the bundled font
+(CC0/MIT) is the only to-do; the FM `MIDI_SB.HQR` variant is unneeded when synthesising `MIDI_MI`.
+
+**Sequencing:** (1) vendor + decouple the synth core; (2) AIL MIDI contract + render-to-stream,
+validate an `MIDI_MI.HQR` track headless; (3) FLA decoder + `PlayFla` (silent), then its cues to
+AIL; (4) optional disc-image resource source (`flade`/`cueplay`); (5) `GameProfile` routes the
+per-game video/music drivers. Assets stay native throughout.
+
+---
+
+## 7. Open decisions for go/no-go
+
+1. **Path:** confirm **B (in-repo, game-id-gated)**, with C extraction deferred. *Recommended.*
+2. **Game-id keystone:** confirm a `GameProfile`/game-id is introduced with the first
+   LBA1-loading PR (selects opcode table, asset names, menu descriptor, save schema). *Rec.*
+3. **Menu:** confirm the agnostic-shell extraction + game-select UI come *after* LBA1 content
+   loads (two real content sets), scoped to the start/load/save/options shell; in-world HUD
+   stays per-game. *Recommended.*
+4. **Fidelity bar:** accept LBA2-engine behaviour for LBA1 content (sort-tree vs painter's
+   order, SVGA vs MCGA), to be verified per-scene, rather than bit-faithful LBA1 rendering.
+5. **Flag width:** confirm the remap shim bridges LBA1 `UBYTE` flags ↔ LBA2 `S16` vars
+   (not just opcode renumbering), the trickiest correctness point.
+6. **Spikes:** confirm the §6 ladder (body → opcode/flag → scene; VOC optional) as the
+   de-risking sequence before any committed PR plan.
+7. **Doc home:** this doc is the plan; keep [LBA1_PORTING_SURFACE.md](LBA1_PORTING_SURFACE.md)
+   as the cost survey and extend [ENGINE_GAME_INTERFACE.md](ENGINE_GAME_INTERFACE.md) /
+   [ENGINE_FILE_FORMATS.md](ENGINE_FILE_FORMATS.md) with the remap table + format deltas as
+   they are pinned. Confirm.
+8. **Script path: transcode vs dual-table VM** (§6.4, raised by `../lba2remake`): run LBA1 Life
+   scripts by either **(A) transcode** LBA1 bytecode to LBA2 bytecode so the existing `GERELIFE`
+   runs it unchanged (no VM change, safest for LBA2; the spike-2 approach), or **(B) dual-table**
+   the engine VM, i.e. teach `GERELIFE` a game-id-gated LBA1 opcode+operand table plus LBA1-only
+   handlers (touches the shared VM, but proven at full-game scale by `lba2remake`, which keeps
+   separate `data/lba1` + `data/lba2` tables and switches at parse time). Both need handlers for
+   LBA1-only/media ops. *Lean: A first (zero VM risk); reconsider B if transcode edge cases
+   (jump recompute, missing ops) pile up.* `lba2remake`'s per-game tables are the operand-layout
+   reference for either path. Open.
+9. **Asset strategy: offline convert vs in-engine adapt** (raised re spike 3; generalizes §8 to
+   every asset type). Producing converted LBA2-format asset files would modify the user's retail
+   data, add a conversion pipeline, and create a derivative (non-redistributable) copy. The
+   preferred end-state is **in-engine adaptation, realized as the `GameProfile`'s per-game
+   loader/resolver set** (decision 2 / §5): each game's native on-disk format is read and adapted
+   to the engine's shared in-memory structures at load, leaving the retail assets untouched (the
+   same model the engine already uses for LBA2). This makes asset adaptation a **facet of the
+   `GameProfile` keystone, not a separate mechanism**: the one game-id that picks the opcode
+   table, menu descriptor, and save schema also picks the body/background/sprite/script loaders.
+   It keeps the LBA2 load path byte-identical (gate + test-guard) while reading LBA1 assets as-is. For background
+   (§6.5) the abstraction is both simpler and more faithful than repacking: route grid/block/brick
+   lookups to LBA1's three HQRs and compute `UsedBlock` at load, exactly as LBA1's own
+   `LoadUsedBrick` does. The §8 script choice (in-memory transcode vs dual-table VM) is a sub-case;
+   both keep assets untouched. The spike transcoders stay as the validated mapping reference +
+   test oracles, not the pipeline. *Lean: in-engine adaptation; never modify the retail assets.*
+   Open (recommended).
+
+---
+
+## 8. Traceability & preservation `[design]`
+
+Path B confines all new work to the community SDL3 layer + new transcoder/remap code; the
+upstream-traceable core (ASM-equivalence pairs, the Life/Track VM, the format parsers) is
+**never moved or modified**, the same guarantee as [PLATFORM_PAL_PLAN.md](PLATFORM_PAL_PLAN.md)
+§5.2. LBA1 content is *data* read by the existing engine; the LBA1 source (`lba1-classic`) and
+`twin-e` are references (`lba1-classic` is the source of truth, twin-e a helper), not vendored engine code. The shared Adeline lineage is exactly
+why this is cheap, and isolating LBA1 behind a game-id keeps both titles' provenance legible.
+
+---
+
+*Prepared read-only. The only changes are additive dev tooling under `scripts/dev/`
+(`lba1_body_probe.py`, `lba1_body_render.py`, `lba1_script_remap.py`, `lba1_bkg_repack.py`,
+`lba1_voc_probe.py`) plus this doc; no engine, build, or game behaviour changed. Awaiting
+go/no-go on §7.*

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ The engine mapped as a whole: layers, the engine/game membrane, and the on-disk 
 | [ENGINE_GAME_INTERFACE.md](ENGINE_GAME_INTERFACE.md) | The engine↔game membrane: the Life/Track per-object script VM. |
 | [ENGINE_FILE_FORMATS.md](ENGINE_FILE_FORMATS.md) | Data contract: the Adeline on-disk formats (HQR, LZ, body, anim, sprite, samples, XMIDI, XCF), each with its cross-title version timeline. |
 | [LBA1_PORTING_SURFACE.md](LBA1_PORTING_SURFACE.md) | Per-subsystem cost of hosting LBA1 on this engine; verified against LBA1 retail data. |
+| [LBA1_PORT_PLAN.md](LBA1_PORT_PLAN.md) | Plan (awaiting go/no-go): how to bring LBA1 to this groundwork. Costs three paths (native port / host on lba2cc / hybrid repo), recommends hosting LBA1 content on the lba2cc engine in-repo behind a game-id, with an agnostic-menu/shell design, twin-e as oracle, and a feasibility-spike ladder. |
 
 ## Build & debug
 

--- a/scripts/dev/lba1_bkg_repack.py
+++ b/scripts/dev/lba1_bkg_repack.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Feasibility spike 3: re-index LBA1's 3 background HQRs into LBA2's 1 merged container.
+
+Source of truth: LBA2 layout from this repo's SOURCES/GRILLE.CPP (T_BKG_HEADER / T_GRI_HEADER);
+LBA1 from ../lba1-classic/SOURCES/GRILLE.C (3 HQRs LBA_GRI / LBA_BLL / LBA_BRK).
+
+LBA2 packs everything in one LBA_BKG.HQR, partitioned by a T_BKG_HEADER index (28 B):
+  U16 Gri_Start, Grm_Start, Bll_Start, Brk_Start, Max_Brk, ForbidenBrick; U32 Max_Size_* x4
+Each grid is prefixed by T_GRI_HEADER (34 B): U8 My_Bll, My_Grm; U8 UsedBlock[32].
+A grid's block library resolves to merged entry (Bll_Start + My_Bll); bricks to (Brk_Start + n).
+
+LBA1 keeps them in three HQRs (grid N pairs with block-lib N; bricks shared); the used-block
+bitmap is computed at load (LoadUsedBrick) rather than stored. The converter merges the three
+into one container, synthesizes a T_BKG_HEADER, and prefixes each grid with a T_GRI_HEADER
+(My_Bll = the grid's block-lib index; UsedBlock = computed from the grid's block usage).
+
+This spike confirms the target layout on real LBA2 data, confirms the LBA1 structure, and lays
+out + validates the re-index arithmetic. (Computing UsedBlock + emitting the HQR is the
+mechanical remainder.)
+
+Usage: lba1_bkg_repack.py [--lba1dir ../LBA] [--lba2-bkg ../LBA2-GOG/LBA_BKG.HQR]
+"""
+import argparse
+import os
+import struct
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import hqr_inspect  # noqa: E402
+
+BKG_HDR = struct.Struct("<6H4I")     # T_BKG_HEADER, 28 bytes
+GRI_HDR_LEN = 2 + 32                  # T_GRI_HEADER: My_Bll, My_Grm, UsedBlock[32]
+
+
+def slots_present(path):
+    ents, _ = hqr_inspect.entries(path)
+    return len(ents), sum(1 for e in ents if e[2] is not None)
+
+
+def entry_bytes(path, idx):
+    ents, data = hqr_inspect.entries(path)
+    i, off, size, csize, method = ents[idx]
+    if size is None:
+        return None
+    return hqr_inspect.decompress_entry(data, off, size, csize, method)
+
+
+def decode_bkg_header(b):
+    f = BKG_HDR.unpack_from(b, 0)
+    return dict(zip(("Gri_Start", "Grm_Start", "Bll_Start", "Brk_Start", "Max_Brk",
+                     "ForbidenBrick", "Max_Size_Gri", "Max_Size_Bll",
+                     "Max_Size_Brick_Cube", "Max_Size_Mask_Brick_Cube"), f))
+
+
+def line(t, ok, extra=""):
+    return f"  [{'PASS' if ok else 'FAIL'}] {t}" + (f"  ({extra})" if extra else "")
+
+
+def main():
+    hacking = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--lba1dir", default=os.path.join(hacking, "LBA"))
+    ap.add_argument("--lba2-bkg", default=os.path.join(hacking, "LBA2-GOG", "LBA_BKG.HQR"))
+    a = ap.parse_args()
+    all_ok = True
+
+    print("=" * 74)
+    print("LBA1 background (3 separate HQRs):")
+    counts = {}
+    for f in ("LBA_GRI", "LBA_BLL", "LBA_BRK"):
+        p = os.path.join(a.lba1dir, f + ".HQR")
+        if not os.path.exists(p):
+            print(f"  MISSING {p}"); return 2
+        n, present = slots_present(p)
+        counts[f] = present
+        print(f"  {f}.HQR: {present} present ({n} slots)")
+    grids, blls, brks = counts["LBA_GRI"], counts["LBA_BLL"], counts["LBA_BRK"]
+    print(line("grid count == block-lib count (grid N pairs with style N)",
+               grids == blls, f"{grids} grids, {blls} block-libs")); all_ok &= (grids == blls)
+
+    print("-" * 74)
+    print(f"LBA2 merged container: {a.lba2_bkg}")
+    if not os.path.exists(a.lba2_bkg):
+        print("  MISSING (skipping LBA2 target decode)")
+        h = None
+    else:
+        n2, present2 = slots_present(a.lba2_bkg)
+        hdr_blob = entry_bytes(a.lba2_bkg, 0)
+        h = decode_bkg_header(hdr_blob)
+        print(f"  {present2} present ({n2} slots); T_BKG_HEADER (entry 0):")
+        print(f"    Gri_Start={h['Gri_Start']} Grm_Start={h['Grm_Start']} "
+              f"Bll_Start={h['Bll_Start']} Brk_Start={h['Brk_Start']} Max_Brk={h['Max_Brk']}")
+        ordered = h["Gri_Start"] <= h["Grm_Start"] <= h["Bll_Start"] <= h["Brk_Start"] < n2
+        print(line("partition starts ascending & in-bounds (4-partition layout confirmed)",
+                   ordered, f"{h['Gri_Start']}<={h['Grm_Start']}<={h['Bll_Start']}<={h['Brk_Start']}<{n2}"))
+        all_ok &= ordered
+        # decode one real grid header to confirm T_GRI_HEADER shape
+        g = entry_bytes(a.lba2_bkg, h["Gri_Start"] if h["Gri_Start"] > 0 else 1)
+        if g and len(g) >= GRI_HDR_LEN:
+            my_bll, my_grm = g[0], g[1]
+            used = sum(bin(x).count("1") for x in g[2:34])
+            print(f"    sample grid T_GRI_HEADER: My_Bll={my_bll} My_Grm={my_grm} "
+                  f"UsedBlock popcount={used}/256")
+            print(line("grid's block-lib resolves inside the BLL partition",
+                       h["Bll_Start"] + my_bll < h["Brk_Start"],
+                       f"Bll_Start+My_Bll={h['Bll_Start'] + my_bll} < Brk_Start={h['Brk_Start']}"))
+            all_ok &= (h["Bll_Start"] + my_bll < h["Brk_Start"])
+
+    print("-" * 74)
+    print("Re-index plan LBA1 -> LBA2 merged container:")
+    # LBA1 has no GRM; layout the four partitions in T_BKG_HEADER order.
+    gri_start, grm_start = 0, grids
+    bll_start = grm_start + 0                  # 0 GRMs in LBA1
+    brk_start = bll_start + blls
+    total = brk_start + brks
+    syn = {"Gri_Start": gri_start, "Grm_Start": grm_start, "Bll_Start": bll_start,
+           "Brk_Start": brk_start, "Max_Brk": brks}
+    print(f"  synthesized T_BKG_HEADER: Gri_Start={gri_start} Grm_Start={grm_start} "
+          f"Bll_Start={bll_start} Brk_Start={brk_start} Max_Brk={brks} (total {total} entries)")
+    print(f"  per-grid T_GRI_HEADER: My_Bll = grid index (style N <-> grid N), My_Grm = none, "
+          f"UsedBlock[32] = computed from the grid's block usage")
+    # validate the arithmetic + a sample resolution
+    ok_layout = (gri_start <= grm_start <= bll_start <= brk_start < total
+                 and brk_start == grids + 0 + blls and syn["Max_Brk"] == brks)
+    print(line("merged-index arithmetic consistent (starts ascending, sizes add up)", ok_layout,
+               f"Brk_Start={brk_start}=={grids}+0+{blls}")); all_ok &= ok_layout
+    sample = grids // 2
+    print(line(f"sample grid {sample}: block-lib resolves in merged container",
+               bll_start + sample < brk_start, f"Bll_Start+{sample}={bll_start + sample} < Brk_Start={brk_start}"))
+    all_ok &= (bll_start + sample < brk_start)
+
+    print("=" * 74)
+    print(f"SPIKE 3 {'PASS' if all_ok else 'FAIL'}: LBA2's merged 4-partition T_BKG_HEADER layout "
+          "is confirmed on real data; LBA1's 3 HQRs (matched grid/block-lib counts + bricks) "
+          "re-index into it by simple offset arithmetic, with a synthesized per-grid T_GRI_HEADER. "
+          "Remaining (mechanical): compute each grid's UsedBlock bitmap (LoadUsedBrick four-pass) "
+          "and emit the merged HQR; brick/block/column payloads are unchanged.")
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/lba1_body_probe.py
+++ b/scripts/dev/lba1_body_probe.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Feasibility spike: transcode an LBA1 body to the lba2cc engine's format (docs/LBA1_PORT_PLAN.md §6).
+
+Source of truth for the LBA1 format is ../lba1-classic (the original Adeline source):
+  - body stream walk: LIB386/LIB_3D/P_OBJET.ASM  (AffObjet / AnimNuage / RotateNuage /
+    ComputeStaticNormal / ComputeAnimNormal); poly/line/sphere records in AffObjet
+  - section layout & 38-byte group: LIB386/LIB_3D/P_ANIM.ASM (SetAngleGroupe); P_DEFINE.ASH
+    (INFO_ANIM=2). ComputeAnimNormal shows group[+18] = NbNormal.
+Target format: this repo's LIB386/H/AFF_OBJ.INC (STRUC_OBJ_*) and H/OBJECT/AFF_OBJ.H
+(T_BODY_HEADER). twin-e is only a readable cross-check, never authoritative.
+
+LBA1 body layout (P_OBJET.ASM):
+  u16 Info; s16 bbox[6]; u16 zone_size; <zone_size bytes>;
+  u16 nbPoints;  point[nbPoints]    = {s16 X,Y,Z}                      (6 B)
+  if (Info & INFO_ANIM): u16 nbGroups; group[nbGroups]                 (38 B each)
+  u16 nbNormals; normal[nbNormals]  = {s16 X,Y,Z,range}                (8 B)
+  u16 nbPolys;   poly[nbPolys]      (variable; material-tagged, n-gon)
+  u16 nbLines;   line[nbLines]      = {u16 mat,coul; idx p1,p2}        (8 B)
+  u16 nbSpheres; sphere[nbSpheres]  = {u16 mat,coul,rayon; idx p1}     (8 B)
+  (+ up to a couple of trailing padding bytes AffObjet never reads)
+Poly point indices are pre-multiplied by SIZE_LIST_POINT (6); LBA2 uses plain indices.
+For animated bodies points are group-LOCAL, so they do NOT reproduce the header bbox.
+
+Material (AffObjet): mat>=9 gouraud (per-vertex normals), 7..8 flat (one face normal),
+<7 solid/triste/trame (color only).
+
+Usage:
+  lba1_body_probe.py [--lba1 LBA/BODY.HQR] [--lba2 LBA2-GOG/BODY.HQR]
+                     [--entry N] [--emit OUT.bin]
+"""
+import argparse
+import os
+import struct
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import hqr_inspect  # noqa: E402
+
+INFO_ANIM = 2
+SIZE_LIST_POINT = 6
+GROUP_SIZE = 38
+GROUP_OFF_NBNORM = 18          # ComputeAnimNormal: cx = [group+18]
+LBA2_HDR = 96
+POLY_SOLID, POLY_FLAT, POLY_GOURAUD = 0, 1, 4
+MASK_QUADRILATERE = 1 << 15
+PAD_TOLERANCE = 2              # trailing bytes AffObjet never reads
+
+LBA1_BODY1_INFO = 0x0003
+LBA1_BODY1_BBOX = (-253, 260, 0, 1240, -153, 200)
+
+
+def u16(b, o): return struct.unpack_from("<H", b, o)[0]
+def s16(b, o): return struct.unpack_from("<h", b, o)[0]
+
+
+def hqr_entry(path, idx):
+    ents, data = hqr_inspect.entries(path)
+    if idx >= len(ents):
+        raise IndexError(f"{path}: entry {idx} out of range (has {len(ents)} slots)")
+    _, off, size, csize, method = ents[idx]
+    if size is None:
+        raise ValueError(f"{path}: entry {idx} is empty")
+    meth = {0: "stored", 1: "LZSS", 2: "LZMIT"}.get(method, method)
+    blob = hqr_inspect.decompress_entry(data, off, size, csize, method)
+    if len(blob) != size:
+        raise ValueError(f"{path}: entry {idx} decompressed {len(blob)} != declared {size}")
+    return blob, size, meth
+
+
+# ---------------------------------------------------------------- LBA1 decode
+
+def decode_lba1_body(b):
+    off = {}
+    info = u16(b, 0)
+    bbox = struct.unpack_from("<6h", b, 2)
+    zone_size = u16(b, 14)
+    p = 16 + zone_size
+
+    off["points"] = p
+    nb_points = u16(b, p); p += 2
+    points = [struct.unpack_from("<3h", b, p + 6 * i) for i in range(nb_points)]
+    p += 6 * nb_points
+
+    groups = []
+    if info & INFO_ANIM:
+        off["groups"] = p
+        nb_groups = u16(b, p); p += 2
+        for _ in range(nb_groups):
+            groups.append(b[p:p + GROUP_SIZE]); p += GROUP_SIZE
+
+    off["normals"] = p
+    nb_norm = u16(b, p); p += 2
+    normals = [struct.unpack_from("<4h", b, p + 8 * i) for i in range(nb_norm)]
+    p += 8 * nb_norm
+
+    off["polys"] = p
+    nb_poly = u16(b, p); p += 2
+    polys = []
+    for _ in range(nb_poly):
+        mat = b[p]; nbp = b[p + 1]; p += 2
+        coul = u16(b, p); p += 2
+        kind = "gouraud" if mat >= 9 else "flat" if mat >= 7 else "solid"
+        face_normal = None
+        verts = []
+        if kind == "flat":
+            face_normal = u16(b, p); p += 2
+            for _ in range(nbp):
+                verts.append(u16(b, p) // SIZE_LIST_POINT); p += 2
+        elif kind == "gouraud":
+            for _ in range(nbp):
+                verts.append(u16(b, p + 2) // SIZE_LIST_POINT); p += 4
+        else:
+            for _ in range(nbp):
+                verts.append(u16(b, p) // SIZE_LIST_POINT); p += 2
+        polys.append({"mat": mat, "kind": kind, "coul": coul,
+                      "face_normal": face_normal, "verts": verts})
+
+    off["lines"] = p
+    nb_line = u16(b, p); p += 2
+    lines = [{"mat": u16(b, p + 8 * i), "coul": u16(b, p + 8 * i + 2),
+              "p1": u16(b, p + 8 * i + 4) // SIZE_LIST_POINT,
+              "p2": u16(b, p + 8 * i + 6) // SIZE_LIST_POINT} for i in range(nb_line)]
+    p += 8 * nb_line
+
+    off["spheres"] = p
+    nb_sph = u16(b, p); p += 2
+    spheres = [{"mat": u16(b, p + 8 * i), "coul": u16(b, p + 8 * i + 2),
+                "rayon": u16(b, p + 8 * i + 4),
+                "p1": u16(b, p + 8 * i + 6) // SIZE_LIST_POINT} for i in range(nb_sph)]
+    p += 8 * nb_sph
+    off["end"] = p
+
+    return {"info": info, "bbox": bbox, "zone_size": zone_size,
+            "points": points, "groups": groups, "normals": normals,
+            "polys": polys, "lines": lines, "spheres": spheres,
+            "consumed": p, "off": off}
+
+
+def analyze_groups(groups, nb_points, nb_normals):
+    """Recover the per-group point/normal counts. group[+18]=NbNormal is known from
+    ComputeAnimNormal; find the point-count word by cumulative sum == nb_points."""
+    out = {"pts_off": None, "norm_off": None, "norm_sum": None}
+    if not groups:
+        return out
+    out["norm_sum"] = sum(u16(g, GROUP_OFF_NBNORM) for g in groups)
+    if out["norm_sum"] == nb_normals:
+        out["norm_off"] = GROUP_OFF_NBNORM
+    for cand in (16, 0, 2, 4, 6):                 # skip type(8)/angles(10,12,14)
+        if sum(u16(g, cand) for g in groups) == nb_points:
+            out["pts_off"] = cand
+            break
+    return out
+
+
+def validate_lba1(b, d, ga):
+    checks = []
+    leftover = len(b) - d["consumed"]
+    checks.append((f"parse consumed body (leftover {leftover} B pad)",
+                   0 <= leftover <= PAD_TOLERANCE, f"{d['consumed']}/{len(b)}"))
+    pts = d["points"]
+    if not (d["info"] & INFO_ANIM):
+        xs = [q[0] for q in pts]; ys = [q[1] for q in pts]; zs = [q[2] for q in pts]
+        got = (min(xs), max(xs), min(ys), max(ys), min(zs), max(zs))
+        checks.append(("points bbox == header ZV (static)", got == tuple(d["bbox"]), ""))
+    else:
+        checks.append(("points bbox == header ZV", True, "N/A (animated: group-local points)"))
+    n = len(pts)
+    idx_ok = all(0 <= v < n for pol in d["polys"] for v in pol["verts"]) \
+        and all(0 <= ln["p1"] < n and 0 <= ln["p2"] < n for ln in d["lines"]) \
+        and all(0 <= sp["p1"] < n for sp in d["spheres"])
+    checks.append((f"all point indices in [0,{n})", idx_ok, ""))
+    if d["groups"]:
+        checks.append(("group[+18] sums to nbNormals (group decode)",
+                       ga["norm_off"] is not None, f"sum={ga['norm_sum']} nbNorm={len(d['normals'])}"))
+        checks.append(("a group word sums to nbPoints (skinning recovered)",
+                       ga["pts_off"] is not None,
+                       f"pts_off={ga['pts_off']}" if ga["pts_off"] is not None else "not found"))
+    return checks
+
+
+# ---------------------------------------------------------------- LBA2 emit
+
+def emit_lba2_body(d, ga):
+    pts, groups, norms = d["points"], d["groups"], d["normals"]
+    nb_points = len(pts)
+
+    pt_group = [0] * nb_points
+    g_table = []
+    if groups and ga["pts_off"] is not None:
+        cur = 0
+        for gi, g in enumerate(groups):
+            cnt = u16(g, ga["pts_off"])
+            nbn = u16(g, GROUP_OFF_NBNORM) if ga["norm_off"] else 0
+            for i in range(cur, min(cur + cnt, nb_points)):
+                pt_group[i] = gi
+            g_table.append((0, cur, cnt, nbn))    # OrgGroupe(parent) stub=0
+            cur += cnt
+        skin = f"per-group (pts_off={ga['pts_off']}, {len(groups)} groups)"
+    else:
+        g_table.append((0, 0, nb_points, len(norms)))
+        skin = "SINGLE-GROUP fallback"
+
+    base_type = {"solid": POLY_SOLID, "flat": POLY_FLAT, "gouraud": POLY_GOURAUD}
+    buckets = {}
+    for pol in d["polys"]:
+        v = pol["verts"]; t = base_type[pol["kind"]]; coul = pol["coul"]
+        faces = [v] if len(v) <= 4 else [[v[0], v[i], v[i + 1]] for i in range(1, len(v) - 1)]
+        for f in faces:
+            buckets.setdefault((t, len(f) == 4), []).append((f, coul, 0))
+
+    off_groups = LBA2_HDR
+    off_points = off_groups + len(g_table) * 8
+    off_norms = off_points + nb_points * 8
+    off_normfaces = off_norms + len(norms) * 8
+    off_polys = off_normfaces
+    poly_blob = bytearray()
+    for (t, is_quad), recs in buckets.items():
+        poly_blob += struct.pack("<HHI", t | (MASK_QUADRILATERE if is_quad else 0),
+                                 len(recs), 8 + len(recs) * 12)
+        for f, coul, normale in recs:
+            p4 = f[3] if is_quad else 0
+            poly_blob += struct.pack("<6H", f[0], f[1], f[2], p4, coul, normale)
+    off_lines = off_polys + len(poly_blob)
+    off_spheres = off_lines + len(d["lines"]) * 8
+    off_textures = off_spheres + len(d["spheres"]) * 8
+
+    lba2_info = (d["info"] & 0xff) | (0x100 if (d["info"] & INFO_ANIM) else 0)
+    hdr = struct.pack("<i hh 6i", lba2_info, LBA2_HDR, 0, *d["bbox"])
+    hdr += struct.pack("<16i",
+                       len(g_table), off_groups, nb_points, off_points,
+                       len(norms), off_norms, 0, off_normfaces,
+                       sum(len(r) for r in buckets.values()), off_polys,
+                       len(d["lines"]), off_lines, len(d["spheres"]), off_spheres,
+                       0, off_textures)
+    assert len(hdr) == LBA2_HDR, len(hdr)
+
+    body = bytearray(hdr)
+    for og, op, nbp, nbn in g_table:
+        body += struct.pack("<4H", og, op, nbp, nbn)
+    for (x, y, z), g in zip(pts, pt_group):
+        body += struct.pack("<4h", x, y, z, g)
+    for nx, ny, nz, _rng in norms:
+        body += struct.pack("<4h", nx, ny, nz, 0)
+    body += poly_blob
+    for ln in d["lines"]:
+        body += struct.pack("<4H", ln["mat"], ln["coul"], ln["p1"], ln["p2"])
+    for sp in d["spheres"]:
+        body += struct.pack("<4H", sp["mat"], sp["coul"], sp["p1"], sp["rayon"])
+    return bytes(body), skin, len(poly_blob), buckets
+
+
+def decode_lba2_header(b):
+    f = struct.unpack_from("<i hh 6i 16i", b, 0)
+    names = ["Groupes", "Points", "Normales", "NormFaces",
+             "Polys", "Lines", "Spheres", "Textures"]
+    sec = f[9:]
+    return {"Info": f[0], "SizeHeader": f[1], "bbox": f[3:9],
+            "sections": {names[k]: (sec[2 * k], sec[2 * k + 1]) for k in range(8)}}
+
+
+def validate_lba2(blob, nb_points):
+    h = decode_lba2_header(blob)
+    checks = [("SizeHeader == 96", h["SizeHeader"] == LBA2_HDR, str(h["SizeHeader"]))]
+    s = h["sections"]
+    offs = [s[k][1] for k in ("Groupes", "Points", "Normales", "NormFaces",
+                              "Polys", "Lines", "Spheres", "Textures")]
+    mono = all(LBA2_HDR <= offs[i] <= offs[i + 1] for i in range(len(offs) - 1)) and offs[-1] <= len(blob)
+    checks.append(("section offsets monotonic & in-bounds", mono, str(offs)))
+    p = s["Polys"][1]; end = s["Lines"][1]; ok = True; seen = 0
+    while p < end and ok:
+        type_word, nbpoly, nextoff = struct.unpack_from("<HHI", blob, p)
+        is_quad = bool(type_word & MASK_QUADRILATERE)
+        rp = p + 8
+        for _ in range(nbpoly):
+            vs = struct.unpack_from("<4H", blob, rp)[:4 if is_quad else 3]
+            if any(v >= nb_points for v in vs):
+                ok = False
+            seen += 1; rp += 12
+        p += nextoff
+    checks.append((f"emitted poly indices < {nb_points} ({seen} tris/quads)", ok, ""))
+    return checks
+
+
+def default_data():
+    here = os.path.abspath(__file__)
+    hacking = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(here))))
+    lba1 = os.path.join(hacking, "LBA", "BODY.HQR")
+    for cand in ("LBA2-GOG", os.path.join("LBA2", "Common")):
+        pth = os.path.join(hacking, cand, "BODY.HQR")
+        if os.path.exists(pth):
+            return lba1, pth
+    return lba1, os.path.join(hacking, "LBA2-GOG", "BODY.HQR")
+
+
+def line(t, ok, extra=""):
+    return f"  [{'PASS' if ok else 'FAIL'}] {t}" + (f"  ({extra})" if extra else "")
+
+
+def main():
+    d1, d2 = default_data()
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--lba1", default=d1)
+    ap.add_argument("--lba2", default=d2)
+    ap.add_argument("--entry", type=int, default=1)
+    ap.add_argument("--emit", default=None)
+    a = ap.parse_args()
+    all_ok = True
+
+    print("=" * 72)
+    print(f"LBA1 body  : {a.lba1}  (entry {a.entry})")
+    if not os.path.exists(a.lba1):
+        print("  MISSING. Pass --lba1 /path/to/LBA/BODY.HQR"); return 2
+    b1, size1, meth1 = hqr_entry(a.lba1, a.entry)
+    print(f"  HQR read  : {size1} bytes, {meth1}")
+    d = decode_lba1_body(b1)
+    ga = analyze_groups(d["groups"], len(d["points"]), len(d["normals"]))
+    bb = d["bbox"]
+    anim = "animated" if d["info"] & INFO_ANIM else "static"
+    print(f"  Info=0x{d['info']:04x} ({anim})  bbox X[{bb[0]},{bb[1]}] Y[{bb[2]},{bb[3]}] Z[{bb[4]},{bb[5]}]")
+    print(f"  decoded   : {len(d['points'])} points, {len(d['groups'])} groups, "
+          f"{len(d['normals'])} normals, {len(d['polys'])} polys, "
+          f"{len(d['lines'])} lines, {len(d['spheres'])} spheres")
+    nshape = {}
+    for pol in d["polys"]:
+        nshape[len(pol["verts"])] = nshape.get(len(pol["verts"]), 0) + 1
+    print(f"  section offsets: {d['off']}")
+    print(f"  poly vert counts: {dict(sorted(nshape.items()))}  (n>4 triangulated)")
+    print("  LBA1 decode validation (source of truth = lba1-classic P_OBJET.ASM):")
+    for t, ok, extra in validate_lba1(b1, d, ga):
+        print(line(t, ok, extra)); all_ok &= ok
+    if a.entry == 1:
+        v = (d["info"] == LBA1_BODY1_INFO and tuple(bb) == LBA1_BODY1_BBOX)
+        print(line("body-1 header matches documented retail values", v)); all_ok &= v
+
+    print("-" * 72)
+    print(f"LBA2 body  : {a.lba2}  (entry {a.entry}, reference target)")
+    if os.path.exists(a.lba2):
+        try:
+            b2, size2, meth2 = hqr_entry(a.lba2, a.entry)
+            h2 = decode_lba2_header(b2)
+            print(f"  {size2} B, {meth2}; SizeHeader={h2['SizeHeader']}; "
+                  + ", ".join(f"{k}={v[0]}@{v[1]}" for k, v in h2["sections"].items()))
+        except (ValueError, IndexError, struct.error) as e:
+            print(f"  NOTE: LBA2 side not decoded ({e})")
+    else:
+        print("  MISSING (skipping). Pass --lba2 /path/to/LBA2/BODY.HQR")
+
+    print("-" * 72)
+    print("Transcode LBA1 -> LBA2 T_BODY_HEADER:")
+    emitted, skin, polybytes, buckets = emit_lba2_body(d, ga)
+    print(f"  emitted {len(emitted)} B; {sum(len(r) for r in buckets.values())} LBA2 tris/quads "
+          f"in {len(buckets)} type-groups ({polybytes} B)")
+    print(f"  group skinning: {skin}")
+    print("  validation:")
+    for t, ok, extra in validate_lba2(emitted, len(d["points"])):
+        print(line(t, ok, extra)); all_ok &= ok
+    print("  STUBBED (flagged; needed before on-engine render): per-poly face Normale + "
+          "NormFaces synthesis; fine material->type map (dither/trame/env); normal range; group parent.")
+    if a.emit:
+        with open(a.emit, "wb") as f:
+            f.write(emitted)
+        print(f"  wrote {a.emit}")
+
+    print("=" * 72)
+    print(f"SPIKE {'PASS' if all_ok else 'FAIL'}: LBA1 body decoded + validated against the "
+          "source-of-truth layout (incl. group skinning); geometry transcoded to a valid LBA2 "
+          "body. Next: synthesize face normals, then render headless (Control_*/SNAPSHOT).")
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/lba1_body_render.py
+++ b/scripts/dev/lba1_body_render.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Standalone visual gut-check for the LBA1 body decoder + skeleton (docs/LBA1_PORT_PLAN.md §6).
+
+Renders decoded LBA1 body geometry to a grayscale PNG with a tiny built-in software rasteriser
+(stdlib only). No engine build, no deps. Reuses the validated decoder in lba1_body_probe.py.
+
+LBA1 bodies are animated: points are stored GROUP-LOCAL and must be assembled through the bone
+hierarchy. The 38-byte group (from P_OBJET.ASM RotateGroupe / P_TRIGO.ASM RotList) is:
+  +0 startPoint(x6)  +2 nbPoints  +4 pivotPoint(x6)  +6 parentGroup(x38, -1=root)
+  +8 type  +10/12/14 angles  +18 nbNormal  +20 3x3 matrix (9 words, Q14 row-major)
+Bind pose: assembled[i] = (M_group . rawPoint[i]) >> 14 + assembled[pivot]; root pivot = origin.
+
+Usage:
+  lba1_body_render.py [--lba1 LBA/BODY.HQR] [--entry N] [--outdir /tmp]
+                      [--dumpgroups] [--raw] [--shift 14]
+  (no --entry: render a few representative bodies)
+"""
+import argparse
+import math
+import os
+import struct
+import sys
+import zlib
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import lba1_body_probe as P  # noqa: E402
+
+
+def write_png_gray(path, w, h, buf):
+    def chunk(typ, data):
+        body = typ + data
+        return struct.pack(">I", len(data)) + body + struct.pack(">I", zlib.crc32(body) & 0xffffffff)
+    raw = bytearray()
+    for y in range(h):
+        raw.append(0)
+        raw += buf[y * w:(y + 1) * w]
+    with open(path, "wb") as f:
+        f.write(b"\x89PNG\r\n\x1a\n")
+        f.write(chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 0, 0, 0, 0)))
+        f.write(chunk(b"IDAT", zlib.compress(bytes(raw), 9)))
+        f.write(chunk(b"IEND", b""))
+
+
+def fill_tri(buf, zbuf, W, H, p0, p1, p2, shade):
+    def e(ax, ay, bx, by, cx, cy):
+        return (cx - ax) * (by - ay) - (cy - ay) * (bx - ax)
+    minx = max(0, int(min(p0[0], p1[0], p2[0])))
+    maxx = min(W - 1, int(max(p0[0], p1[0], p2[0])) + 1)
+    miny = max(0, int(min(p0[1], p1[1], p2[1])))
+    maxy = min(H - 1, int(max(p0[1], p1[1], p2[1])) + 1)
+    area = e(p0[0], p0[1], p1[0], p1[1], p2[0], p2[1])
+    if area == 0:
+        return
+    z0, z1, z2 = p0[2], p1[2], p2[2]
+    for y in range(miny, maxy + 1):
+        for x in range(minx, maxx + 1):
+            px, py = x + 0.5, y + 0.5
+            w0 = e(p1[0], p1[1], p2[0], p2[1], px, py)
+            w1 = e(p2[0], p2[1], p0[0], p0[1], px, py)
+            w2 = e(p0[0], p0[1], p1[0], p1[1], px, py)
+            if not ((w0 >= 0 and w1 >= 0 and w2 >= 0) or (w0 <= 0 and w1 <= 0 and w2 <= 0)):
+                continue
+            z = (w0 * z0 + w1 * z1 + w2 * z2) / area
+            o = y * W + x
+            if z >= zbuf[o]:                # nearer (larger z toward viewer) wins
+                zbuf[o] = z
+                buf[o] = shade
+
+
+def rot(p, yaw, pitch):
+    x, y, z = p
+    cy, sy = math.cos(yaw), math.sin(yaw)
+    cx, sx = math.cos(pitch), math.sin(pitch)
+    x1, z1 = x * cy + z * sy, -x * sy + z * cy
+    y2, z2 = y * cx - z1 * sx, y * sx + z1 * cx
+    return (x1, y2, z2)
+
+
+def decode_group(g):
+    return {"start": P.u16(g, 0) // 6, "nb": P.u16(g, 2),
+            "pivot": P.u16(g, 4) // 6, "parent": P.s16(g, 6),
+            "type": P.u16(g, 8), "angles": (P.s16(g, 10), P.s16(g, 12), P.s16(g, 14)),
+            "nbnorm": P.u16(g, 18), "mat": [P.s16(g, 20 + 2 * k) for k in range(9)]}
+
+
+def assemble(d):
+    """Bind pose: walk the bone hierarchy (parents first) and offset each group's local points
+    by its pivot on the parent. The body's per-group angles are all 0 (rest), so every group's
+    rotation matrix is identity (RotMat of identity + zero angles); RotList then reduces to
+    translation by assembled[pivot]. Per-frame limb rotations live in ANIM.HQR, not the body."""
+    raw = d["points"]
+    out = [None] * len(raw)
+    for g in (decode_group(x) for x in d["groups"]):
+        ox, oy, oz = (0, 0, 0) if g["parent"] == -1 else (out[g["pivot"]] or (0, 0, 0))
+        for i in range(g["start"], min(g["start"] + g["nb"], len(raw))):
+            x, y, z = raw[i]
+            out[i] = (x + ox, y + oy, z + oz)
+    return [out[i] if out[i] is not None else raw[i] for i in range(len(raw))]
+
+
+def render(points, polys, path, W=360, H=460, yaw=0.5, pitch=-0.25):
+    pts = [rot(q, yaw, pitch) for q in points]
+    xs = [q[0] for q in pts]; ys = [q[1] for q in pts]
+    minx, maxx, miny, maxy = min(xs), max(xs), min(ys), max(ys)
+    scale = min((W - 40) / (maxx - minx or 1), (H - 40) / (maxy - miny or 1))
+
+    def proj(q):
+        return (20 + (q[0] - minx) * scale, H - 20 - (q[1] - miny) * scale, q[2])
+
+    buf = bytearray([248]) * (W * H)
+    zbuf = [-1e30] * (W * H)
+    n = len(pts)
+    tris = 0
+    for pol in polys:
+        v = [i for i in pol["verts"] if 0 <= i < n]
+        for k in range(1, len(v) - 1):
+            a, b, c = pts[v[0]], pts[v[k]], pts[v[k + 1]]
+            ux, uy, uz = b[0] - a[0], b[1] - a[1], b[2] - a[2]
+            vx, vy, vz = c[0] - a[0], c[1] - a[1], c[2] - a[2]
+            nx, ny, nz = uy * vz - uz * vy, uz * vx - ux * vz, ux * vy - uy * vx
+            nl = math.sqrt(nx * nx + ny * ny + nz * nz) or 1.0
+            shade = int(55 + 175 * abs(nz) / nl)
+            fill_tri(buf, zbuf, W, H, proj(a), proj(b), proj(c), shade)
+            tris += 1
+    write_png_gray(path, W, H, buf)
+    return tris
+
+
+def main():
+    here = os.path.abspath(__file__)
+    hacking = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(here))))
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--lba1", default=os.path.join(hacking, "LBA", "BODY.HQR"))
+    ap.add_argument("--entry", type=int, default=None)
+    ap.add_argument("--outdir", default="/tmp")
+    ap.add_argument("--raw", action="store_true", help="render group-local points (no skeleton)")
+    ap.add_argument("--shift", type=int, default=14, help="matrix fixed-point shift (Q14)")
+    ap.add_argument("--dumpgroups", action="store_true")
+    a = ap.parse_args()
+    if not os.path.exists(a.lba1):
+        print(f"MISSING {a.lba1}"); return 2
+
+    entries = [a.entry] if a.entry is not None else [1, 51, 80, 120]
+    for entry in entries:
+        b, _, _ = P.hqr_entry(a.lba1, entry)
+        d = P.decode_lba1_body(b)
+        if a.dumpgroups:
+            print(f"body {entry}: {len(d['groups'])} groups")
+            for gi, gb in enumerate(d["groups"]):
+                g = decode_group(gb)
+                print(f"  g{gi:2}: start={g['start']:4} nb={g['nb']:3} pivot={g['pivot']:4} "
+                      f"parent={g['parent']:4} type={g['type']} ang={g['angles']} "
+                      f"matdiag=({g['mat'][0]},{g['mat'][4]},{g['mat'][8]})")
+            continue
+        pts = d["points"] if a.raw else assemble(d)
+        out = os.path.join(a.outdir, f"lba1_body_{entry}{'_raw' if a.raw else ''}.png")
+        ntri = render(pts, d["polys"], out)
+        ys = [p[1] for p in pts]
+        print(f"  body {entry}: {len(d['groups'])} groups, {len(pts)} pts, {len(d['polys'])} polys "
+              f"-> {ntri} tris; assembled Y span [{min(ys)},{max(ys)}] -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/lba1_script_remap.py
+++ b/scripts/dev/lba1_script_remap.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Feasibility spike 2: run LBA1 Life-script bytecode on the LBA2 VM (docs/LBA1_PORT_PLAN.md §6).
+
+Source of truth for LBA1 opcode numbers is ../lba1-classic/SOURCES/COMMON.H; the LBA2 numbers
+are this repo's SOURCES/COMMON.H. twin-e is only a name legend, not consulted here.
+
+Two parts:
+  1. Parse both COMMON.H opcode tables (LM_/LF_/LT_/TM_) and emit the LBA1->LBA2 remap with a
+     divergence report (identical slot / semantic rename / true collision / title-only).
+  2. The flag-width linchpin. From the engines' own GERELIFE:
+       LBA1: LF_FLAG_GAME -> Value = ListFlagGame[i] (UBYTE), TypeAnswer = RET_BYTE  (1-byte cmp)
+             LM_SET_FLAG_GAME writes 1 byte.
+       LBA2: LF_VAR_GAME   -> Value = ListVarGame[i]  (S16),   TypeAnswer = RET_S16   (2-byte cmp)
+             LM_SET_VAR_GAME writes 2 bytes.
+     IF jumps are absolute 2-byte offsets (PtrPrg = PtrLife + *(WORD*)PtrPrg), so widening the
+     value operands shifts every jump. Transcode a `set flag -> if flag==v -> branch` LBA1
+     script to LBA2 (remap opcodes + widen operands + recompute jumps) and run both on a mini
+     Life-VM; assert identical branching. This is the quest mechanism in miniature.
+
+Usage: lba1_script_remap.py [--lba1-common PATH] [--lba2-common PATH]
+"""
+import argparse
+import os
+import re
+import struct
+import sys
+
+PREFIXES = ("LM_", "LF_", "LT_", "TM_")
+
+
+def parse_defines(path):
+    out = {p: {} for p in PREFIXES}
+    rx = re.compile(r"#define\s+((?:LM_|LF_|LT_|TM_)\w+)\s+(\d+)\b")
+    with open(path, encoding="latin-1") as f:
+        for line in f:
+            m = rx.search(line)
+            if m:
+                name, num = m.group(1), int(m.group(2))
+                out[name[:3]][name] = num
+    return out
+
+
+def by_num(table):
+    return {v: k for k, v in table.items()}
+
+
+def norm(name):
+    # FLAG<->VAR is the systematic LBA1->LBA2 rename (flags became S16 vars).
+    return name.replace("_FLAG_", "_VAR_")
+
+
+def opcode_diff(l1, l2, group, lo=0, hi=56):
+    """Slot-by-slot compare for one opcode group; classify each LBA1 slot."""
+    n1, n2 = by_num(l1[group]), by_num(l2[group])
+    rows, counts = [], {"identical": 0, "rename": 0, "collision": 0, "lba1_only": 0}
+    for num in sorted(n1):
+        a = n1[num]
+        b = n2.get(num)
+        if b is None:
+            kind = "lba1_only"
+        elif a == b:
+            kind = "identical"
+        elif norm(a) == b:
+            kind = "rename"
+        else:
+            kind = "collision"
+        counts[kind] += 1
+        rows.append((num, a, b, kind))
+    in_window = [r for r in rows if lo <= r[0] <= hi]
+    win_clean = sum(1 for r in in_window if r[3] in ("identical", "rename"))
+    return rows, counts, (len(in_window), win_clean)
+
+
+def build_remap(l1_lm, l2_lm):
+    """LBA1 LM_ number -> LBA2 LM_ number, matched by name then by FLAG->VAR rename."""
+    remap, unmapped = {}, []
+    for name, num in l1_lm.items():
+        if name in l2_lm:
+            remap[num] = l2_lm[name]
+        elif norm(name) in l2_lm:
+            remap[num] = l2_lm[norm(name)]
+        else:
+            unmapped.append((num, name))
+    return remap, unmapped
+
+
+# ---------------------------------------------------------- mini Life-VM + transcoder
+# Opcode "roles" used by the demo, resolved to each game's real numbers from COMMON.H.
+# Bytecode layouts (vw = value width: LBA1=1, LBA2=2):
+#   END    : [op]
+#   SET    : [op][idx:1][val:vw]
+#   IF     : [op][cond:1][idx:1][cmp:1][cmpval:vw][jump:2 absolute]
+#   OFFSET : [op][jump:2 absolute]
+
+def roles_for(table_lm, table_lf, table_lt, set_name):
+    return {
+        "END": table_lm["LM_END"], "SET": table_lm[set_name], "IF": table_lm["LM_IF"],
+        "OFFSET": table_lm["LM_OFFSET"],
+        "_cond": table_lf["LF_VAR_GAME"] if "LF_VAR_GAME" in table_lf else table_lf["LF_FLAG_GAME"],
+        "_eq": table_lt["LT_EQUAL"],
+    }
+
+
+def assemble(prog, roles, vw):
+    """prog: list of tuples. Labels resolved to absolute offsets.
+       ("SET", idx, val) ("IF", idx, val, else_label) ("OFFSET", target_label)
+       ("LABEL", name) ("END",)"""
+    # pass 1: offsets
+    off, labels = 0, {}
+    sizes = []
+    for ins in prog:
+        if ins[0] == "LABEL":
+            labels[ins[1]] = off; sizes.append(0); continue
+        sizes.append({"SET": 2 + vw, "IF": 4 + vw + 2, "OFFSET": 3, "END": 1}[ins[0]])
+        off += sizes[-1]
+    end_off = off
+    # pass 2: emit
+    code = bytearray()
+    for ins in prog:
+        k = ins[0]
+        if k == "LABEL":
+            continue
+        if k == "SET":
+            code += bytes([roles["SET"], ins[1]]) + int(ins[2]).to_bytes(vw, "little", signed=True)
+        elif k == "IF":
+            tgt = labels[ins[3]]
+            code += bytes([roles["IF"], roles["_cond"], ins[1], roles["_eq"]])
+            code += int(ins[2]).to_bytes(vw, "little", signed=True)
+            code += struct.pack("<H", tgt)
+        elif k == "OFFSET":
+            code += bytes([roles["OFFSET"]]) + struct.pack("<H", labels[ins[1]])
+        elif k == "END":
+            code += bytes([roles["END"]])
+    return bytes(code), end_off
+
+
+def transcode(src, src_roles, dst_roles, src_vw, dst_vw):
+    """Decode LBA1 bytecode, re-emit as LBA2: remap opcodes, widen value operands, and
+    recompute the absolute jump offsets (two-pass with an old->new offset map)."""
+    n2r = {v: k for k, v in src_roles.items() if not k.startswith("_")}
+    # pass 1: decode to instruction list with source offsets
+    insns, pc = [], 0
+    while pc < len(src):
+        src_off = pc
+        role = n2r[src[pc]]; pc += 1
+        if role == "END":
+            insns.append((src_off, "END", None)); break
+        if role == "SET":
+            idx = src[pc]; val = int.from_bytes(src[pc + 1:pc + 1 + src_vw], "little", signed=True)
+            pc += 1 + src_vw
+            insns.append((src_off, "SET", (idx, val)))
+        elif role == "IF":
+            cond, idx, cmp = src[pc], src[pc + 1], src[pc + 2]
+            cmpval = int.from_bytes(src[pc + 3:pc + 3 + src_vw], "little", signed=True)
+            jump = struct.unpack_from("<H", src, pc + 3 + src_vw)[0]
+            pc += 3 + src_vw + 2
+            insns.append((src_off, "IF", (cond, idx, cmp, cmpval, jump)))
+        elif role == "OFFSET":
+            jump = struct.unpack_from("<H", src, pc)[0]; pc += 2
+            insns.append((src_off, "OFFSET", (jump,)))
+    # pass 2: emit + record old->new offset map and jump-field positions to patch
+    dst = bytearray(); offmap = {}; patches = []
+    for src_off, role, args in insns:
+        offmap[src_off] = len(dst)
+        if role == "END":
+            dst += bytes([dst_roles["END"]])
+        elif role == "SET":
+            idx, val = args
+            dst += bytes([dst_roles["SET"], idx]) + int(val).to_bytes(dst_vw, "little", signed=True)
+        elif role == "IF":
+            cond, idx, cmp, cmpval, jump = args
+            # remap condition + comparator opcodes too (they are LF_/LT_ numbers)
+            dst += bytes([dst_roles["IF"], dst_roles["_cond"], idx, dst_roles["_eq"]])
+            dst += int(cmpval).to_bytes(dst_vw, "little", signed=True)
+            patches.append((len(dst), jump)); dst += b"\x00\x00"
+        elif role == "OFFSET":
+            jump = args[0]
+            dst += bytes([dst_roles["OFFSET"]])
+            patches.append((len(dst), jump)); dst += b"\x00\x00"
+    offmap[len(src)] = len(dst)               # jumps to end-of-script
+    # pass 3: patch jumps through the offset map
+    for pos, old_target in patches:
+        struct.pack_into("<H", dst, pos, offmap[old_target])
+    return bytes(dst)
+
+
+def run_vm(code, roles, vw):
+    n2r = {v: k for k, v in roles.items() if not k.startswith("_")}
+    store, pc, trace = {}, 0, []
+    while True:
+        role = n2r[code[pc]]; pc += 1
+        if role == "END":
+            break
+        if role == "SET":
+            idx = code[pc]; val = int.from_bytes(code[pc + 1:pc + 1 + vw], "little", signed=True)
+            pc += 1 + vw; store[idx] = val; trace.append(f"set v{idx}={val}")
+        elif role == "IF":
+            _cond, idx, _cmp = code[pc], code[pc + 1], code[pc + 2]
+            cmpval = int.from_bytes(code[pc + 3:pc + 3 + vw], "little", signed=True)
+            jump = struct.unpack_from("<H", code, pc + 3 + vw)[0]
+            pc += 3 + vw + 2
+            taken = store.get(idx, 0) == cmpval
+            trace.append(f"if v{idx}({store.get(idx,0)})=={cmpval}? {taken}")
+            if not taken:
+                pc = jump
+        elif role == "OFFSET":
+            pc = struct.unpack_from("<H", code, pc)[0]
+    return store, trace
+
+
+def line(t, ok, extra=""):
+    return f"  [{'PASS' if ok else 'FAIL'}] {t}" + (f"  ({extra})" if extra else "")
+
+
+def main():
+    hacking = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--lba1-common", default=os.path.join(hacking, "lba1-classic", "SOURCES", "COMMON.H"))
+    ap.add_argument("--lba2-common", default=os.path.join(hacking, "lba2-classic-community", "SOURCES", "COMMON.H"))
+    a = ap.parse_args()
+    all_ok = True
+
+    l1 = parse_defines(a.lba1_common)
+    l2 = parse_defines(a.lba2_common)
+    print("=" * 74)
+    print(f"LBA1 opcodes: LM_={len(l1['LM_'])} LF_={len(l1['LF_'])} LT_={len(l1['LT_'])} TM_={len(l1['TM_'])}"
+          f"   LBA2: LM_={len(l2['LM_'])} LF_={len(l2['LF_'])} TM_={len(l2['TM_'])}")
+
+    # --- 1. opcode remap + divergence report (Life commands) ---
+    rows, counts, (winn, winclean) = opcode_diff(l1, l2, "LM_", 0, 56)
+    win_collisions = [(n, a, b) for n, a, b, k in rows if 0 <= n <= 56 and k == "collision"]
+    print("-" * 74)
+    print("Life (LM_) opcode alignment vs LBA2 (over all 101 LBA1 slots):")
+    print(f"  identical={counts['identical']} rename={counts['rename']} "
+          f"collision={counts['collision']} lba1_only={counts['lba1_only']}")
+    print("  FINDING: slots 0..56 are NOT all identical. LBA1_PORTING_SURFACE.md overstates this: "
+          f"{winclean}/{winn} clean in 0..56;")
+    print("    collisions inside 0..56: "
+          + ", ".join(f"{n}({a}->{b})" for n, a, b in win_collisions))
+    print("    renames (FLAG->VAR, same slot): "
+          + ", ".join(f"{n}:{a}->{b}" for n, a, b, k in rows if k == "rename"))
+    n1lm, n2lm = by_num(l1["LM_"]), by_num(l2["LM_"])
+    past = [(num, n1lm[num], n2lm.get(num)) for num in sorted(n1lm)
+            if num > 56 and n2lm.get(num) and n1lm[num] != n2lm[num] and norm(n1lm[num]) != n2lm[num]]
+    print(f"    first collisions >56 (the media wall): {past[:5]}")
+    remap, unmapped = build_remap(l1["LM_"], l2["LM_"])
+    print(line(f"by-name remap covers most LBA1 ops ({len(remap)}/{len(l1['LM_'])})",
+               len(remap) >= 60, f"{len(remap)}/{len(l1['LM_'])}")); all_ok &= (len(remap) >= 60)
+    print(f"    unmapped (need manual alias e.g. LABEL->COMPORTEMENT, or a handler e.g. media): "
+          f"{[n for _, n in unmapped]}")
+
+    # --- 2. flag-width transcode + dual-VM proof ---
+    print("-" * 74)
+    print("Flag-width linchpin: set flag -> if flag==v -> branch, LBA1 byte vs LBA2 S16")
+    l1_roles = roles_for(l1["LM_"], l1["LF_"], l1["LT_"], "LM_SET_FLAG_GAME")
+    l2_roles = roles_for(l2["LM_"], l2["LF_"], l2["LT_"], "LM_SET_VAR_GAME")
+    print(f"  LBA1 nums: SET={l1_roles['SET']} IF={l1_roles['IF']} cond(FLAG_GAME)={l1_roles['_cond']} "
+          f"eq={l1_roles['_eq']} OFFSET={l1_roles['OFFSET']}")
+    print(f"  LBA2 nums: SET={l2_roles['SET']} IF={l2_roles['IF']} cond(VAR_GAME)={l2_roles['_cond']} "
+          f"eq={l2_roles['_eq']} OFFSET={l2_roles['OFFSET']}")
+
+    for trigger, expect in ((1, 42), (0, 99)):
+        prog = [("SET", 5, trigger),
+                ("IF", 5, 1, "else"),     # if flag5 == 1
+                ("SET", 6, 42),
+                ("OFFSET", "end"),
+                ("LABEL", "else"),
+                ("SET", 6, 99),
+                ("LABEL", "end"),
+                ("END",)]
+        lba1_code, _ = assemble(prog, l1_roles, 1)
+        lba2_code = transcode(lba1_code, l1_roles, l2_roles, 1, 2)
+        s1, t1 = run_vm(lba1_code, l1_roles, 1)
+        s2, t2 = run_vm(lba2_code, l2_roles, 2)
+        ok = s1.get(6) == s2.get(6) == expect
+        print(line(f"flag5={trigger}: LBA1({len(lba1_code)}B) v6={s1.get(6)}  "
+                   f"LBA2({len(lba2_code)}B) v6={s2.get(6)}  expect {expect}", ok))
+        all_ok &= ok
+    # show the widening + jump recompute is real, not a no-op
+    p = [("SET", 5, 1), ("IF", 5, 1, "e"), ("SET", 6, 42), ("OFFSET", "end"),
+         ("LABEL", "e"), ("SET", 6, 99), ("LABEL", "end"), ("END",)]
+    c1, _ = assemble(p, l1_roles, 1)
+    c2 = transcode(c1, l1_roles, l2_roles, 1, 2)
+    if_jump1 = struct.unpack_from("<H", c1, c1.index(bytes([l1_roles["IF"]])) + 5)[0]
+    print(line("transcode widened bytecode and recomputed jumps (not identity)",
+               len(c2) > len(c1), f"LBA1={len(c1)}B LBA2={len(c2)}B, IF jump {if_jump1} -> recomputed"))
+
+    print("=" * 74)
+    print(f"SPIKE 2 {'PASS' if all_ok else 'FAIL'}: the quest's set/test/branch transcodes across "
+          "the byte->S16 flag-width seam and branches identically on a mini-VM, and a by-name "
+          "opcode remap covers most LBA1 ops. FINDING: the LM_ tables diverge MORE than "
+          "LBA1_PORTING_SURFACE.md claims (collisions inside 0..56, not just >56), so a real "
+          "by-name remap + per-op aliases/handlers is required, not a 0..56 identity assumption. "
+          "Remaining: full operand-table transcoder + handlers for the LBA1-only/media ops.")
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/lba1_voc_probe.py
+++ b/scripts/dev/lba1_voc_probe.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Feasibility spike 4: confirm LBA1 audio (VOC) plays through lba2cc's EXISTING sample path.
+
+The lba2cc community port already decodes Creative Voice (.voc): LIB386/AIL/SDL/SAMPLE.CPP
+`PlaySample()` calls `ParseVocIfPresent()` (added for LBA2's own VOX voices). Its magic check is
+`memcmp(buffer + 1, "reative Voice File\\x1A", 19)`, i.e. it accepts the 0x00/`C`/`W`-prefixed
+VOC variants. LBA1's SAMPLES.HQR and VOX voices are exactly that VOC format, so they are
+**drop-in**: no new decoder needed.
+
+This tool ports `ParseVocIfPresent` (faithfully) and runs it over real LBA1 audio to confirm
+every entry is VOC in the supported variant (8-bit PCM, sane rate). Source of truth for the VOC
+acceptance rule is lba2cc's SAMPLE.CPP; LBA1 data is from ../LBA.
+
+Usage: lba1_voc_probe.py [--samples ../LBA/SAMPLES.HQR] [--vox ../LBA/VOX/EN_000.VOX]
+"""
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import hqr_inspect  # noqa: E402
+
+VOC_MAGIC = b"reative Voice File\x1a"   # 19 bytes, matched at offset 1 (SAMPLE.CPP:97,105)
+
+
+def parse_voc(buf):
+    """Port of LIB386/AIL/SDL/SAMPLE.CPP ParseVocIfPresent. Detection is the offset-1 magic
+    (the real VOC signature); `gate_ok` records whether lba2cc's CURRENT first-byte gate
+    (buffer[0] in {C,W,0x00}, SAMPLE.CPP:103) would also accept it."""
+    if len(buf) < 26:
+        return None
+    if buf[1:20] != VOC_MAGIC:                       # SAMPLE.CPP:105 (the true signature)
+        return None
+    gate_ok = buf[0] in (ord('C'), ord('W'), 0)      # SAMPLE.CPP:103 (current acceptance gate)
+    pos, ext_rate = 26, 0
+    while pos + 4 <= len(buf):
+        t = buf[pos]
+        bs = buf[pos + 1] | (buf[pos + 2] << 8) | (buf[pos + 3] << 16)
+        if t == 0x00:
+            break
+        if pos + 4 + bs > len(buf):
+            break
+        if t == 0x08 and bs >= 4:                    # extended: rate + channels
+            fd = buf[pos + 4] | (buf[pos + 5] << 8)
+            ch = buf[pos + 7] + 1
+            ch = ch if 1 <= ch <= 8 else 1
+            if fd != 65535 and ch > 0:
+                ext_rate = 256000000 // ((65536 - fd) * ch)
+        if t == 0x01 and bs >= 2:                    # sound data
+            fd, codec = buf[pos + 4], buf[pos + 5]
+            hz = ext_rate if ext_rate > 0 else (1000000 // (256 - fd) if fd != 255 else 0)
+            if hz <= 0 or hz > 192000:
+                hz = 11025
+            return {"rate": hz, "is8bit": codec == 0, "codec": codec,
+                    "pcm": bs - 2, "first_byte": buf[0], "gate_ok": gate_ok}
+        pos += 4 + bs
+    return None
+
+
+def scan(path, label):
+    ents, data = hqr_inspect.entries(path)
+    voc = nonvoc = empty = gate_rejected = 0
+    rates, codecs, firsts = {}, {}, {}
+    bad, gated = [], []
+    for i, off, size, csize, method in ents:
+        if size is None:
+            empty += 1
+            continue
+        blob = hqr_inspect.decompress_entry(data, off, size, csize, method)
+        r = parse_voc(blob)
+        if r is None:
+            nonvoc += 1
+            if len(bad) < 5:
+                bad.append((i, blob[:4].hex(" ")))
+            continue
+        voc += 1
+        rates[r["rate"]] = rates.get(r["rate"], 0) + 1
+        codecs[r["codec"]] = codecs.get(r["codec"], 0) + 1
+        firsts[r["first_byte"]] = firsts.get(r["first_byte"], 0) + 1
+        if not r["gate_ok"]:
+            gate_rejected += 1
+            if len(gated) < 6:
+                gated.append(i)
+    present = voc + nonvoc
+    print(f"{label}: {present} present entries, {voc} are VOC (offset-1 magic), {nonvoc} not, {empty} empty")
+    print(f"    first-byte variants: { {chr(k) if k else f'0x{k:02x}': v for k, v in firsts.items()} }")
+    print(f"    codecs: {codecs}  (0 = 8-bit PCM)   rates: {dict(sorted(rates.items()))}")
+    if gate_rejected:
+        print(f"    !! {gate_rejected} VOC entries rejected by lba2cc's current first-byte gate "
+              f"(buffer[0] not in {{C,W,0x00}}): entries {gated} -> need a 1-line widening")
+    if bad:
+        print(f"    non-VOC entries: {bad}")
+    return present, voc, codecs, gate_rejected
+
+
+def line(t, ok, extra=""):
+    return f"  [{'PASS' if ok else 'FAIL'}] {t}" + (f"  ({extra})" if extra else "")
+
+
+def main():
+    hacking = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--samples", default=os.path.join(hacking, "LBA", "SAMPLES.HQR"))
+    ap.add_argument("--vox", default=os.path.join(hacking, "LBA", "VOX", "EN_000.VOX"))
+    a = ap.parse_args()
+    all_ok = True
+    total_gated = 0
+
+    print("=" * 72)
+    print("Spike 4: LBA1 VOC audio through lba2cc's existing ParseVocIfPresent (SAMPLE.CPP)")
+    print("-" * 72)
+    for path, label in ((a.samples, "SAMPLES.HQR (SFX)"), (a.vox, "VOX EN_000 (voices)")):
+        if not os.path.exists(path):
+            print(f"{label}: MISSING {path}"); continue
+        present, voc, codecs, gated = scan(path, label)
+        ok = present > 0 and voc == present and set(codecs) <= {0}      # all VOC, all 8-bit
+        print(line(f"{label}: all entries are VOC + 8-bit PCM", ok))
+        all_ok &= ok
+        total_gated += gated
+
+    print("=" * 72)
+    print(f"SPIKE 4 {'PASS' if all_ok else 'FAIL'}: LBA1 SAMPLES + VOX are Creative Voice (.voc), "
+          "8-bit PCM, the exact format lba2cc's PlaySample already decodes (VOC support was added "
+          "for LBA2's own VOX voices). SFX are fully drop-in via the existing AIL path.")
+    if total_gated:
+        print(f"FINDING: {total_gated} LBA1 voice entries use a 0x01-prefixed VOC variant that "
+              "lba2cc's current first-byte gate (SAMPLE.CPP:103, {C,W,0x00}) rejects. Fix is one "
+              "line: accept any first byte (the offset-1 magic is the real signature) or add 0x01. "
+              "Then voices are drop-in too, via the GameProfile's sample loader.")
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds `docs/LBA1_PORT_PLAN.md`, a go/no-go plan to host LBA1 content on the existing lba2cc engine, plus the `scripts/dev/lba1_*.py` spike tools that validated the format mappings against retail data.

- Recommends hosting LBA1 on the existing engine (in-repo, game-id-gated via a `GameProfile`; assets read native and adapted in-engine, no asset conversion).
- Four feasibility spikes pass on retail data: body (decode/skeleton/transcode), script (opcode-remap + byte to S16 flag-width), background re-index, VOC audio.
- Media stack (MIDI/FLA/CD via AIL) planned using existing GPLv2 projects.
- Corrects the `LBA1_PORTING_SURFACE.md` section 8 opcode-alignment claim per the spike-2 finding.

Docs + additive `scripts/dev/` tooling only; no engine, build, or game behaviour changes. Awaiting go/no-go on the section 7 decisions.