### PR TITLE
fix(input): let the gamepad skip the end credits

### DIFF
--- a/SOURCES/CREDITS.CPP
+++ b/SOURCES/CREDITS.CPP
@@ -347,8 +347,15 @@ S32 GamePlayCredits(const char *file_name, S32 mode) {
 
         MyKey = Key;
         GetInput(0);
+        UpdateJoystick();
 
-        if (MyKey OR Input) {
+        // Skip the credits on any keyboard key (Key is set for any key) or any
+        // deliberate gamepad button. JoystickButtonPressed() excludes the analog
+        // sticks and triggers, which drift/rest past the deadzone and would end
+        // the credits by accident. We don't test the Input bitfield here: for the
+        // keyboard it's redundant with Key, and it would fold in the pad's
+        // stick/trigger movement bits.
+        if (MyKey OR JoystickButtonPressed()) {
             player_stop = TRUE;
             goto end_credits;
         }

--- a/SOURCES/JOYSTICK.CPP
+++ b/SOURCES/JOYSTICK.CPP
@@ -378,6 +378,32 @@ U32 JoystickFirstPressedScancode(void) {
 }
 
 //***************************************************************************
+// True if a gamepad *button* was newly pressed this frame -- face buttons,
+// Start/Back/Guide, shoulders, D-pad, or a stick-click. Excludes the analog
+// stick directions and the triggers: those rest/drift past the deadzone and
+// would trip a "press any button" prompt (e.g. the credits skip) by accident.
+// Reads the edge-detected first-pressed scancode, so poll the pad
+// (UpdateJoystick/GetJoys) earlier in the same frame before calling this.
+S32 JoystickButtonPressed(void) {
+    switch (s_firstPressedThisFrame) {
+    case 0: // nothing newly pressed
+    case K_GAMEPAD_LSTICK_UP:
+    case K_GAMEPAD_LSTICK_DOWN:
+    case K_GAMEPAD_LSTICK_LEFT:
+    case K_GAMEPAD_LSTICK_RIGHT:
+    case K_GAMEPAD_RSTICK_UP:
+    case K_GAMEPAD_RSTICK_DOWN:
+    case K_GAMEPAD_RSTICK_LEFT:
+    case K_GAMEPAD_RSTICK_RIGHT:
+    case K_GAMEPAD_LTRIGGER:
+    case K_GAMEPAD_RTRIGGER:
+        return 0;
+    default:
+        return 1;
+    }
+}
+
+//***************************************************************************
 S32 JoystickIsPresent(void) {
     return (s_gamepad != NULL) ? 1 : 0;
 }

--- a/SOURCES/JOYSTICK.H
+++ b/SOURCES/JOYSTICK.H
@@ -45,6 +45,12 @@ S32 JoystickMenuNavOnly(void);
 // waits light up on any pad input without per-callsite changes.
 U32 JoystickFirstPressedScancode(void);
 
+// True if a gamepad *button* (face, Start/Back/Guide, shoulder, D-pad,
+// stick-click) was newly pressed this frame -- excludes the analog sticks and
+// triggers, which drift/rest past the deadzone. For "press any button" prompts
+// (e.g. the credits skip) that must not fire on stick drift. Poll the pad first.
+S32 JoystickButtonPressed(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## What

The end credits couldn't be skipped or exited with a controller. The loop read `MyKey = Key; GetInput(0)` and exited on `MyKey OR Input`, but `Key` is keyboard-only (pad scancodes are never written to it) and plain `GetInput()` doesn't poll the pad. It was the last user-facing modal screen still blind to the gamepad after #346.

## Fix

Poll the pad with `UpdateJoystick()` in the credits loop, and exit on any keyboard key (unchanged) or a deliberate gamepad button.

A new `JoystickButtonPressed()` helper reports a newly-pressed pad button (face buttons, Start/Back/Guide, shoulders, D-pad, stick-click) and deliberately excludes the analog sticks and triggers. Those rest or drift past the deadzone (pad movement is bound to the left stick and the triggers), so folding them in would end the credits by accident.

`Input` is dropped from the exit condition: it's redundant with `Key` for the keyboard, and would have re-admitted the pad's stick/trigger movement bits.

Net behaviour: keyboard = any key (faithful to the shipped game), gamepad = any deliberate button, never a stick nudge.

## Testing

- Builds clean; clang-format clean; 34 host tests pass.
- Verified with a controller: a button skips the credits, a resting or wobbling stick does not. Keyboard behaviour unchanged.
