### PR TITLE
feat(camera): manual camera substrate with mouse orbit, elevation, zoom

### DIFF
--- a/LIB386/H/SYSTEM/WINDOW.H
+++ b/LIB386/H/SYSTEM/WINDOW.H
@@ -65,6 +65,7 @@ bool Window_SupportsWindowedMode(void);
 // pixels or simulation state.
 void Window_SetVSync(int enabled);
 
+void SetWindowRelativeMouse(bool enable);
 void ManageWindow();
 void HandleEventsWindow(const void *event);
 

--- a/LIB386/SYSTEM/MOUSE.CPP
+++ b/LIB386/SYSTEM/MOUSE.CPP
@@ -186,6 +186,7 @@ void HandleEventsMouse(const void *event) {
     case SDL_EVENT_MOUSE_BUTTON_DOWN:
         MousePointerMarkActivity();
         Click |= (sdlEvent->button.button == 1) ? 1 : 0;
+        Click |= (sdlEvent->button.button == 2) ? 4 : 0;
         Click |= (sdlEvent->button.button == 3) ? 2 : 0;
         LastInputWasKeyboard = 0;
         break;
@@ -193,6 +194,7 @@ void HandleEventsMouse(const void *event) {
     case SDL_EVENT_MOUSE_BUTTON_UP:
         MousePointerMarkActivity();
         Click &= (sdlEvent->button.button == 1) ? ~1 : Click;
+        Click &= (sdlEvent->button.button == 2) ? ~4 : Click;
         Click &= (sdlEvent->button.button == 3) ? ~2 : Click;
         break;
 

--- a/LIB386/SYSTEM/MOUSE.CPP
+++ b/LIB386/SYSTEM/MOUSE.CPP
@@ -31,6 +31,11 @@ const void *MouseSpriteGraphic = NULL;
 S32 LibMouseXDep, LibMouseYDep;
 U32 MouseBoxX0, MouseBoxX1, MouseBoxY0, MouseBoxY1;
 
+/* Cap the unconsumed wheel bank. In scenes with no wheel consumer (interiors,
+ * or exterior without the mouse camera) nothing drains MouseWheelYAccum, so an
+ * idle scroll would otherwise pile up and dump one oversized step on the next
+ * consumer. The wheel is recent intent, not a ledger. */
+#define MOUSE_WHEEL_ACCUM_CAP 8
 volatile S32 MouseWheelYAccum = 0;
 
 static bool s_showSpriteAfterFirstMotion = false;
@@ -201,6 +206,10 @@ void HandleEventsMouse(const void *event) {
     case SDL_EVENT_MOUSE_WHEEL:
         MousePointerMarkActivity();
         MouseWheelYAccum += (S32)lround((double)sdlEvent->wheel.y);
+        if (MouseWheelYAccum > MOUSE_WHEEL_ACCUM_CAP)
+            MouseWheelYAccum = MOUSE_WHEEL_ACCUM_CAP;
+        if (MouseWheelYAccum < -MOUSE_WHEEL_ACCUM_CAP)
+            MouseWheelYAccum = -MOUSE_WHEEL_ACCUM_CAP;
         LastInputWasKeyboard = 0;
         break;
     }

--- a/LIB386/SYSTEM/WINDOW.CPP
+++ b/LIB386/SYSTEM/WINDOW.CPP
@@ -348,6 +348,11 @@ void WindowToSurfaceCoords(S32 windowX, S32 windowY, S32 *surfaceX, S32 *surface
     *surfaceY = sy;
 }
 
+void SetWindowRelativeMouse(bool enable) {
+    if (sdlWindow != NULL)
+        SDL_SetWindowRelativeMouseMode(sdlWindow, enable);
+}
+
 void SetWindowFullscreen(bool fullscreen) {
     windowFullscreenEnabled = fullscreen;
 

--- a/SOURCES/C_EXTERN.H
+++ b/SOURCES/C_EXTERN.H
@@ -215,6 +215,15 @@ extern S32 Planet;
 extern S32 AllCameras;
 extern S32 FollowCamera;
 extern S32 FollowCamBaseDist;
+extern S32 FlagMouseCamera;
+extern S32 FlagMouseCameraDrag;
+extern S32 MouseCameraSensX;
+extern S32 MouseCameraSensY;
+extern S32 MouseCameraInvertY;
+extern S32 MouseCameraDivisor;
+extern S32 MouseCameraSmoothing;
+extern S32 ManualCameraOrbitActive; /* raised by EXTFUNC while a manual camera source (mouse/stick) orbits */
+extern S32 FollowCamReengageDelay;
 extern S32 ReverseStereo;
 
 extern S32 ScaleFactorSprite;

--- a/SOURCES/EXTFUNC.CPP
+++ b/SOURCES/EXTFUNC.CPP
@@ -15,6 +15,8 @@
 
 #include <SVGA/SCREEN.H>
 #include <SYSTEM/KEYBOARD_KEYS.H>
+#include <SYSTEM/MOUSE.H>
+#include <SYSTEM/WINDOW.H>
 #include "FOLLOWCAM_CFG.H"
 
 extern S32 Nxw, Nyw, Nzw;
@@ -1912,6 +1914,51 @@ S32 GereMouseMovements(S32 boutons) {
 #endif
 
 /*──────────────────────────────────────────────────────────────────────────*/
+#ifndef LBA_EDITOR
+/* Apply a per-frame manual camera nudge from an analog source (mouse drag or
+ * right stick).  dBeta orbits horizontally (AddBetaCam), dAlpha tilts elevation
+ * (AlphaCam), dZoom dollies the arm (FollowCamBaseDist; positive zooms in).
+ * Shared by every manual-camera source so they clamp and re-engage the follow
+ * grace period identically.  Only horizontal orbit raises ManualCameraOrbitActive
+ * (it selects the tight BetaCam lerp in PERSO.CPP); elevation and zoom do not.
+ * Returns nonzero if any axis changed so the caller can flag a redraw.  The
+ * caller clears ManualCameraOrbitActive once per frame before driving sources. */
+static S32 ApplyManualCameraNudge(S32 dBeta, S32 dAlpha, S32 dZoom) {
+    S32 changed = 0;
+
+    if (dBeta != 0) {
+        AddBetaCam = (AddBetaCam - dBeta) & 4095;
+        ManualCameraOrbitActive = TRUE;
+        FirstTime = AFF_ALL_FLIP;
+        changed = 1;
+    }
+    if (dAlpha != 0) {
+        AlphaCam += dAlpha;
+        if (AlphaCam < FOLLOW_CAM_ALPHA_MIN)
+            AlphaCam = FOLLOW_CAM_ALPHA_MIN;
+        if (AlphaCam > FOLLOW_CAM_ALPHA_MAX)
+            AlphaCam = FOLLOW_CAM_ALPHA_MAX;
+        FirstTime = AFF_ALL_FLIP;
+        changed = 1;
+    }
+    if (dBeta != 0 OR dAlpha != 0)
+        FollowCamReengageDelay = FOLLOW_CAM_REENGAGE_FRAMES;
+
+    if (dZoom != 0) {
+        FollowCamBaseDist -= dZoom;
+        if (FollowCamBaseDist < FOLLOW_CAM_DIST_MIN)
+            FollowCamBaseDist = FOLLOW_CAM_DIST_MIN;
+        if (FollowCamBaseDist > FOLLOW_CAM_DIST_MAX)
+            FollowCamBaseDist = FOLLOW_CAM_DIST_MAX;
+        FirstTime = AFF_ALL_FLIP;
+        changed = 1;
+    }
+
+    return changed;
+}
+#endif
+
+/*──────────────────────────────────────────────────────────────────────────*/
 // Gestion zoom/pivot du terrain et position caméra
 #ifdef LBA_EDITOR
 S32 GereExtKeys(U32 key, U32 flagmenu)
@@ -2235,6 +2282,56 @@ S32 GereExtKeys(U32 key)
                 FollowCamBaseDist += FOLLOW_CAM_ZOOM_STEP;
             FirstTime = AFF_ALL_FLIP;
             flag = 1;
+        }
+
+        /* --- Manual camera: mouse drag orbit, elevation, wheel zoom, recenter --- */
+        ManualCameraOrbitActive = FALSE;
+        {
+            /* Relative mouse mode: deltas keep flowing past window edge.
+             * Drag mode: active while right button held.
+             * Free mode: always active.
+             * Disabled when mouse camera conditions not met. */
+            static S32 prevRelative = 0;
+            S32 wantRelative = 0;
+            if (FlagMouseCamera AND CubeMode == CUBE_EXTERIEUR)
+                wantRelative = FlagMouseCameraDrag ? (Click & 2) : 1;
+            if (wantRelative != prevRelative) {
+                SetWindowRelativeMouse(wantRelative ? true : false);
+                prevRelative = wantRelative;
+            }
+        }
+        if (FlagMouseCamera AND CubeMode == CUBE_EXTERIEUR) {
+            ManageMouse();
+
+            S32 orbitActive = FlagMouseCameraDrag ? (Click & 2) : 1;
+            if (orbitActive) {
+                S32 rawX = MouseXDep;
+                S32 rawY = MouseYDep;
+
+                /* Dead zone on raw pixels before scaling */
+                if (rawX > -MOUSE_CAM_DEAD_ZONE AND rawX < MOUSE_CAM_DEAD_ZONE)
+                    rawX = 0;
+                if (rawY > -MOUSE_CAM_DEAD_ZONE AND rawY < MOUSE_CAM_DEAD_ZONE)
+                    rawY = 0;
+
+                S32 dx = rawX * MouseCameraSensX / MouseCameraDivisor;
+                S32 dy = rawY * MouseCameraSensY / MouseCameraDivisor;
+                if (MouseCameraInvertY)
+                    dy = -dy;
+
+                flag |= ApplyManualCameraNudge(dx, dy, 0);
+            }
+
+            S32 wy = ConsumeMouseWheelY();
+            if (wy != 0)
+                flag |= ApplyManualCameraNudge(
+                    0, 0, wy * FOLLOW_CAM_ZOOM_STEP * MOUSE_CAM_ZOOM_MULT);
+
+            if (Click & 4) {
+                CameraCenter(1);
+                FirstTime = AFF_ALL_FLIP;
+                flag = 1;
+            }
         }
     }
 #endif

--- a/SOURCES/EXTFUNC.CPP
+++ b/SOURCES/EXTFUNC.CPP
@@ -1918,11 +1918,12 @@ S32 GereMouseMovements(S32 boutons) {
 /* Apply a per-frame manual camera nudge from an analog source (mouse drag or
  * right stick).  dBeta orbits horizontally (AddBetaCam), dAlpha tilts elevation
  * (AlphaCam), dZoom dollies the arm (FollowCamBaseDist; positive zooms in).
- * Shared by every manual-camera source so they clamp and re-engage the follow
- * grace period identically.  Only horizontal orbit raises ManualCameraOrbitActive
- * (it selects the tight BetaCam lerp in PERSO.CPP); elevation and zoom do not.
- * Returns nonzero if any axis changed so the caller can flag a redraw.  The
- * caller clears ManualCameraOrbitActive once per frame before driving sources. */
+ * Shared by every manual-camera source so they clamp each axis identically.
+ * Only horizontal orbit raises ManualCameraOrbitActive (it selects the tight
+ * BetaCam lerp in PERSO.CPP) and re-engages the follow grace period; elevation
+ * and zoom leave the auto-follow tracking the hero.  Returns nonzero if any axis
+ * changed so the caller can flag a redraw.  The caller clears
+ * ManualCameraOrbitActive once per frame before driving sources. */
 static S32 ApplyManualCameraNudge(S32 dBeta, S32 dAlpha, S32 dZoom) {
     S32 changed = 0;
 
@@ -1941,7 +1942,9 @@ static S32 ApplyManualCameraNudge(S32 dBeta, S32 dAlpha, S32 dZoom) {
         FirstTime = AFF_ALL_FLIP;
         changed = 1;
     }
-    if (dBeta != 0 OR dAlpha != 0)
+    /* Only horizontal orbit pauses the auto-recenter; elevation and zoom leave
+     * the follow tracking the hero (matches the numpad keyboard controls). */
+    if (dBeta != 0)
         FollowCamReengageDelay = FOLLOW_CAM_REENGAGE_FRAMES;
 
     if (dZoom != 0) {

--- a/SOURCES/FOLLOWCAM_CFG.H
+++ b/SOURCES/FOLLOWCAM_CFG.H
@@ -29,3 +29,10 @@
 
 /* Horizontal pan keys [ ] ---------------------------------------------------*/
 #define FOLLOW_CAM_PAN_STEP 30 /* AddBetaCam change per [ / ] key press per frame */
+
+/* Mouse camera --------------------------------------------------------------*/
+#define MOUSE_CAM_DIVISOR_DEFAULT 4   /* pixel-to-angle scaling (lower = faster) */
+#define MOUSE_CAM_SMOOTHING_DEFAULT 2 /* BetaCam lerp divisor during orbit (1=snap, higher=laggier) */
+#define MOUSE_CAM_DEAD_ZONE 2         /* ignore deltas smaller than this (pixels, pre-scale) */
+#define MOUSE_CAM_ZOOM_MULT 1         /* wheel zoom multiplier (applied to FOLLOW_CAM_ZOOM_STEP) */
+#define MOUSE_CAM_SENS_DEFAULT 4      /* default sensitivity (1-10 range) */

--- a/SOURCES/GLOBAL.CPP
+++ b/SOURCES/GLOBAL.CPP
@@ -1,4 +1,5 @@
 #include "C_EXTERN.H"
+#include "FOLLOWCAM_CFG.H"
 
 /*══════════════════════════════════════════════════════════════════════════*
 			 █▀▀▀█ █▀▀▀▀ █▀▀▀█ ██▀▀▀ █▀▀▀█
@@ -205,6 +206,14 @@ S32 ExtraConque = -1; // Numero extra visant Twinsen (avec Conque)
 S32 AllCameras = TRUE;
 S32 FollowCamera = FALSE;
 S32 FollowCamBaseDist = 0; /* player's chosen zoom distance (0 = uninitialised) */
+S32 FlagMouseCamera = TRUE;
+S32 FlagMouseCameraDrag = TRUE; /* 0=free orbit on move, 1=require right-drag */
+S32 MouseCameraSensX = MOUSE_CAM_SENS_DEFAULT;
+S32 MouseCameraSensY = MOUSE_CAM_SENS_DEFAULT;
+S32 MouseCameraInvertY = FALSE;
+S32 MouseCameraDivisor = MOUSE_CAM_DIVISOR_DEFAULT;
+S32 MouseCameraSmoothing = MOUSE_CAM_SMOOTHING_DEFAULT;
+S32 ManualCameraOrbitActive = FALSE;
 S32 ReverseStereo = FALSE;
 S32 Island = 0;
 S32 Planet = 0;

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -77,7 +77,7 @@ static S32 FollowCamPrevHeroBeta = 0;
 static S32 FollowCamPrevAddBeta = 0;   /* dirty check: last seen AddBetaCam */
 static S32 FollowCamEffectiveDist = 0; /* spring arm: smoothed distance (0 = uninitialised) */
 static S32 FollowCamTargetBeta = 0;    /* rotation lag: desired BetaCam */
-static S32 FollowCamReengageDelay = 0; /* frames before auto-center resumes after manual pan */
+S32 FollowCamReengageDelay = 0;        /* frames before auto-center resumes after manual pan */
 static S32 FollowCamPrevBaseDist = -1; /* dirty: zoom from GereExtKeys (numpad * /) */
 static S32 FollowCamPrevAlphaCam = -1; /* dirty: numpad +/- elevation while follow */
 
@@ -1803,16 +1803,23 @@ restartloop:
 
                         if (manualPan) {
                             BetaCam = FollowCamTargetBeta;
-                        } else if (FollowCamReengageDelay == 0) {
+                        } else if (ManualCameraOrbitActive OR FollowCamReengageDelay == 0) {
                             S32 diff = FollowCamTargetBeta - BetaCam;
                             if (diff > 2048)
                                 diff -= 4096;
                             if (diff < -2048)
                                 diff += 4096;
                             if (diff > FOLLOW_CAM_ROT_THRESHOLD OR diff < -FOLLOW_CAM_ROT_THRESHOLD) {
-                                S32 dynamicDiv = FOLLOW_CAM_ROT_DIVISOR * FollowCamEffectiveDist / FollowCamBaseDist;
-                                if (dynamicDiv < FOLLOW_CAM_ROT_DIVISOR / 3)
-                                    dynamicDiv = FOLLOW_CAM_ROT_DIVISOR / 3;
+                                /* Manual orbit (mouse/stick): tight lerp for responsive feel.
+                                 * Auto-follow: distance-scaled inertia for cinematic drift. */
+                                S32 dynamicDiv;
+                                if (ManualCameraOrbitActive) {
+                                    dynamicDiv = MouseCameraSmoothing;
+                                } else {
+                                    dynamicDiv = FOLLOW_CAM_ROT_DIVISOR * FollowCamEffectiveDist / FollowCamBaseDist;
+                                    if (dynamicDiv < FOLLOW_CAM_ROT_DIVISOR / 3)
+                                        dynamicDiv = FOLLOW_CAM_ROT_DIVISOR / 3;
+                                }
                                 S32 step = diff / dynamicDiv;
                                 // Clamp to a minimum magnitude toward the target. Integer
                                 // division truncates to 0 whenever |diff| < dynamicDiv (e.g.
@@ -2056,6 +2063,48 @@ void ReadConfigFile(void) {
         FlagMenuMouse = TRUE;
     else
         FlagMenuMouse = FALSE;
+
+    FlagMouseCamera = DefFileBufferReadValueDefault("MouseCamera", TRUE);
+    if (FlagMouseCamera != 0)
+        FlagMouseCamera = TRUE;
+    else
+        FlagMouseCamera = FALSE;
+
+    FlagMouseCameraDrag = DefFileBufferReadValueDefault("MouseCameraDrag", TRUE);
+    if (FlagMouseCameraDrag != 0)
+        FlagMouseCameraDrag = TRUE;
+    else
+        FlagMouseCameraDrag = FALSE;
+
+    MouseCameraSensX = DefFileBufferReadValueDefault("MouseSensitivityX", MOUSE_CAM_SENS_DEFAULT);
+    if (MouseCameraSensX < 1)
+        MouseCameraSensX = 1;
+    if (MouseCameraSensX > 10)
+        MouseCameraSensX = 10;
+
+    MouseCameraSensY = DefFileBufferReadValueDefault("MouseSensitivityY", MOUSE_CAM_SENS_DEFAULT);
+    if (MouseCameraSensY < 1)
+        MouseCameraSensY = 1;
+    if (MouseCameraSensY > 10)
+        MouseCameraSensY = 10;
+
+    MouseCameraInvertY = DefFileBufferReadValueDefault("MouseInvertY", FALSE);
+    if (MouseCameraInvertY != 0)
+        MouseCameraInvertY = TRUE;
+    else
+        MouseCameraInvertY = FALSE;
+
+    MouseCameraDivisor = DefFileBufferReadValueDefault("MouseCameraDivisor", MOUSE_CAM_DIVISOR_DEFAULT);
+    if (MouseCameraDivisor < 1)
+        MouseCameraDivisor = 1;
+    if (MouseCameraDivisor > 16)
+        MouseCameraDivisor = 16;
+
+    MouseCameraSmoothing = DefFileBufferReadValueDefault("MouseCameraSmoothing", MOUSE_CAM_SMOOTHING_DEFAULT);
+    if (MouseCameraSmoothing < 1)
+        MouseCameraSmoothing = 1;
+    if (MouseCameraSmoothing > 16)
+        MouseCameraSmoothing = 16;
 }
 
 /*──────────────────────────────────────────────────────────────────────────*/
@@ -2098,6 +2147,13 @@ void WriteConfigFile(void) {
         DefFileBufferWriteString("FlagDisplayText", "OFF");
 
     DefFileBufferWriteValue("MenuMouse", FlagMenuMouse);
+    DefFileBufferWriteValue("MouseCamera", FlagMouseCamera);
+    DefFileBufferWriteValue("MouseCameraDrag", FlagMouseCameraDrag);
+    DefFileBufferWriteValue("MouseSensitivityX", MouseCameraSensX);
+    DefFileBufferWriteValue("MouseSensitivityY", MouseCameraSensY);
+    DefFileBufferWriteValue("MouseInvertY", MouseCameraInvertY);
+    DefFileBufferWriteValue("MouseCameraDivisor", MouseCameraDivisor);
+    DefFileBufferWriteValue("MouseCameraSmoothing", MouseCameraSmoothing);
 }
 
 /*══════════════════════════════════════════════════════════════════════════*

--- a/docs/CONTROLLER.md
+++ b/docs/CONTROLLER.md
@@ -34,8 +34,7 @@ directly in `GereExtKeys`.
 ### Mouse
 
 Right-drag (or free move) orbits and tilts, the wheel zooms, and middle-click
-recenters behind the hero. Relative mouse mode captures the cursor during a drag
-so the orbit continues past the window edge. Tunables in `lba2.cfg`:
+recenters behind the hero. Tunables in `lba2.cfg`:
 
 | Key | Default | Description |
 |-----|---------|-------------|

--- a/docs/CONTROLLER.md
+++ b/docs/CONTROLLER.md
@@ -1,0 +1,57 @@
+# Controller and camera
+
+How the manual camera works and which input sources drive it.
+
+## Manual camera (Auto camera mode)
+
+In exterior scenes with Auto camera (`FollowCamera`) on, the player can orbit,
+tilt, and zoom the follow camera. Every manual source feeds one shared routine,
+`ApplyManualCameraNudge` in [SOURCES/EXTFUNC.CPP](../SOURCES/EXTFUNC.CPP), which
+applies and clamps three axes and re-engages the auto-follow grace period:
+
+| Axis | Variable | Bound |
+|------|----------|-------|
+| Horizontal orbit | `AddBetaCam` | wraps mod 4096 |
+| Elevation | `AlphaCam` | `FOLLOW_CAM_ALPHA_MIN..MAX` |
+| Zoom (dolly) | `FollowCamBaseDist` | `FOLLOW_CAM_DIST_MIN..MAX` |
+
+Only horizontal orbit raises `ManualCameraOrbitActive`, which switches
+[PERSO.CPP](../SOURCES/PERSO.CPP) to a tight rotation lerp for a responsive feel
+while the player is actively turning. On release the camera drifts back behind
+the hero after `FOLLOW_CAM_REENGAGE_FRAMES` (tunables in
+[FOLLOWCAM_CFG.H](../SOURCES/FOLLOWCAM_CFG.H)).
+
+Manual camera is exterior plus Auto camera only. Interior scenes and the classic
+fixed cameras have no orbit to drive.
+
+## Input sources
+
+### Keyboard
+
+`[` / `]` orbit, numpad `+` / `-` tilt elevation, numpad `*` / `/` zoom. Handled
+directly in `GereExtKeys`.
+
+### Mouse
+
+Right-drag (or free move) orbits and tilts, the wheel zooms, and middle-click
+recenters behind the hero. Relative mouse mode captures the cursor during a drag
+so the orbit continues past the window edge. Tunables in `lba2.cfg`:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `MouseCamera` | 1 | enable (0 = off) |
+| `MouseCameraDrag` | 1 | 1 = right-drag to orbit, 0 = free orbit on move |
+| `MouseSensitivityX` | 4 | horizontal orbit speed (1-10) |
+| `MouseSensitivityY` | 4 | elevation speed (1-10) |
+| `MouseInvertY` | 0 | invert elevation axis |
+| `MouseCameraDivisor` | 4 | pixel-to-angle scaling (lower = faster, 1-16) |
+| `MouseCameraSmoothing` | 2 | orbit lerp (1 = snap, higher = laggier, 1-16) |
+
+### Gamepad right stick (next)
+
+The gamepad stack ([SOURCES/JOYSTICK.CPP](../SOURCES/JOYSTICK.CPP)) and the
+Controller options menu already ship; today the right stick drives camera
+elevation and the classic camera turn digitally through the binding system. The
+planned step routes the raw right-stick axes through this same
+`ApplyManualCameraNudge` routine for smooth analog orbit and elevation in Auto
+camera mode, with a digital fallback in classic mode.

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@ The engine mapped as a whole: layers, the engine/game membrane, and the on-disk 
 
 | Doc | Description |
 |-----|-------------|
+| [CONTROLLER.md](CONTROLLER.md) | Manual camera (orbit, elevation, zoom) and the input sources that drive it: keyboard, mouse, gamepad. |
 | [FEATURE_WORKFLOW.md](FEATURE_WORKFLOW.md) | Reasoning and docs for big features: console commands, headless mode, menu changes, camera. |
 | [AUDIO.md](AUDIO.md) | Audio system: AIL contract, SDL backend, sound scripting patterns, known issues. |
 | [ASM_TO_CPP_REFERENCE.md](ASM_TO_CPP_REFERENCE.md) | Which modules are ported from ASM to C++ in this fork. |


### PR DESCRIPTION
Reworks #57 (mouse camera) into a shared, source-agnostic substrate so the same
orbit/elevation/zoom logic can later drive the gamepad right stick without
duplicating it. Supersedes #57.

## Summary

In exterior scenes with Auto camera (`FollowCamera`) on:

- right-drag (or free move) orbits and tilts the follow camera
- the wheel zooms
- middle-click recenters behind the hero

## What changed vs #57

- All three axes go through one routine, `ApplyManualCameraNudge(dBeta, dAlpha,
  dZoom)` in `SOURCES/EXTFUNC.CPP`, which clamps each axis (`AddBetaCam` wrap,
  `AlphaCam` to `FOLLOW_CAM_ALPHA_*`, `FollowCamBaseDist` to `FOLLOW_CAM_DIST_*`)
  and re-engages the follow grace period. The mouse path computes its deltas
  (dead zone, sensitivity, invert) and feeds the routine.
- `MouseCameraOrbitActive` renamed to `ManualCameraOrbitActive`: the flag that
  selects the tight `BetaCam` lerp in `PERSO.CPP` is no longer mouse-specific, so
  any analog source gets the same responsive feel.
- `docs/CONTROLLER.md` rewritten from the old phased roadmap (its gamepad and
  controls-menu phases already shipped on main) to a present-tense description of
  the model and its input sources.

The mouse feel is unchanged relative to #57: dead zone, sensitivity, divisor,
smoothing, invert, and reengage logic are identical, just relocated behind the
shared routine.

## Config (`lba2.cfg`)

| Key | Default | Description |
|-----|---------|-------------|
| `MouseCamera` | 1 | enable (0 = off) |
| `MouseCameraDrag` | 1 | 1 = right-drag to orbit, 0 = free orbit on move |
| `MouseSensitivityX` | 4 | horizontal orbit speed (1-10) |
| `MouseSensitivityY` | 4 | elevation speed (1-10) |
| `MouseInvertY` | 0 | invert elevation axis |
| `MouseCameraDivisor` | 4 | pixel-to-angle scaling (lower = faster, 1-16) |
| `MouseCameraSmoothing` | 2 | orbit lerp (1 = snap, higher = laggier, 1-16) |

Mouse camera is on by default. It only does anything in exterior scenes with
Auto camera, which is itself opt-in, so default play is unaffected unless you
turn Auto camera on.

## Scope

Exterior plus Auto camera only. Interior scenes and the classic fixed cameras are
untouched. Camera nudges are view-only (no effect on simulation or collision), so
the `--dump-state` regression net is unaffected.

## Next

The right-stick analog hook (a follow-up) routes the raw gamepad right-stick axes
through this same `ApplyManualCameraNudge` routine, with a digital fallback in
classic mode.

## Test plan

- [x] builds (Ninja Debug)
- [x] `check-format.sh` clean
- [x] exterior smoke: Desert Island, 20 ticks, clean exit
- [x] right-drag orbit, diagonal smoothness
- [x] wheel zoom in/out
- [x] middle-click recenters behind hero
- [x] walk after orbiting: camera drifts back behind hero after the grace period
- [x] interior scene and classic camera: mouse does nothing to the camera
