### PR TITLE
test(music): extract a testable park/resume seam in STREAM.CPP + unit-test it

### DIFF
--- a/LIB386/AIL/SDL/STREAM.CPP
+++ b/LIB386/AIL/SDL/STREAM.CPP
@@ -4,6 +4,7 @@
 
 #include "stb_vorbis.h"
 
+#include <AIL/STREAM_PARK.H> /* pure park/resume/focus decision logic (host-tested) */
 #include <SYSTEM/CUE.H>
 #include <SYSTEM/DISCIMG.H>
 #include <SYSTEM/FILES.H> /* ESeekOrigin */
@@ -661,7 +662,7 @@ void StopStream() {
 }
 
 void PauseStream() {
-    if (stream && !streamPaused) {
+    if (Stream_ShouldPark(stream != NULL, streamPaused)) {
         /* Park the position so a later Resume can restore even if a different
            stream (e.g. the in-game menu theme) plays and tears this one down in
            the meantime. MILES does the same in PauseCD (save Cur/End/track). */
@@ -677,21 +678,23 @@ void PauseStream() {
 }
 
 void ResumeStream() {
-    /* Fast path: the parked stream is still alive and paused -> just unpause the
-       device. This is the dialogue/holomap case (nothing played in between). */
-    if (stream && streamPaused && hasRemembered && strcmp(streamPathName, rememberedPath) == 0) {
+    switch (Stream_ResumeAction(stream != NULL, streamPaused, hasRemembered,
+                                strcmp(streamPathName, rememberedPath) == 0,
+                                rememberedPath[0] != '\0')) {
+    case STREAM_RESUME_UNPAUSE:
+        /* Fast path: the parked stream is still alive and paused -> just unpause the
+           device. This is the dialogue/holomap case (nothing played in between). */
         if (musicLogEnabled)
             SDL_Log("[MUSIC] ResumeStream unpause %s", streamPathName);
         SDL_ResumeAudioStreamDevice(stream);
         streamPaused = false;
         hasRemembered = false;
-        return;
-    }
+        break;
 
-    /* Restore path: a different stream replaced the parked one (the menu theme
-       played between Pause and Resume), so re-open the parked file and seek back
-       to where it was. Mirrors MILES ResumeCD replaying from the saved Cur. */
-    if (hasRemembered && rememberedPath[0]) {
+    case STREAM_RESUME_RESTORE: {
+        /* Restore path: a different stream replaced the parked one (the menu theme
+           played between Pause and Resume), so re-open the parked file and seek back
+           to where it was. Mirrors MILES ResumeCD replaying from the saved Cur. */
         char path[ADELINE_MAX_PATH];
         strncpy(path, rememberedPath, ADELINE_MAX_PATH - 1);
         path[ADELINE_MAX_PATH - 1] = '\0';
@@ -700,6 +703,11 @@ void ResumeStream() {
         if (musicLogEnabled)
             SDL_Log("[MUSIC] ResumeStream restore %s frame=%d", path, (int)frame);
         PlayStreamInternal(path, frame);
+        break;
+    }
+
+    case STREAM_RESUME_NONE:
+        break;
     }
 }
 
@@ -718,7 +726,7 @@ void SuspendStreamOutput() {
 void ResumeStreamOutput() {
     /* Re-resume the device only if the stream is not logically paused; otherwise
        a focus blip during a dialogue/menu music pause would un-pause it. */
-    if (stream && !streamPaused) {
+    if (Stream_ShouldResumeDeviceOnFocus(stream != NULL, streamPaused)) {
         if (musicLogEnabled)
             SDL_Log("[MUSIC] ResumeStreamOutput");
         SDL_ResumeAudioStreamDevice(stream);

--- a/LIB386/H/AIL/STREAM_PARK.H
+++ b/LIB386/H/AIL/STREAM_PARK.H
@@ -1,0 +1,62 @@
+//--------------------------------------------------------------------------
+#ifndef LIB_AIL_STREAM_PARK
+#define LIB_AIL_STREAM_PARK
+
+/* Pure, SDL-free decision logic for the stream park/resume + focus-suspend model.
+ *
+ * The music stream has two pause layers (see AIL/STREAM.H):
+ *   - LOGICAL PauseStream/ResumeStream: parks {path, frame} so a resume can restore
+ *     even if a different stream (the menu theme) played and tore this one down in
+ *     between. Mirrors the MILES redbook PauseCD/ResumeCD.
+ *   - DEVICE SuspendStreamOutput/ResumeStreamOutput: a window-focus pause that must
+ *     NOT disturb an outer logical pause.
+ *
+ * The choice of what to do lives here, extracted from the SDL side effects so the
+ * invariants are host-testable without an audio device. LIB386/AIL/SDL/STREAM.CPP
+ * supplies the state and runs the SDL calls; tests/music/test_music_stream_park.cpp
+ * exercises every state combination.
+ *
+ * Args are plain ints (0/1) so the header stays usable from C and C++.
+ */
+
+typedef enum {
+    STREAM_RESUME_NONE = 0, /* nothing parked -> nothing to do */
+    STREAM_RESUME_UNPAUSE,  /* parked stream still live -> just unpause the device in place */
+    STREAM_RESUME_RESTORE   /* a different stream replaced it -> re-open + seek the parked file */
+} StreamResumeAction;
+
+/* PauseStream: park + pause only a live stream that is not already logically paused
+   (pausing an already-paused stream would overwrite its parked position). */
+static inline int Stream_ShouldPark(int hasStream, int streamPaused) {
+    return hasStream && !streamPaused;
+}
+
+/* ResumeStream: choose fast-unpause vs restore-from-park vs nothing.
+ *   hasStream       - a stream object currently exists
+ *   streamPaused    - the stream is logically paused (PauseStream ran)
+ *   hasRemembered   - a parked {path, frame} snapshot exists
+ *   currentIsParked - the currently-loaded stream name == the parked path
+ *   parkedNonEmpty  - the parked path is non-empty
+ * Fast unpause only when the parked stream is still the live, paused one; otherwise a
+ * remembered non-empty path means something replaced it and we restore + seek. */
+static inline StreamResumeAction Stream_ResumeAction(int hasStream, int streamPaused,
+                                                     int hasRemembered, int currentIsParked,
+                                                     int parkedNonEmpty) {
+    if (hasStream && streamPaused && hasRemembered && currentIsParked)
+        return STREAM_RESUME_UNPAUSE;
+    if (hasRemembered && parkedNonEmpty)
+        return STREAM_RESUME_RESTORE;
+    return STREAM_RESUME_NONE;
+}
+
+/* ResumeStreamOutput (window focus regain): un-pause the DEVICE only if the stream is
+   not logically paused, so a focus blip during a menu/dialogue pause does not un-pause
+   it. This is the nesting invariant: device-resume must respect an outer logical pause. */
+static inline int Stream_ShouldResumeDeviceOnFocus(int hasStream, int streamPaused) {
+    return hasStream && !streamPaused;
+}
+
+//--------------------------------------------------------------------------
+#endif // LIB_AIL_STREAM_PARK
+
+//--------------------------------------------------------------------------

--- a/tests/music/CMakeLists.txt
+++ b/tests/music/CMakeLists.txt
@@ -39,3 +39,17 @@ set_target_properties(test_music_pause_resume PROPERTIES CXX_STANDARD 11)
 add_test(NAME test_music_pause_resume COMMAND test_music_pause_resume)
 
 register_host_test(test_music_pause_resume)
+
+# Host unit test for the stream park/resume + focus-suspend decision logic
+# (LIB386/H/AIL/STREAM_PARK.H). Pure and SDL-free: no backend, no audio device, no assets.
+add_executable(test_music_stream_park test_music_stream_park.cpp)
+
+target_include_directories(test_music_stream_park PRIVATE
+    ${CMAKE_SOURCE_DIR}/LIB386/H
+)
+
+set_target_properties(test_music_stream_park PROPERTIES CXX_STANDARD 11)
+
+add_test(NAME test_music_stream_park COMMAND test_music_stream_park)
+
+register_host_test(test_music_stream_park)

--- a/tests/music/test_music_stream_park.cpp
+++ b/tests/music/test_music_stream_park.cpp
@@ -1,0 +1,46 @@
+// Host unit tests for the stream park/resume + focus-suspend DECISION logic
+// (LIB386/H/AIL/STREAM_PARK.H). Pure and SDL-free: no backend, no audio device.
+//
+// Verifies the fast-unpause vs restore-from-park vs do-nothing choice, and the nesting
+// invariant that a window-focus regain must not un-pause a logically paused
+// (menu/dialogue) stream. This is the exact layer the "ResumeMusic must not StopMusic"
+// bug lived in; STREAM.CPP's PauseStream/ResumeStream/ResumeStreamOutput are now thin
+// wrappers that call these functions and run the SDL side effects.
+#include <AIL/STREAM_PARK.H>
+
+#include <cassert>
+#include <cstdio>
+
+int main(void) {
+    // ── Stream_ShouldPark: park a live, not-already-paused stream ──
+    assert(!Stream_ShouldPark(0, 0) && "no stream -> nothing to park");
+    assert(Stream_ShouldPark(1, 0) && "live and unpaused -> park it");
+    assert(!Stream_ShouldPark(1, 1) && "already paused -> do not re-park (would lose the position)");
+
+    // ── Stream_ResumeAction: fast-unpause vs restore-from-park vs nothing ──
+    // Dialogue/holomap: the parked stream is still current and paused -> just unpause.
+    assert(Stream_ResumeAction(1, 1, 1, /*currentIsParked*/ 1, /*parkedNonEmpty*/ 1) == STREAM_RESUME_UNPAUSE &&
+           "parked stream still current -> fast unpause in place");
+    // Menu theme played in between: current stream != parked -> re-open + seek.
+    assert(Stream_ResumeAction(1, 0, 1, /*currentIsParked*/ 0, 1) == STREAM_RESUME_RESTORE &&
+           "a different stream replaced the parked one -> restore from park");
+    // Path mismatch even while flagged paused still restores (never a mis-aimed unpause).
+    assert(Stream_ResumeAction(1, 1, 1, /*currentIsParked*/ 0, 1) == STREAM_RESUME_RESTORE &&
+           "path mismatch takes the restore path, not a same-stream unpause");
+    // Nothing parked -> nothing to do.
+    assert(Stream_ResumeAction(1, 1, /*hasRemembered*/ 0, 0, 0) == STREAM_RESUME_NONE &&
+           "no park -> nothing");
+    // Defensive: remembered flag set but path empty -> nothing (don't restore garbage).
+    assert(Stream_ResumeAction(0, 0, 1, 0, /*parkedNonEmpty*/ 0) == STREAM_RESUME_NONE &&
+           "remembered but empty path -> nothing");
+
+    // ── Stream_ShouldResumeDeviceOnFocus: the nesting invariant ──
+    assert(Stream_ShouldResumeDeviceOnFocus(1, 0) &&
+           "focus regain resumes the device when the stream is not logically paused");
+    assert(!Stream_ShouldResumeDeviceOnFocus(1, 1) &&
+           "focus regain must NOT un-pause a logically paused (menu/dialogue) stream");
+    assert(!Stream_ShouldResumeDeviceOnFocus(0, 0) && "no stream -> nothing to resume");
+
+    std::printf("test_music_stream_park: OK\n");
+    return 0;
+}


### PR DESCRIPTION
## What

Makes the STREAM.CPP stream park/resume + focus-suspend **decision logic** host-testable by extracting it into a pure, SDL-free seam, then unit-tests every state combination. This is the layer the `ResumeMusic`-must-not-`StopMusic` regression lived in, and it was previously untestable (welded to SDL audio + OGG decode + a background decode thread).

## Change

- **New `LIB386/H/AIL/STREAM_PARK.H`** - three SDL-free, C-compatible inline decisions:
  - `Stream_ShouldPark` - park+pause only a live, not-already-paused stream.
  - `Stream_ResumeAction` - fast-unpause (parked stream still current) vs restore-from-park (a menu theme replaced it) vs nothing.
  - `Stream_ShouldResumeDeviceOnFocus` - the nesting invariant: a window-focus regain un-pauses the device only if the stream is not *logically* paused.
- **STREAM.CPP** - `PauseStream`/`ResumeStream`/`ResumeStreamOutput` now call the helpers and run the SDL side effects. Behaviour-preserving: the conditions are identical (verified by the game build plus the existing MUSIC.CPP tests, which exercise the pause/resume contract end to end).
- **`tests/music/test_music_stream_park.cpp`** - covers all combinations of the three decisions. No SDL, no audio device, no assets; deterministic.

## Why the seam (not a mock or real SDL)

Stubbing ~25 `SDL_*` + 6 `stb_vorbis_*` + disc/cue calls would be a large, fragile scaffold; linking real SDL with a dummy driver is timing/threading-nondeterministic (the audio queue drains in real time). Extracting the decision keeps SDL in a thin wrapper and makes the invariants trivially, deterministically testable.

## Testing

- Game builds (refactor compiles + links). 35/35 host tests pass. Format clean.
