### PR TITLE
feat(ui): vertically centre the 2D UI at tall framebuffers

### DIFF
--- a/SOURCES/COMPORTE.CPP
+++ b/SOURCES/COMPORTE.CPP
@@ -92,13 +92,14 @@ S32 IndexComportement = 0;
    width (768, 1024, 1280, 1920…) rather than sticking to the top-left of
    the wider framebuffer. Box width is preserved so the 4-tile layout +
    info-bar geometry inside (which all derive from CTRL_X0..CTRL_X1)
-   reflows automatically. Y stays authored-pixel for now — Y-axis
-   widescreen is HD-only work tracked under Phase 5 of WIDESCREEN.md. */
+   reflows automatically. CTRL_Y0/Y1 float via UI_VCENTER_OFS so the box also
+   centres vertically on a taller framebuffer; the 190px height and the tile /
+   info-bar geometry (all derived from CTRL_Y0..CTRL_Y1) follow. No-op at 480. */
 #define CTRL_BOX_W 450
 #define CTRL_X0 (((S32)ModeDesiredX - CTRL_BOX_W) / 2)
 #define CTRL_X1 (CTRL_X0 + CTRL_BOX_W)
-#define CTRL_Y0 100
-#define CTRL_Y1 290
+#define CTRL_Y0 (100 + UI_VCENTER_OFS)
+#define CTRL_Y1 (290 + UI_VCENTER_OFS)
 
 /*══════════════════════════════════════════════════════════════════════════*/
 

--- a/SOURCES/DEFINES.H
+++ b/SOURCES/DEFINES.H
@@ -244,6 +244,21 @@
 #define SCREEN_SHADE_LVL 8 // Shade sous les menus
 
 /*──────────────────────────────────────────────────────────────────────────*/
+/* UI vertical re-anchor (widescreen / tall framebuffers)
+ *
+ * The 2D UI was authored against a 480-tall 4:3 canvas. X was already routed
+ * through ModeDesiredX/2; these do the same for Y. On a taller framebuffer
+ * (ModeDesiredY > 480) they float the authored canvas so it stays vertically
+ * centred (UI_VCENTER_OFS) or pinned to the bottom edge (UI_VBOTTOM_OFS).
+ * Both are 0 when ModeDesiredY == 480, so the classic 4:3 layout is
+ * byte-identical. These read ModeDesiredY (SVGA/SCREEN.H) live on every
+ * expansion; never cache the result, or it goes stale after a runtime
+ * resolution switch (Res_Switch). See docs/WIDESCREEN.md. */
+#define UI_CANVAS_H 480
+#define UI_VCENTER_OFS (((S32)ModeDesiredY - UI_CANVAS_H) / 2)
+#define UI_VBOTTOM_OFS ((S32)ModeDesiredY - UI_CANVAS_H)
+
+/*──────────────────────────────────────────────────────────────────────────*/
 /*──────────────────────────────────────────────────────────────────────────*/
 /*──────────────────────────────────────────────────────────────────────────*/
 

--- a/SOURCES/DEFINES.H
+++ b/SOURCES/DEFINES.H
@@ -253,10 +253,16 @@
  * Both are 0 when ModeDesiredY == 480, so the classic 4:3 layout is
  * byte-identical. These read ModeDesiredY (SVGA/SCREEN.H) live on every
  * expansion; never cache the result, or it goes stale after a runtime
- * resolution switch (Res_Switch). See docs/WIDESCREEN.md. */
+ * resolution switch (Res_Switch). See docs/WIDESCREEN.md.
+ *
+ * Clamped to >= 0: below the 480 canvas (e.g. --resolution 320x200) the
+ * authored UI does not fit, and a negative offset would push draws to a
+ * negative Y, an out-of-bounds index in the unclamped TabOffLine[] row lookup
+ * (BackupAngles and friends). There we fall back to the canvas-top origin,
+ * matching the pre-re-anchor behaviour. */
 #define UI_CANVAS_H 480
-#define UI_VCENTER_OFS (((S32)ModeDesiredY - UI_CANVAS_H) / 2)
-#define UI_VBOTTOM_OFS ((S32)ModeDesiredY - UI_CANVAS_H)
+#define UI_VCENTER_OFS ((S32)ModeDesiredY > UI_CANVAS_H ? ((S32)ModeDesiredY - UI_CANVAS_H) / 2 : 0)
+#define UI_VBOTTOM_OFS ((S32)ModeDesiredY > UI_CANVAS_H ? (S32)ModeDesiredY - UI_CANVAS_H : 0)
 
 /*──────────────────────────────────────────────────────────────────────────*/
 /*──────────────────────────────────────────────────────────────────────────*/

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -49,6 +49,12 @@
    horizontally centred on the framebuffer. At 640 this resolves to 240 (the
    historical literal); at wider widths it tracks ModeDesiredX/2. */
 #define SAVE_THUMB_X ((S32)ModeDesiredX / 2 - SCREEN_SAVE_WIDTH / 2)
+/* Top of the save thumbnail on the save/load list screen (ChoosePlayerName).
+   The historical literal is 50, on the 480-tall canvas; UI_VCENTER_OFS floats
+   it with the rest of that screen on a taller framebuffer (0 at 480). The
+   in-game save (y=10) and load-confirm (y=130) thumbnails are other screens
+   and keep their own literals. */
+#define SAVE_THUMB_Y (50 + UI_VCENTER_OFS)
 
 U8 CoulTextMenu = COUL_TEXT_MENU;
 S32 LargeurMenu = 550;
@@ -1237,17 +1243,20 @@ void DrawCadreNewGame(void) {
 
     GetDxDyGraph(0, &dx, &dy, ptr);
 
-    DrawCadreSave(SAVE_THUMB_X, 50);
+    DrawCadreSave(SAVE_THUMB_X, SAVE_THUMB_Y);
 
     x = (S32)ModeDesiredX / 2 - dx / 2;
-    y = 50 + (SCREEN_SAVE_HEIGHT) / 2 - dy / 2;
+    y = SAVE_THUMB_Y + (SCREEN_SAVE_HEIGHT) / 2 - dy / 2;
 
     AffGraph(0, x, y, ptr);
 }
 
 /*──────────────────────────────────────────────────────────────────────────*/
 #define NB_GAME_CHOICE 5
-#define Y_START_CHOICE 205
+// Save/load + name-entry slot list origin (also feeds the hit-test and the
+// name-entry cursor). Authored on the 480-tall canvas; UI_VCENTER_OFS floats
+// the list to the vertical middle on a taller framebuffer (no-op at 480).
+#define Y_START_CHOICE (205 + UI_VCENTER_OFS)
 #define GM_MENU_HALF_WIDTH_SAVE 275
 
 static S32 GameMenuSaveListHitTest(U32 mx, U32 my, S32 nb, S32 start, S32 *outSel) {
@@ -1542,7 +1551,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
         ManageTime();
 
         if (flag == 3) {
-            DrawSingleString((S32)ModeDesiredX / 2, 25, (char *)GetMultiText(mess, string));
+            DrawSingleString((S32)ModeDesiredX / 2, 25 + UI_VCENTER_OFS, (char *)GetMultiText(mess, string));
             flag = 1;
         }
 
@@ -1613,7 +1622,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                     FindPlayerFile();
                 ptr = LoadGameScreen();
                 if (ptr)
-                    DrawScreenSave(ptr, SAVE_THUMB_X, 50);
+                    DrawScreenSave(ptr, SAVE_THUMB_X, SAVE_THUMB_Y);
             } else // Nouvelle partie
             {
                 //                                DrawCadreSave( 240, 50 ) ;
@@ -1935,7 +1944,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                         FindPlayerFile();
                     ptr = LoadGameScreen();
                     if (ptr)
-                        DrawScreenSave(ptr, SAVE_THUMB_X, 50);
+                        DrawScreenSave(ptr, SAVE_THUMB_X, SAVE_THUMB_Y);
                 } else // Nouvelle partie
                 {
                     //					DrawCadreSave( 240, 50 ) ;
@@ -2388,9 +2397,16 @@ void DrawGameMenu(U16 *ptrmenu, S32 justone) {
 
     if (y == 0) // depuis le haut
     {
-        y = HAUTEUR_STANDARD / 2 + 10;
+        // Top-anchored list (the ask-choice menu, GameChoiceMenu, the only
+        // y==0 user). Float with the canvas so the choices track the rest of
+        // the UI on a taller framebuffer instead of staying stranded at the top
+        // edge while the question bubble (MyDial) bottom-anchors. No-op at 480.
+        y = HAUTEUR_STANDARD / 2 + 10 + UI_VCENTER_OFS;
     } else // centre sur y
     {
+        // The table y-centre is authored on the 480-tall canvas; float it to
+        // the vertical middle of a taller framebuffer (no-op at 480).
+        y += UI_VCENTER_OFS;
         y -= (HAUTEUR_STANDARD * nb + (nb - 1) * MENU_SPACE) / 2;
     }
 
@@ -2980,7 +2996,10 @@ S32 DoGameMenu(U16 *ptrmenu) {
 
                 ptr = LoadGameScreen();
                 if (ptr)
-                    DrawScreenSave(ptr, SAVE_THUMB_X, 10);
+                    // Main-menu current-save preview box. Float it with the menu
+                    // list (both use UI_VCENTER_OFS) so the box-to-menu gap stays
+                    // as authored on a taller framebuffer. No-op at 480.
+                    DrawScreenSave(ptr, SAVE_THUMB_X, 10 + UI_VCENTER_OFS);
 
                 strcpy(GamePathname, memogamepathname);
                 strcpy(PlayerName, memoplayername);
@@ -3504,10 +3523,12 @@ S32 DeleteSavedGame(void) {
     S32 ret = -1;
     S32 select;
 
-    DrawOneString((S32)ModeDesiredX / 2, 80, PlayerName, 2);
+    // Delete-save confirmation: float the name + preview with SavedConfirmMenu
+    // (which floats via DrawGameMenu) so the whole screen stays coherent. No-op at 480.
+    DrawOneString((S32)ModeDesiredX / 2, 80 + UI_VCENTER_OFS, PlayerName, 2);
     ptr = LoadGameScreen();
     if (ptr)
-        DrawScreenSave(ptr, SAVE_THUMB_X, 130);
+        DrawScreenSave(ptr, SAVE_THUMB_X, 130 + UI_VCENTER_OFS);
     BoxUpdate();
 
     SavedConfirmMenu[0] = 0;
@@ -3968,7 +3989,9 @@ S32 MainGameMenu(S32 load) {
 
                     BoxReset(); // pas de flip
 
-                    ZoomSavedGame(SAVE_THUMB_X, 10);
+                    // Zoom starts from the floated preview box (must match the
+                    // SAVE_THUMB_X, 10 + UI_VCENTER_OFS draw site above).
+                    ZoomSavedGame(SAVE_THUMB_X, 10 + UI_VCENTER_OFS);
 
                     HQ_ResumeSamples();
                     RestoreTimer();
@@ -4040,7 +4063,7 @@ S32 MainGameMenu(S32 load) {
 
                 BoxReset(); // pas de flip
 
-                ZoomSavedGame(SAVE_THUMB_X, 50);
+                ZoomSavedGame(SAVE_THUMB_X, SAVE_THUMB_Y);
 
                 HQ_ResumeSamples();
                 RestoreTimer();
@@ -4125,7 +4148,7 @@ S32 MainGameMenu(S32 load) {
 
                 BoxReset(); // pas de flip
 
-                ZoomSavedGame(SAVE_THUMB_X, 50);
+                ZoomSavedGame(SAVE_THUMB_X, SAVE_THUMB_Y);
 
                 HQ_ResumeSamples();
                 RestoreTimer();

--- a/SOURCES/GAMEMENU_MOUSE.CPP
+++ b/SOURCES/GAMEMENU_MOUSE.CPP
@@ -4,12 +4,16 @@
 
 #include <SYSTEM/MOUSE.H>
 #include <SYSTEM/WINDOW.H>
+#include <SVGA/SCREEN.H> /* ModeDesiredX/Y for the centred + floated hit-test */
 
 extern U16 GameMainMenu[];
 
 #define GM_HAUTEUR_STANDARD 50
 #define GM_MENU_SPACE 6
-#define GM_MENU_XMID 320
+// Menu centre X. Must track DrawGameMenu's draw (DrawOneChoice at
+// ModeDesiredX/2); was hardcoded 320, so mouse clicks missed the menu at any
+// width != 640. Matches GameMenuSaveListHitTest's ModeDesiredX/2 convention.
+#define GM_MENU_XMID ((S32)ModeDesiredX / 2)
 #define GM_MENU_HALF_WIDTH 275
 
 static int s_menuMouseRefCount = 0;
@@ -70,10 +74,11 @@ S32 GameMenuHitTestRow(const U16 *ptrmenu, U32 mx, U32 my, const U16 *gameMainMe
     if (nb <= 0)
         return -1;
 
+    // Y must track DrawGameMenu's UI_VCENTER_OFS float (both branches); no-op at 480.
     if (ycenter == 0)
-        y = GM_HAUTEUR_STANDARD / 2 + 10;
+        y = GM_HAUTEUR_STANDARD / 2 + 10 + UI_VCENTER_OFS;
     else
-        y = ycenter - (GM_HAUTEUR_STANDARD * nb + (nb - 1) * GM_MENU_SPACE) / 2;
+        y = ycenter + UI_VCENTER_OFS - (GM_HAUTEUR_STANDARD * nb + (nb - 1) * GM_MENU_SPACE) / 2;
 
     for (n = 0; n < nb; n++) {
         S32 num = ptrmenu[4 + n * 2 + 1];

--- a/SOURCES/HOLOGLOB.CPP
+++ b/SOURCES/HOLOGLOB.CPP
@@ -11,6 +11,13 @@
 #include <SYSTEM/KEYBOARD_KEYS.H>
 #include <string.h>
 
+// Globe planet vertical centre. CENTERY (220) is authored on the 480-tall UI
+// canvas; UI_VCENTER_OFS floats the whole globe to the vertical middle on a
+// taller framebuffer (no-op at 480). Raw CENTERY stays put for HOLOPLAN's
+// zoom-in, which adds the same offset separately (anim_imageY0), so the plan
+// zoom starts exactly on the floated globe centre.
+#define PLANET_CENTREY (CENTERY + UI_VCENTER_OFS)
+
 //────────────────────────────────────────────────────────────────────────────
 //	Concerning BODY and ANIM
 T_OBJ_3D ObjTwinsen;
@@ -339,7 +346,7 @@ void ComputeObjectifPlanet(S32 arrow) {
     LongWorldRotatePoint(x, y, z);
     LongProjectPoint(X0, Y0, Z0);
 
-    dist = Distance2D(Xp, Yp, (S32)ModeDesiredX / 2, CENTERY);
+    dist = Distance2D(Xp, Yp, (S32)ModeDesiredX / 2, PLANET_CENTREY);
 
     if (dist < DistObjectif) {
         DistObjectif = dist;
@@ -834,7 +841,7 @@ void InitHoloGlobe(S32 planet) {
 
     //-----
 
-    SetProjection((S32)ModeDesiredX / 2, CENTERY, 128, 1024, 1024);
+    SetProjection((S32)ModeDesiredX / 2, PLANET_CENTREY, 128, 1024, 1024);
     //	SetProjection( CENTERX, CENTERY, 128,700,700 ) ;
     SetLightVector(0, 0, 0);
 
@@ -921,7 +928,7 @@ void FindAngleIsland(S32 island) {
 
             LongProjectPoint(X0, Y0, Z0);
 
-            dist = Distance2D(Xp, Yp, (S32)ModeDesiredX / 2, CENTERY);
+            dist = Distance2D(Xp, Yp, (S32)ModeDesiredX / 2, PLANET_CENTREY);
             if (dist < min) {
                 min = dist;
                 DestAlpha = halpha;

--- a/SOURCES/INVENT.CPP
+++ b/SOURCES/INVENT.CPP
@@ -1411,20 +1411,21 @@ void MenuInventory(U32 tempo) {
    inventory icon at the top-left". At wider widths the box stuck in the
    left half (centre at 320, not ModeDesiredX/2), so the object cinema
    appeared off-centre.
-   Re-anchor X via ModeDesiredX/2; box width 128 is preserved. The fly-
-   to destination at lines 1677-1680 (top-left "16") stays literal — that
-   is the actual position of the inventory HUD icon on screen-left and is
-   not anchored to the framebuffer centre. Y stays authored-pixel (HD work
-   tracked under Phase 5 / task #99). At ModeDesiredX==640 the math
-   collapses to the original (256, 320, 384) so the existing
-   ui_found_object golden still matches. */
+   Re-anchor X via ModeDesiredX/2 and Y via UI_VCENTER_OFS so the appear box
+   tracks the centre of a taller framebuffer too; box size 128×130 is preserved.
+   The fly-to destination at lines 1677-1680 (top-left "16") stays literal;
+   that is the actual position of the inventory HUD icon (corner-anchored, does
+   not float), so the item flies from its centred appear box to the HUD icon.
+   At 640×480 both offsets are 0 and the math collapses to the original
+   (256, 320, 384 / 48, 178) so the existing ui_found_object golden still
+   matches. */
 #define FOUND_BOX_W 128
 #define FOUND_X0 (((S32)ModeDesiredX - FOUND_BOX_W) / 2)
-#define FOUND_Y0 48
+#define FOUND_Y0 (48 + UI_VCENTER_OFS)
 #define FOUND_X1 (FOUND_X0 + FOUND_BOX_W)
-#define FOUND_Y1 178
+#define FOUND_Y1 (178 + UI_VCENTER_OFS)
 #define FOUND_XO (FOUND_X0 + FOUND_BOX_W / 2)
-#define FOUND_YO ((48 + 178) / 2)
+#define FOUND_YO ((FOUND_Y0 + FOUND_Y1) / 2)
 
 extern S32 Dial_Y0;
 
@@ -1884,13 +1885,13 @@ void DoFoundObj(S32 numvar) {
 // inner offsets are the historical literals against the slate's 640x480
 // authored canvas.
 #define L_X0 (78 + INV_LEFT_OFFSET)
-#define L_Y0 436
+#define L_Y0 (436 + INV_TOP_OFFSET)
 #define L_X1 (L_X0 + 50)
 #define L_Y1 (L_Y0 + 29)
 
 // Coordonnees de la boite de la fleche droite
 #define R_X0 (495 + INV_LEFT_OFFSET)
-#define R_Y0 436
+#define R_Y0 (436 + INV_TOP_OFFSET)
 #define R_X1 (R_X0 + 50)
 #define R_Y1 (R_Y0 + 29)
 
@@ -1898,9 +1899,12 @@ void DoFoundObj(S32 numvar) {
 // PLAN_X0 carries the INV_LEFT_OFFSET so the slate-plan box stays inside the
 // centred inventory region at wider framebuffers; the 78 inner offset is the
 // historical literal (matches the slate art's left margin within its 640x480
-// authored canvas). PLAN_Y stays absolute — slate art top-aligns at y=61.
+// authored canvas). PLAN_Y0 carries INV_TOP_OFFSET so the plan box tracks the
+// slate art, which DrawArdoise loads via Image_LoadCentered (centred by the
+// same (ModeDesiredY-480)/2). Without it, on a taller framebuffer the slate
+// bg would float while the plan/arrow overlays stayed at the top. No-op at 480.
 #define PLAN_X0 (78 + INV_LEFT_OFFSET)
-#define PLAN_Y0 61
+#define PLAN_Y0 (61 + INV_TOP_OFFSET)
 #define PLAN_X1 (PLAN_X0 + 479)
 #define PLAN_Y1 (PLAN_Y0 + 360)
 

--- a/SOURCES/INVENT.H
+++ b/SOURCES/INVENT.H
@@ -10,7 +10,8 @@
 //--------------------------	Can change
 
 #define INV_START_X_MARGIN 8 //	Margin inventory screen X (from the 4:3 inner box's left edge)
-#define INV_START_Y 8        //	Margin inventory screen Y
+#define INV_START_Y_MARGIN 8 //	Margin inventory screen Y (from the 4:3 inner box's top edge)
+#define INV_NAME_Y0_RAW 429  //	Name-box top on the authored 480 canvas (size math; floated below)
 
 #define INV_NBOBJ_X 7 //	Nb Object X ex 8
 #define INV_NBOBJ_Y 5 //	Nb Object Y
@@ -29,10 +30,12 @@
    literal (10/8/0/...). The iso-relative INV_ZOOM box centres on
    ModeDesiredX/2 - 3 (matches the historical 317 anchor at 640). */
 #define INV_LEFT_OFFSET (((S32)ModeDesiredX - 640) / 2)
+#define INV_TOP_OFFSET (((S32)ModeDesiredY - 480) / 2) // vertical twin of INV_LEFT_OFFSET (== UI_VCENTER_OFS)
 #define INV_START_X (INV_START_X_MARGIN + INV_LEFT_OFFSET)
+#define INV_START_Y (INV_START_Y_MARGIN + INV_TOP_OFFSET)
 
-#define INV_DELTA_X (640 - INV_START_X_MARGIN * 2 - 1) //	Size Inventory in X (623, fixed inner width)
-#define INV_DELTA_Y (INV_NAME_Y0 - (INV_START_Y * 2))  //	            in Y
+#define INV_DELTA_X (640 - INV_START_X_MARGIN * 2 - 1)           //	Size Inventory in X (623, fixed inner width)
+#define INV_DELTA_Y (INV_NAME_Y0_RAW - (INV_START_Y_MARGIN * 2)) //	in Y (413, fixed inner height; offset-free)
 
 #define INV_END_X (INV_START_X + INV_DELTA_X)
 #define INV_END_Y (INV_START_Y + INV_DELTA_Y)
@@ -43,14 +46,14 @@
 //	Before : 317-120, 218-140, 317+120, 218+140
 
 #define INV_ZOOM_X0 ((S32)ModeDesiredX / 2 - 3 - 120)
-#define INV_ZOOM_Y0 (210 - 120)
+#define INV_ZOOM_Y0 (210 - 120 + INV_TOP_OFFSET)
 #define INV_ZOOM_X1 ((S32)ModeDesiredX / 2 - 3 + 120)
-#define INV_ZOOM_Y1 (210 + 120)
+#define INV_ZOOM_Y1 (210 + 120 + INV_TOP_OFFSET)
 
-#define INV_NAME_X0 INV_START_X //	Name Object X0
-#define INV_NAME_Y0 429         //	Name Object Y0
-#define INV_NAME_X1 INV_END_X   //	Name Object X1
-#define INV_NAME_Y1 471         //	Name Object Y1
+#define INV_NAME_X0 INV_START_X                        //	Name Object X0
+#define INV_NAME_Y0 (INV_NAME_Y0_RAW + INV_TOP_OFFSET) //	Name Object Y0
+#define INV_NAME_X1 INV_END_X                          //	Name Object X1
+#define INV_NAME_Y1 (471 + INV_TOP_OFFSET)             //	Name Object Y1
 
 extern S32 ProtectActif;
 extern S32 FlagZoomed;

--- a/SOURCES/INVENT.H
+++ b/SOURCES/INVENT.H
@@ -30,7 +30,7 @@
    literal (10/8/0/...). The iso-relative INV_ZOOM box centres on
    ModeDesiredX/2 - 3 (matches the historical 317 anchor at 640). */
 #define INV_LEFT_OFFSET (((S32)ModeDesiredX - 640) / 2)
-#define INV_TOP_OFFSET (((S32)ModeDesiredY - 480) / 2) // vertical twin of INV_LEFT_OFFSET (== UI_VCENTER_OFS)
+#define INV_TOP_OFFSET UI_VCENTER_OFS // vertical twin of INV_LEFT_OFFSET; shared with the other UI surfaces (DEFINES.H, clamped >= 0)
 #define INV_START_X (INV_START_X_MARGIN + INV_LEFT_OFFSET)
 #define INV_START_Y (INV_START_Y_MARGIN + INV_TOP_OFFSET)
 

--- a/SOURCES/MESSAGE.CPP
+++ b/SOURCES/MESSAGE.CPP
@@ -132,6 +132,17 @@ static S32 DialLetterboxInset(void) {
     return Dial_Letterbox ? (((S32)ModeDesiredX - 640) / 2) : 0;
 }
 
+/* Vertical twin of DialLetterboxInset (== UI_VCENTER_OFS when letterboxed):
+   half the gap between the framebuffer height and the authored 480 px PCX
+   height. Matches Image_LoadCentered's yOffset so the dialog box stays inside
+   the centred picture instead of spilling into the black letterbox bars on a
+   taller framebuffer (e.g. the end-game story text over its backdrop). Zero at
+   480 and during normal (non-letterboxed) gameplay, so the bottom-anchored
+   play dialogue is unchanged. */
+static S32 DialLetterboxInsetY(void) {
+    return Dial_Letterbox ? UI_VCENTER_OFS : 0;
+}
+
 static char BufLine[256];
 static char *PtLine;
 static S32 SizeLine;
@@ -1248,10 +1259,11 @@ void TestCoulDial(S32 coul) {
 /*-------------------------------------------------------------------------*/
 void NormalWinDial() {
     S32 inset = DialLetterboxInset();
+    S32 insetY = DialLetterboxInsetY();
     Dial_X0 = inset + 8;
-    Dial_Y0 = ClipWindowYMax - 137; // 334 lorsque ClipWindowYMax==479
+    Dial_Y0 = ClipWindowYMax - insetY - 137; // 334 at YMax==479; insetY pins to picture bottom when letterboxed
     Dial_X1 = (S32)ModeDesiredX - 1 - inset - 8;
-    Dial_Y1 = ClipWindowYMax - 8;
+    Dial_Y1 = ClipWindowYMax - insetY - 8;
 
     MaxLineDial = 3;
     DialMaxSize = ((Dial_X1 - 8) - (Dial_X0 + 8));
@@ -1270,10 +1282,11 @@ void DemoWinDial() {
 /*-------------------------------------------------------------------------*/
 void BigWinDial() {
     S32 inset = DialLetterboxInset();
+    S32 insetY = DialLetterboxInsetY();
     Dial_X0 = inset + 8;
-    Dial_Y0 = ClipWindowYMin + 8;
+    Dial_Y0 = ClipWindowYMin + insetY + 8;
     Dial_X1 = (S32)ModeDesiredX - 1 - inset - 8;
-    Dial_Y1 = ClipWindowYMax - 8;
+    Dial_Y1 = ClipWindowYMax - insetY - 8;
 
     MaxLineDial = (Dial_Y1 - Dial_Y0) / 42;
     DialMaxSize = ((Dial_X1 - 8) - (Dial_X0 + 8));
@@ -1282,9 +1295,12 @@ void BigWinDial() {
 void HoloWinDial() {
     S32 inset = DialLetterboxInset();
     Dial_X0 = inset + 8;
-    Dial_Y0 = 425;
+    // Single-line holomap name strip. Authored at the bottom of the 480 canvas;
+    // UI_VBOTTOM_OFS pins it to the bottom edge of a taller framebuffer so it
+    // stays a bottom strip rather than drifting to mid-screen. No-op at 480.
+    Dial_Y0 = 425 + UI_VBOTTOM_OFS;
     Dial_X1 = (S32)ModeDesiredX - 1 - inset - 8;
-    Dial_Y1 = 477;
+    Dial_Y1 = 477 + UI_VBOTTOM_OFS;
 
     MaxLineDial = 1;
     DialMaxSize = ((Dial_X1 - 8) - (Dial_X0 + 8));

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -540,7 +540,10 @@ restartloop:
 
                     BoxReset(); // pas de flip
 
-                    ZoomSavedGame(240, 10);
+                    // In-game save zoom. Float to match the menu-driven sibling
+                    // (GAMEMENU MainGameMenu): 80 = SCREEN_SAVE_WIDTH/2 so X tracks
+                    // SAVE_THUMB_X, and Y floats with the rest of the UI. No-op at 640x480.
+                    ZoomSavedGame((S32)ModeDesiredX / 2 - 80, 10 + UI_VCENTER_OFS);
 
                     FlagFade = FALSE;
                     RestartRainSample = TRUE;
@@ -998,7 +1001,10 @@ restartloop:
 
                     BoxReset(); // pas de flip
 
-                    ZoomSavedGame(240, 10);
+                    // In-game save zoom. Float to match the menu-driven sibling
+                    // (GAMEMENU MainGameMenu): 80 = SCREEN_SAVE_WIDTH/2 so X tracks
+                    // SAVE_THUMB_X, and Y floats with the rest of the UI. No-op at 640x480.
+                    ZoomSavedGame((S32)ModeDesiredX / 2 - 80, 10 + UI_VCENTER_OFS);
 
                     FlagFade = FALSE;
                     RestartRainSample = TRUE;

--- a/docs/WIDESCREEN.md
+++ b/docs/WIDESCREEN.md
@@ -97,8 +97,39 @@ Lets the player change render resolution from a console verb or a Display option
 
 This phase had two strands. The UI strand is done; the HD strand moved to its own phase.
 
-- UI strategy: **C2 chosen and shipped.** The re-anchor campaign (PRs #213–#228, plus #260, #289, #291, #310) routed every menu, inventory, holomap, dialogue, and save surface through `ModeDesiredX/Y`, so the 2D UI is correct in a wider frame. See [UI strategy](#ui-strategy-c1-vs-c2) for why C2 over C1.
+- UI strategy: **C2 chosen and shipped.** The re-anchor campaign (PRs #213–#228, plus #260, #289, #291, #310) routed every menu, inventory, holomap, dialogue, and save surface through `ModeDesiredX/Y`, so the 2D UI is correct in a wider frame. The [vertical re-anchor](#ui-vertical-re-anchor-tall-framebuffers) below extends the same discipline to a taller frame. See [UI strategy](#ui-strategy-c1-vs-c2) for why C2 over C1.
 - HD-only concerns (filler precision, bitmap fonts, the 16-bit Z-buffer and `Fill_ZBuffer_Factor`, mouse-coordinate inversion, Smacker upscale): **moved to [Phase 7](#phase-7-native-hd).** Widescreen shipped without resolving them, so they are tracked separately as the native-HD frontier. The analysis below is the record of what the X-axis campaign settled for HD.
+
+#### UI vertical re-anchor (tall framebuffers)
+
+The C2 campaign above centred the 2D UI horizontally (`ModeDesiredX/2`) for a *wider* frame. It left UI height at the authored 480, so vertical positions stayed authored-pixel. This sweep (branch `fix/ui-vertical-centre`) does the Y axis, so the UI is also correct in a *taller* frame (`ModeDesiredY > 480`, reachable via `--resolution` and the `resolution` console verb even though the shipped widescreen modes stay 480-tall).
+
+The model is one 480-tall authored canvas floated into the live framebuffer. Two macros in `SOURCES/DEFINES.H`, both read live (never cache; they must survive a runtime `Res_Switch`) and both `0` at `ModeDesiredY == 480` so every site is behaviour-preserving at the classic resolution:
+
+- `UI_VCENTER_OFS = ((S32)ModeDesiredY - 480) / 2`, to float the canvas to the vertical middle.
+- `UI_VBOTTOM_OFS = (S32)ModeDesiredY - 480`, to pin to the bottom edge.
+
+Each surface's anchor mode mirrors how it reads on the 4:3 canvas:
+
+| Surface | Site | Anchor |
+|---|---|---|
+| Menus, save screen, ask-choice list | `GAMEMENU.CPP` (`DrawGameMenu` both branches, `Y_START_CHOICE`, `SAVE_THUMB_Y`, save title, current-save preview box) | centre |
+| Menu mouse hit-test | `GAMEMENU_MOUSE.CPP` (`GameMenuHitTestRow`) | tracks the draw (see note) |
+| Holomap planet | `HOLOGLOB.CPP` (`PLANET_CENTREY`, the three `CENTERY` sites) | centre |
+| Holomap name strip | `MESSAGE.CPP` (`HoloWinDial`) | bottom |
+| Dialogue box | `MESSAGE.CPP` (`NormalWinDial`, `BigWinDial`) | bottom, already correct via `ClipWindowYMax`; no change |
+| End-game / pcx-message text | `MESSAGE.CPP` (`DialLetterboxInsetY`) | confined to the centred backdrop |
+| Inventory wheel, slate, found-object | `INVENT.H` (`INV_TOP_OFFSET`), `INVENT.CPP` (slate `PLAN_Y0`/`L_Y0`/`R_Y0`, `FOUND_Y*`) | centre |
+| Action (behaviour) menu | `COMPORTE.CPP` (`CTRL_Y0`/`CTRL_Y1`) | centre |
+| HUD (life, magic, coins) | `OBJECT.CPP` | corner/edge, already correct |
+
+Notes:
+
+- `INV_TOP_OFFSET` is the vertical twin of the pre-existing `INV_LEFT_OFFSET`. The slate's `PLAN_Y` overlays now track the slate art, which `DrawArdoise` already loads vertically centred via `Image_LoadCentered`; previously the art floated while the overlays stayed at the top.
+- `DialLetterboxInsetY` is the vertical twin of `DialLetterboxInset`. When a centred PCX backdrop is up (`Dial_Letterbox`), the text is inset to the picture on both axes instead of spilling into the letterbox bars. The backdrop stays a 640x480 centred letterbox (the project's cinematic convention), not scaled, since a fixed 4:3 pixel-art image cannot fill a taller frame without distortion or cropping.
+- Mouse hit-test: `GameMenuHitTestRow` is a separate copy of the `DrawGameMenu` layout math. It carried a hardcoded `320` X centre (a pre-existing widescreen bug the X campaign missed, so clicks missed the menu at any width other than 640) and no Y offset. Both now mirror the draw (`ModeDesiredX/2` plus `UI_VCENTER_OFS`). When floating a menu's draw, check for a duplicate hit-test doing the same math separately.
+
+Verification: every site is `0` at 640x480 by construction and the host suite stays green. At tall res, captures confirm the menu block, holomap planet, and inventory wheel each translate by exactly `UI_VCENTER_OFS`, the holomap strip and dialogue box pin to the bottom, and the end-game text lands on its backdrop. The ask-choice list, action menu, found-object appear phase, and mouse hit-test have no headless capture path and were verified in-game.
 
 #### HD prerequisites — what the X-axis campaign settled
 
@@ -120,7 +151,7 @@ The X-axis C2 campaign (PRs #213–#228) settled the structural prerequisites fo
 | Concern | Notes |
 |---|---|
 | Y-axis clamps | **Done** (branch `fix/widescreen-y-clamp`). A4 (terrain horizon `Y=479`, 8 sites in `3DEXT/TERRAIN.CPP` `FillBlackPolyZBuf`) and A5 (holomap Z-buffer Y bounds, 4 sites in `HOLOGLOB.CPP`) now route through `(S32)ModeDesiredY - 1`. The literals were *not* the real pin, though: the 3D view stayed capped at 480 at any resolution because `LoadContexte` restored `ClipWindowYMax` verbatim from the save file (`SAVEGAME.CPP:2053`). `SaveContexte` persists the play clip window at its render height, so a 640×480 save carries `479`; the fix re-derives the full window from `ModeDesiredY` on load. All three changes are behavior-preserving at 640×480 (`ModeDesiredY-1 == 479`; projrec corpus hashes byte-identical with/without via git-stash A/B). Opening the view exposed the vertical-framing question — see [Vertical framing at HD](#vertical-framing-at-hd--open-question) below. |
-| Holomap at Y > 480 | A4/A5 done, but `ui holoplan` at `1024×768` still times out — a cinema-mode rendering bug independent of the Z-buffer bounds and the planet bitmap centring. The A5 fix is correct and 640-identical but **not yet verified at tall res** until this timeout is resolved. Add `test_ui_holoplan_768x768.sh` once unblocked. |
+| Holomap at Y > 480 | A4/A5 done, but `ui holoplan` at `1024×768` still times out, a cinema-mode rendering bug independent of the Z-buffer bounds and the planet bitmap centring. The globe holomap (`ui holomap`, the rotating planet and its name strip) is verified at 768 via the [UI vertical re-anchor](#ui-vertical-re-anchor-tall-framebuffers) above; the `ui holoplan` island zoom is the part still blocked by this timeout. The A5 Z-buffer fix itself is correct and 640-identical but **not verified at tall res** until the timeout is resolved. Add `test_ui_holoplan_768x768.sh` once unblocked. |
 | Filler precision | **Swept at 1920 — de-risked** (2026-05-29). Captured a 6-scene polyrec corpus at 1920-wide and replayed it under ASan+UBSan and ASM-vs-CPP. No overflow, no out-of-bounds across ~24k full-width draw calls (the feared accumulator overflow does not occur). ASM↔CPP equivalence degrades from bit-exact (640) to **118/1,966,080 pixels = 0.006%** (1–2px edge rounding on a few triangles through the FPU slope path — the long-double/x87 precision class, not overflow); cosmetically invisible. Practical consequence: the 640 ASM-equivalence corpus can't be extended to 1920 without tolerancing or pinning FP, but the fillers render correctly at HD width. |
 | Bitmap fonts | `LIB386/SVGA/FONT.CPP` / `AFFSTR.CPP` blit at 1:1 pixel size. At 1920×1080 in-game text is tiny. Either pixel-scale the existing 8×N glyphs (cheap, blocky) or re-author a higher-DPI font set (slow, clean). |
 | Z-buffer precision | 16-bit Z + `Fill_ZBuffer_Factor` is tuned for the 4:3 frustum's depth range. May Z-fight at HD aspect ratios on distant geometry; the polyrec harness catches drift here too if you log Z values. |


### PR DESCRIPTION
## What

Completes the 2D UI re-anchor on the **Y axis**. The shipped C2 campaign centred the UI horizontally (`ModeDesiredX/2`) for *wider* frames but left height at the authored 480, so on a *taller* framebuffer (`ModeDesiredY > 480`, reachable via `--resolution` and the `resolution` console verb) the UI stayed pinned to the top. This floats the authored 480-tall canvas into the live framebuffer.

## Model

Two macros in `SOURCES/DEFINES.H`, both read `ModeDesiredY` live (never cached, so they survive a runtime `Res_Switch`), both `0` at `ModeDesiredY == 480` and clamped to `>= 0` below it:

- `UI_VCENTER_OFS` floats the canvas to the vertical middle.
- `UI_VBOTTOM_OFS` pins to the bottom edge.

Each surface's anchor mode mirrors how it reads on the 4:3 canvas (centre / bottom / corner). Full per-surface table in `docs/WIDESCREEN.md` (Phase 5, "UI vertical re-anchor").

## Surfaces

- Menus, save/load screen, ask-choice list, and the menu mouse hit-test (`GAMEMENU.CPP`, `GAMEMENU_MOUSE.CPP`)
- Holomap planet and its name strip (`HOLOGLOB.CPP`, `MESSAGE.CPP`)
- Dialogue box (already bottom-anchored via `ClipWindowYMax`) and the end-game / pcx-message text, now confined to its centred backdrop (`MESSAGE.CPP`)
- Inventory wheel, slate, and the found-object cinematic (`INVENT.H`, `INVENT.CPP`)
- Action (behaviour) menu (`COMPORTE.CPP`)

## Pre-existing widescreen bugs fixed in passing

- `GameMenuHitTestRow` used a hardcoded `320` menu centre, so menu mouse clicks missed at any width other than 640. It now tracks `ModeDesiredX/2`, matching the draw.
- `PERSO.CPP`'s in-game save zoom used a hardcoded `(240, 10)` origin while the identical menu-driven sibling was already re-anchored. It now matches.

## Testing

- Every site is a no-op at 640x480 by construction, so the classic 4:3 layout is byte-identical.
- `make test` (28 host tests) green; `scripts/ci/check-format.sh` clean.
- The `ui_*` automation goldens (menu-main, menu-options, inventory, holomap, holoplan, dialog, found-object, video, plus the wide variants) all pass.
- Tall-res captures confirm the menu block, holomap planet, and inventory wheel each translate by exactly the offset; the holomap strip and dialogue box pin to the bottom; and the end-game text lands on its backdrop. The ask-choice list, action menu, found-object appear phase, and mouse hit-test have no headless capture path and were verified in-game.

Two automation tests (`projection_corpus`, `ui_display`) fail on this branch, but they fail identically on `main` and are unrelated to these changes.
