### PR TITLE
fix(fade): scene/FMV fade-to-black uses the managed clock (#353)

### DIFF
--- a/SOURCES/AMBIANCE.CPP
+++ b/SOURCES/AMBIANCE.CPP
@@ -613,15 +613,31 @@ void FadeToPal(U8 *ptrpal) {
 
 //──────────────────────────────────────────────────────────────────────────
 void FadeToBlackAndSamples(U8 *ptrpal) {
-    S32 delta = 0;
+    S32 starttime, delta;
 
     SaveTimer();
 
     if (!FlagBlackPal) {
+        // Visual fade timed off the managed game clock (TimerSystemHR), like
+        // FadeToBlack/FadeToPal -- NOT off the audio sample-fade countdown, whose
+        // SDL_GetTicks() baseline goes stale across the cube load and collapses the
+        // fade to a single step (#353). FadeOutSamples() still ramps the SFX volume;
+        // its return value is deliberately ignored so audio state cannot break the
+        // visual fade.
+        starttime = TimerSystemHR;
+
         do {
-            delta = FadeOutSamples(FADE_DELAY);
+            Timer_FixedDtPump();
+            ManageTime();
+
+            delta = starttime + FADE_DELAY - TimerSystemHR;
+
+            if (delta < 0)
+                delta = 0;
+
+            FadeOutSamples(FADE_DELAY);
             FadePal(0, 0, 0, ptrpal, delta);
-        } while (delta != 0);
+        } while (delta);
     }
 
     if ((CubeMode == CUBE_INTERIEUR OR TEMPETE_FINIE)
@@ -638,7 +654,7 @@ void FadeToBlackAndSamples(U8 *ptrpal) {
 
 //──────────────────────────────────────────────────────────────────────────
 void FadeToPalAndSamples(U8 *ptrpal) {
-    S32 delta = FADE_DELAY;
+    S32 starttime, delta;
 
     SaveTimer();
 
@@ -649,8 +665,20 @@ void FadeToPalAndSamples(U8 *ptrpal) {
         HQ_StopOneSample(SAMPLE_RAIN);
     }
 
+    // Visual fade timed off the managed game clock (TimerSystemHR); see the note
+    // in FadeToBlackAndSamples. FadeInSamples() still ramps the SFX volume.
+    starttime = TimerSystemHR;
+
     do {
-        delta = FadeInSamples(FADE_DELAY);
+        Timer_FixedDtPump();
+        ManageTime();
+
+        delta = TimerSystemHR - starttime;
+
+        if (delta > FADE_DELAY)
+            delta = FADE_DELAY;
+
+        FadeInSamples(FADE_DELAY);
         FadePal(0, 0, 0, ptrpal, delta);
     } while (delta != FADE_DELAY);
 


### PR DESCRIPTION
## What

Scene and FMV transitions cut straight into the next scene instead of fading through black, with actors popping in at full brightness once the fade window should have ended. This restores the retail fade behaviour. Fixes #353.

## Root cause

`FadeToBlackAndSamples` / `FadeToPalAndSamples` timed the visual palette ramp off the audio sample-fade countdown (`FadeOutSamples` / `FadeInSamples`). The SDL audio backend implements those on `SDL_GetTicks()` wall-clock, which keeps advancing across the synchronous cube load. `HQ_StopSample()` stamps the fade baseline and clears the fade latch *before* the load, so by the time the fade-in runs the wall-clock delta already exceeds `FADE_DELAY` and the loop exits after a single step.

It's a port regression: the original Miles backend drove these off the managed `TimerSystemHR`, which does not advance during a synchronous load. All fade call sites are original (git `-S` confirms nothing was removed) — only the clock changed.

## Fix

Drive the palette ramp on `TimerSystemHR` (`Timer_FixedDtPump` + `ManageTime`), the same loop `FadeToBlack` / `FadeToPal` already use. `FadeOut/InSamples` are still called each iteration to ramp SFX volume, but no longer gate the visual fade. Side effects: fades now also work under the null-audio backend, and the fixed-dt pumping added in 5465e0c6 now covers these two functions.

## Testing

- Host tests: 34/34 pass.
- Manual: interior/exterior door transitions and an FMV, instrumented with a temporary fade-iteration trace. Fade-in iteration count went from 1 (instant reveal) to ~13 (a visible ~0.2 s ramp); actors no longer pop in. The intermittent already-black fade-out skip cleared up as a side effect. Trace removed before commit.
