### PR TITLE
feat(console): keyboard UX overhaul + text-input character entry

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE.CPP
+++ b/SOURCES/CONSOLE/CONSOLE.CPP
@@ -27,6 +27,8 @@
 #define CONSOLE_MAX_CVARS 16
 #define CONSOLE_MAX_ARGV 16
 #define CONSOLE_KEY_QUEUE_SIZE 32
+/* Sentinel scancode for a queued text-input character (vs a physical key). */
+#define CONSOLE_TEXT_CHAR (-1)
 
 struct cmd_entry {
     const char *name;
@@ -38,6 +40,7 @@ struct cmd_entry {
 struct key_event {
     int scancode;
     int keycode;
+    int mod; /* SDL_Keymod bitmask captured at key-down (Ctrl/Shift for clipboard) */
 };
 struct cvar_entry {
     const char *name;
@@ -91,6 +94,22 @@ static Console_LineSinkFn s_line_sink_for_tests = NULL;
 
 static void Console_SubmitLine(void);
 
+/* Enable/disable SDL text input so the console receives correctly-cased,
+ * layout-aware characters via SDL_EVENT_TEXT_INPUT. SDL_GetKeyFromScancode does
+ * not apply Shift on every platform (hence the old '-'->'_' workaround), so the
+ * keycode path alone can't produce capitals or shifted symbols. Targets the
+ * focused window to stay decoupled from the video layer; a no-op when there is
+ * no window (e.g. host tests with no SDL video). */
+static void console_set_text_input(int on) {
+    SDL_Window *w = SDL_GetKeyboardFocus();
+    if (!w)
+        return;
+    if (on)
+        SDL_StartTextInput(w);
+    else
+        SDL_StopTextInput(w);
+}
+
 void Console_SetSlideShowActive(int active) {
     s_slide_show_active = (active != 0);
 }
@@ -125,6 +144,8 @@ void Console_RequestScreenshot(const char *path, int use_png) {
     s_screenshot_png = use_png ? 1 : 0;
     strncpy(s_screenshot_path, path, CONSOLE_SCREENSHOT_PATH_MAX - 1);
     s_screenshot_path[CONSOLE_SCREENSHOT_PATH_MAX - 1] = '\0';
+    if (s_console_open)
+        console_set_text_input(0);
     s_console_open = 0;
     free(s_console_buf);
     s_console_buf = NULL;
@@ -168,7 +189,9 @@ void Console_Toggle(void) {
     if (s_console_open) {
         Console_EnsureRegistered();
         s_history_index = -1;
+        console_set_text_input(1);
     } else {
+        console_set_text_input(0);
         /* Clear input line when closing so it doesn't persist on next open */
         free(s_console_buf);
         s_console_buf = NULL;
@@ -184,6 +207,7 @@ void Console_Close(void) {
     if (!s_console_open)
         return;
     s_console_open = 0;
+    console_set_text_input(0);
     free(s_console_buf);
     s_console_buf = NULL;
     s_console_w = 0;
@@ -333,54 +357,305 @@ static int cvar_index_cmp(const void *a, const void *b) {
     return strcmp(s_cvars[ia].name, s_cvars[ib].name);
 }
 
-static void Console_UpdateKey(int scancode, int keycode) {
-    (void)keycode;
+/* --- Input-line editing primitives. All operate at s_cursor_pos so the line can
+ * be edited mid-string (Left/Right/Home/End/Delete), not just appended to. --- */
+static void input_insert_char(char c) {
+    if (s_input_len >= CONSOLE_INPUT_MAX - 1)
+        return;
+    memmove(&s_input_line[s_cursor_pos + 1], &s_input_line[s_cursor_pos],
+            (size_t)(s_input_len - s_cursor_pos));
+    s_input_line[s_cursor_pos] = c;
+    s_input_len++;
+    s_cursor_pos++;
+    s_input_line[s_input_len] = '\0';
+}
+
+static void input_backspace(void) {
+    if (s_cursor_pos <= 0)
+        return;
+    memmove(&s_input_line[s_cursor_pos - 1], &s_input_line[s_cursor_pos],
+            (size_t)(s_input_len - s_cursor_pos));
+    s_cursor_pos--;
+    s_input_len--;
+    s_input_line[s_input_len] = '\0';
+}
+
+static void input_delete(void) { /* delete the char *at* the cursor (Del key) */
+    if (s_cursor_pos >= s_input_len)
+        return;
+    memmove(&s_input_line[s_cursor_pos], &s_input_line[s_cursor_pos + 1],
+            (size_t)(s_input_len - s_cursor_pos - 1));
+    s_input_len--;
+    s_input_line[s_input_len] = '\0';
+}
+
+static void input_clear(void) {
+    s_input_len = 0;
+    s_cursor_pos = 0;
+    s_input_line[0] = '\0';
+    s_history_index = -1; /* a cleared line starts history browsing fresh */
+}
+
+/* Scroll the scrollback view; delta > 0 reveals older lines. Clamped to the
+ * visible window exactly as Console_Draw clamps. Shared by PgUp/PgDn and wheel. */
+static void Console_ScrollLines(int delta) {
+    int n = (int)(s_console_h / CONSOLE_LINE_HEIGHT) - 1;
+    int maxScroll;
+    if (n < 0)
+        n = 0;
+    maxScroll = s_scrollback_count - n;
+    if (maxScroll < 0)
+        maxScroll = 0;
+    s_scroll_offset += delta;
+    if (s_scroll_offset > maxScroll)
+        s_scroll_offset = maxScroll;
+    if (s_scroll_offset < 0)
+        s_scroll_offset = 0;
+}
+
+/* Recall command history into the input line. dir < 0 = older, dir > 0 = newer.
+ * Down past the newest entry restores an empty line and stops browsing. */
+static void Console_HistoryRecall(int dir) {
+    if (s_history_count == 0)
+        return;
+    if (s_history_index < 0) {
+        if (dir >= 0)
+            return;                        /* Down with nothing recalled yet: keep the in-progress line */
+        s_history_index = s_history_count; /* step back from one-past-newest */
+    }
+    s_history_index += dir;
+    if (s_history_index < 0)
+        s_history_index = 0;
+    if (s_history_index >= s_history_count) {
+        input_clear(); /* walked past the newest entry: restore an empty line */
+        return;
+    }
+    strncpy(s_input_line, s_history[s_history_index], CONSOLE_INPUT_MAX - 1);
+    s_input_line[CONSOLE_INPUT_MAX - 1] = '\0';
+    s_input_len = (int)strlen(s_input_line);
+    s_cursor_pos = s_input_len;
+}
+
+/* Insert the printable chars of the system clipboard at the cursor (drops control
+ * chars / newlines so a multi-line paste can't smuggle a submit). */
+static void clipboard_paste(void) {
+    char *txt = SDL_GetClipboardText();
+    const char *p;
+    if (!txt)
+        return;
+    for (p = txt; *p; p++) {
+        unsigned char c = (unsigned char)*p;
+        if (c >= 32 && c < 127)
+            input_insert_char((char)c);
+    }
+    SDL_free(txt);
+}
+
+/* Accumulate one completion candidate: record the match and shrink `out` to the
+ * longest common prefix of all matches seen so far. */
+static void complete_consider(const char *name, const char *prefix, size_t plen,
+                              char *out, size_t outsz, const char **matches, int max,
+                              int *count, int *have_first) {
+    size_t k;
+    if (strncmp(name, prefix, plen) != 0)
+        return;
+    if (matches && *count < max)
+        matches[*count] = name;
+    if (!*have_first) {
+        strncpy(out, name, outsz - 1);
+        out[outsz - 1] = '\0';
+        *have_first = 1;
+    } else {
+        for (k = 0; out[k] && name[k] && out[k] == name[k]; k++)
+            ;
+        out[k] = '\0';
+    }
+    (*count)++;
+}
+
+/* Complete `prefix` against registered commands, cvars and the built-ins. `out`
+ * receives the longest common prefix of all matches (the full name for a unique
+ * match); `matches` receives up to `max` name pointers. Returns the match count.
+ * Non-static so host tests can exercise it against a registered table. */
+int Console_CompletePrefix(const char *prefix, char *out, size_t outsz, const char **matches, int max) {
+    static const char *const builtins[] = {"help", "cmdlist", "varlist"};
+    size_t plen = prefix ? strlen(prefix) : 0;
+    int count = 0;
+    int have_first = 0;
+    int i;
+    if (out && outsz)
+        out[0] = '\0';
+    if (!prefix || !out || outsz == 0)
+        return 0;
+    for (i = 0; i < s_cmd_count; i++)
+        complete_consider(s_cmds[i].name, prefix, plen, out, outsz, matches, max, &count, &have_first);
+    for (i = 0; i < s_cvar_count; i++)
+        complete_consider(s_cvars[i].name, prefix, plen, out, outsz, matches, max, &count, &have_first);
+    for (i = 0; i < (int)(sizeof(builtins) / sizeof(builtins[0])); i++)
+        complete_consider(builtins[i], prefix, plen, out, outsz, matches, max, &count, &have_first);
+    return count;
+}
+
+/* Tab-complete the command at the start of the line. Argument completion (after a
+ * space) is intentionally left for later. */
+static void Console_TabComplete(void) {
+    char token[CONSOLE_INPUT_MAX];
+    char lcp[CONSOLE_INPUT_MAX];
+    const char *matches[CONSOLE_MAX_CMDS + CONSOLE_MAX_CVARS + 4];
+    const int maxmatch = (int)(sizeof(matches) / sizeof(matches[0]));
+    int nmatch, i, tlen, newlen, tail;
+
+    for (i = 0; i < s_cursor_pos; i++)
+        if (s_input_line[i] == ' ' || s_input_line[i] == '\t')
+            return; /* cursor is past the command word */
+    tlen = s_cursor_pos;
+    if (tlen <= 0)
+        return;
+    if (tlen >= (int)sizeof(token))
+        tlen = (int)sizeof(token) - 1;
+    memcpy(token, s_input_line, (size_t)tlen);
+    token[tlen] = '\0';
+
+    nmatch = Console_CompletePrefix(token, lcp, sizeof lcp, matches, maxmatch);
+    if (nmatch <= 0)
+        return;
+
+    /* Replace the typed token with the common prefix (or the full unique name). */
+    newlen = (int)strlen(lcp);
+    tail = s_input_len - s_cursor_pos;
+    if (newlen + tail >= CONSOLE_INPUT_MAX)
+        return;
+    memmove(&s_input_line[newlen], &s_input_line[s_cursor_pos], (size_t)tail);
+    memcpy(s_input_line, lcp, (size_t)newlen);
+    s_input_len = newlen + tail;
+    s_cursor_pos = newlen;
+    s_input_line[s_input_len] = '\0';
+
+    if (nmatch == 1) {
+        if (s_cursor_pos == s_input_len && s_input_len < CONSOLE_INPUT_MAX - 1) {
+            s_input_line[s_input_len++] = ' ';
+            s_input_line[s_input_len] = '\0';
+            s_cursor_pos = s_input_len;
+        }
+    } else {
+        /* Ambiguous: list the candidates (Quake-style). */
+        char line[CONSOLE_LINE_MAX];
+        size_t off = 0;
+        line[0] = '\0';
+        for (i = 0; i < nmatch && i < maxmatch; i++) {
+            int w = snprintf(line + off, sizeof(line) - off, "%s%s", off ? "  " : "", matches[i]);
+            if (w < 0 || off + (size_t)w >= sizeof(line))
+                break;
+            off += (size_t)w;
+        }
+        Console_Print("%s", line);
+    }
+}
+
+static void Console_UpdateKey(int scancode, int keycode, int mod) {
+    /* AltGr is Ctrl+Alt on many layouts; treat Ctrl as a command modifier only
+     * when Alt is not also held so AltGr text entry still works. */
+    int ctrl = (mod & SDL_KMOD_CTRL) && !(mod & SDL_KMOD_ALT);
+
+    s_cursor_blink = 0; /* any keypress makes the cursor immediately visible */
+
+    /* Text-input characters arrive already cased and layout-resolved, queued with
+     * the CONSOLE_TEXT_CHAR sentinel; insert the printable ASCII ones. Physical
+     * keys (below) are handled by scancode and never insert text themselves. */
+    if (scancode == CONSOLE_TEXT_CHAR) {
+        if (keycode >= 32 && keycode < 127)
+            input_insert_char((char)keycode);
+        return;
+    }
+
+    /* Control combos are commands, never text: handle the few we support and
+     * swallow the rest so e.g. Ctrl+A doesn't type 'a'. */
+    if (ctrl) {
+        /* Lowercase in-range without tolower(): keycode may be a large SDL keysym
+         * (e.g. arrows), which is out of tolower()'s defined domain. */
+        int kl = (keycode >= 'A' && keycode <= 'Z') ? (keycode - 'A' + 'a') : keycode;
+        if (kl == 'v')
+            clipboard_paste();
+        else if (kl == 'c')
+            SDL_SetClipboardText(s_input_line);
+        else if (kl == 'l')
+            input_clear();
+        return;
+    }
+    /* Shift+Insert also pastes (X11/terminal convention). */
+    if (scancode == (int)SDL_SCANCODE_INSERT && (mod & SDL_KMOD_SHIFT)) {
+        clipboard_paste();
+        return;
+    }
+
     if (scancode == K_ENTER || scancode == K_NUMPAD_ENTER) {
         Console_SubmitLine();
         return;
     }
-    /* Backspace: match by scancode or keycode (8 = ASCII BS) for different layouts */
+    if (scancode == K_ESC) {
+        if (s_input_len > 0)
+            input_clear(); /* first Esc clears the line ... */
+        else
+            Console_Close(); /* ... Esc on an empty line closes the console */
+        return;
+    }
+    if (scancode == K_TAB) {
+        Console_TabComplete();
+        return;
+    }
+    /* Backspace: match by scancode or keycode (8 = ASCII BS) for different layouts. */
     if (scancode == K_BACKSPACE || keycode == 8) {
-        if (s_input_len > 0) {
-            s_input_len--;
-            s_cursor_pos = s_input_len;
-            s_input_line[s_input_len] = '\0';
-        }
+        input_backspace();
+        return;
+    }
+    if (scancode == K_SUPPR) {
+        input_delete();
+        return;
+    }
+    if (scancode == K_LEFT) {
+        if (s_cursor_pos > 0)
+            s_cursor_pos--;
+        return;
+    }
+    if (scancode == K_RIGHT) {
+        if (s_cursor_pos < s_input_len)
+            s_cursor_pos++;
+        return;
+    }
+    if (scancode == K_HOME) {
+        s_cursor_pos = 0;
+        return;
+    }
+    if (scancode == K_END) {
+        s_cursor_pos = s_input_len;
         return;
     }
     if (scancode == K_UP) {
-        /* Scroll up through scrollback. */
-        int n = (int)(s_console_h / CONSOLE_LINE_HEIGHT) - 1;
-        if (n < 0)
-            n = 0;
-        if (n < s_scrollback_count) {
-            int maxScroll = s_scrollback_count - n;
-            if (maxScroll < 0)
-                maxScroll = 0;
-            if (s_scroll_offset < maxScroll)
-                s_scroll_offset++;
-        }
+        Console_HistoryRecall(-1); /* older */
         return;
     }
     if (scancode == K_DOWN) {
-        /* Scroll down toward the newest lines. */
-        if (s_scroll_offset > 0)
-            s_scroll_offset--;
+        Console_HistoryRecall(1); /* newer */
         return;
     }
-    /* Printable character from event keycode (SDL keycode is Unicode-ish) */
-    if (keycode >= 32 && keycode < 127 && s_input_len < CONSOLE_INPUT_MAX - 1) {
-        s_input_line[s_input_len++] = (char)keycode;
-        s_input_line[s_input_len] = '\0';
-        s_cursor_pos = s_input_len;
+    if (scancode == K_PAGE_UP || scancode == K_PAGE_DOWN) {
+        int page = (int)(s_console_h / CONSOLE_LINE_HEIGHT) - 1;
+        if (page < 1)
+            page = 1;
+        Console_ScrollLines(scancode == K_PAGE_UP ? page : -page);
+        return;
     }
-    (void)s_cursor_blink;
+    /* Printable characters are not inserted here: they arrive via text input as
+     * CONSOLE_TEXT_CHAR events (handled at the top), so casing and shifted symbols
+     * are resolved by the OS keyboard layout. The keypad types digits when Num Lock
+     * is on (text input); with it off the keypad keeps its OS navigation role. */
 }
 
 void Console_Update(void) {
+    s_cursor_blink++; /* advance the cursor-blink phase once per frame */
     while (s_key_head != s_key_tail) {
         struct key_event *e = &s_key_queue[s_key_tail];
-        Console_UpdateKey(e->scancode, e->keycode);
+        Console_UpdateKey(e->scancode, e->keycode, e->mod);
         s_key_tail = (s_key_tail + 1) % CONSOLE_KEY_QUEUE_SIZE;
     }
 }
@@ -545,15 +820,6 @@ static void console_fixed_rgb(U8 idx, U8 *r, U8 *g, U8 *b) {
     }
 }
 
-/* Faux-bold blit: AffStringToBuffer over-writes only set pixels (no paper), so a
- * second pass shifted 1px right thickens every vertical stroke. Used for the cyan
- * banner/section lines so they read as boldly in the F12 console as the terminal
- * sink's bold-cyan bookends do (see term_sink_write in LOG.CPP). */
-static void AffStringToBufferBold(U8 *dst, U32 pitch, S32 x, S32 y, const char *str, U8 ink) {
-    AffStringToBuffer(dst, pitch, x, y, str, ink);
-    AffStringToBuffer(dst, pitch, x + 1, y, str, ink);
-}
-
 /** Draw scrollback + input line into s_console_buf (call when open and buffer ready). */
 static void Console_Draw(void) {
     int i, y, start, n;
@@ -598,10 +864,7 @@ static void Console_Draw(void) {
             char rendered[CONSOLE_LINE_MAX];
             utf8_to_cp437(s_scrollback[idx], rendered, sizeof rendered);
             U8 col = s_scrollback_col[idx];
-            if (col == CONSOLE_COL_BANNER)
-                AffStringToBufferBold(s_console_buf, s_console_w, 8, y, rendered, col);
-            else
-                AffStringToBuffer(s_console_buf, s_console_w, 8, y, rendered, col);
+            AffStringToBuffer(s_console_buf, s_console_w, 8, y, rendered, col);
             y += CONSOLE_LINE_HEIGHT;
         }
 
@@ -613,10 +876,17 @@ static void Console_Draw(void) {
     }
     {
         char prompt[CONSOLE_INPUT_MAX + 8];
-        snprintf(prompt, sizeof(prompt), "]> %s_", s_input_line);
+        snprintf(prompt, sizeof(prompt), "]> %s", s_input_line);
         char rendered[CONSOLE_INPUT_MAX + 8];
         utf8_to_cp437(prompt, rendered, sizeof rendered);
         AffStringToBuffer(s_console_buf, s_console_w, 8, y, rendered, CONSOLE_TEXT_COLOUR);
+        /* Blinking underline cursor at the edit position. "]> " is a 3-char prefix
+         * and the font advances 8px/glyph; blink off for ~half of each cycle. */
+        if (((s_cursor_blink >> 5) & 1u) == 0u) {
+            S32 cx = 8 + (3 + s_cursor_pos) * 8;
+            if (cx + 8 <= (S32)s_console_w)
+                AffStringToBuffer(s_console_buf, s_console_w, cx, y, "_", CONSOLE_TEXT_COLOUR);
+        }
     }
 }
 
@@ -702,14 +972,48 @@ void Console_PrePresent(U32 *frameBuffer, U32 pitch, U32 width, U32 height, cons
 
 int Console_FeedEvent(const void *sdlEvent) {
     const SDL_Event *ev = (const SDL_Event *)sdlEvent;
+
+    /* Mouse wheel scrolls the scrollback while the console is open. */
+    if (ev->type == SDL_EVENT_MOUSE_WHEEL) {
+        if (!s_console_open)
+            return 0;
+        if (ev->wheel.y > 0)
+            Console_ScrollLines(3); /* wheel up -> older lines */
+        else if (ev->wheel.y < 0)
+            Console_ScrollLines(-3);
+        return 1;
+    }
+
+    /* Typed characters arrive here already cased and layout-resolved (uppercase,
+     * shifted symbols, AZERTY, numpad-with-NumLock). Queue the printable ASCII
+     * ones as CONSOLE_TEXT_CHAR events; physical keys come through KEY_DOWN below. */
+    if (ev->type == SDL_EVENT_TEXT_INPUT) {
+        const char *t;
+        if (!s_console_open)
+            return 0;
+        for (t = ev->text.text; t && *t; t++) {
+            unsigned char c = (unsigned char)*t;
+            int next;
+            if (c < 32 || c >= 127)
+                continue; /* ASCII printable only, like paste */
+            next = (s_key_head + 1) % CONSOLE_KEY_QUEUE_SIZE;
+            if (next == s_key_tail)
+                break;
+            s_key_queue[s_key_head].scancode = CONSOLE_TEXT_CHAR;
+            s_key_queue[s_key_head].keycode = (int)c;
+            s_key_queue[s_key_head].mod = 0;
+            s_key_head = next;
+        }
+        return 1;
+    }
+
     if (ev->type != SDL_EVENT_KEY_DOWN)
         return 0;
 
     SDL_Scancode scan = ev->key.scancode;
+    /* Keycode is used only for the Ctrl combos below (paste/copy/clear); character
+     * entry is handled by text input above, so no Shift/layout fix-up is needed. */
     SDL_Keycode key = SDL_GetKeyFromScancode(scan, ev->key.mod, true);
-    /* Fallback: some layouts don't report Shift; ensure minus+Shift gives underscore. */
-    if ((key == 45 || key == (SDL_Keycode)'-') && (ev->key.mod & SDL_KMOD_SHIFT))
-        key = (SDL_Keycode)'_';
 
     /* Toggle only on first key down, not key repeat. */
     if ((scan == (SDL_Scancode)s_toggle_scancode) && !ev->key.repeat) {
@@ -731,6 +1035,7 @@ int Console_FeedEvent(const void *sdlEvent) {
         return 1;
     s_key_queue[s_key_head].scancode = (int)scan;
     s_key_queue[s_key_head].keycode = (int)key;
+    s_key_queue[s_key_head].mod = (int)ev->key.mod;
     s_key_head = next;
     return 1;
 }
@@ -774,17 +1079,19 @@ static void Console_SubmitLine(void) {
         return;
     s_input_line[s_input_len] = '\0';
     scrollback_push_one(s_input_line, CONSOLE_COL_DEFAULT);
-    /* Add to history */
-    if (s_history_count < CONSOLE_HISTORY_SIZE) {
-        strncpy(s_history[s_history_count], s_input_line, CONSOLE_LINE_MAX - 1);
-        s_history[s_history_count][CONSOLE_LINE_MAX - 1] = '\0';
-        s_history_count++;
-    } else {
-        int j;
-        for (j = 0; j < CONSOLE_HISTORY_SIZE - 1; j++)
-            strcpy(s_history[j], s_history[j + 1]);
-        strncpy(s_history[CONSOLE_HISTORY_SIZE - 1], s_input_line, CONSOLE_LINE_MAX - 1);
-        s_history[CONSOLE_HISTORY_SIZE - 1][CONSOLE_LINE_MAX - 1] = '\0';
+    /* Add to history, skipping a verbatim repeat of the previous entry. */
+    if (!(s_history_count > 0 && strcmp(s_history[s_history_count - 1], s_input_line) == 0)) {
+        if (s_history_count < CONSOLE_HISTORY_SIZE) {
+            strncpy(s_history[s_history_count], s_input_line, CONSOLE_LINE_MAX - 1);
+            s_history[s_history_count][CONSOLE_LINE_MAX - 1] = '\0';
+            s_history_count++;
+        } else {
+            int j;
+            for (j = 0; j < CONSOLE_HISTORY_SIZE - 1; j++)
+                strcpy(s_history[j], s_history[j + 1]);
+            strncpy(s_history[CONSOLE_HISTORY_SIZE - 1], s_input_line, CONSOLE_LINE_MAX - 1);
+            s_history[CONSOLE_HISTORY_SIZE - 1][CONSOLE_LINE_MAX - 1] = '\0';
+        }
     }
     Console_Execute(s_input_line);
     s_input_len = 0;

--- a/SOURCES/CONSOLE/CONSOLE.H
+++ b/SOURCES/CONSOLE/CONSOLE.H
@@ -2,6 +2,7 @@
 #define CONSOLE_H
 
 #include <SYSTEM/ADELINE_TYPES.H>
+#include <stddef.h> /* size_t */
 
 #ifdef __cplusplus
 extern "C" {
@@ -105,6 +106,12 @@ void Console_SetLineSinkForTests(Console_LineSinkFn sink);
 /* Copy up to max recent scrollback line pointers (chronological, newest last) into
    out[]; returns the count. Pointers are valid until the next console output. */
 int Console_GetScrollback(const char **out, int max);
+
+/* Tab-completion core (also used by host tests): match \a prefix against the
+   registered commands, cvars and built-ins. \a out receives the longest common
+   prefix of all matches (the full name when unique); \a matches receives up to
+   \a max candidate name pointers. Returns the number of matches. */
+int Console_CompletePrefix(const char *prefix, char *out, size_t outsz, const char **matches, int max);
 
 #ifdef __cplusplus
 }

--- a/docs/CONSOLE.md
+++ b/docs/CONSOLE.md
@@ -18,9 +18,14 @@ The console is supported with the SDL backend (default in this project).
 - **F12** by default: open/close the console.
 - Optional override in `lba2.cfg`: set `ConsoleToggleKey=<SDL scancode int>` (for example `41` for `K_CARRE` on AZERTY layouts).
 - When the console is open, all keyboard input is consumed by the console (no game/menu input).
-- Type a line and press **Enter** to run a command or cheat.
-- **Backspace**: delete last character.
-- **Up/Down**: scroll console output; the input line stays fixed at the bottom. When you are not at the newest lines, the last visible scrollback line shows `...`.
+- Type a line and press **Enter** (or numpad Enter) to run a command or cheat.
+- **Esc**: clear the input line; pressing Esc on an already-empty line closes the console.
+- **Up/Down**: recall previous commands (input history).
+- **Page Up / Page Down** and the **mouse wheel**: scroll console output; the input line stays fixed at the bottom. When you are not at the newest lines, the last visible scrollback line shows `...`.
+- **Left/Right/Home/End**: move the edit cursor within the input line. **Backspace** deletes the character before the cursor; **Delete** the one at it.
+- **Tab**: complete the command at the prompt against the known commands, cvars and built-ins. A unique prefix completes in full (and adds a trailing space); an ambiguous prefix extends to the longest common prefix and lists the candidates.
+- **Casing and symbols**: typing goes through the OS text-input layer, so **Shift**/**Caps Lock** give capitals and shifted symbols, and non-US keyboard layouts type the right characters. The numpad types digits and `.` `/` `*` `+` `-` when **Num Lock** is on.
+- **Clipboard**: **Ctrl+C** copies the input line; **Ctrl+V** (or **Shift+Insert**) pastes into it; **Ctrl+L** clears the line.
 
 ## Discovery
 
@@ -82,13 +87,13 @@ Get/set with `varname` (print value) or `varname value` (set).
 ## Layout
 
 - Console is a panel at the top of the screen.
-- Scrollback shows recent lines; the last line is the input with a `]> ... _` prompt. When scrolled up, an ellipsis `...` appears on the last visible scrollback line to indicate older messages above.
+- Scrollback shows recent lines; the last line is the input with a `]> ` prompt and a blinking underline cursor at the edit position. When scrolled up, an ellipsis `...` appears on the last visible scrollback line to indicate older messages above.
 - Output from commands and cheats appears in the scrollback.
 
 ## Implementation notes
 
 - **Independent of game buffer**: The console uses its own 8-bit overlay buffer. It is drawn via `AffStringToBuffer` (LIB386/SVGA) and composited in the video layer’s pre-present callback (`Console_PrePresent`), so it never touches the game’s `Log` or dirty-box pipeline.
-- **Event-driven input**: Keys are fed from the event loop via `Console_FeedEvent` (registered with `SetEventFilter`). When the console is open, key events are queued and processed each frame by `Console_Update()` (no arguments). The configured toggle key is reserved from gameplay input to avoid double-handling.
+- **Event-driven input**: Keys are fed from the event loop via `Console_FeedEvent` (registered with `SetEventFilter`). When the console is open, key events are queued and processed each frame by `Console_Update()` (no arguments). The configured toggle key is reserved from gameplay input to avoid double-handling. Character entry uses SDL text input (enabled on open, disabled on close) so casing, shifted symbols and non-US layouts resolve through the OS keyboard layout; physical keys (Enter, arrows, Backspace/Delete, Tab, Esc, Home/End, Page Up/Down, the Ctrl combos) are handled by scancode. The mouse wheel scrolls the scrollback.
 - **Hooks**: `SetEventFilter(Console_FeedEvent)` and `SetPrePresentCallback(Console_PrePresent)` are registered in `main()` after `InitAdeline()`. `MyGetInput()` reserves the configured toggle key, and when the console is open calls `Console_Update()` and returns.
 - **Module**: `SOURCES/CONSOLE/` – `CONSOLE.H`, `CONSOLE.CPP` (core), `CONSOLE_CMD.CPP` (commands/cvars). Core links only LIB386 (AFFSTR for text) and SDL for events; no dependency on game `Log` or dirty-box.
 - **Gameplay integration**: Commands call existing engine functions (`LoadGameNumCube`, `PlayAcf`, `DoFoundObj`, etc.) rather than introducing console-only code paths. Cube changes no longer trigger autosave to keep debug teleports tidy; other save behavior is unchanged.

--- a/tests/console/CMakeLists.txt
+++ b/tests/console/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(test_console_state test_console_state.cpp)
 add_executable(test_console_commands test_console_commands.cpp)
 add_executable(test_console_give test_console_give.cpp)
 add_executable(test_console_render test_console_render.cpp)
+add_executable(test_console_complete test_console_complete.cpp)
 
 target_include_directories(test_console_state PRIVATE
     ${CMAKE_SOURCE_DIR}/SOURCES
@@ -12,6 +13,10 @@ target_include_directories(test_console_commands PRIVATE
     ${CMAKE_SOURCE_DIR}/LIB386/H
 )
 target_include_directories(test_console_render PRIVATE
+    ${CMAKE_SOURCE_DIR}/SOURCES
+    ${CMAKE_SOURCE_DIR}/LIB386/H
+)
+target_include_directories(test_console_complete PRIVATE
     ${CMAKE_SOURCE_DIR}/SOURCES
     ${CMAKE_SOURCE_DIR}/LIB386/H
 )
@@ -28,18 +33,22 @@ target_link_libraries(test_console_state PRIVATE console)
 target_link_libraries(test_console_commands PRIVATE console)
 target_link_libraries(test_console_give PRIVATE console)
 target_link_libraries(test_console_render PRIVATE console)
+target_link_libraries(test_console_complete PRIVATE console)
 
 set_target_properties(test_console_state PROPERTIES CXX_STANDARD 11)
 set_target_properties(test_console_commands PROPERTIES CXX_STANDARD 11)
 set_target_properties(test_console_give PROPERTIES CXX_STANDARD 11)
 set_target_properties(test_console_render PROPERTIES CXX_STANDARD 11)
+set_target_properties(test_console_complete PROPERTIES CXX_STANDARD 11)
 
 add_test(NAME test_console_state COMMAND test_console_state)
 add_test(NAME test_console_commands COMMAND test_console_commands)
 add_test(NAME test_console_give COMMAND test_console_give)
 add_test(NAME test_console_render COMMAND test_console_render)
+add_test(NAME test_console_complete COMMAND test_console_complete)
 
 register_host_test(test_console_state)
 register_host_test(test_console_commands)
 register_host_test(test_console_give)
 register_host_test(test_console_render)
+register_host_test(test_console_complete)

--- a/tests/console/test_console_complete.cpp
+++ b/tests/console/test_console_complete.cpp
@@ -1,0 +1,86 @@
+/* Host test for Console_CompletePrefix: tab-completion matching over the
+ * registered command/cvar tables plus the built-ins (help/cmdlist/varlist).
+ * Mirrors what the K_TAB handler runs in the live console. */
+#include "CONSOLE/CONSOLE.H"
+
+#include <cstdio>
+#include <cstring>
+
+/* Link stubs: the console lib references these, but completion doesn't use them. */
+extern "C" void AffStringToBuffer(U8 *dst, U32 pitch, S32 x, S32 y, const char *str, U8 ink) {
+    (void)dst;
+    (void)pitch;
+    (void)x;
+    (void)y;
+    (void)str;
+    (void)ink;
+}
+void Console_RegisterAll(void) {}
+int TryExecuteCheatByName(const char *name) {
+    (void)name;
+    return 0;
+}
+
+static void cmd_noop(int argc, const char *argv[]) {
+    (void)argc;
+    (void)argv;
+}
+
+static int g_failures = 0;
+#define CHECK(cond)                                          \
+    do {                                                     \
+        if (!(cond)) {                                       \
+            printf("FAIL: %s (line %d)\n", #cond, __LINE__); \
+            g_failures++;                                    \
+        }                                                    \
+    } while (0)
+
+int main(void) {
+    int fps = 0;
+    char out[256];
+    const char *m[64];
+    int n;
+
+    Console_RegisterCommand("cube", cmd_noop, "");
+    Console_RegisterCommand("load", cmd_noop, "");
+    Console_RegisterCommand("loadbug", cmd_noop, "");
+    Console_RegisterCommand("listsaves", cmd_noop, "");
+    Console_RegisterCommand("listbugs", cmd_noop, "");
+    Console_RegisterCvar("fps", &fps, CONSOLE_CVAR_INT, "");
+
+    /* Unique prefix -> full name in out, a single match. */
+    n = Console_CompletePrefix("cu", out, sizeof out, m, 64);
+    CHECK(n == 1);
+    CHECK(strcmp(out, "cube") == 0);
+
+    /* Ambiguous prefix -> out is the longest common prefix of the matches. */
+    n = Console_CompletePrefix("lo", out, sizeof out, m, 64);
+    CHECK(n == 2); /* load, loadbug */
+    CHECK(strcmp(out, "load") == 0);
+
+    /* "l" matches load/loadbug/listsaves/listbugs -> common prefix is just "l". */
+    n = Console_CompletePrefix("l", out, sizeof out, m, 64);
+    CHECK(n == 4);
+    CHECK(strcmp(out, "l") == 0);
+
+    /* Cvars and built-ins are completion candidates too. */
+    n = Console_CompletePrefix("fp", out, sizeof out, m, 64);
+    CHECK(n == 1 && strcmp(out, "fps") == 0);
+    n = Console_CompletePrefix("cmd", out, sizeof out, m, 64);
+    CHECK(n == 1 && strcmp(out, "cmdlist") == 0); /* built-in */
+    n = Console_CompletePrefix("var", out, sizeof out, m, 64);
+    CHECK(n == 1 && strcmp(out, "varlist") == 0); /* built-in */
+
+    /* No match leaves out empty and returns 0. */
+    n = Console_CompletePrefix("zzz", out, sizeof out, m, 64);
+    CHECK(n == 0);
+    CHECK(out[0] == '\0');
+
+    /* Empty prefix matches every candidate: 5 cmds + 1 cvar + 3 built-ins. */
+    n = Console_CompletePrefix("", out, sizeof out, m, 64);
+    CHECK(n == 5 + 1 + 3);
+
+    if (g_failures == 0)
+        printf("test_console_complete: OK\n");
+    return g_failures != 0;
+}

--- a/tests/console/test_console_render.cpp
+++ b/tests/console/test_console_render.cpp
@@ -99,9 +99,9 @@ int main(void) {
     CHECK(err && err->ink == CONSOLE_COL_ERROR);
     CHECK(bnr && bnr->ink == CONSOLE_COL_BANNER);
 
-    /* Banner lines render faux-bold: a second 1px-shifted pass thickens the
-     * strokes, so the banner is drawn twice while ordinary lines are drawn once. */
-    CHECK(count_draws("bnr-line") == 2);
+    /* Every scrollback line, banner included, is drawn exactly once: the banner
+     * keeps its cyan ink but no longer gets a faux-bold second pass. */
+    CHECK(count_draws("bnr-line") == 1);
     CHECK(count_draws("info-line") == 1);
     CHECK(count_draws("warn-line") == 1);
 


### PR DESCRIPTION
Brings the F12 console up to Quake/readline-grade input handling. Several of these were half-built already and just needed wiring (history storage existed but was never recalled; `s_cursor_pos` was tracked but unused).

## What changed

- **History** on Up/Down. **Page Up/Down** and the **mouse wheel** scroll the scrollback, which frees the arrow keys for history.
- **Mid-line editing**: Left/Right/Home/End/Delete with a blinking underline cursor.
- **Tab completion** over commands, cvars and the built-ins (`help`/`cmdlist`/`varlist`). Unique prefix completes in full; an ambiguous one extends to the longest common prefix and lists the candidates.
- **Clipboard**: Ctrl+C copies the input line, Ctrl+V / Shift+Insert paste, Ctrl+L clears.
- **Two-stage Esc**: clears the input line, then closes the console on an empty line.
- **Character entry now goes through SDL text input.** The old keycode path never applied Shift (hence the previous `-`→`_` workaround), and text input was never started, so capitals and shifted symbols didn't work and the keypad produced nothing. Enabling text input on open resolves casing, shifted symbols and non-US keyboard layouts through the OS, and the keypad types digits when Num Lock is on. Physical/navigation keys still come through key-down by scancode.
- **Removed the faux-bold banner blit** in the console (the cyan ink is kept; the terminal-sink bold is unchanged). The double-blit looked rough at the console's resolution.

## Fixes #306

Keypad numbers didn't register in the console because SDL text input was never enabled, so no typed characters reached the input line at all. With text input on, the keypad types digits when Num Lock is on (standard behavior; with Num Lock off the keypad keeps its OS navigation role).

## Testing

- New `tests/console/test_console_complete.cpp` covers the completion matching (unique / ambiguous / cvars / built-ins / no-match / empty).
- `tests/console/test_console_render.cpp` updated for the un-bolded banner (drawn once, not twice).
- `make test` green (29/29 host tests); full engine build links clean; clang-format clean.
- The live SDL paths (text-input casing, wheel, clipboard) are compile- and review-verified but not exercised by the headless suite.

## Follow-up

Mouse text selection + copy is scoped as a separate PR (interaction-heavy: click-to-cell mapping, highlight rendering, multi-line copy).
