### PR TITLE
fix(mem): size HQR caches in bytes so they scale past the original minimums

### DIFF
--- a/LIB386/SYSTEM/AVAILMEM.CPP
+++ b/LIB386/SYSTEM/AVAILMEM.CPP
@@ -9,8 +9,11 @@ extern "C" {
 
 // --- Interface ---------------------------------------------------------------
 U64 AvailableMem() {
-    // Not the same as available, but good enough for now...
-    return SDL_GetSystemRAM();
+    // SDL_GetSystemRAM() reports installed RAM in MiB; the engine's memory
+    // budgeting (AdjustHQRMem) works in bytes, so convert. Returning MiB here
+    // silently collapsed every HQR cache to its minimum, because the
+    // byte-fraction formulas saw a tiny number (e.g. 32768 for 32 GB).
+    return (U64)SDL_GetSystemRAM() * 1024 * 1024;
 }
 
 // =============================================================================

--- a/SOURCES/3DEXT/LOADISLE.CPP
+++ b/SOURCES/3DEXT/LOADISLE.CPP
@@ -82,7 +82,10 @@ S32 InitExternalView() {
         TheEnd(NOT_ENOUGH_MEM, "PtrZvBuffer (3DExt)");
 #endif
 
-    HQR_Isle_Obj = HQR_Init_Ressource("", IsleObjMem, 200);
+    /* 1024 (was 200) LRU slots, headroom so an object-dense island's distinct
+       decor bodies stay resident rather than evicting; pairs with the larger
+       MAX_ISLE_OBJ_MEM. The block table is ~20 bytes/slot, so this is a few KB. */
+    HQR_Isle_Obj = HQR_Init_Ressource("", IsleObjMem, 1024);
     if (!HQR_Isle_Obj)
         TheEnd(NOT_ENOUGH_MEM, "HQR_Isle_Obj (3DExt)");
 

--- a/SOURCES/DEFINES.H
+++ b/SOURCES/DEFINES.H
@@ -120,7 +120,10 @@
 //#define	MAX_ISLE_MEM	1500000L	// 1000000L
 
 #define MIN_ISLE_OBJ_MEM 200000L // a determiner dynamiquement par mounfrac
-#define MAX_ISLE_OBJ_MEM 800000L
+// HQR_Isle_Obj decor-body cache ceiling, raised above the original 800 KB for
+// headroom on modern RAM (heap-backed). Only takes effect with the
+// AvailableMem() byte fix, which lets these budgets reach their ceilings.
+#define MAX_ISLE_OBJ_MEM 16000000L
 
 #define MIN_CUBE_INFOS_MEM 100L
 #define MAX_CUBE_INFOS_MEM 1000L

--- a/SOURCES/MEM.CPP
+++ b/SOURCES/MEM.CPP
@@ -92,7 +92,15 @@ void AdjustHQRMem(void) {
     struct SizeInfo sizeinfo;
     char tmpFilePath[ADELINE_MAX_PATH];
 
-    memory = AvailableMem();
+    /* Each budget below is a byte fraction of RAM, then clamped to a MAX_*_MEM
+       ceiling. AvailableMem() is bytes; cap the base at 1 GB so memory/16 etc.
+       stay inside these U32 fields on large-RAM machines. The fractions still
+       exceed every ceiling there, so this cap never shrinks a cache: any machine
+       with more than ~1 GB lands on the MAX_*_MEM values regardless. */
+    {
+        U64 totalMem = AvailableMem();
+        memory = (totalMem > 0x40000000ULL) ? 0x40000000U : (U32)totalMem;
+    }
 
     SpriteMem = (memory / 32);
     Anim3DSMem = (memory / 16);


### PR DESCRIPTION
## Problem

`AvailableMem()` returns `SDL_GetSystemRAM()`, which is **MiB** (e.g. `32768` for 32 GB), but `AdjustHQRMem()` treats it as **bytes** — each HQR cache budget is a byte fraction of it (`memory / 16`, …). With a MiB-sized base those fractions are a few KB, so every cache clamps to its **minimum**, regardless of installed RAM.

At its minimum the island-object cache (`HQR_Isle_Obj`) holds only about one decor body, so in an object-dense exterior island `AffichageObjetDecorsZBuf` reloads a body per visible object (open/read/close of the island `.obl`). Profiling one such island showed almost all CPU in the `open()` syscall.

(Found while play-testing the GOG disc-image work, which is what let that content be reached; the bug is pre-existing and independent of it. The cache size is a fraction of total RAM fixed at boot, so it is not affected by other allocations.)

## Fix

- `AvailableMem()` returns bytes.
- `AdjustHQRMem()` caps the base at 1 GB so `memory / 16` etc. stay within the `U32` budget fields on large-RAM machines (the fractions then exceed every `MAX_*_MEM` ceiling, so caches sit at their maxima).
- Raise the island-object ceiling and slot count for headroom: `MAX_ISLE_OBJ_MEM` 800 KB → 16 MB, LRU slots 200 → 1024. Caches are plain heap (`NormMalloc` == `malloc`), so this is not pool-bound.

## Result

Verified with a temporary debug print of the computed budgets (in `AdjustHQRMem`, removed before commit): the island-object cache sizes to its 16 MB ceiling (`MAX_ISLE_OBJ_MEM`) and the other HQR caches to theirs. The profiled island runs smoothly; host tests pass.