### PR TITLE
fix(render): scale exterior near-clip with render height

### DIFF
--- a/SOURCES/EXTFUNC.CPP
+++ b/SOURCES/EXTFUNC.CPP
@@ -98,8 +98,19 @@ void Init3DExtView(void) {
     // At the default 640x480 this is the original (320, 240) — the hardcoded
     // literal Phase 0 of the widescreen plan flagged; see docs/WIDESCREEN.md
     // and docs/WIDESCREEN_PROJECTION_AUDIT.md.
+    // Near clip scales down as the framebuffer grows taller. The focal is fixed
+    // (ChampX/ChampZ), so a taller frame reveals more vertical FOV, which pulls
+    // the bottom of the frustum's ground intersection closer to the camera. The
+    // terrain trivial-rejects whole cells whose depth is within the near plane
+    // (zr <= NearClip in TERRAIN.CPP MaskVisible), so a fixed plane drops near
+    // terrain/buildings that are plainly in view at HD ("clipped on the right").
+    // Scale it with height to keep the near plane at the original screen-space
+    // position. Exact CLIP_NEAR at the original 480, so 480 is unchanged.
+    S32 nearClip = CLIP_NEAR;
+    if (ModeDesiredY > 480)
+        nearClip = CLIP_NEAR * 480 / (S32)ModeDesiredY;
     SetProjection((S32)(ModeDesiredX / 2), (S32)(ModeDesiredY / 2),
-                  CLIP_NEAR, ChampX, ChampZ);
+                  nearClip, ChampX, ChampZ);
     SetFollowCamera(VueOffsetX, VueOffsetY, VueOffsetZ,
                     AlphaCam, BetaCam, GammaCam,
                     VueDistance);


### PR DESCRIPTION
## Problem

At a taller framebuffer the exterior projection's fixed focal (`ChampX`/`ChampZ` = 600) reveals more vertical field of view, which pulls the bottom of the frustum's ground intersection closer to the camera. The terrain trivial-rejects whole cells whose along-axis depth is within the near plane (`zr <= NearClip` in `TERRAIN.CPP` `MaskVisible`, the flag-32 path), so a fixed 3000-unit `NearClip` culls near terrain and buildings that are plainly in view at HD — most visibly "the whole building clipped on one side" at 1080p.

The X/Y screen-edge culls are already resolution-aware (`ClipXMax = ModeResX-1`), so only the fixed near plane was the casualty.

## Fix

Scale the exterior near-clip down with render height in `Init3DExtView`, so the plane keeps its original screen-space position:

- 3000 at 480 (exact `CLIP_NEAR`, so the 480 path is byte-identical)
- ~1333 at 1080

Objects already near-plane *clip* via `POLYCLIP`, so they render correctly closer; only the terrain whole-cell reject needed addressing.

## Notes

- This is a baseline FHD rendering bug independent of any camera mode — the classic camera at FHD hits it too — which is why it's split out as its own change.
- No-op at 480, so the 768×480 projrec baseline is unaffected.
- A more complete fix (per-cell near-plane clipping of the terrain grid) is left for later; this height scaling resolves the visible cases.
