### PR TITLE
feat(input): ungroup the D-pad from the left stick (#360)

### DIFF
--- a/SOURCES/JOYSTICK.CPP
+++ b/SOURCES/JOYSTICK.CPP
@@ -313,17 +313,11 @@ void UpdateJoystick(void) {
         }
     }
 
-    // D-pad also lights up the LSTICK directional virtual keys, so bindings
-    // that target the left stick cover the D-pad for free (standard action-game
-    // convention where stick and D-pad are interchangeable for movement).
-    if (SDL_GetGamepadButton(s_gamepad, SDL_GAMEPAD_BUTTON_DPAD_UP))
-        SetVirtualKeyDown(K_GAMEPAD_LSTICK_UP);
-    if (SDL_GetGamepadButton(s_gamepad, SDL_GAMEPAD_BUTTON_DPAD_DOWN))
-        SetVirtualKeyDown(K_GAMEPAD_LSTICK_DOWN);
-    if (SDL_GetGamepadButton(s_gamepad, SDL_GAMEPAD_BUTTON_DPAD_LEFT))
-        SetVirtualKeyDown(K_GAMEPAD_LSTICK_LEFT);
-    if (SDL_GetGamepadButton(s_gamepad, SDL_GAMEPAD_BUTTON_DPAD_RIGHT))
-        SetVirtualKeyDown(K_GAMEPAD_LSTICK_RIGHT);
+    // The D-pad emits only its own K_GAMEPAD_DPAD_* scancodes (above), never
+    // the left-stick virtual keys. That keeps the D-pad and left stick as
+    // independent, separately bindable input sources (issue #360): whatever a
+    // player binds to a D-pad direction in the controls menu is all it does, no
+    // hidden aliasing onto the stick's cardinals.
 
     S16 lx = SDL_GetGamepadAxis(s_gamepad, SDL_GAMEPAD_AXIS_LEFTX);
     S16 ly = SDL_GetGamepadAxis(s_gamepad, SDL_GAMEPAD_AXIS_LEFTY);

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -769,6 +769,19 @@ U8 WaitNoKey35 = FALSE;
 
 /*──────────────────────────────────────────────────────────────────────────*/
 
+// True if the keyboard (DefKeys) OR gamepad (GamepadKeys) binding for input
+// slot n is held. The four spell/gadget slots (32-35) sit outside the Input
+// bitfield (INPUT_TABLE_SLOTS == 32, and a 1<<i mask can't reach them), so both
+// sources are polled directly here. Reading GamepadKeys too is what lets the
+// pad's D-pad bindings actually cast, now that the D-pad is its own input
+// source rather than an alias of the left stick (issue #360).
+static S32 SpellKeyDown(S32 n) {
+    return CheckKey(DefKeys[n].Key1) OR CheckKey(DefKeys[n].Key2)
+        OR CheckKey(GamepadKeys[n].Key1) OR CheckKey(GamepadKeys[n].Key2);
+}
+
+/*──────────────────────────────────────────────────────────────────────────*/
+
 S32 MainLoop() {
     S32 xm, ym, zm;
     T_OBJET *ptrobj;
@@ -1654,8 +1667,7 @@ restartloop:
                     InitWaitNoInput(I_WEAPON_7);
                 }
 
-                if (CheckKey(DefKeys[33].Key1) // ProtoPack/SuperJetPack
-                    OR CheckKey(DefKeys[33].Key2)) {
+                if (SpellKeyDown(33)) { // ProtoPack/SuperJetPack
                     if (!WaitNoKey33
                             AND ListVarGame[FLAG_PROTOPACK]) {
                         U8 comp;
@@ -1675,8 +1687,7 @@ restartloop:
                 } else
                     WaitNoKey33 = FALSE;
 
-                if (CheckKey(DefKeys[32].Key1) // NitroMecaPingouin
-                    OR CheckKey(DefKeys[32].Key2)) {
+                if (SpellKeyDown(32)) { // NitroMecaPingouin
                     if (!WaitNoKey32
                             AND ListVarGame[FLAG_MECA_PINGOUIN] > 0) {
                         SaveTimer();
@@ -1689,8 +1700,7 @@ restartloop:
                 } else
                     WaitNoKey32 = FALSE;
 
-                if (CheckKey(DefKeys[34].Key1) // Sort de Protection
-                    OR CheckKey(DefKeys[34].Key2)) {
+                if (SpellKeyDown(34)) { // Sort de Protection
                     if (!WaitNoKey34
                             AND ListVarGame[FLAG_PROTECTION] > 0 AND MagicPoint > 0) {
                         SaveTimer();
@@ -1703,8 +1713,7 @@ restartloop:
                 } else
                     WaitNoKey34 = FALSE;
 
-                if (CheckKey(DefKeys[35].Key1) // Sort de Foudre
-                    OR CheckKey(DefKeys[35].Key2)) {
+                if (SpellKeyDown(35)) { // Sort de Foudre
                     if (!WaitNoKey35
                             AND ListVarGame[FLAG_ANNEAU_FOUDRE] > 0 AND MagicPoint >= (MagicLevel * 20)) {
                         SaveTimer();


### PR DESCRIPTION
Closes #360.

## Problem

`UpdateJoystick()` aliased each D-pad direction onto the matching left-stick virtual key, so a D-pad press also drove the stick's cardinals. The two couldn't be bound independently: whatever you mapped a D-pad direction to also fired `I_LEFT`/`I_RIGHT`. In practice the D-pad only turned Twinsen (via the alias); up/down did nothing.

## Change

Drop the alias. The D-pad already emits its own `K_GAMEPAD_DPAD_*` scancodes via the button table, so it becomes a separate, independently bindable input source. The controls menu already exposes all 36 action rows and captures pad scancodes, so any D-pad direction can now be rebound cleanly.

There's a catch that has to be fixed in the same PR: the default D-pad bindings target the four spell/gadget slots (32-35), which live **outside** the Input bitfield (`INPUT_TABLE_SLOTS == 32`, and a `1<<i` mask can't reach them). Those slots are read via `CheckKey(DefKeys[32..35])` — keyboard only — so the pad defaults never fired. This adds a small `SpellKeyDown()` helper that polls both `DefKeys` and `GamepadKeys` at the four spell sites, symmetric with the keyboard path. Without it, removing the alias would leave the D-pad bound to dead slots by default and looking broken until rebound.

## Behaviour

- D-pad left/right **no longer turns** Twinsen (that was only the alias).
- By default the D-pad now **casts the four spells** (Protection / Jetpack / Pingouin / Foudre) — what the default binding table always intended, finally wired for the pad.
- Movement stays on the left stick and triggers. Keyboard behaviour unchanged.
- Every action, spells included, is now independently rebindable to the D-pad (or anything else) in the controls menu.

## For review

One design call worth a second opinion, @EPmager especially: the default D-pad role is now **spells**, matching the existing default table. The alternative would be D-pad = **movement** (bind the D-pad scancodes into slots 0-3 instead). I went with spells because it honours the shipped default table and frees the D-pad from movement as the issue asks, but either is a one-line-of-defaults change if the preference is movement.

## Testing

- Builds clean; clang-format clean; 34 host tests pass.
- Needs a manual controller pass: confirm the D-pad casts spells, the left stick still moves/turns, and the two no longer cross-drive. (No headless harness covers pad gameplay.)
