### PR TITLE
fix(console): keep intentional blank lines in the F12 console

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE.CPP
+++ b/SOURCES/CONSOLE/CONSOLE.CPP
@@ -248,8 +248,21 @@ static void scrollback_push_wrapped(const char *line, U8 colour) {
 /* Split buf on '\n' so callers can pass multi-line strings naturally (matches
  * printf intuition: '\n' means "advance to a new line"). Empty segments — from
  * leading, trailing, or repeated '\n' — are skipped (no spurious blank lines).
- * The sink-for-tests sees exactly what gets pushed to the scrollback. */
+ * The sink-for-tests sees exactly what gets pushed to the scrollback.
+ *
+ * Exception: a wholly-empty message is an intentional blank-line spacer. The
+ * boot log groups itself with Log_Raw("") (and LogPrintf's internal blanks
+ * arrive as their own empty record), which the terminal and file sinks render
+ * as a blank line; preserve it here so the F12 console keeps the same vertical
+ * rhythm. Blanks *within* a non-empty message still collapse, per the rule
+ * above. */
 static void console_push_multiline(char *buf, U8 colour) {
+    if (*buf == '\0') {
+        scrollback_push_one("", colour);
+        if (s_line_sink_for_tests)
+            s_line_sink_for_tests("");
+        return;
+    }
     char *p = buf;
     while (*p) {
         char *nl = strchr(p, '\n');

--- a/tests/console/test_console_commands.cpp
+++ b/tests/console/test_console_commands.cpp
@@ -102,6 +102,15 @@ int main(void) {
     assert(g_lines.size() == 1);
     assert(g_lines[0] == "single line, no newline");
 
+    /* A wholly-empty message is an intentional blank-line spacer (Log_Raw("")
+     * between boot-log groups) and is preserved as one blank line, matching the
+     * terminal and file sinks. Blanks *within* a non-empty message (above) still
+     * collapse. */
+    clear_lines();
+    Console_Print("");
+    assert(g_lines.size() == 1);
+    assert(g_lines[0] == "");
+
     Console_SetLineSinkForTests(NULL);
     return 0;
 }


### PR DESCRIPTION
The boot log groups itself with blank-line spacers, and the terminal/file sinks print them, but the F12 console dropped them so it read as more cramped than the boot log it mirrors.

## Cause
The boot log uses intentional blank lines for grouping:
- `Log_Raw("")` after the identity block (`INITADEL.C`) and before the `Ready` banner (`PERSO.CPP`)
- `LogPrintf`'s internal blanks, which `RouteOrFallback` emits as their own empty `Log_Raw` records

`console_push_multiline` skipped *every* empty segment (to suppress the printf trailing-newline idiom like `"foo\n"`), which also swallowed these intentional spacers.

## Fix
Preserve a wholly-empty message as one blank line, matching the terminal and file sinks. Blank segments *within* a non-empty message still collapse, so `"foo\n"` gains no spurious blank, and the existing leading/trailing/repeated-newline collapse for direct `Console_Print` callers is unchanged.

## Verification
- `test_console_commands` gains a `Console_Print("")` -> one blank line assertion; the existing `"\nfoo\n\nbar\n"` -> 2-line contract still holds.
- `test_console_render`, `test_log`, `test_log_spine` pass; full `make test` green; clang-format clean.