### PR TITLE
fix(save): show the "Game Saved" confirmation on the in-game quick-save

### DIFF
--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -3818,6 +3818,13 @@ static void ShowSaveConfirmation(enum MenuLocalizedLabel label) {
     InitWaitNoInput(I_FIRE | I_ACTION | I_MENUS);
 }
 
+// Non-static entry so the in-game quick-save (PERSO.CPP) can show the same
+// "Game Saved" chime + overlay as the main-menu Save path. Keeps the localized
+// label enum internal to this module.
+void ShowGameSavedConfirmation(void) {
+    ShowSaveConfirmation(MENU_LABEL_GAME_SAVED);
+}
+
 void BuildGameMainMenu(S32 firstloop) {
     char memoplayername[MAX_SIZE_PLAYER_NAME + 1];
     char memogamepathname[ADELINE_MAX_PATH];

--- a/SOURCES/GAMEMENU.H
+++ b/SOURCES/GAMEMENU.H
@@ -45,6 +45,8 @@ extern S32 InputPlayerName(S32 choice, char *name);
 /*--------------------------------------------------------------------------*/
 extern S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew);
 /*--------------------------------------------------------------------------*/
+extern void ShowGameSavedConfirmation(void);
+/*--------------------------------------------------------------------------*/
 extern void DrawOneChoice(S32 x, S32 y, S32 type, S32 num, S32 select);
 /*--------------------------------------------------------------------------*/
 extern void DrawGameMenu(U16 *ptrmenu, S32 justone);

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -1275,6 +1275,12 @@ restartloop:
                         if (FileSize(OldGamePathname))
                             Delete(OldGamePathname);
                         SaveGame(TRUE);
+                        // Match the main-menu Save path: resume samples for the
+                        // chime, then show the "Game Saved" confirmation. Without
+                        // it the quick-save writes silently, so a successful save
+                        // looks identical to a failure (menu just closes).
+                        HQ_ResumeSamples();
+                        ShowGameSavedConfirmation();
                     }
                     ClearPlasmaMenu();
 #endif


### PR DESCRIPTION
Controller-tester feedback: the in-game quick Save menu looked like it did nothing — the menu closed and dropped back into the game with no sign a save had happened. The save was in fact being written; it was just silent.

## Cause

The main-menu Save path plays a chime and shows a shaded "Game Saved" overlay (`ShowSaveConfirmation`, [GAMEMENU.CPP:4222](../SOURCES/GAMEMENU.CPP)). The in-game quick-save path ([PERSO.CPP](../SOURCES/PERSO.CPP), `Input & I_SAVE`) called `SaveGame()` but showed nothing. A successful quick-save was therefore indistinguishable from a failure — especially on a controller, where the auto-named save skips text entry, so there's no other on-screen step to confirm anything took.

## Fix

Give the quick-save the same confirmation the main-menu save already uses:

- Expose `ShowSaveConfirmation` through a thin non-static `ShowGameSavedConfirmation()` wrapper, keeping the localized-label enum internal to `GAMEMENU`.
- Call it from the quick-save path after `SaveGame()`, resuming samples first (the quick-save menu pauses them) so the chime plays.

Side benefit: the confirmation is now consistent across all input methods — pad, keyboard, and touch — not just the case the tester hit. No default gamepad Save binding is added (there's no free controller button, and the main-menu Save already works on a pad).

## Testing

- Engine builds clean; clang-format clean.
- Manually verified on Windows with an Xbox controller: the quick Save menu now plays the chime and shows the "Game Saved" overlay, and the `.LBA` file is written; loading it back works. The main-menu Save path is unchanged.

Last of a short series from the same controller feedback (movement/menu fixes are in #346).
