### PR TITLE
chore(console): hardening from arch review (CP437 dedup, loud table overflow, input test seam)

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE.CPP
+++ b/SOURCES/CONSOLE/CONSOLE.CPP
@@ -24,7 +24,7 @@
 #define CONSOLE_WRAP_WIDTH 78
 #define CONSOLE_PANEL_HEIGHT 140
 #define CONSOLE_LINE_HEIGHT 9
-#define CONSOLE_MAX_CMDS 32
+#define CONSOLE_MAX_CMDS 48 /* ~27 registered today; headroom before the loud drop */
 #define CONSOLE_MAX_CVARS 16
 #define CONSOLE_MAX_ARGV 16
 #define CONSOLE_KEY_QUEUE_SIZE 32
@@ -520,96 +520,62 @@ static int is_modifier_scancode(int sc) {
     }
 }
 
-/* Unicode codepoint for a CP437 high byte (the inverse of cp_to_cp437, for the
- * bytes the console renders), or 0 when there is no mapping. Lets the CP437 row
- * snapshot copy back out as proper UTF-8 (e.g. the boot log's "·" separator). */
+/* CP437 <-> Unicode for the Latin-1 range the console actually draws (the boot
+ * log's "·" separator, accented language names, etc.). Single source of truth so
+ * the draw-time fold (cp_to_cp437) and the copy-time unfold (cp437_to_unicode)
+ * cannot disagree. All these codepoints are U+0080..U+07FF (2-byte UTF-8). */
+static const struct cp437_pair {
+    unsigned int cp; /* Unicode codepoint */
+    unsigned char b; /* CP437 byte */
+} cp437_map[] = {
+    {0x00B7, 0xFA}, /* · */ {0x00B0, 0xF8}, /* ° */ {0x00A1, 0xAD}, /* ¡ */
+    {0x00BF, 0xA8},
+    /* ¿ */ {0x00AB, 0xAE},
+    /* « */ {0x00BB, 0xAF}, /* » */
+    {0x00A3, 0x9C},
+    /* £ */ {0x00C7, 0x80},
+    /* Ç */ {0x00FC, 0x81}, /* ü */
+    {0x00E9, 0x82},
+    /* é */ {0x00E2, 0x83},
+    /* â */ {0x00E4, 0x84}, /* ä */
+    {0x00E0, 0x85},
+    /* à */ {0x00E5, 0x86},
+    /* å */ {0x00E7, 0x87}, /* ç */
+    {0x00EA, 0x88},
+    /* ê */ {0x00EB, 0x89},
+    /* ë */ {0x00E8, 0x8A}, /* è */
+    {0x00EF, 0x8B},
+    /* ï */ {0x00EE, 0x8C},
+    /* î */ {0x00EC, 0x8D}, /* ì */
+    {0x00C4, 0x8E},
+    /* Ä */ {0x00C5, 0x8F},
+    /* Å */ {0x00C9, 0x90}, /* É */
+    {0x00E6, 0x91},
+    /* æ */ {0x00C6, 0x92},
+    /* Æ */ {0x00F4, 0x93}, /* ô */
+    {0x00F6, 0x94},
+    /* ö */ {0x00F2, 0x95},
+    /* ò */ {0x00FB, 0x96}, /* û */
+    {0x00F9, 0x97},
+    /* ù */ {0x00FF, 0x98},
+    /* ÿ */ {0x00D6, 0x99}, /* Ö */
+    {0x00DC, 0x9A},
+    /* Ü */ {0x00E1, 0xA0},
+    /* á */ {0x00ED, 0xA1}, /* í */
+    {0x00F3, 0xA2},
+    /* ó */ {0x00FA, 0xA3},
+    /* ú */ {0x00F1, 0xA4}, /* ñ */
+    {0x00D1, 0xA5},
+    /* Ñ */ {0x00DF, 0xE1}, /* ß */
+};
+
+/* Unicode codepoint for a CP437 high byte, or 0 if unmapped. Turns the CP437 row
+ * snapshot back into proper UTF-8 for the clipboard. */
 static unsigned int cp437_to_unicode(unsigned char b) {
-    switch (b) {
-    case 0xFA:
-        return 0x00B7; /* · */
-    case 0xF8:
-        return 0x00B0; /* ° */
-    case 0xAD:
-        return 0x00A1; /* ¡ */
-    case 0xA8:
-        return 0x00BF; /* ¿ */
-    case 0xAE:
-        return 0x00AB; /* « */
-    case 0xAF:
-        return 0x00BB; /* » */
-    case 0x9C:
-        return 0x00A3; /* £ */
-    case 0x80:
-        return 0x00C7; /* Ç */
-    case 0x81:
-        return 0x00FC; /* ü */
-    case 0x82:
-        return 0x00E9; /* é */
-    case 0x83:
-        return 0x00E2; /* â */
-    case 0x84:
-        return 0x00E4; /* ä */
-    case 0x85:
-        return 0x00E0; /* à */
-    case 0x86:
-        return 0x00E5; /* å */
-    case 0x87:
-        return 0x00E7; /* ç */
-    case 0x88:
-        return 0x00EA; /* ê */
-    case 0x89:
-        return 0x00EB; /* ë */
-    case 0x8A:
-        return 0x00E8; /* è */
-    case 0x8B:
-        return 0x00EF; /* ï */
-    case 0x8C:
-        return 0x00EE; /* î */
-    case 0x8D:
-        return 0x00EC; /* ì */
-    case 0x8E:
-        return 0x00C4; /* Ä */
-    case 0x8F:
-        return 0x00C5; /* Å */
-    case 0x90:
-        return 0x00C9; /* É */
-    case 0x91:
-        return 0x00E6; /* æ */
-    case 0x92:
-        return 0x00C6; /* Æ */
-    case 0x93:
-        return 0x00F4; /* ô */
-    case 0x94:
-        return 0x00F6; /* ö */
-    case 0x95:
-        return 0x00F2; /* ò */
-    case 0x96:
-        return 0x00FB; /* û */
-    case 0x97:
-        return 0x00F9; /* ù */
-    case 0x98:
-        return 0x00FF; /* ÿ */
-    case 0x99:
-        return 0x00D6; /* Ö */
-    case 0x9A:
-        return 0x00DC; /* Ü */
-    case 0xA0:
-        return 0x00E1; /* á */
-    case 0xA1:
-        return 0x00ED; /* í */
-    case 0xA2:
-        return 0x00F3; /* ó */
-    case 0xA3:
-        return 0x00FA; /* ú */
-    case 0xA4:
-        return 0x00F1; /* ñ */
-    case 0xA5:
-        return 0x00D1; /* Ñ */
-    case 0xE1:
-        return 0x00DF; /* ß */
-    default:
-        return 0;
-    }
+    for (size_t i = 0; i < sizeof(cp437_map) / sizeof(cp437_map[0]); i++)
+        if (cp437_map[i].b == b)
+            return cp437_map[i].cp;
+    return 0;
 }
 
 /* Append one display cell (a CP437 byte) to the clipboard buffer as UTF-8: ASCII
@@ -995,97 +961,73 @@ void Console_Update(void) {
     }
 }
 
-/* Map a Unicode codepoint to its CP437 byte (the AffStringToBuffer font), or 0
- * if CP437 has no glyph for it. Covers the printable Latin-1 range — enough for
- * the boot log's "·" separator and accented language names (Français, Español)
- * and any Western-European text a command might print. */
-static unsigned char cp_to_cp437(unsigned int cp) {
-    switch (cp) {
-    case 0x00B7:
-        return 0xFA; /* · middle dot (the title separator) */
-    case 0x00B0:
-        return 0xF8; /* ° */
-    case 0x00A1:
-        return 0xAD; /* ¡ */
-    case 0x00BF:
-        return 0xA8; /* ¿ */
-    case 0x00AB:
-        return 0xAE; /* « */
-    case 0x00BB:
-        return 0xAF; /* » */
-    case 0x00A3:
-        return 0x9C; /* £ */
-    case 0x00C7:
-        return 0x80; /* Ç */
-    case 0x00FC:
-        return 0x81; /* ü */
-    case 0x00E9:
-        return 0x82; /* é */
-    case 0x00E2:
-        return 0x83; /* â */
-    case 0x00E4:
-        return 0x84; /* ä */
-    case 0x00E0:
-        return 0x85; /* à */
-    case 0x00E5:
-        return 0x86; /* å */
-    case 0x00E7:
-        return 0x87; /* ç (Français) */
-    case 0x00EA:
-        return 0x88; /* ê */
-    case 0x00EB:
-        return 0x89; /* ë */
-    case 0x00E8:
-        return 0x8A; /* è */
-    case 0x00EF:
-        return 0x8B; /* ï */
-    case 0x00EE:
-        return 0x8C; /* î */
-    case 0x00EC:
-        return 0x8D; /* ì */
-    case 0x00C4:
-        return 0x8E; /* Ä */
-    case 0x00C5:
-        return 0x8F; /* Å */
-    case 0x00C9:
-        return 0x90; /* É */
-    case 0x00E6:
-        return 0x91; /* æ */
-    case 0x00C6:
-        return 0x92; /* Æ */
-    case 0x00F4:
-        return 0x93; /* ô */
-    case 0x00F6:
-        return 0x94; /* ö */
-    case 0x00F2:
-        return 0x95; /* ò */
-    case 0x00FB:
-        return 0x96; /* û */
-    case 0x00F9:
-        return 0x97; /* ù */
-    case 0x00FF:
-        return 0x98; /* ÿ */
-    case 0x00D6:
-        return 0x99; /* Ö */
-    case 0x00DC:
-        return 0x9A; /* Ü */
-    case 0x00E1:
-        return 0xA0; /* á */
-    case 0x00ED:
-        return 0xA1; /* í */
-    case 0x00F3:
-        return 0xA2; /* ó */
-    case 0x00FA:
-        return 0xA3; /* ú */
-    case 0x00F1:
-        return 0xA4; /* ñ (Español) */
-    case 0x00D1:
-        return 0xA5; /* Ñ */
-    case 0x00DF:
-        return 0xE1; /* ß */
-    default:
-        return 0;
+/* --- Host-test hooks for the input/selection state machine. These drive the same
+ * Console_UpdateKey path the live console runs after draining the event queue, so
+ * tests exercise the real code without needing SDL scancode/modifier constants. --- */
+static int testkey_scancode(Console_TestKey k) {
+    switch (k) {
+    case CONSOLE_TKEY_LEFT:
+        return K_LEFT;
+    case CONSOLE_TKEY_RIGHT:
+        return K_RIGHT;
+    case CONSOLE_TKEY_HOME:
+        return K_HOME;
+    case CONSOLE_TKEY_END:
+        return K_END;
+    case CONSOLE_TKEY_BACKSPACE:
+        return K_BACKSPACE;
+    case CONSOLE_TKEY_DELETE:
+        return K_SUPPR;
+    case CONSOLE_TKEY_ENTER:
+        return K_ENTER;
+    case CONSOLE_TKEY_ESC:
+        return K_ESC;
+    case CONSOLE_TKEY_TAB:
+        return K_TAB;
+    case CONSOLE_TKEY_UP:
+        return K_UP;
+    case CONSOLE_TKEY_DOWN:
+        return K_DOWN;
     }
+    return 0;
+}
+
+void Console_TestType(const char *s) {
+    if (!s)
+        return;
+    for (; *s; s++)
+        Console_UpdateKey(CONSOLE_TEXT_CHAR, (unsigned char)*s, 0);
+}
+
+void Console_TestSpecial(Console_TestKey key, int shift) {
+    Console_UpdateKey(testkey_scancode(key), 0, shift ? SDL_KMOD_SHIFT : 0);
+}
+
+void Console_TestCtrl(char letter) {
+    Console_UpdateKey(0, (unsigned char)letter, SDL_KMOD_CTRL);
+}
+
+const char *Console_TestInput(void) {
+    return s_input_line;
+}
+
+int Console_TestCursor(void) {
+    return s_cursor_pos;
+}
+
+int Console_TestSelection(int *lo, int *hi) {
+    return sel_span(lo, hi);
+}
+
+/* Map a Unicode codepoint to its CP437 byte (the AffStringToBuffer font), or 0 if
+ * CP437 has no glyph for it. Covers the printable Latin-1 range the boot log and
+ * command output use (the "·" separator, accented language names). Shares cp437_map
+ * with cp437_to_unicode so the fold and unfold stay in lockstep. */
+static unsigned char cp_to_cp437(unsigned int cp) {
+    for (size_t i = 0; i < sizeof(cp437_map) / sizeof(cp437_map[0]); i++)
+        if (cp437_map[i].cp == cp)
+            return cp437_map[i].b;
+    return 0;
 }
 
 /* Fold a UTF-8 string into the CP437 bytes the font draws. ASCII passes through;
@@ -1575,8 +1517,11 @@ int Console_ShouldSuppressInputThisFrame(void) {
 }
 
 void Console_RegisterCommandEx(const char *name, Console_CmdFn callback, const char *help, const char *usage, const char *context) {
-    if (s_cmd_count >= CONSOLE_MAX_CMDS)
+    if (s_cmd_count >= CONSOLE_MAX_CMDS) {
+        fprintf(stderr, "console: command table full (%d), dropped '%s' (raise CONSOLE_MAX_CMDS)\n",
+                CONSOLE_MAX_CMDS, name ? name : "(null)");
         return;
+    }
     s_cmds[s_cmd_count].name = name;
     s_cmds[s_cmd_count].fn = callback;
     s_cmds[s_cmd_count].help = help;
@@ -1590,8 +1535,11 @@ void Console_RegisterCommand(const char *name, Console_CmdFn callback, const cha
 }
 
 void Console_RegisterCvar(const char *name, void *ptr, Console_CvarType type, const char *help) {
-    if (s_cvar_count >= CONSOLE_MAX_CVARS)
+    if (s_cvar_count >= CONSOLE_MAX_CVARS) {
+        fprintf(stderr, "console: cvar table full (%d), dropped '%s' (raise CONSOLE_MAX_CVARS)\n",
+                CONSOLE_MAX_CVARS, name ? name : "(null)");
         return;
+    }
     s_cvars[s_cvar_count].name = name;
     s_cvars[s_cvar_count].ptr = ptr;
     s_cvars[s_cvar_count].type = type;

--- a/SOURCES/CONSOLE/CONSOLE.H
+++ b/SOURCES/CONSOLE/CONSOLE.H
@@ -113,6 +113,28 @@ int Console_GetScrollback(const char **out, int max);
    \a max candidate name pointers. Returns the number of matches. */
 int Console_CompletePrefix(const char *prefix, char *out, size_t outsz, const char **matches, int max);
 
+/* Host-test hooks for the input/selection state machine. They drive the same code
+   the live console runs after the event queue, without needing SDL scancodes. */
+typedef enum {
+    CONSOLE_TKEY_LEFT,
+    CONSOLE_TKEY_RIGHT,
+    CONSOLE_TKEY_HOME,
+    CONSOLE_TKEY_END,
+    CONSOLE_TKEY_BACKSPACE,
+    CONSOLE_TKEY_DELETE,
+    CONSOLE_TKEY_ENTER,
+    CONSOLE_TKEY_ESC,
+    CONSOLE_TKEY_TAB,
+    CONSOLE_TKEY_UP,
+    CONSOLE_TKEY_DOWN
+} Console_TestKey;
+void Console_TestType(const char *s);                     /* type printable chars */
+void Console_TestSpecial(Console_TestKey key, int shift); /* a nav/edit key, optional Shift */
+void Console_TestCtrl(char letter);                       /* Ctrl+<letter> */
+const char *Console_TestInput(void);                      /* current input line */
+int Console_TestCursor(void);                             /* cursor position */
+int Console_TestSelection(int *lo, int *hi);              /* 1 + [lo,hi) when a selection exists */
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/console/CMakeLists.txt
+++ b/tests/console/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(test_console_commands test_console_commands.cpp)
 add_executable(test_console_give test_console_give.cpp)
 add_executable(test_console_render test_console_render.cpp)
 add_executable(test_console_complete test_console_complete.cpp)
+add_executable(test_console_input test_console_input.cpp)
 
 target_include_directories(test_console_state PRIVATE
     ${CMAKE_SOURCE_DIR}/SOURCES
@@ -20,6 +21,10 @@ target_include_directories(test_console_complete PRIVATE
     ${CMAKE_SOURCE_DIR}/SOURCES
     ${CMAKE_SOURCE_DIR}/LIB386/H
 )
+target_include_directories(test_console_input PRIVATE
+    ${CMAKE_SOURCE_DIR}/SOURCES
+    ${CMAKE_SOURCE_DIR}/LIB386/H
+)
 target_include_directories(test_console_give PRIVATE
     ${CMAKE_SOURCE_DIR}/SOURCES
     ${CMAKE_SOURCE_DIR}/LIB386/H
@@ -34,21 +39,25 @@ target_link_libraries(test_console_commands PRIVATE console)
 target_link_libraries(test_console_give PRIVATE console)
 target_link_libraries(test_console_render PRIVATE console)
 target_link_libraries(test_console_complete PRIVATE console)
+target_link_libraries(test_console_input PRIVATE console)
 
 set_target_properties(test_console_state PROPERTIES CXX_STANDARD 11)
 set_target_properties(test_console_commands PROPERTIES CXX_STANDARD 11)
 set_target_properties(test_console_give PROPERTIES CXX_STANDARD 11)
 set_target_properties(test_console_render PROPERTIES CXX_STANDARD 11)
 set_target_properties(test_console_complete PROPERTIES CXX_STANDARD 11)
+set_target_properties(test_console_input PROPERTIES CXX_STANDARD 11)
 
 add_test(NAME test_console_state COMMAND test_console_state)
 add_test(NAME test_console_commands COMMAND test_console_commands)
 add_test(NAME test_console_give COMMAND test_console_give)
 add_test(NAME test_console_render COMMAND test_console_render)
 add_test(NAME test_console_complete COMMAND test_console_complete)
+add_test(NAME test_console_input COMMAND test_console_input)
 
 register_host_test(test_console_state)
 register_host_test(test_console_commands)
 register_host_test(test_console_give)
 register_host_test(test_console_render)
 register_host_test(test_console_complete)
+register_host_test(test_console_input)

--- a/tests/console/test_console_input.cpp
+++ b/tests/console/test_console_input.cpp
@@ -1,0 +1,145 @@
+/* Host test for the console input/selection state machine. Drives the real
+ * Console_UpdateKey path through the Console_Test* hooks (the same code the live
+ * console runs after draining the SDL event queue), with no SDL or engine init.
+ * Covers cursor editing, shift-selection, select-all, type-over-selection,
+ * command history recall, tab completion, and two-stage Escape. */
+#include "CONSOLE/CONSOLE.H"
+
+#include <cstdio>
+#include <cstring>
+
+/* Link stubs: the console lib references these LIB386 symbols. */
+extern "C" void AffStringToBuffer(U8 *dst, U32 pitch, S32 x, S32 y, const char *str, U8 ink) {
+    (void)dst;
+    (void)pitch;
+    (void)x;
+    (void)y;
+    (void)str;
+    (void)ink;
+}
+extern "C" void WindowToSurfaceCoords(S32 windowX, S32 windowY, S32 *surfaceX, S32 *surfaceY) {
+    if (surfaceX)
+        *surfaceX = windowX;
+    if (surfaceY)
+        *surfaceY = windowY;
+}
+void Console_RegisterAll(void) {}
+int TryExecuteCheatByName(const char *name) {
+    (void)name;
+    return 0;
+}
+
+static void cmd_noop(int argc, const char *argv[]) {
+    (void)argc;
+    (void)argv;
+}
+
+static int g_failures = 0;
+#define CHECK(cond)                                          \
+    do {                                                     \
+        if (!(cond)) {                                       \
+            printf("FAIL: %s (line %d)\n", #cond, __LINE__); \
+            g_failures++;                                    \
+        }                                                    \
+    } while (0)
+
+static void clear_input(void) {
+    Console_TestCtrl('l'); /* Ctrl+L clears the input line */
+}
+
+int main(void) {
+    int lo = 0, hi = 0;
+
+    Console_Toggle(); /* open so the two-stage Escape test can close it */
+    Console_RegisterCommand("cube", cmd_noop, "");
+    Console_RegisterCommand("clear", cmd_noop, "");
+    Console_RegisterCommand("close", cmd_noop, "");
+
+    /* Typing and cursor motion. */
+    clear_input();
+    Console_TestType("hello");
+    CHECK(strcmp(Console_TestInput(), "hello") == 0);
+    CHECK(Console_TestCursor() == 5);
+    Console_TestSpecial(CONSOLE_TKEY_BACKSPACE, 0);
+    CHECK(strcmp(Console_TestInput(), "hell") == 0 && Console_TestCursor() == 4);
+    Console_TestSpecial(CONSOLE_TKEY_HOME, 0);
+    CHECK(Console_TestCursor() == 0);
+    Console_TestType("X");
+    CHECK(strcmp(Console_TestInput(), "Xhell") == 0 && Console_TestCursor() == 1);
+    Console_TestSpecial(CONSOLE_TKEY_END, 0);
+    CHECK(Console_TestCursor() == 5);
+    Console_TestSpecial(CONSOLE_TKEY_LEFT, 0);
+    Console_TestSpecial(CONSOLE_TKEY_LEFT, 0);
+    CHECK(Console_TestCursor() == 3);
+    Console_TestSpecial(CONSOLE_TKEY_DELETE, 0); /* "Xhell", cursor 3 -> delete [3]='l' */
+    CHECK(strcmp(Console_TestInput(), "Xhel") == 0);
+
+    /* Shift-selection then type-over. */
+    clear_input();
+    Console_TestType("abcdef");
+    Console_TestSpecial(CONSOLE_TKEY_LEFT, 1); /* Shift+Left x3 selects "def" */
+    Console_TestSpecial(CONSOLE_TKEY_LEFT, 1);
+    Console_TestSpecial(CONSOLE_TKEY_LEFT, 1);
+    CHECK(Console_TestSelection(&lo, &hi) && lo == 3 && hi == 6);
+    Console_TestType("Z"); /* typing replaces the selection */
+    CHECK(strcmp(Console_TestInput(), "abcZ") == 0 && Console_TestCursor() == 4);
+    CHECK(!Console_TestSelection(&lo, &hi));
+
+    /* Plain Left collapses a selection to its near edge (no further move). */
+    clear_input();
+    Console_TestType("abcdef");
+    Console_TestSpecial(CONSOLE_TKEY_LEFT, 1);
+    Console_TestSpecial(CONSOLE_TKEY_LEFT, 1); /* select "ef", cursor at 4 */
+    Console_TestSpecial(CONSOLE_TKEY_LEFT, 0); /* collapse to lo (4), not 3 */
+    CHECK(!Console_TestSelection(&lo, &hi) && Console_TestCursor() == 4);
+
+    /* Ctrl+A selects all; Backspace deletes the selection. */
+    clear_input();
+    Console_TestType("word");
+    Console_TestCtrl('a');
+    CHECK(Console_TestSelection(&lo, &hi) && lo == 0 && hi == 4);
+    Console_TestSpecial(CONSOLE_TKEY_BACKSPACE, 0);
+    CHECK(Console_TestInput()[0] == '\0');
+
+    /* Command history recall. */
+    clear_input();
+    Console_TestType("alpha");
+    Console_TestSpecial(CONSOLE_TKEY_ENTER, 0);
+    Console_TestType("beta");
+    Console_TestSpecial(CONSOLE_TKEY_ENTER, 0);
+    Console_TestSpecial(CONSOLE_TKEY_UP, 0);
+    CHECK(strcmp(Console_TestInput(), "beta") == 0);
+    Console_TestSpecial(CONSOLE_TKEY_UP, 0);
+    CHECK(strcmp(Console_TestInput(), "alpha") == 0);
+    Console_TestSpecial(CONSOLE_TKEY_DOWN, 0);
+    CHECK(strcmp(Console_TestInput(), "beta") == 0);
+    Console_TestSpecial(CONSOLE_TKEY_DOWN, 0); /* past newest -> empty */
+    CHECK(Console_TestInput()[0] == '\0');
+
+    /* Tab completion: unique prefix completes and adds a space. */
+    clear_input();
+    Console_TestType("cu");
+    Console_TestSpecial(CONSOLE_TKEY_TAB, 0);
+    CHECK(strcmp(Console_TestInput(), "cube ") == 0);
+    /* Ambiguous prefix extends to the longest common prefix only. */
+    clear_input();
+    Console_TestType("cl");
+    Console_TestSpecial(CONSOLE_TKEY_TAB, 0);
+    CHECK(strcmp(Console_TestInput(), "cl") == 0); /* clear / close -> "cl" */
+    Console_TestType("o");
+    Console_TestSpecial(CONSOLE_TKEY_TAB, 0);
+    CHECK(strcmp(Console_TestInput(), "close ") == 0);
+
+    /* Two-stage Escape: clear the line, then close the console. */
+    clear_input();
+    Console_TestType("x");
+    Console_TestSpecial(CONSOLE_TKEY_ESC, 0);
+    CHECK(Console_TestInput()[0] == '\0');
+    CHECK(Console_IsOpen() == 1);
+    Console_TestSpecial(CONSOLE_TKEY_ESC, 0);
+    CHECK(Console_IsOpen() == 0);
+
+    if (g_failures == 0)
+        printf("test_console_input: OK\n");
+    return g_failures != 0;
+}


### PR DESCRIPTION
Follow-up to an architecture review of the console module. Targets the highest-value, lowest-risk findings. (Builds on the text-selection work merged in #332 — the test seam covers shift-selection and the CP437 dedup folds in #332's `cp437_to_unicode`.)

## Changes

**1. Single source of truth for CP437 / Unicode.** The draw-time fold (`cp_to_cp437`) and the copy-time unfold (`cp437_to_unicode`) were two hand-maintained switch tables that had to stay in sync. Both now scan one `cp437_map` array, so a future glyph addition can't desync them. Net -30 lines.

**2. Loud table overflow + headroom.** `Console_RegisterCommandEx`/`Console_RegisterCvar` silently returned when their fixed tables filled. The command table was at 27/32. They now warn on stderr (with the dropped name) instead of vanishing, and `CONSOLE_MAX_CMDS` is raised 32 to 48.

**3. Input/selection test seam.** The biggest coverage gap from the review: `Console_UpdateKey` held the most logic and all the recent churn, but only the *pure* helpers (completion, `*_FromState`, render) were tested. New `Console_Test*` hooks drive the real `Console_UpdateKey` path (no SDL constants needed), and `test_console_input.cpp` covers cursor editing, shift-selection, select-all, type-over-selection, history recall, tab completion, and two-stage Escape. The new test already caught one off-by-one in its own expectations during development.

## Deliberately deferred
- **Grouping the ~80 file-statics into structs** (the review's medium-effort item): a large mechanical refactor better done on its own branch where the diff is reviewable in isolation.
- **Gating the per-frame row snapshot**: skipped because the first click needs the prior frame's snapshot, so gating on "selection active" would read a stale/empty one. Not worth the correctness risk for a sub-millisecond memcpy.

## Testing
`make test` green (30/30 host tests, including the new `test_console_input`); clean engine build; clang-format clean.
