### PR TITLE
feat(log): bold the cyan banner and section lines

### DIFF
--- a/LIB386/SYSTEM/LOG.CPP
+++ b/LIB386/SYSTEM/LOG.CPP
@@ -134,18 +134,18 @@ const char *severity_color(LogSeverity sev) {
 void term_sink_write(LogSink *s, LogSeverity sev, int kind, const char *msg) {
     FILE *out = s->fp; /* stderr */
     if (kind == REC_SECTION_BEGIN) {
-        fprintf(out, "\033[36m------ %s ", msg);
-        int used = 7 + (int)strlen(msg) + 1; /* "------ " + msg + " " */
+        fprintf(out, "\033[1;36m------ %s ", msg); /* bold cyan structural accent */
+        int used = 7 + (int)strlen(msg) + 1;       /* "------ " + msg + " " */
         for (int i = used; i < LOG_TERM_WIDTH; ++i)
             fputc('-', out);
         fputs("\033[0m\n", out);
     } else if (kind == REC_SECTION_END) {
-        fputs("\033[36m", out);
+        fputs("\033[1;36m", out);
         for (int i = 0; i < LOG_TERM_WIDTH; ++i)
             fputc('-', out);
         fputs("\033[0m\n", out);
     } else if (kind == REC_BANNER) {
-        fprintf(out, "\033[36m%s\033[0m\n", msg); /* cyan, like section rules */
+        fprintf(out, "\033[1;36m%s\033[0m\n", msg); /* bold cyan, like section rules */
     } else if (kind == REC_RAW) {
         fprintf(out, "%s\n", msg);
     } else {

--- a/SOURCES/CONSOLE/CONSOLE.CPP
+++ b/SOURCES/CONSOLE/CONSOLE.CPP
@@ -532,6 +532,15 @@ static void console_fixed_rgb(U8 idx, U8 *r, U8 *g, U8 *b) {
     }
 }
 
+/* Faux-bold blit: AffStringToBuffer over-writes only set pixels (no paper), so a
+ * second pass shifted 1px right thickens every vertical stroke. Used for the cyan
+ * banner/section lines so they read as boldly in the F12 console as the terminal
+ * sink's bold-cyan bookends do (see term_sink_write in LOG.CPP). */
+static void AffStringToBufferBold(U8 *dst, U32 pitch, S32 x, S32 y, const char *str, U8 ink) {
+    AffStringToBuffer(dst, pitch, x, y, str, ink);
+    AffStringToBuffer(dst, pitch, x + 1, y, str, ink);
+}
+
 /** Draw scrollback + input line into s_console_buf (call when open and buffer ready). */
 static void Console_Draw(void) {
     int i, y, start, n;
@@ -575,8 +584,11 @@ static void Console_Draw(void) {
             int idx = (start + i) % CONSOLE_SCROLLBACK_LINES;
             char rendered[CONSOLE_LINE_MAX];
             utf8_to_cp437(s_scrollback[idx], rendered, sizeof rendered);
-            AffStringToBuffer(s_console_buf, s_console_w, 8, y, rendered,
-                              s_scrollback_col[idx]);
+            U8 col = s_scrollback_col[idx];
+            if (col == CONSOLE_COL_BANNER)
+                AffStringToBufferBold(s_console_buf, s_console_w, 8, y, rendered, col);
+            else
+                AffStringToBuffer(s_console_buf, s_console_w, 8, y, rendered, col);
             y += CONSOLE_LINE_HEIGHT;
         }
 

--- a/tests/console/test_console_render.cpp
+++ b/tests/console/test_console_render.cpp
@@ -47,6 +47,15 @@ static const DrawCall *draw_with(const char *needle) {
     return 0;
 }
 
+/* How many draws recorded the line containing needle (faux-bold = 2). */
+static int count_draws(const char *needle) {
+    int n = 0;
+    for (size_t i = 0; i < g_draws.size(); i++)
+        if (g_draws[i].str.find(needle) != std::string::npos)
+            n++;
+    return n;
+}
+
 static bool contains_byte(const std::string &s, unsigned char b) {
     return s.find((char)b) != std::string::npos;
 }
@@ -89,6 +98,12 @@ int main(void) {
     CHECK(warn && warn->ink == CONSOLE_COL_WARN);
     CHECK(err && err->ink == CONSOLE_COL_ERROR);
     CHECK(bnr && bnr->ink == CONSOLE_COL_BANNER);
+
+    /* Banner lines render faux-bold: a second 1px-shifted pass thickens the
+     * strokes, so the banner is drawn twice while ordinary lines are drawn once. */
+    CHECK(count_draws("bnr-line") == 2);
+    CHECK(count_draws("info-line") == 1);
+    CHECK(count_draws("warn-line") == 1);
 
     /* The "·" reaches the font as CP437 0xFA, never the UTF-8 bytes 0xC2/0xB7. */
     const DrawCall *dot = draw_with("LBA2 ");


### PR DESCRIPTION
The boot banner and section headers already render in cyan on both the terminal sink and the F12 console. This makes them bold so the structural bookends stand out from ordinary log output.

## Changes
- **Terminal sink** (`LOG.CPP`): add the ANSI bold attribute (`1;36`) to the banner and section rules.
- **Console** (`CONSOLE.CPP`): faux-bold the banner-ink lines via a 1px right-shifted overdraw. `AffStringToBuffer` writes only set pixels, so the second pass just thickens the stems. This is the fixed-cell/terminal convention — the advance stays at one cell and the extra pixel is absorbed by the glyph's right-side bearing. Printable letters and `=` never use the glyph's rightmost column, so there is no inter-glyph bleed (only `*` and `_` touch column 7, and neither appears bold in banner text).
- **test_console_render**: assert banner lines are drawn twice (bold) while ordinary lines are drawn once.

## Verification
- `test_console_render`, `test_log`, `test_log_spine` pass; full `make test` green.
- clang-format clean.