### PR TITLE
fix(music): play a scene's queued track instead of deferring it forever (#355)

### DIFF
--- a/SOURCES/MUSIC.CPP
+++ b/SOURCES/MUSIC.CPP
@@ -490,7 +490,13 @@ void FadeInVolumeMusic(void) {
 void CheckNextMusic(void) {
     if (NextMusic != -1) {
         if (TimerRefHR > NextMusicTimer) {
-            PlayMusic(NextMusic, FALSE);
+            // #355: force the switch (playit=TRUE) once the defer window has elapsed. A
+            // soft PlayMusic(FALSE) here re-defers whenever the current track is still
+            // playing, so with looping area music the queued track never gets to play.
+            // Forcing replaces the current track, matching the intent of the queue:
+            // defer briefly (TEST_MUSIC_TEMPO) so a quick pass-through doesn't cut the
+            // music, then take over.
+            PlayMusic(NextMusic, TRUE);
         }
     }
 }

--- a/tests/music/test_music_pause_resume.cpp
+++ b/tests/music/test_music_pause_resume.cpp
@@ -47,6 +47,7 @@ void PauseMusic(S32 fade);
 void ResumeMusic(S32 fade);
 void InitJingle(void);
 S32 GetMusic(void);
+void CheckNextMusic(void);
 S32 InitCD(char *name);
 
 // SOURCES/DIRECTORIES.H is an extern "C" header.
@@ -161,8 +162,18 @@ void GetJinglePath(char *outPath, U16 pathMaxSize, const char *jingleFilename) {
     std::snprintf(outPath, pathMaxSize, "music/%s", jingleFilename ? jingleFilename : "");
 }
 char *GetFileName(char *pathname) {
+    // Match the real LIB386 GetFileName: strip the directory *and* the extension, so
+    // GetNumJingle() can round-trip a stream path ("music/JADPCM09.WAV") back to its
+    // jingle index. The queue decision in PlayMusic() depends on this working.
+    static char fileName[64];
     char *slash = std::strrchr(pathname, '/');
-    return slash ? slash + 1 : pathname;
+    const char *start = slash ? slash + 1 : pathname;
+    std::strncpy(fileName, start, sizeof(fileName) - 1);
+    fileName[sizeof(fileName) - 1] = '\0';
+    char *dot = std::strrchr(fileName, '.');
+    if (dot)
+        *dot = '\0';
+    return fileName;
 }
 
 void Log_Info(const char *fmt, ...) {
@@ -232,6 +243,31 @@ int main(void) {
     spy_clear();
     ResumeMusic(1);
     assert_resume_never_stops();
+
+    // ── Scenario 4: #355 - a queued track must take over, not defer forever ───
+    // Field repro: area music (jingle 16 / jadpcm09) keeps playing; a scene wants a
+    // DIFFERENT track; PlayMusic(FALSE) defers it into NextMusic; CheckNextMusic() (run
+    // every frame by PERSO's main loop) must eventually PLAY it instead of re-deferring
+    // while the looping track never ends. Before the fix these asserts fail: B is queued
+    // and never starts.
+    DistribVersion = 3; // EU layout: TrackCD, every entry a jingle/stream
+    InitCD(empty);
+    InitJingle();
+
+    PlayMusic(14, 0); // TrackCD[14] = JINGLE|16 -> jingle 16 (jadpcm09) starts
+    assert(called("PlayStream") && "area track A should start");
+    assert(GetMusic() == 16 && "A (jingle 16) is the current music");
+
+    spy_clear();
+    PlayMusic(5, 0); // TrackCD[5] = JINGLE|7 -> jingle 7, a DIFFERENT track, deferred
+    assert(!called("PlayStream") && "B must be deferred while A is still playing");
+    assert(GetMusic() == 16 && "A still current right after the deferred request");
+
+    spy_clear();
+    TimerRefHR += 5000; // elapse past the 2s (TEST_MUSIC_TEMPO) defer window
+    CheckNextMusic();   // the per-frame queue service
+    assert(called("PlayStream") && "queued track B must start once the defer elapses (#355)");
+    assert(GetMusic() == 7 && "B (jingle 7) is the current music after the queue drains");
 
     // ── Observability: the [MUSIC] trace actually fired ──────────────────────
     bool sawResumeTrace = false;


### PR DESCRIPTION
## What

Entering a scene while a *different* area track is still playing left the new scene's music silent — you kept hearing the previous track until a menu toggle nudged it. Fixes #355.

## Root cause

`PlayMusic(num, FALSE)` (scene entry) defers a different track into `NextMusic` rather than cutting the current one, and `CheckNextMusic()` retries it each frame with `PlayMusic(NextMusic, FALSE)`. That soft retry **re-defers** whenever the current track is still playing — and area music loops, so the queued track is re-queued forever and never plays.

Confirmed from a field trace: `PlayMusic num=7 cur=16 -> NextMusic=7 (QUEUED)` repeating every 2 s, jingle 7 never starting while track 16 kept looping.

## Fix

`CheckNextMusic` forces the switch (`playit=TRUE`) once the defer window (`TEST_MUSIC_TEMPO`, 2 s) has elapsed, so the queued track replaces the looping one. This only changes behaviour when the current track is *still playing* past the window; if it already ended, the soft and forced paths are identical.

## Test

New Scenario 4 in `tests/music/test_music_pause_resume.cpp` reproduces it against the spy backend: set a track "playing", request a different one (it defers), tick past the window, assert it takes over. Fails before the fix, passes after. Also fixed the mock `GetFileName` to strip the extension like the real `LIB386` one, so `GetMusic()` round-trips a stream path back to its jingle index.

The runtime `--exec` harness can't reproduce this (headless audio never reports "playing", so the queue path is never taken) — which is exactly why the mock-backend host test is the right regression guard.

## Testing

- Host tests: 34/34 pass, including the new scenario.
- Manual: real-audio playthrough — the new area's music now takes over within ~2 s instead of the old track continuing.
