### PR TITLE
feat(save): restore autosave on scene transitions

### DIFF
--- a/SOURCES/OBJECT.CPP
+++ b/SOURCES/OBJECT.CPP
@@ -6148,6 +6148,17 @@ startaffscene:
     }
 
     if (FlagChgCube) {
+        // Autosave on every scene (cube) transition, as the retail game did --
+        // a fresh autosave.lba checkpoint so a crash or quit-without-saving
+        // doesn't drop the player back to a much older current.lba. Skipped for
+        // the phantom cube (a transient cutscene/holomap cube, never a save
+        // point). Genuine transitions only: FlagChgCube is set by zone
+        // crossings, Life-script CHANGE_CUBE, and the phantom teleport -- never
+        // by console warps or menu loads, so those don't clobber the autosave.
+        if (NumCube != NUM_CUBE_PHANTOM) {
+            AutoSaveGame();
+        }
+
         FlagChgCube = 0;
     }
 

--- a/SOURCES/SAVEGAME.CPP
+++ b/SOURCES/SAVEGAME.CPP
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <time.h>
 #include <SYSTEM/LOADSAVE.H>
+#include <SYSTEM/LOG.H>
 #include <SYSTEM/LZ.H>
 #include "SAVEGAME_LOAD_BOUNDS.H"
 
@@ -639,6 +640,12 @@ Save(GamePathname, BufSpeak + 50000L, PtrSave - (BufSpeak + 50000L));
 #else
     Save(GamePathname, (U8 *)Screen, PtrSave - (U8 *)Screen);
 #endif
+
+// Save audit trail. Debug level, so it always lands in adeline.log but stays
+// off the F12 overlay until `loglevel debug`. Covers every save path:
+// AutoSaveGame (autosave.lba), CurrentSaveGame (current.lba), and the menu's
+// named saves -- GamePathname distinguishes which, NumCube which scene.
+Log_Debug("save: wrote \"%s\" (cube %d)", GamePathname, (int)NumCube);
 }
 
 // Version 4 : LBA II only !! (LoadSize + read limit via SaveLoadFileToScreen)


### PR DESCRIPTION
## What

Restores the original game's per-scene autosave. Every time Twinsen crosses into a new cube (scene), the engine writes a fresh `autosave.lba` checkpoint, the behaviour the retail game shipped with.

## Why

The cube-change autosave was removed in #24 ("Cube change no longer triggers autosave"), which left the feature half-wired: the write path was gone, but the read path stayed live. The Load menu still lists an "AUTOSAVE" slot and uses it as a fallback player, so the safety net was lost without the UI reflecting it.

The gap it fills is the crash / hard-quit / death-back-to-menu case: if you cross several scenes without opening the pause menu, "Continue" (`current.lba`, only updated on menu entry and load) drops you back to your last menu visit, potentially far behind. Field feedback flagged this as sorely missed, with real backtracking risk.

## How

Reinstates the original block in `AffScene`:

- Fires only on genuine scene transitions. `FlagChgCube` is set by zone crossings, Life-script `CHANGE_CUBE`, and the phantom teleport. Console `cube` warps and menu loads never set it, so they do not clobber the player's autosave.
- Skips the phantom cube (transient cutscene / holomap cube, never a save point), matching the original guard.

The read side (Load-menu slot, fallback lookup, delete-protection) was already intact, so this single call restores the feature end to end.

The second commit adds a debug-level save audit line in the shared writer, `save: wrote "<file>" (cube N)`, covering autosave, current, and named saves. It always lands in `adeline.log` and surfaces on the F12 console via `loglevel debug`, which makes verifying transitions a one-line check.

## Testing

- `make build`, `make test` (34 host tests), and clang-format all clean.
- Via the control harness, confirmed the autosave path writes `autosave.lba` with the correct newly-entered cube stored (decoded the header), and that a console `cube` warp does not trigger it.
- Recommend a quick in-game confirm before merge: load a game, walk through a scene exit, and check the "AUTOSAVE" slot updates (or watch the `save: wrote` line with `loglevel debug`).
