### PR TITLE
feat(picker): trim first-launch data dialogs, fix Android and dialog-less UX

### DIFF
--- a/SOURCES/RES_PICKER.CPP
+++ b/SOURCES/RES_PICKER.CPP
@@ -3,12 +3,44 @@
 #include "RES_PICKER.H"
 #include "DIRECTORIES.H"
 
+#include "SYSTEM/ANDROID.H"
 #include "SYSTEM/LIMITS.H"
 #include "SYSTEM/LOG.H"
 
 #include <SDL3/SDL.h>
 
 #include <string.h>
+
+/* Message-box bodies live as named constants (not inline in the SDL calls) so a
+   host test can hold the line on the wording contract: no em-dash, recovery
+   tokens present, and a length ceiling -- the "don't grow a README inside a
+   modal" guard. Keep them short. The long-form setup guide is README.txt
+   (shipped next to the binary; .md docs are NOT in the release), and
+   docs/GAME_DATA.md for anyone reading the source. Declared in RES_PICKER.H.
+   File scope (not the anonymous namespace below): extern "C" external linkage
+   so the host test can reference them by name. */
+
+extern "C" const char kPickerMsgDataNotFound[] =
+    "Little Big Adventure 2 game data wasn't found.\n\n"
+    "Pick the folder that contains lba2.hqr (your retail LBA2 install).\n\n"
+    "Your choice is saved for next time.";
+
+extern "C" const char kPickerMsgInvalidPick[] =
+    "That folder doesn't contain lba2.hqr.\n\n"
+    "Pick your retail LBA2 install folder (the one with lba2.hqr).";
+
+extern "C" const char kPickerMsgNoPicker[] =
+    "The system folder picker isn't available here.\n\n"
+    "Start the game with your data folder instead:\n"
+    "    lba2cc --game-dir /path/to/your/lba2/install\n"
+    "or set the LBA2_GAME_DIR environment variable.\n\n"
+    "See README.txt for setup help.";
+
+extern "C" const char kPickerMsgAndroidData[] =
+    "Little Big Adventure 2 game data wasn't found.\n\n"
+    "Copy your retail LBA2 data (lba2.hqr, music/, video/, vox/) to:\n"
+    "    /sdcard/lba2cc/\n\n"
+    "then relaunch the app.";
 
 namespace {
 
@@ -82,14 +114,8 @@ void SDLCALL OnFolderChosen(void *userdata, const char *const *filelist,
 }
 
 void ShowInvalidPickMessage(void) {
-    SDL_ShowSimpleMessageBox(
-        SDL_MESSAGEBOX_WARNING,
-        "Game data not found",
-        "This folder doesn't contain lba2.hqr.\n\n"
-        "Please pick the folder containing your retail Little Big "
-        "Adventure 2 install (the one with lba2.hqr, music/, video/, "
-        "vox/, etc.).",
-        NULL);
+    SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "Game data not found",
+                             kPickerMsgInvalidPick, NULL);
 }
 
 } // namespace
@@ -115,37 +141,28 @@ void EnsureTrailingSeparator(char *path, U16 maxLen) {
 }
 
 void ShowDiscoveryFailedMessage(void) {
-    SDL_ShowSimpleMessageBox(
-        SDL_MESSAGEBOX_INFORMATION,
-        "Game data folder not found",
-        "Little Big Adventure 2 retail game data wasn't found in any of "
-        "the usual places.\n\n"
-        "Please pick the folder containing your LBA2 install (the one "
-        "with lba2.hqr, music/, video/, vox/, etc.).\n\n"
-        "Your choice will be remembered for future launches.",
-        NULL);
+    SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION,
+                             "Game data folder not found",
+                             kPickerMsgDataNotFound, NULL);
 }
 
-/* The picker fired but the OS couldn't actually open a folder dialog
- * — no backend installed (common on WSL without zenity, on minimal
- * Linux containers, on locked-down corporate setups). Surface
- * actionable recovery rather than just exiting with the existing
- * "no game data" log buried in the terminal. */
+/* The picker fired but the OS couldn't actually open a folder dialog: no
+ * backend installed (common on WSL without zenity, on minimal Linux
+ * containers, on locked-down corporate setups). Point at the universal
+ * escape hatch and README.txt rather than dumping the per-distro install
+ * matrix into a modal -- that matrix lives in README.txt / docs/GAME_DATA.md.
+ * The advice is platform-neutral (no apt/pacman/dnf) so it reads correctly on
+ * every desktop, not just Linux. */
 void ShowDialogUnavailableMessage(void) {
-    SDL_ShowSimpleMessageBox(
-        SDL_MESSAGEBOX_WARNING,
-        "Couldn't open folder picker",
-        "The system folder-picker isn't available on this setup.\n\n"
-        "Quickest fix on most Linux setups (including WSL):\n"
-        "    sudo apt install zenity\n"
-        "    (or: pacman -S zenity / dnf install zenity)\n\n"
-        "For native-styled dialogs on KDE / GNOME / Hyprland, install\n"
-        "the matching xdg-desktop-portal package. See docs/GAME_DATA.md\n"
-        "section 'Picker backends per environment'.\n\n"
-        "Or skip the picker entirely: launch from a terminal with\n"
-        "    lba2cc --game-dir /path/to/your/lba2/install\n"
-        "or set the LBA2_GAME_DIR environment variable.",
-        NULL);
+    SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "Couldn't open folder picker",
+                             kPickerMsgNoPicker, NULL);
+}
+
+/* Android has no usable folder picker, so instead of browsing the user is told
+ * exactly where to copy their data. Shown in place of the picker flow above. */
+void ShowAndroidDataMessage(void) {
+    SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION, "Game data not found",
+                             kPickerMsgAndroidData, NULL);
 }
 
 } // namespace
@@ -158,6 +175,19 @@ extern "C" bool PromptForResDir(char *outPath, U16 outMax) {
     if (!SDL_InitSubSystem(SDL_INIT_VIDEO)) {
         Log_Warn("RES_PICKER: SDL_INIT_VIDEO failed (%s); skipping picker",
                  SDL_GetError());
+        return false;
+    }
+
+    /* Android has no usable folder picker: SDL's file dialog there returns
+     * content:// document URIs, not filesystem paths IsValidResourceDir can
+     * probe. So instead of browsing, tell the user where to copy their data
+     * and fall through to the caller's exit. Android_GetExternalFilesDir is a
+     * no-op returning 0 off-Android, so desktop builds skip this and reach the
+     * picker below -- the seam keeps this caller #ifdef-free. */
+    char androidProbe[ADELINE_MAX_PATH];
+    if (Android_GetExternalFilesDir(androidProbe, ADELINE_MAX_PATH)) {
+        Log_Info("RES_PICKER: Android - no folder picker; showing data-copy hint");
+        ShowAndroidDataMessage();
         return false;
     }
 

--- a/SOURCES/RES_PICKER.H
+++ b/SOURCES/RES_PICKER.H
@@ -30,6 +30,14 @@ extern "C" {
  * adapted to a synchronous loop via SDL_PumpEvents). */
 bool PromptForResDir(char *outPath, U16 outMax);
 
+/* Message-box bodies, defined in RES_PICKER.CPP and exposed so a host test can
+ * assert the wording contract (no em-dash, no unshipped .md pointer, length
+ * ceiling, recovery tokens present). Not for general use; call the picker. */
+extern const char kPickerMsgDataNotFound[];
+extern const char kPickerMsgInvalidPick[];
+extern const char kPickerMsgNoPicker[];
+extern const char kPickerMsgAndroidData[];
+
 #ifdef __cplusplus
 }
 #endif

--- a/docs/GAME_DATA.md
+++ b/docs/GAME_DATA.md
@@ -27,6 +27,8 @@ If none of the above resolves a valid directory, the engine falls back to the [F
 
 When all four override mechanisms above fail and the engine is running in a windowed environment, it shows the platform-native folder dialog (NSOpenPanel on macOS, IFileDialog on Windows, GTK / xdg-desktop-portal on Linux). The user picks the folder containing `lba2.hqr`; the engine validates it via `IsValidResourceDir`, persists the choice to `last_game_dir.txt`, and continues startup.
 
+Android is the exception: there is no folder picker (SDL's file dialog returns `content://` document URIs, not filesystem paths the engine can probe). When discovery fails there, the engine shows a message telling the user to copy their data to `/sdcard/lba2cc/` and relaunch, instead of opening a dialog. See [docs/ANDROID.md](ANDROID.md) for the full Android data layout.
+
 | Scenario | Behavior |
 |---|---|
 | User picks a valid folder (contains `lba2.hqr`) | Engine launches; `last_game_dir.txt` updated; subsequent launches skip the dialog. |

--- a/scripts/packaging/linux-readme.txt.in
+++ b/scripts/packaging/linux-readme.txt.in
@@ -53,8 +53,19 @@ RUNNING
 
     ./@LBA2_EXECUTABLE_NAME@
 
-If it can't find game data and the picker isn't available for some
-reason, the log printed to stderr lists every directory it tried.
+If the folder picker doesn't open (common on minimal Linux setups and
+WSL, where no dialog backend is installed), either install one:
+
+    sudo apt install zenity          (Debian / Ubuntu / WSL)
+    pacman -S zenity                 (Arch)
+    dnf install zenity               (Fedora)
+
+or skip the picker entirely by passing the path:
+
+    ./@LBA2_EXECUTABLE_NAME@ --game-dir /path/to/game
+
+If it still can't find game data, the log printed to stderr lists every
+directory it tried.
 
 
 LICENSE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ function(register_host_test test_name)
 endfunction()
 
 add_subdirectory(discovery)
+add_subdirectory(picker)
 add_subdirectory(console)
 add_subdirectory(logging)
 add_subdirectory(asset_preflight)

--- a/tests/picker/CMakeLists.txt
+++ b/tests/picker/CMakeLists.txt
@@ -1,0 +1,29 @@
+# RES_PICKER.CPP defines the message bodies and the Android gate; DIRECTORIES.CPP
+# supplies IsValidResourceDir that RES_PICKER references. Android_GetExternalFilesDir
+# and Log_* come from the `sys` library; SDL3 satisfies the picker's SDL calls at
+# link time (the test never calls PromptForResDir, so no display is needed).
+set(_PICKER_SOURCES
+    ${CMAKE_SOURCE_DIR}/SOURCES/RES_PICKER.CPP
+    ${CMAKE_SOURCE_DIR}/SOURCES/DIRECTORIES.CPP
+)
+
+add_executable(test_res_picker test_res_picker.cpp ${_PICKER_SOURCES})
+
+target_include_directories(test_res_picker PRIVATE
+    ${CMAKE_SOURCE_DIR}/SOURCES
+    ${CMAKE_SOURCE_DIR}/LIB386/H
+    ${CMAKE_BINARY_DIR}
+)
+
+target_link_libraries(test_res_picker PRIVATE sys SDL3::SDL3)
+
+target_compile_definitions(test_res_picker PRIVATE
+    LBA2_BUILD_TESTS
+    "TEST_SOURCE_ROOT=\"${CMAKE_SOURCE_DIR}/\""
+)
+
+set_target_properties(test_res_picker PROPERTIES CXX_STANDARD 11)
+
+add_test(NAME test_res_picker COMMAND test_res_picker)
+
+register_host_test(test_res_picker)

--- a/tests/picker/test_res_picker.cpp
+++ b/tests/picker/test_res_picker.cpp
@@ -1,0 +1,95 @@
+/**
+ * Host-only tests for the first-launch folder-picker (no Docker, no retail
+ * data, no display).
+ *
+ * The picker UI itself can't be driven headless, but two things it depends on
+ * can be locked down here:
+ *
+ *   1. Message-box wording, held to a contract: no em-dash, no pointer to an
+ *      unshipped .md doc (release packages carry README.txt, not docs/), a
+ *      length ceiling (the "don't grow a README inside a modal" guard), and the
+ *      recovery tokens each message promises to the user.
+ *
+ *   2. The platform gate. Off-Android, Android_GetExternalFilesDir is a no-op
+ *      returning 0, so PromptForResDir never takes the Android branch and
+ *      reaches the desktop picker. Lock that invariant so a stub change can't
+ *      silently divert desktop builds into the Android copy-data message.
+ */
+
+#include "RES_PICKER.H"
+
+#include <SYSTEM/ANDROID.H>
+#include <SYSTEM/LIMITS.H>
+
+#include <cstdio>
+#include <cstring>
+
+static int g_failures = 0;
+
+static void check(bool cond, const char *what) {
+    if (!cond) {
+        fprintf(stderr, "FAIL: %s\n", what);
+        ++g_failures;
+    }
+}
+
+/* The em-dash, U+2014, is 0xE2 0x80 0x94 in UTF-8. The repo's commit hook
+   blocks newly-added ones in source; this is the user-facing-string backstop so
+   a message body can't regress one in unnoticed. */
+static bool HasEmDash(const char *s) {
+    return strstr(s, "\xe2\x80\x94") != NULL;
+}
+
+/* Ceiling 350 keeps every box well clear of "a README in a modal"; the longest
+   today (no-picker) is ~220 chars. */
+static const size_t kMaxLen = 350;
+
+static void check_message(const char *name, const char *body) {
+    char ctx[128];
+
+    snprintf(ctx, sizeof ctx, "%s: no em-dash", name);
+    check(!HasEmDash(body), ctx);
+
+    /* Release artifacts ship README.txt, not the .md docs, so a user-facing
+       dialog must never point the player at a docs/*.md file they don't have. */
+    snprintf(ctx, sizeof ctx, "%s: no .md pointer (not shipped with release)",
+             name);
+    check(strstr(body, ".md") == NULL, ctx);
+
+    snprintf(ctx, sizeof ctx, "%s: under length ceiling (%zu)", name, kMaxLen);
+    check(strlen(body) <= kMaxLen, ctx);
+}
+
+int main(void) {
+    /* Wording contract: no em-dash, no unshipped-doc pointer, length ceiling. */
+    check_message("DataNotFound", kPickerMsgDataNotFound);
+    check_message("InvalidPick", kPickerMsgInvalidPick);
+    check_message("NoPicker", kPickerMsgNoPicker);
+    check_message("AndroidData", kPickerMsgAndroidData);
+
+    /* Each message must carry the action it promises. */
+    check(strstr(kPickerMsgDataNotFound, "lba2.hqr") != NULL,
+          "DataNotFound: names lba2.hqr");
+    check(strstr(kPickerMsgInvalidPick, "lba2.hqr") != NULL,
+          "InvalidPick: names lba2.hqr");
+    check(strstr(kPickerMsgNoPicker, "--game-dir") != NULL,
+          "NoPicker: offers --game-dir");
+    check(strstr(kPickerMsgNoPicker, "LBA2_GAME_DIR") != NULL,
+          "NoPicker: offers LBA2_GAME_DIR");
+    check(strstr(kPickerMsgNoPicker, "README.txt") != NULL,
+          "NoPicker: points at README.txt");
+    check(strstr(kPickerMsgAndroidData, "/sdcard/lba2cc/") != NULL,
+          "AndroidData: names the copy target");
+
+    /* Off-Android, the gate must fall through to the desktop picker:
+       Android_GetExternalFilesDir is a no-op returning 0 here. */
+    char buf[ADELINE_MAX_PATH];
+    check(Android_GetExternalFilesDir(buf, ADELINE_MAX_PATH) == 0,
+          "off-Android: external-files probe returns 0 (gate falls through)");
+
+    if (g_failures) {
+        fprintf(stderr, "%d check(s) failed\n", g_failures);
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## What

Tightens the first-launch game-data discovery dialogs and makes them work on platforms that have no usable native dialog (Android, dialog-less Linux/WSL).

The in-engine localised dialogs (resolution-revert confirm, the retail boxes) were already fine; this only touches the native SDL message-box onboarding flow that fires when game data isn't found.

## Why

The native onboarding boxes didn't fit every target:

- **Wrong advice off-Linux.** The "couldn't open folder picker" box dumped a per-distro install matrix (`apt`/`pacman`/`dnf`/`xdg-desktop-portal`) into a modal, and that Linux-only advice showed on every platform, including macOS and Windows.
- **Wordy / repetitive.** The three picker boxes repeated the same `(lba2.hqr, music/, video/, vox/)` litany. A modal isn't the place for an install matrix that already lives in `README.txt` and `docs/GAME_DATA.md`.
- **Android had no path through it.** Android has no usable folder picker (SDL's file dialog returns `content://` document URIs, not filesystem paths the engine can probe), yet Android users still hit the zenity message.

## Changes

- Trimmed and de-duped the three native message boxes. Each is now one statement plus the action.
- Made the picker-unavailable box platform-neutral: the `--game-dir` / `LBA2_GAME_DIR` escape hatch plus a `README.txt` pointer.
- Gated the desktop picker on Android behind the existing `Android_GetExternalFilesDir` seam (a no-op returning 0 off-Android, so the caller stays `#ifdef`-free). On Android it shows a self-contained "copy your data to `/sdcard/lba2cc/`, then relaunch" message instead of opening a dialog that can't return a usable path.
- Recovery help points at `README.txt` (shipped next to the binary), not `docs/*.md` (source-only, absent from release packages). Added the picker-unavailable recovery to the Linux README template so the pointer is truthful, and noted the Android no-picker behavior in `docs/GAME_DATA.md`.

## Tests

New host test `tests/picker/test_res_picker.cpp` holds the wording contract: no em-dash, no `.md` pointer, a length ceiling (the "not a README in a modal" guard), the promised recovery tokens, and the off-Android gate invariant. Runs under `make test` (no Docker, no retail data).

- All 33 host tests pass; full engine builds and links.
- Verified via `strings` that the new copy is compiled in and the old zenity/portal dump is gone.
- clang-format clean.

## Note

Only the Linux README template gained the picker-recovery section, since Linux/WSL is the only desktop where the dialog backend can be missing (macOS/Windows always have a native picker). Happy to add a short note to the macOS/Windows templates for parity if preferred.
