### PR TITLE
feat(reso): auto-detect a widescreen resolution on first launch

### DIFF
--- a/LIB386/H/SYSTEM/WINDOW.H
+++ b/LIB386/H/SYSTEM/WINDOW.H
@@ -34,6 +34,15 @@ bool ResizeWindowSurface(U32 newW, U32 newH);
  *  returns true on success. Returns false if SDL hasn't initialised a
  *  window yet; *outW and *outH are untouched in that case. */
 bool Window_GetDisplayDimensions(U32 *outW, U32 *outH);
+
+/** Query the primary display's logical dimensions WITHOUT a window, for the
+ *  boot path that needs the display size before CreateWindowSurface runs
+ *  (SDL_GetPrimaryDisplay + SDL_GetCurrentDisplayMode). Requires
+ *  SDL_INIT_VIDEO to be up. Returns false (outputs untouched) when video
+ *  isn't initialised, no display is reported, or the driver is the headless
+ *  dummy/offscreen one, so resolution auto-detection never fires under the
+ *  test harness. */
+bool Window_GetPrimaryDisplayDimensions(U32 *outW, U32 *outH);
 void PresentRendererFrame(const void *pixels, U32 pitch);
 bool LockRendererTexture(void **pixels, int *pitch);
 void UnlockAndPresentRendererTexture();

--- a/LIB386/SYSTEM/WINDOW.CPP
+++ b/LIB386/SYSTEM/WINDOW.CPP
@@ -237,6 +237,37 @@ bool Window_GetDisplayDimensions(U32 *outW, U32 *outH) {
     return true;
 }
 
+bool Window_GetPrimaryDisplayDimensions(U32 *outW, U32 *outH) {
+    if (outW == NULL || outH == NULL) {
+        return false;
+    }
+    /* Boot-path query: no window exists yet, so go straight to the primary
+       display. Requires the video subsystem to be up (the caller brings it
+       up before sizing the framebuffer). */
+    if (!SDL_WasInit(SDL_INIT_VIDEO)) {
+        return false;
+    }
+    /* Never auto-detect under the headless drivers. The test harness runs
+       with SDL_VIDEODRIVER=dummy and pins --resolution, but guard anyway so a
+       stray dummy boot can't pick up the driver's synthetic display mode. */
+    const char *driver = SDL_GetCurrentVideoDriver();
+    if (driver == NULL || SDL_strcmp(driver, "dummy") == 0 ||
+        SDL_strcmp(driver, "offscreen") == 0) {
+        return false;
+    }
+    SDL_DisplayID display = SDL_GetPrimaryDisplay();
+    if (display == 0) {
+        return false;
+    }
+    const SDL_DisplayMode *mode = SDL_GetCurrentDisplayMode(display);
+    if (mode == NULL || mode->w <= 0 || mode->h <= 0) {
+        return false;
+    }
+    *outW = (U32)mode->w;
+    *outH = (U32)mode->h;
+    return true;
+}
+
 bool ResizeWindowSurface(U32 newW, U32 newH) {
     /* No-op if the surface was never created.  Caller should fall through to
        CreateWindowSurface in that case (boot path), not Resize. */

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2077,10 +2077,14 @@ void WriteConfigFile(void) {
     DefFileBufferWriteValue("VSync", DisplayVSync);
     DefFileBufferWriteValue("ConsoleToggleKey", Console_GetToggleScancode());
     /* Render resolution. Read at boot by Res_LoadBootDimensions (CLI > cfg >
-       compile-time default precedence) and updated here by the revert
-       dialog's Keep handler so a confirmed switch survives across launches. */
-    DefFileBufferWriteValue("ResolutionX", (S32)ModeDesiredX);
-    DefFileBufferWriteValue("ResolutionY", (S32)ModeDesiredY);
+       auto-detect > compile-time default). Persist it only when the player
+       chose it explicitly (CLI/cfg at boot, or a runtime Res_Switch); an
+       auto-detected or defaulted resolution is left out so it re-derives from
+       the display each launch instead of freezing into the cfg on first exit. */
+    if (!Res_ResolutionIsAutoDerived()) {
+        DefFileBufferWriteValue("ResolutionX", (S32)ModeDesiredX);
+        DefFileBufferWriteValue("ResolutionY", (S32)ModeDesiredY);
+    }
 
     if (FlagDisplayText)
         DefFileBufferWriteString("FlagDisplayText", "ON");

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2504,6 +2504,15 @@ int main(int argc, char *argv[]) {
        --resolution CLI > lba2.cfg ResolutionX/Y > compile-time default. The cfg
        read uses a transient stack/BSS buffer (no heap, no MainBuffer dependency),
        so we get the right MainBuffer size in a single allocation cycle. */
+    /* Bring up the video subsystem now (idempotent, since InitProgram's later
+       SDL_INIT_VIDEO init is guarded by SDL_WasInit) so Res_LoadBootDimensions
+       can query the primary display for widescreen auto-detect BEFORE we size
+       the framebuffer here. Without this the early resolve would have no display
+       (windowed/640) while InitAdeline's later resolve (video up) would pick the
+       wide size, and the two MUST agree or MainBuffer and Log/Screen mismatch. */
+    if (!SDL_WasInit(SDL_INIT_VIDEO))
+        SDL_InitSubSystem(SDL_INIT_VIDEO);
+
     U32 reqResX, reqResY;
     Res_LoadBootDimensions(&reqResX, &reqResY);
     Mem_ConfigureScreenBuffers(reqResX, reqResY);
@@ -2539,13 +2548,15 @@ int main(int argc, char *argv[]) {
     InitProgram();
     InitMemory(); // Alloue petits buffers
 
-    /* "Display" status: WxH render resolution + the real SDL window mode
-       (Window_IsFullscreen, the actual flags — not the cached request flag).
-       Logged here in main with the rest of the post-init summary. */
+    /* "Display" status: WxH render resolution, where it came from (CLI / cfg /
+       auto-detect / default), and the real SDL window mode. The mode comes from
+       Window_IsFullscreen (the actual SDL flag state, not the cached request
+       flag). Logged here in main with the rest of the post-init summary. */
     {
         U32 dispW = 0, dispH = 0;
         Res_LoadBootDimensions(&dispW, &dispH);
-        Log_Info("Display    %ux%u %s", dispW, dispH,
+        Log_Info("Display    %ux%u (%s) %s", dispW, dispH,
+                 Res_BootDimensionsSource(),
                  Window_IsFullscreen() ? "fullscreen" : "windowed");
     }
 

--- a/SOURCES/RES_MENU.CPP
+++ b/SOURCES/RES_MENU.CPP
@@ -11,28 +11,12 @@
 
 #include "RES_MENU.H"
 
+#include "RES_SWITCH.H"    /* Res_SnapWidescreenWidth (shared with the boot path) */
 #include <SVGA/SCREEN.H>   /* ModeDesiredX / ModeDesiredY */
 #include <SYSTEM/WINDOW.H> /* Window_GetDisplayDimensions */
 
 #include <stdio.h>
 #include <string.h>
-
-/* Snap a display W down to the nearest %8 multiple inside engine
-   bounds. Matches res_snap_native_w in CONSOLE_CMD.CPP — duplicated
-   here on purpose for the v1 to keep this module standalone. Lift
-   to a shared RES_CATALOG.{H,CPP} when both console and menu need
-   to share more. */
-static U32 snap_widescreen_width(U32 dispW, U32 dispH) {
-    if (dispW == 0 || dispH == 0)
-        return 0;
-    /* W = round_down((480 * dispW / dispH) / 8) * 8 — preserves the
-       display's aspect at our render height of 480. */
-    U32 w = (U32)(((U64)480 * (U64)dispW) / (U64)dispH);
-    w &= ~(U32)7;
-    if (w < 320 || w > 1920)
-        return 0;
-    return w;
-}
 
 /* GCD-reduce w,h to its (a:b) form. Same as res_aspect in CONSOLE_CMD.CPP. */
 static void aspect_ratio(U32 w, U32 h, U32 *outA, U32 *outB) {
@@ -61,7 +45,7 @@ S32 Display_BuildEntries(DisplayEntry *out) {
     if (!Window_GetDisplayDimensions(&dispW, &dispH))
         return n;
 
-    U32 wsW = snap_widescreen_width(dispW, dispH);
+    U32 wsW = Res_SnapWidescreenWidth(dispW, dispH);
     if (wsW == 0 || wsW <= 640)
         return n;
 

--- a/SOURCES/RES_SWITCH.CPP
+++ b/SOURCES/RES_SWITCH.CPP
@@ -229,14 +229,48 @@ bool Res_Switch(U32 newW, U32 newH) {
 }
 
 /*══════════════════════════════════════════════════════════════════════════*
- *   Boot-time resolution resolution (CLI > cfg > default)                   *
+ *   Boot-time resolution resolution (CLI > cfg > auto-detect > default)     *
  *══════════════════════════════════════════════════════════════════════════*/
+
+U32 Res_SnapWidescreenWidth(U32 dispW, U32 dispH) {
+    if (dispW == 0 || dispH == 0)
+        return 0;
+    /* W = round_down((480 * dispW / dispH) / 8) * 8, preserving the display
+       aspect at the engine's 480 render height. 64-bit intermediate so wide
+       displays don't overflow the multiply. */
+    U32 w = (U32)(((U64)480 * (U64)dispW) / (U64)dispH);
+    w &= ~(U32)7;
+    if (w < (U32)RES_SWITCH_MIN_X || w > (U32)RES_SWITCH_MAX_X)
+        return 0;
+    return w;
+}
+
+bool Res_AutoDetectDimensions(U32 *outW, U32 *outH) {
+    U32 dispW = 0, dispH = 0;
+    if (!Window_GetPrimaryDisplayDimensions(&dispW, &dispH))
+        return false;
+    const U32 w = Res_SnapWidescreenWidth(dispW, dispH);
+    /* Only override the Classic default when the display is genuinely wider
+       than 4:3; a 4:3 (or narrower) monitor keeps 640×480. No 16:9 cap: an
+       ultra-wide display gets its true aspect up to the engine's max width,
+       matching the Widescreen entry the Display options submenu offers. */
+    if (w <= 640)
+        return false;
+    *outW = w;
+    *outH = 480;
+    return true;
+}
+
+/* Provenance of the last Res_LoadBootDimensions result, for the boot log. */
+static const char *g_bootDimSource = "default";
+const char *Res_BootDimensionsSource(void) { return g_bootDimSource; }
 
 void Res_LoadBootDimensions(U32 *outW, U32 *outH) {
     /* --resolution CLI overrides everything (one-shot launch). */
     if (Control_HasResolution()) {
         *outW = (U32)Control_GetResolutionX();
         *outH = (U32)Control_GetResolutionY();
+        g_bootDimSource = "CLI";
         return;
     }
 
@@ -259,6 +293,7 @@ void Res_LoadBootDimensions(U32 *outW, U32 *outH) {
             } else if (w > 0 && h > 0 && Res_ValidateDimensions((U32)w, (U32)h)) {
                 *outW = (U32)w;
                 *outH = (U32)h;
+                g_bootDimSource = "cfg";
                 return;
             } else {
                 LogPrintf(
@@ -272,9 +307,22 @@ void Res_LoadBootDimensions(U32 *outW, U32 *outH) {
         }
     }
 
+    /* No CLI override and no saved resolution: auto-detect a widescreen render
+       size from the display. Derive-each-launch (never persisted), so it
+       adapts if the player changes monitors, and any explicit choice (Display
+       submenu / console verb / --resolution) takes over by writing the cfg
+       keys above. Falls through to the compile-time default on a 4:3 display,
+       a failed display query, or the headless/dummy driver. See
+       docs/WIDESCREEN.md Phase 4. */
+    if (Res_AutoDetectDimensions(outW, outH)) {
+        g_bootDimSource = "auto";
+        return;
+    }
+
     /* Compile-time fallback. */
     *outW = RESOLUTION_X;
     *outH = RESOLUTION_Y;
+    g_bootDimSource = "default";
 }
 
 /*══════════════════════════════════════════════════════════════════════════*/

--- a/SOURCES/RES_SWITCH.CPP
+++ b/SOURCES/RES_SWITCH.CPP
@@ -44,6 +44,16 @@
 #define RES_SWITCH_MAX_X 1920
 #define RES_SWITCH_MAX_Y 1024
 
+/* True when the live resolution came from auto-detect or the compile-time
+   default, i.e. the player never explicitly chose it. WriteConfigFile skips
+   persisting ResolutionX/Y in that case, so an auto resolution re-derives from
+   the display every launch instead of freezing into the cfg on first exit.
+   Cleared the moment the player picks a resolution explicitly: a successful
+   Res_Switch (menu / console verb), or a CLI / cfg value at boot. Defined here
+   so Res_Switch (below) and the boot resolver (further down) both see it. */
+static bool g_resIsAutoDerived = false;
+bool Res_ResolutionIsAutoDerived(void) { return g_resIsAutoDerived; }
+
 bool Res_ValidateDimensions(U32 w, U32 h) {
     if (w < RES_SWITCH_MIN_X || w > RES_SWITCH_MAX_X)
         return false;
@@ -117,6 +127,8 @@ bool Res_Switch(U32 newW, U32 newH) {
        everything down just to put it back wastes time and would still drop
        a frame.  The caller (console verb / menu) can rely on this. */
     if (ModeDesiredX == newW && ModeDesiredY == newH) {
+        /* Confirming the current mode is still an explicit choice. */
+        g_resIsAutoDerived = false;
         return true;
     }
 
@@ -225,6 +237,9 @@ bool Res_Switch(U32 newW, U32 newH) {
                 "preserve it\n",
                 (int)wasFullscreen, (int)isFullscreen);
     }
+    /* The switch landed: this is now an explicit player resolution, so let
+       WriteConfigFile persist it across launches. */
+    g_resIsAutoDerived = false;
     return true;
 }
 
@@ -271,6 +286,7 @@ void Res_LoadBootDimensions(U32 *outW, U32 *outH) {
         *outW = (U32)Control_GetResolutionX();
         *outH = (U32)Control_GetResolutionY();
         g_bootDimSource = "CLI";
+        g_resIsAutoDerived = false;
         return;
     }
 
@@ -294,6 +310,7 @@ void Res_LoadBootDimensions(U32 *outW, U32 *outH) {
                 *outW = (U32)w;
                 *outH = (U32)h;
                 g_bootDimSource = "cfg";
+                g_resIsAutoDerived = false;
                 return;
             } else {
                 LogPrintf(
@@ -316,6 +333,7 @@ void Res_LoadBootDimensions(U32 *outW, U32 *outH) {
        docs/WIDESCREEN.md Phase 4. */
     if (Res_AutoDetectDimensions(outW, outH)) {
         g_bootDimSource = "auto";
+        g_resIsAutoDerived = true;
         return;
     }
 
@@ -323,6 +341,7 @@ void Res_LoadBootDimensions(U32 *outW, U32 *outH) {
     *outW = RESOLUTION_X;
     *outH = RESOLUTION_Y;
     g_bootDimSource = "default";
+    g_resIsAutoDerived = true;
 }
 
 /*══════════════════════════════════════════════════════════════════════════*/

--- a/SOURCES/RES_SWITCH.H
+++ b/SOURCES/RES_SWITCH.H
@@ -74,6 +74,26 @@ bool Res_ValidateDimensions(U32 w, U32 h);
    the cfg held an invalid value so the player can spot a corrupted key. */
 void Res_LoadBootDimensions(U32 *outW, U32 *outH);
 
+/* Snap a display's (W, H) to a widescreen render width that preserves the
+   display aspect at the engine's 480 render height, rounded down to the %8
+   width constraint and clamped to the supported range. Returns 0 if the
+   inputs are zero or the result falls outside the range. Shared by the boot
+   auto-detect path and the Display options submenu so both derive the same
+   widescreen entry. */
+U32 Res_SnapWidescreenWidth(U32 dispW, U32 dispH);
+
+/* Auto-detect a widescreen boot resolution from the primary display: writes
+   (snapped-width, 480) and returns true when the display is wider than 4:3.
+   Returns false (outputs untouched) on a 4:3 display or a failed/headless
+   display query, so the caller falls back to the 640×480 default. Used only
+   when neither --resolution nor a saved lba2.cfg resolution is present, so the
+   auto value is never persisted (derive-each-launch). */
+bool Res_AutoDetectDimensions(U32 *outW, U32 *outH);
+
+/* One-word provenance of the last Res_LoadBootDimensions result, for the boot
+   log: "CLI", "cfg", "auto", or "default". Static literal; never NULL. */
+const char *Res_BootDimensionsSource(void);
+
 /* Read the boot fullscreen choice (lba2.cfg DisplayFullScreen) the same
    transient, heap-free way as Res_LoadBootDimensions, so the window can be
    created fullscreen from the start instead of created windowed then flipped

--- a/SOURCES/RES_SWITCH.H
+++ b/SOURCES/RES_SWITCH.H
@@ -94,6 +94,13 @@ bool Res_AutoDetectDimensions(U32 *outW, U32 *outH);
    log: "CLI", "cfg", "auto", or "default". Static literal; never NULL. */
 const char *Res_BootDimensionsSource(void);
 
+/* True when the live resolution was auto-detected (or fell back to the
+   compile-time default) rather than chosen by the player. WriteConfigFile uses
+   this to skip persisting ResolutionX/Y, so an auto resolution re-derives from
+   the display each launch instead of freezing into the cfg. Cleared by a
+   successful Res_Switch and by a CLI/cfg value at boot. */
+bool Res_ResolutionIsAutoDerived(void);
+
 /* Read the boot fullscreen choice (lba2.cfg DisplayFullScreen) the same
    transient, heap-free way as Res_LoadBootDimensions, so the window can be
    created fullscreen from the start instead of created windowed then flipped

--- a/docs/WIDESCREEN.md
+++ b/docs/WIDESCREEN.md
@@ -28,11 +28,14 @@ The projection audit ([WIDESCREEN_PROJECTION_AUDIT.md](WIDESCREEN_PROJECTION_AUD
 
 ## Target behaviour
 
-The product goal the phases build toward:
+What the engine does today:
 
-- Windowed mode keeps the original 4:3 behaviour. Nothing changes for windowed players.
-- Fullscreen detects the display's aspect ratio automatically and renders to match. There is no player-facing aspect or resolution setting.
-- 16:9 is the target. A display wider than 16:9 renders at 16:9 and pillarboxes the rest; the engine does not render arbitrarily wide.
+- **First launch auto-detects.** With no `--resolution` flag and no saved `lba2.cfg` resolution, the engine reads the primary display's aspect and boots a widescreen render size at the original 480 height (for example 848×480 on a 16:9 monitor), fullscreen by default (the shipped cfg template carries `DisplayFullScreen: 1`). A 4:3 display keeps 640×480.
+- **The player stays in control.** The auto choice is re-derived each launch, never persisted, so it follows a monitor swap. Any explicit choice overrides it and sticks: the Display options submenu, the `resolution` console verb, or `--resolution` all write `lba2.cfg`. Reverting to Classic 640×480 is one toggle in the Display menu.
+- **Precedence: `--resolution` CLI > `lba2.cfg` ResolutionX/Y > auto-detect > 640×480.** A headless/dummy driver or a failed display query falls back to 640×480, which is why the test harness (always pinned to `--resolution 640x480`) is unaffected.
+- **No forced 16:9 cap.** A display wider than 16:9 renders at its true aspect up to the engine's maximum width (1920); height stays at 480. The render-space work supports arbitrary width, and SDL letterboxes/pillarboxes the framebuffer to the physical display.
+
+> Historical note: the original goal (sketched in issue #45 and the first draft of this doc) was a no-setting auto-detector tied to fullscreen, capped at 16:9. The shipped design keeps the auto-detection but makes it the *default*, not the only option, and renders true display aspect rather than a 16:9 cap. See [Phase 4](#phase-4-fullscreen-and-runtime-resolution).
 
 ## Phases
 
@@ -76,20 +79,26 @@ Verified at 768×480 via [How to test a wider build](#how-to-test-a-wider-build)
 
 The wide build still requires a compile-time `RESOLUTION_X` override; runtime selection lands in Phase 4.
 
-### Phase 4 — SDL fullscreen detection
+### Phase 4: fullscreen and runtime resolution
 
-Wire the [target behaviour](#target-behaviour) into the present and window layer (`LIB386/SYSTEM/WINDOW.CPP`, `LIB386/SVGA/SDL.CPP`). Windowed stays 4:3; fullscreen reads the display aspect ratio and sets the render width to match, capped at 16:9 with pillarboxing beyond. No player-facing setting.
+**Done.** Two strands combine into the [target behaviour](#target-behaviour): explicit player choice (the runtime-resolution work) plus first-launch auto-detection layered on top of it. The engine boots widescreen by default and the player can override or revert at any time.
+
+Boot resolution resolves in `Res_LoadBootDimensions` (`SOURCES/RES_SWITCH.CPP`) with precedence **`--resolution` CLI > `lba2.cfg` ResolutionX/Y > auto-detect > 640×480**:
+
+- **Auto-detect** (`Res_AutoDetectDimensions`) queries the primary display windowlessly (`Window_GetPrimaryDisplayDimensions`, `SDL_GetPrimaryDisplay` + `SDL_GetCurrentDisplayMode`) and snaps to a widescreen width that preserves the display aspect at 480 height (`Res_SnapWidescreenWidth`, shared with the Display submenu's catalog). It runs only when CLI and cfg are both silent, returns false on a 4:3 display or a dummy/offscreen driver, and is never persisted. The video subsystem is brought up early in `PERSO.CPP` (idempotent) so the display is queryable before the framebuffer is sized. The two boot resolves (MainBuffer in `PERSO.CPP`, Log/Screen in `INITADEL.C`) must agree, which is why the early resolve also has to see the display.
+- **Fullscreen** is an independent `DisplayFullScreen` cfg flag (`Res_LoadBootFullscreen`) plus an in-game toggle; the shipped cfg template defaults it on, so a fresh install boots fullscreen. `CreateWindowSurface` brings the window up fullscreen directly, and `WINDOW.CPP` aspect-correctly letterboxes/pillarboxes the chosen framebuffer to the physical display.
+- The boot log's `Display` line reports the chosen `WxH`, its source (`CLI` / `cfg` / `auto` / `default`), and the window mode.
 
 #### Runtime resolution switching
 
-A separate strand of work running parallel to (and reusing) the Phase 4 plumbing: let the player change render resolution from a console verb or a Display options submenu, without relaunching. **Phase 0 shipped** (PRs #237–#241, #244) — `resolution` console verb, keep/revert dialog, `lba2.cfg` persistence. The Display submenu (Phase 2) is the remaining surface for menu-driven discovery. See [`RUNTIME_RESOLUTION.md`](RUNTIME_RESOLUTION.md) for the design, phasing, and risks.
+Lets the player change render resolution from a console verb or a Display options submenu without relaunching. **Shipped.** The `resolution` console verb, keep/revert dialog, and `lba2.cfg` persistence landed in PRs #237–#241, #244; the Display options submenu (a "Resolution: <current>" cycle row over the curated Classic + display-aspect Widescreen catalog, plus a "Fullscreen" toggle, `SOURCES/GAMEMENU.CPP` `GereDisplayMenu` / `CycleResolution`) landed after. The auto-detect default reuses the same catalog math, so the booted resolution is the same Widescreen entry the menu offers. See [`RUNTIME_RESOLUTION.md`](RUNTIME_RESOLUTION.md) for the design, phasing, and risks.
 
-### Phase 5 — polish
+### Phase 5: UI (C2) and HD groundwork
 
-The deferred, larger surface:
+This phase had two strands. The UI strand is done; the HD strand moved to its own phase.
 
-- UI strategy — pick C1 or C2 (see [UI strategy](#ui-strategy-c1-vs-c2) below) and apply it so the 2D UI is correct in the wider frame.
-- HD-only concerns, if native high resolution is later pursued: filler precision (the `LIB386/pol_work/` fillers use 16-bit fixed-point step accumulation calibrated to 640-wide spans — the polyrec harness is the tool for measuring drift), bitmap fonts (`LIB386/SVGA/FONT.CPP` / `AFFSTR.CPP` blit 1:1), the 16-bit Z-buffer and `Fill_ZBuffer_Factor` (tuned for the 4:3 frustum), mouse-coordinate inversion against any UI scale, and a Smacker cutscene upscale policy.
+- UI strategy: **C2 chosen and shipped.** The re-anchor campaign (PRs #213–#228, plus #260, #289, #291, #310) routed every menu, inventory, holomap, dialogue, and save surface through `ModeDesiredX/Y`, so the 2D UI is correct in a wider frame. See [UI strategy](#ui-strategy-c1-vs-c2) for why C2 over C1.
+- HD-only concerns (filler precision, bitmap fonts, the 16-bit Z-buffer and `Fill_ZBuffer_Factor`, mouse-coordinate inversion, Smacker upscale): **moved to [Phase 7](#phase-7-native-hd).** Widescreen shipped without resolving them, so they are tracked separately as the native-HD frontier. The analysis below is the record of what the X-axis campaign settled for HD.
 
 #### HD prerequisites — what the X-axis campaign settled
 
@@ -183,7 +192,7 @@ windows) — it bounds how much vertical reveal we ever have to handle. Cheap to
 evaluate empirically: A/B Desert Island at 1920×1024 across a few `VueDistance`
 values with the polyrec capture/replay harness.
 
-#### Testing posture, honestly
+#### Testing posture
 
 What the campaign protected against, and what it didn't:
 
@@ -226,6 +235,16 @@ person on the branch should re-eyeball them before merging.
 ### Phase 6 — regression
 
 Run the polyrec suite and the host tests. Confirm the default 640×480 build is byte-identical to before, and check the wide build across representative scenes — exterior terrain, brick interiors, cinema bars, the HUD — for centring and clipping. Lock the result in.
+
+### Phase 7: native HD
+
+Widescreen shipped without true high resolution: the framebuffer grows horizontally, the UI is C2-correct, and fullscreen letterboxes the chosen resolution. Native HD, meaning crisp and legible rendering at 1080p-class resolutions rather than just wider, is the remaining frontier. It is its own phase because none of it blocks widescreen and each item ships independently. The detailed engineering notes are in [HD prerequisites and Still HD-only work](#hd-prerequisites--what-the-x-axis-campaign-settled) under Phase 5; this is the actionable, priority-ordered view.
+
+1. **Bitmap fonts (open, highest player impact).** `LIB386/SVGA/FONT.CPP` and `AFFSTR.CPP` blit glyphs 1:1, so HUD, dialogue, and menu text is tiny at 1080p. Pixel-scale the 8×N glyphs by an integer factor derived from `ModeDesiredY`, scaling advance widths and line spacing with them. Nothing is in flight, so it is a clean slate.
+2. **Iso interior sharpness (experimental).** The isometric brick layer is a 640-class blit; at HD it wants scaling or edge-upscaling (xBR / EPX) so interiors stay crisp. Five unmerged branches explore this: `feat/iso-xbr-optimized` (furthest along), `feat/iso-xbr-bricks`, `feat/iso-brick-scale`, `feat/iso-scale`, and `feat/iso-zoom-screenspace`. Findings live on-branch in `ISO_SCALE_FINDINGS.md`; the on-main groundwork is [`ISO_SPACE_AUDIT.md`](ISO_SPACE_AUDIT.md). Needs triage down to one mergeable approach.
+3. **Holomap at Y > 480 (blocked).** The A4/A5 Z-buffer-bounds fix is correct and 640-identical but cannot be verified at tall resolution: `ui holoplan` at 1024×768 times out on a cinema-mode rendering bug. Resolve that, then add `test_ui_holoplan_768x768.sh`.
+4. **Vertical framing (decision pending).** A taller frame reveals more vertical field of view, exposing the sky edge and map seams. The levers and the current leaning are in [Vertical framing at HD](#vertical-framing-at-hd--open-question). Cheap to A/B with the polyrec harness.
+5. **Watch-items.** The 16-bit Z-buffer plus `Fill_ZBuffer_Factor` may Z-fight on distant geometry at HD aspect; filler precision is de-risked (swept at 1920, 0.006% sub-pixel edge drift, no overflow). Smacker centred-letterbox and 1:1 mouse coords need no action.
 
 ## UI strategy: C1 vs C2
 
@@ -293,12 +312,13 @@ LBA2_BIN=build-wide/SOURCES/lba2cc \
 
 | Phase | State |
 |-------|-------|
-| 0 — research | Done ([WIDESCREEN_PROJECTION_AUDIT.md](WIDESCREEN_PROJECTION_AUDIT.md)) |
-| 1 — projection capture | Done (#193–#198; corpus + demo baselines, see [tests/projection/](../tests/projection/)) |
-| 2 — projection correction | Done (#199–#203; eight call sites routed through `ModeDesiredX/Y`) |
-| 3 — widen the framebuffer | Done (#204; wide build verified, `corpus_768x480.projrec.hash` baseline committed) |
-| 4 — SDL fullscreen detection | Not started |
-| 5 — polish (UI + HD) | Not started |
-| 6 — regression | Not started |
+| 0 – research | Done ([WIDESCREEN_PROJECTION_AUDIT.md](WIDESCREEN_PROJECTION_AUDIT.md)) |
+| 1 – projection capture | Done (#193–#198; corpus + demo baselines, see [tests/projection/](../tests/projection/)) |
+| 2 – projection correction | Done (#199–#203; eight call sites routed through `ModeDesiredX/Y`) |
+| 3 – widen the framebuffer | Done (#204; wide build verified, `corpus_768x480.projrec.hash` baseline committed) |
+| 4 – fullscreen + runtime resolution | Done. Explicit player choice (`--resolution` / `lba2.cfg` / Display submenu / `resolution` verb) plus first-launch widescreen auto-detect; precedence CLI > cfg > auto > 640×480. Fullscreen defaults on via the cfg template. See [Phase 4](#phase-4-fullscreen-and-runtime-resolution). |
+| 5 – UI (C2) | Done for the menu/UI surfaces (#213–#228 re-anchor campaign, plus #260, #289, #291, #310). HD-only concerns split out to Phase 7. |
+| 6 – regression | Ongoing per-PR (projrec corpus, `host_quick`, and `ui_*` capture tests gate the 640×480 contract). No final lock-in pass yet. |
+| 7 – native HD | Not started. Fonts blit 1:1, iso interior sharpness (experiment branches), holomap tall-res timeout, vertical-framing decision. See [Phase 7](#phase-7-native-hd). |
 
 Foundation already in place: PR #134 (`RESOLUTION_X` / `RESOLUTION_Y` constants, and most render-space literals routed through them).


### PR DESCRIPTION
## What

On first launch (no `--resolution` and no saved `lba2.cfg` resolution), the engine auto-detects the display aspect and boots a widescreen render size at the original 480 height (e.g. `848x480` on a 16:9 monitor) instead of a fixed 640x480. A 4:3 display keeps 640x480.

Boot precedence: `--resolution` CLI > `lba2.cfg` ResolutionX/Y > auto-detect > 640x480.

The auto value is never persisted (derive-each-launch), so it follows a monitor swap or a laptop dock/undock. Any explicit choice (Display submenu, `resolution` console verb, `--resolution`) writes the cfg and takes over; reverting to Classic 640x480 is one toggle in the Display menu. Fullscreen is unchanged: the shipped cfg template already defaults it on.

## How

- `Res_AutoDetectDimensions` queries the primary display windowlessly (`Window_GetPrimaryDisplayDimensions` via `SDL_GetPrimaryDisplay`) and snaps to a width that preserves the display aspect at 480 height (`Res_SnapWidescreenWidth`, now shared with the Display submenu's catalog instead of a duplicate). No 16:9 cap: ultra-wide renders true aspect up to the engine's 1920 max width, matching the menu's Widescreen entry.
- `SDL_INIT_VIDEO` is brought up early in `PERSO.CPP` (idempotent) so the display is queryable before the framebuffer is sized; the two boot resolves (MainBuffer, Log/Screen) stay in agreement.
- Auto-detect is guarded off under the dummy/offscreen drivers, and the test harness pins `--resolution 640x480`, so projrec/UI baselines are untouched.
- `WriteConfigFile` skips persisting an auto-detected or defaulted resolution (a `g_resIsAutoDerived` flag, cleared on any explicit pick), so detection runs every launch rather than freezing into cfg on first exit.
- The boot log's `Display` line now reports the source, e.g. `Display 848x480 (auto) fullscreen`.

Also reconciles `docs/WIDESCREEN.md`: the status table had drifted (phases 4/5 listed as "Not started" while the C2 UI campaign, runtime resolution, the Display submenu, and the Y-clamp work had merged). Updates the table and Phase 4/5 prose, marks Phase 6 as the ongoing per-PR contract, and adds Phase 7 for the remaining native-HD work (fonts, iso interior sharpness, holomap tall-res, vertical framing).

## Testing

- `make test`: 27/27 host tests green.
- Maintained res-switch tests pass: `test_res_switch_cfg`, `test_res_switch`, `test_res_switch_console`.
- Boot precedence confirmed under the dummy driver: `(CLI)`, `(cfg)`, `(default)`.
- The cfg write/persistence path is not part of the headless test surface (no maintained test verifies `WriteConfigFile`'s disk write; the res tests assert via log lines and `--dump-state`). The derive-each-launch persistence behaviour was checked in the real app.

Save format is unaffected: `MAX_PLAYER` stays keyed to literal 640x480 per the widescreen invariant, so saves still cross resolutions without migration.