### PR TITLE
fix(ci): pin SDL3 in the test image to release-3.2.16

### DIFF
--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -23,7 +23,13 @@ RUN dpkg --add-architecture i386 \
 # 64-bit: full build with all backends for CPP tests / game build
 # 32-bit: minimal build (no graphics/audio backends) just to satisfy the linker
 #         for ASM equivalence tests that pull in SDL3 transitively
-RUN git clone --depth 1 --branch main https://github.com/libsdl-org/SDL.git /tmp/SDL \
+#
+# Pin to a release tag, not main: the image rebuilds on every CI run, so an
+# unpinned clone rides the tip of SDL's dev branch and breaks the build the
+# moment upstream regresses (e.g. SDL_UDEV=OFF no longer dropping the -ludev
+# link dep on the 32-bit build). release-3.2.16 matches the pin already used by
+# the Android and linux-tarball builds; keep the four in sync when bumping.
+RUN git clone --depth 1 --branch release-3.2.16 https://github.com/libsdl-org/SDL.git /tmp/SDL \
     && cmake -S /tmp/SDL -B /tmp/SDL/build64 -G Ninja \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr/local \


### PR DESCRIPTION
## Problem

The ASM-equivalence Docker `test` job started failing on every PR (and would on `main`'s next run). The failure is in **building the test image**, before any test runs:

```
/usr/bin/ld: cannot find -ludev: No such file or directory
collect2: error: ld returned 1 exit status
FAILED: libSDL3.so.0.5.0
```

[`docker/Dockerfile.test`](docker/Dockerfile.test) clones SDL3 from **unpinned `--branch main`** and rebuilds the image every CI run, so it rides the tip of SDL's dev branch. A recent upstream change makes the **32-bit** shared lib link `-ludev` even though the Dockerfile passes `-DSDL_UDEV=OFF`; there's no i386 libudev in the image, so the link dies. Nothing in any open PR caused it.

## Fix

Pin to `release-3.2.16` — which is **already** the pin used by the Android build (`reusable-build-android.yml`), `build-sdl3-android.sh`, and `build-linux-tarball.sh`. The test image was the only place still tracking `main`, so this brings it in line rather than introducing a new policy. `release-3.2.16` predates the regression and links cleanly with `SDL_UDEV=OFF`.

## Follow-up (not in this PR)

The version string `release-3.2.16` is now duplicated across four files. A future cleanup could hoist it into a single source of truth (build ARG / shared env) so bumps are one edit. Left out here to keep the unblock minimal.