### PR TITLE
fix(cutscene): letterbox slides out on cutscene end instead of sticking/popping (#354)

### DIFF
--- a/SOURCES/OBJECT.CPP
+++ b/SOURCES/OBJECT.CPP
@@ -4698,7 +4698,23 @@ void ResetCinemaMode(void) {
 }
 
 /*──────────────────────────────────────────────────────────────────────────*/
+static U8 PrevCinemaMode = FALSE; // #354: previous-frame CinemaMode, to detect the retract start
+
 void FixeCinemaMode(S32 flagflip) {
+    // #354: re-arm the letterbox out-ramp whenever the cutscene ends. LM_CINEMA_MODE 0
+    // re-arms it (DebCycleCinema/LastYCinema/TimerCinema/DureeCycleCinema), but
+    // ResetCinemaMode and the abrupt clears do not, leaving TimerCinema stale so the
+    // retract snaps to 0 in a single frame instead of sliding. Detect CinemaMode
+    // dropping to 0 with bars still up and restart the ramp from the current position,
+    // mirroring the slide-in.
+    if (!CinemaMode AND PrevCinemaMode AND ClipWindowYMin > 0) {
+        DebCycleCinema = ClipWindowYMin;
+        LastYCinema = ClipWindowYMin;
+        TimerCinema = TimerRefHR;
+        DureeCycleCinema = BoundRegleTrois(1, 500, 39, ClipWindowYMin);
+    }
+    PrevCinemaMode = CinemaMode;
+
     if (CinemaMode) {
         if (ClipWindowYMin < 40) {
             // Scrolle vers l'interieur
@@ -6135,7 +6151,17 @@ startaffscene:
         break;
 
     case AFF_ALL_FLIP:
-        FixeCinemaMode(FALSE); // Scrolle les bandes noires
+        // #354: while the letterbox is retracting (cutscene ended, bars still up),
+        // animate it here too (TRUE) instead of only redrawing (FALSE). Camera work
+        // (auto-cam FollowCamera lerp back behind the hero, edge-snap recenter) forces
+        // AFF_ALL_FLIP every frame while it moves; the retract otherwise only animates
+        // in AFF_OBJETS_FLIP, so the bars stick until the camera settles then snap.
+        // Restricted to the retract so the active-cutscene redraw (FALSE, the
+        // "changement de caméra" branch) is untouched.
+        if (!CinemaMode AND ClipWindowYMin > 0)
+            FixeCinemaMode(TRUE); // Scrolle les bandes noires
+        else
+            FixeCinemaMode(FALSE); // Scrolle les bandes noires
         AffNbFps();
         BoxBlit();
         UnlockTimer();


### PR DESCRIPTION
## What

After a cutscene, the letterbox black bars stayed on screen (until the hero moved, or indefinitely while idle) and then popped out instead of sliding, unlike the smooth slide-in. This restores in/out parity. Fixes #354.

## Root cause

Two issues in the letterbox retract (`FixeCinemaMode`):

1. **Retract starved by full-frame redraws.** The bar retract only animates in `AFF_OBJETS_FLIP` frames. Camera operations force `AFF_ALL_FLIP` every frame while they move — the exterior auto-camera recenter (added in #50) and the `FollowCamera` lerp back behind the hero after a cutscene — so the retract never rendered during its ~0.5 s window and the bars stuck until the camera settled.

2. **Stale ramp timer.** Only the scenario's `LM_CINEMA_MODE 0` re-arms the out-ramp (`TimerCinema`/`DebCycleCinema`/`LastYCinema`/`DureeCycleCinema`). Cutscenes ending via `ResetCinemaMode` or abrupt clears leave the timer stale, so once the retract did run, `BoundRegleTrois` was already past `DureeCycleCinema` and it snapped straight to 0.

## Fix (OBJECT.CPP only)

- Animate the retract in `AFF_ALL_FLIP` too, restricted to the retract (`CinemaMode == 0` with bars up) so the active-cutscene redraw path (the "changement de caméra" branch) is untouched. Makes the slide-out immune to any camera op forcing a full frame.
- Re-arm the out-ramp when `CinemaMode` drops to 0 with bars still up, mirroring what `LM_CINEMA_MODE 0` does for the scenario-driven case.

## Testing

- Host tests: 34/34 pass.
- Manual: cutscenes in both manual and auto camera at multiple resolutions — the letterbox now slides out smoothly, matching the slide-in, with no stick or pop. Verified via a temporary per-frame `ClipYMin`/`dt` trace (removed before commit).
