### PR TITLE
test(render): body-primitive geometry harness + sphere div-by-zero guard

### DIFF
--- a/LIB386/OBJECT/AFF_OBJ.CPP
+++ b/LIB386/OBJECT/AFF_OBJ.CPP
@@ -1062,6 +1062,8 @@ S32 Sphere(U32 typePoly, void *poly) {
     } else {
         // @@Radius_Proj:
         S16 z = Obj_ListRotatedPoints[sphere->P1].Z;
+        if (z + PosZWr == 0) // ASM @@SkipSphere: point on the camera Z plane
+            return 0;
         radius *= LFactorX;
         radius /= z + PosZWr;
     }
@@ -1116,6 +1118,8 @@ S32 Sphere_Transp(U32 typePoly, void *poly) {
         radius = -radius; // ASM `neg eax`: two's-complement, not bitwise ~ (#357)
     } else {
         S16 z = Obj_ListRotatedPoints[sphere->P1].Z;
+        if (z + PosZWr == 0) // ASM @@SkipSphere: point on the camera Z plane
+            return 0;
         radius *= LFactorX;
         radius /= z + PosZWr;
     }

--- a/tests/render/CMakeLists.txt
+++ b/tests/render/CMakeLists.txt
@@ -1,25 +1,26 @@
-# Host regression test for body-primitive geometry (issue #357).
+# Host regression tests for body-primitive geometry (issue #357 class).
 #
-# Compiles the real LIB386/OBJECT/AFF_OBJ.CPP and links the real 3D math library,
-# then drives Sphere()/Sphere_Transp() directly and asserts the radius they emit
-# against the original AFF_OBJ.ASM formula. The test file provides spy/stub
-# definitions for the pol_work fillers (Fill_Sphere spy, Fill_Poly/Line_A stubs)
-# so no framebuffer, palette, or game assets are needed - a self-contained host
-# build, no SDL, no Docker.
-add_executable(test_sphere_radius
-    test_sphere_radius.cpp
-    ${CMAKE_SOURCE_DIR}/LIB386/OBJECT/AFF_OBJ.CPP
-)
+# Each target compiles the real LIB386/OBJECT/AFF_OBJ.CPP + the shared harness
+# (spies for the pol_work fillers) and links the real 3D math library, then drives
+# one primitive directly and asserts the geometry it emits against the original
+# AFF_OBJ.ASM formula. No framebuffer, palette, or game assets: a self-contained
+# host build, no SDL, no Docker. See primitive_harness.h for the design.
+function(add_render_primitive_test test_name)
+    add_executable(${test_name}
+        ${test_name}.cpp
+        primitive_harness.cpp
+        ${CMAKE_SOURCE_DIR}/LIB386/OBJECT/AFF_OBJ.CPP
+    )
+    target_include_directories(${test_name} PRIVATE
+        ${CMAKE_SOURCE_DIR}/LIB386/H
+        ${CMAKE_BINARY_DIR}
+    )
+    # AFF_OBJ.CPP's rotation/projection/camera externs come from the 3D library.
+    target_link_libraries(${test_name} PRIVATE 3D)
+    set_target_properties(${test_name} PROPERTIES CXX_STANDARD 11)
+    add_test(NAME ${test_name} COMMAND ${test_name})
+    register_host_test(${test_name})
+endfunction()
 
-target_include_directories(test_sphere_radius PRIVATE
-    ${CMAKE_SOURCE_DIR}/LIB386/H
-    ${CMAKE_BINARY_DIR}
-)
-
-# AFF_OBJ.CPP's rotation/projection/camera externs come from the 3D library.
-target_link_libraries(test_sphere_radius PRIVATE 3D)
-
-set_target_properties(test_sphere_radius PROPERTIES CXX_STANDARD 11)
-
-add_test(NAME test_sphere_radius COMMAND test_sphere_radius)
-register_host_test(test_sphere_radius)
+add_render_primitive_test(test_sphere_radius)
+add_render_primitive_test(test_line_geometry)

--- a/tests/render/primitive_harness.cpp
+++ b/tests/render/primitive_harness.cpp
@@ -1,0 +1,66 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// tests/render/primitive_harness.cpp
+//
+// Definitions for the body-primitive geometry harness: the pol_work stub globals
+// the AFF_OBJ.CPP translation unit references, the filler spies that capture the
+// emitted draw-call geometry, and the shared reset/assert helpers.
+// See primitive_harness.h for the design.
+// ─────────────────────────────────────────────────────────────────────────────
+#include "primitive_harness.h"
+
+#include <cstdio>
+
+// pol_work / svga data globals the primitives read or update.
+U8 Fill_Flag_ZBuffer = 0;
+U8 Fill_Flag_NZW = 0;
+U32 Fill_ZBuffer_Factor = 0;
+S32 ScreenXMin, ScreenXMax, ScreenYMin, ScreenYMax;
+S32 ClipXMin, ClipXMax, ClipYMin, ClipYMax;
+S32 RepMask = 0;
+U8 *PtrMap = 0;
+
+SpyCapture g_spy;
+int g_failures = 0;
+
+// The pol_work fillers have C linkage (POLY.H wraps them in extern "C").
+struct Struc_Point;
+extern "C" {
+void Fill_Sphere(S32 type, S32 col, S32 cx, S32 cy, S32 rayon, S32 /*z*/) {
+    g_spy.sphere_calls++;
+    g_spy.sphere_type = type;
+    g_spy.sphere_col = col;
+    g_spy.sphere_cx = cx;
+    g_spy.sphere_cy = cy;
+    g_spy.sphere_radius = rayon;
+}
+
+void Line_A(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 /*z1*/, S32 /*z2*/) {
+    g_spy.line_calls++;
+    g_spy.line_x0 = x0;
+    g_spy.line_y0 = y0;
+    g_spy.line_x1 = x1;
+    g_spy.line_y1 = y1;
+    g_spy.line_col = col;
+}
+
+S32 Fill_Poly(S32, S32, S32, Struc_Point *) {
+    g_spy.poly_calls++;
+    return 0;
+}
+}
+
+void spy_reset() {
+    g_spy = SpyCapture(); // value-initialise: zero every field
+    ScreenXMin = ScreenYMin = 0x7FFFFFFF;
+    ScreenXMax = ScreenYMax = (S32)0x80000000;
+    Fill_Flag_ZBuffer = 0;
+}
+
+void check(const char *what, S32 got, S32 want) {
+    if (got != want) {
+        printf("  FAIL  %-40s got=%d want=%d\n", what, got, want);
+        g_failures++;
+    } else {
+        printf("  ok    %-40s = %d\n", what, got);
+    }
+}

--- a/tests/render/primitive_harness.h
+++ b/tests/render/primitive_harness.h
@@ -1,0 +1,86 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// tests/render/primitive_harness.h
+//
+// Shared scaffolding for host TDD of body-primitive geometry (issue #357 class).
+//
+// The body renderer's primitives (Sphere, Line, the triangle/quad fillers) each
+// take rotated + projected points and compute screen geometry, then emit a draw
+// call (Fill_Sphere / Line_A / Fill_Poly). This harness links the REAL primitives
+// from LIB386/OBJECT/AFF_OBJ.CPP + the REAL 3D math library, and spies the emitted
+// draw calls, so a test can assert the computed geometry against the original
+// AFF_OBJ.ASM formula on a 64-bit host.
+//
+// Why it exists: the ASM/CPP polyrec equivalence tests compare the fillers on
+// identical inputs and only run under 32-bit Docker, so the geometry each
+// primitive DERIVES is never checked on the host. That is where #357 (interior
+// sphere radius off by one) hid. Add a primitive by writing a small test that
+// sets up projected points, calls the primitive, and reads g_spy.
+//
+// Each test executable links [<test>.cpp + primitive_harness.cpp + AFF_OBJ.CPP]
+// against the 3D library; the spies and pol_work stub globals live in
+// primitive_harness.cpp so no framebuffer, palette, or game data is needed.
+// ─────────────────────────────────────────────────────────────────────────────
+#ifndef PRIMITIVE_HARNESS_H
+#define PRIMITIVE_HARNESS_H
+
+#include <cstdint>
+
+typedef int32_t S32;
+typedef uint32_t U32;
+typedef int16_t S16;
+typedef uint16_t U16;
+typedef uint8_t U8;
+
+// Layouts must match AFF_OBJ.CPP's file-local structs byte-for-byte.
+#pragma pack(push, 1)
+struct T_OBJ_POINT {
+    S16 X, Y, Z, Group;
+};
+struct TYPE_PT {
+    S16 X, Y;
+};
+struct T_OBJ_SPHERE {
+    U16 Type, Coul, P1, Rayon;
+};
+struct T_OBJ_LINE {
+    U16 Type, Coul, P1, P2;
+};
+#pragma pack(pop)
+
+enum { TYPE_3D = 0,
+       TYPE_ISO = 1 };
+
+// ── Real code under test (AFF_OBJ.CPP, compiled into each executable) ────────
+extern S32 Sphere(U32 typePoly, void *poly);
+extern S32 Sphere_Transp(U32 typePoly, void *poly);
+extern S32 Line(U32 typePoly, void *poly);
+extern T_OBJ_POINT Obj_ListRotatedPoints[];
+extern TYPE_PT Obj_ListProjectedPoints[];
+extern S32 PosZWr;
+
+// ── Real 3D library (linked) ─────────────────────────────────────────────────
+extern S32 TypeProj;
+extern S32 LFactorX;
+
+// ── pol_work globals the primitives read (defined in primitive_harness.cpp) ──
+extern U8 Fill_Flag_ZBuffer;
+extern U32 Fill_ZBuffer_Factor;
+
+// ── Captured draw calls (populated by the spies in primitive_harness.cpp) ────
+struct SpyCapture {
+    int sphere_calls;
+    S32 sphere_radius, sphere_cx, sphere_cy, sphere_type, sphere_col;
+    int line_calls;
+    S32 line_x0, line_y0, line_x1, line_y1, line_col;
+    int poly_calls;
+};
+extern SpyCapture g_spy;
+
+// Clear the capture, reset the 2D-bbox globals, and disable the z-buffer flag.
+void spy_reset();
+
+// ── Assertion helper ─────────────────────────────────────────────────────────
+extern int g_failures;
+void check(const char *what, S32 got, S32 want);
+
+#endif // PRIMITIVE_HARNESS_H

--- a/tests/render/test_line_geometry.cpp
+++ b/tests/render/test_line_geometry.cpp
@@ -1,0 +1,82 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// tests/render/test_line_geometry.cpp
+//
+// Body-primitive geometry: the Line primitive.
+//
+// Line() reads the two already-projected endpoints, drops the primitive when
+// either endpoint is the projection's clip sentinel (-0x8000, -0x8000), and
+// otherwise emits Line_A(x0, y0, x1, y1, colour, ...). This pins the common path
+// on the host: correct endpoints forwarded, and the clip-skip honoured.
+//
+// The 3D z-buffer branch (Line's z1/z2 derivation) is deliberately not asserted
+// yet: it is only reached for perspective + z-buffer lines and its z1/z2 vs P1/P2
+// pairing needs Line_A's register convention decoded against the ASM. Follow-up.
+//
+// See primitive_harness.h for the harness design.
+// ─────────────────────────────────────────────────────────────────────────────
+#include "primitive_harness.h"
+
+#include <cstdio>
+
+static void set_point(int i, S16 px, S16 py, S16 pz) {
+    Obj_ListProjectedPoints[i].X = px;
+    Obj_ListProjectedPoints[i].Y = py;
+    Obj_ListRotatedPoints[i].Z = pz;
+    Obj_ListRotatedPoints[i].Group = 0;
+}
+
+int main() {
+    printf("=== body primitive: line endpoints ===\n");
+
+    // ISO so the 3D z-buffer branch is not taken; endpoints forward verbatim.
+    TypeProj = TYPE_ISO;
+
+    printf("\n[normal line -> Line_A with projected endpoints]\n");
+    {
+        T_OBJ_LINE l;
+        l.Type = 0;
+        l.Coul = 7;
+        l.P1 = 0;
+        l.P2 = 1;
+        set_point(0, 10, 20, 0);
+        set_point(1, 100, 120, 0);
+        spy_reset();
+        Line(0, &l);
+        check("line emitted", g_spy.line_calls, 1);
+        check("line x0", g_spy.line_x0, 10);
+        check("line y0", g_spy.line_y0, 20);
+        check("line x1", g_spy.line_x1, 100);
+        check("line y1", g_spy.line_y1, 120);
+        check("line colour", g_spy.line_col, 7);
+    }
+
+    printf("\n[clipped endpoint (-0x8000) -> skipped]\n");
+    {
+        T_OBJ_LINE l;
+        l.Type = 0;
+        l.Coul = 7;
+        l.P1 = 0;
+        l.P2 = 1;
+        set_point(0, (S16)-0x8000, (S16)-0x8000, 0); // projection clip sentinel
+        set_point(1, 50, 60, 0);
+        spy_reset();
+        Line(0, &l);
+        check("clipped P1 suppresses draw", g_spy.line_calls, 0);
+    }
+    {
+        T_OBJ_LINE l;
+        l.Type = 0;
+        l.Coul = 7;
+        l.P1 = 0;
+        l.P2 = 1;
+        set_point(0, 30, 40, 0);
+        set_point(1, (S16)-0x8000, (S16)-0x8000, 0);
+        spy_reset();
+        Line(0, &l);
+        check("clipped P2 suppresses draw", g_spy.line_calls, 0);
+    }
+
+    printf("\n%s (%d failure%s)\n", g_failures ? "FAILED" : "PASSED", g_failures,
+           g_failures == 1 ? "" : "s");
+    return g_failures ? 1 : 0;
+}

--- a/tests/render/test_sphere_radius.cpp
+++ b/tests/render/test_sphere_radius.cpp
@@ -1,136 +1,34 @@
 // ─────────────────────────────────────────────────────────────────────────────
 // tests/render/test_sphere_radius.cpp
 //
-// Host TDD harness for body-primitive geometry: the sphere-radius projection.
+// Body-primitive geometry: the sphere-radius projection (issue #357).
 //
-// Drives the REAL Sphere() / Sphere_Transp() from LIB386/OBJECT/AFF_OBJ.CPP with
-// controlled projected-point state, spies the radius those functions pass to the
-// filler, and asserts it equals the value the original AFF_OBJ.ASM computes.
+// Character eyes are body spheres; their on-screen radius is derived by Sphere()/
+// Sphere_Transp() in AFF_OBJ.CPP, independently of the body's vertex projection.
+// The ISO (interior) branch mistranslated the original AFF_OBJ.ASM `neg eax` as
+// `radius = ~radius` (bitwise NOT, missing the +1), so every interior sphere came
+// out one pixel too big. On 1-3px eyes that is dot-vs-blob. The 3D branch has a
+// compensating extra negate and is bit-exact.
 //
-// Why this exists (issue #357 - "square billboards larger than retail"):
-//   Character eyes are body spheres. Their on-screen radius is derived by
-//   Sphere(), independently of the body's vertex projection. The C++ port of the
-//   ISO (interior) branch mis-translated the ASM `neg eax` as `radius = ~radius`
-//   (bitwise NOT, missing the +1), so every interior sphere came out exactly one
-//   pixel too big - invisible on the body silhouette but glaring on 1-3px eyes.
-//
-// Why the existing tests missed it:
-//   The ASM<->CPP polyrec equiv tests compare the *fillers* (Fill_Sphere given a
-//   radius). They capture the radius AFTER Sphere() derives it and feed the same
-//   value to both paths, so the derivation is never checked. They also only run
-//   under 32-bit Docker. This test exercises the derivation on the 64-bit host -
-//   the layer nothing else covered.
-//
-// Extending: Line() and the Triangle_/Quad_ primitives read the same projected-
-// point globals and emit Line_A / Fill_Poly. Add a spy + a case the same way to
-// grow this into a full body-primitive geometry sweep.
+// See primitive_harness.h for why this layer needs host coverage.
 // ─────────────────────────────────────────────────────────────────────────────
+#include "primitive_harness.h"
 
-#include <cstdint>
 #include <cstdio>
 
-typedef int32_t S32;
-typedef uint32_t U32;
-typedef int16_t S16;
-typedef uint16_t U16;
-typedef uint8_t U8;
-
-// Layouts must match AFF_OBJ.CPP's file-local structs byte-for-byte.
-#pragma pack(push, 1)
-struct T_OBJ_POINT {
-    S16 X, Y, Z, Group;
-};
-struct TYPE_PT {
-    S16 X, Y;
-};
-struct T_OBJ_SPHERE {
-    U16 Type, Coul, P1, Rayon;
-};
-#pragma pack(pop)
-
-enum { TYPE_3D = 0,
-       TYPE_ISO = 1 };
-
-// ── Symbols defined in AFF_OBJ.CPP (compiled into this test) ────────────────
-extern S32 Sphere(U32 typePoly, void *poly);
-extern S32 Sphere_Transp(U32 typePoly, void *poly);
-extern T_OBJ_POINT Obj_ListRotatedPoints[];
-extern TYPE_PT Obj_ListProjectedPoints[];
-extern S32 PosZWr;
-
-// ── Symbols defined in the real 3D library (linked) ─────────────────────────
-extern S32 TypeProj;
-extern S32 LFactorX;
-
-// ── pol_work / svga symbols: provided here (spy + stubs) ────────────────────
-// Data globals Sphere() reads/writes.
-U8 Fill_Flag_ZBuffer = 0;
-U8 Fill_Flag_NZW = 0;
-U32 Fill_ZBuffer_Factor = 0;
-S32 ScreenXMin, ScreenXMax, ScreenYMin, ScreenYMax;
-S32 ClipXMin, ClipXMax, ClipYMin, ClipYMax;
-S32 RepMask = 0;
-U8 *PtrMap = 0;
-
-// Spy: capture the geometry Sphere() hands to the rasteriser.
-static int g_fs_calls = 0;
-static S32 g_fs_radius = 0;
-static S32 g_fs_cx = 0, g_fs_cy = 0, g_fs_type = 0, g_fs_col = 0;
-
-// The pol_work fillers have C linkage (POLY.H wraps them in extern "C").
-struct Struc_Point;
-extern "C" {
-void Fill_Sphere(S32 type, S32 col, S32 cx, S32 cy, S32 rayon, S32 /*z*/) {
-    g_fs_calls++;
-    g_fs_type = type;
-    g_fs_col = col;
-    g_fs_cx = cx;
-    g_fs_cy = cy;
-    g_fs_radius = rayon;
-}
-
-// Stubs: referenced by other functions in the AFF_OBJ.CPP TU that this test
-// never calls; present only so the translation unit links.
-S32 Fill_Poly(S32, S32, S32, Struc_Point *) { return 0; }
-void Line_A(S32, S32, S32, S32, S32, S32, S32) {}
-}
-
 // ── Oracles: what the original AFF_OBJ.ASM computes ─────────────────────────
-//
-// ISO branch: `radius *34/512`, then a `neg` that is undone by the common
-// `@@Return_Radius` negate - net magnitude 34*Rayon/512.
+// ISO branch: `radius *34/512`, then a `neg` undone by the common negate.
 static S32 asm_iso_radius(S32 rayon) { return (34 * rayon) >> 9; }
 
-// 3D branch: 64-bit `imul LFactorX` / `idiv (Zrot+PosZWr)`, then the
-// `@@Return_Radius` negate. 64-bit intermediate matches the ASM edx:eax product.
+// 3D branch: 64-bit `imul LFactorX` / `idiv (Zrot+PosZWr)`, then the negate.
 static S32 asm_3d_radius(S32 rayon, S32 lfactor, S32 zrot, S32 poszwr) {
     long long prod = (long long)rayon * (long long)lfactor;
     long long q = prod / (long long)(zrot + poszwr); // idiv truncates toward zero
     return (S32)(-q);
 }
 
-// ── Test scaffolding ────────────────────────────────────────────────────────
-static int g_failures = 0;
-
-static void reset_bounds() {
-    ScreenXMin = ScreenYMin = 0x7FFFFFFF;
-    ScreenXMax = ScreenYMax = (S32)0x80000000;
-    Fill_Flag_ZBuffer = 0;
-    g_fs_calls = 0;
-    g_fs_radius = 0;
-}
-
-static void check(const char *what, S32 got, S32 want) {
-    if (got != want) {
-        printf("  FAIL  %-32s got=%d want=%d\n", what, got, want);
-        g_failures++;
-    } else {
-        printf("  ok    %-32s = %d\n", what, got);
-    }
-}
-
-// Call the real Sphere() with a synthetic one-sphere body and return the radius
-// it emitted to Fill_Sphere.
+// Drive the real Sphere()/Sphere_Transp() with a synthetic one-sphere body and
+// return the radius it emitted to the filler.
 static S32 emit_sphere_radius(S32 rayon, S32 zrot, bool transp) {
     T_OBJ_SPHERE s;
     s.Type = transp ? 2 : 0;
@@ -145,25 +43,23 @@ static S32 emit_sphere_radius(S32 rayon, S32 zrot, bool transp) {
     Obj_ListProjectedPoints[0].X = 100; // on-screen centre; irrelevant to radius
     Obj_ListProjectedPoints[0].Y = 100;
 
-    reset_bounds();
+    spy_reset();
     if (transp)
         Sphere_Transp(0, &s);
     else
         Sphere(0, &s);
 
-    if (g_fs_calls != 1) {
-        printf("  FAIL  Fill_Sphere call count = %d (expected 1)\n", g_fs_calls);
+    if (g_spy.sphere_calls != 1) {
+        printf("  FAIL  Fill_Sphere call count = %d (expected 1)\n", g_spy.sphere_calls);
         g_failures++;
     }
-    return g_fs_radius;
+    return g_spy.sphere_radius;
 }
 
 int main() {
-    printf("=== body-primitive geometry: sphere radius ===\n");
+    printf("=== body primitive: sphere radius ===\n");
 
     // ── Interior (isometric) spheres: the reported #357 case ────────────────
-    // Radius must match retail's 34*Rayon/512 exactly. The port's ISO branch
-    // used ~radius instead of -radius, so each of these was 1px too big.
     printf("\n[interior / ISO]  (character eyes; issue #357)\n");
     TypeProj = TYPE_ISO;
     const S32 iso_rayons[] = {15, 30, 60, 100, 200, 400, 800};
@@ -174,7 +70,6 @@ int main() {
         check(label, emit_sphere_radius(r, /*zrot*/ 0, /*transp*/ false),
               asm_iso_radius(r));
     }
-    // Sphere_Transp shares the identical radius path.
     check("iso transp Rayon=100 -> radius",
           emit_sphere_radius(100, 0, /*transp*/ true), asm_iso_radius(100));
 
@@ -198,6 +93,40 @@ int main() {
         check(label, emit_sphere_radius(cases[i].rayon, cases[i].zrot, false),
               asm_3d_radius(cases[i].rayon, LFactorX, cases[i].zrot, cases[i].poszwr));
     }
+
+    // ── Degenerate: sphere point on the camera Z plane ──────────────────────
+    // Zrot + PosZWr == 0. The ASM guards this (@@SkipSphere); the C++ port used
+    // to divide by zero here. Expect the sphere to be skipped (no draw call).
+    printf("\n[3D degenerate: point on camera Z plane]\n");
+    TypeProj = TYPE_3D;
+    LFactorX = 600;
+    PosZWr = 100;
+    {
+        T_OBJ_SPHERE s;
+        s.Type = 0;
+        s.Coul = 1;
+        s.P1 = 0;
+        s.Rayon = 50;
+        Obj_ListRotatedPoints[0].Z = (S16)(-100); // Zrot + PosZWr = 0
+        Obj_ListProjectedPoints[0].X = 100;
+        Obj_ListProjectedPoints[0].Y = 100;
+        spy_reset();
+        Sphere(0, &s);
+        check("camera-plane sphere skipped (no draw)", g_spy.sphere_calls, 0);
+    }
+
+    // ── Characterisation: 3D radius uses a 32-bit multiply ──────────────────
+    // The ASM keeps a 64-bit imul/idiv intermediate; the C++ multiplies in S32.
+    // At the shipping focal (600) with the largest possible Rayon (U16 max) the
+    // product is ~39M, well within S32, so the two agree. This pins that the
+    // current code is safe as shipped; a larger focal would need the 64-bit form.
+    printf("\n[3D characterisation: 32-bit multiply safe at focal 600]\n");
+    TypeProj = TYPE_3D;
+    LFactorX = 600;
+    PosZWr = -1000;
+    check("3d Rayon=65535 (U16 max) matches 64-bit oracle",
+          emit_sphere_radius(65535, /*zrot*/ 0, false),
+          asm_3d_radius(65535, 600, 0, -1000));
 
     printf("\n%s (%d failure%s)\n", g_failures ? "FAILED" : "PASSED", g_failures,
            g_failures == 1 ? "" : "s");


### PR DESCRIPTION
Follow-up to #380 (the #357 interior-sphere fix, now merged). Turns that fix's one-off test into a reusable **body-primitive geometry harness** and grows the coverage of the class of bug it exposed: ASM-to-C++ geometry mistranslations that the 32-bit-Docker filler-equivalence tests never check on a 64-bit host.

## Harness

Extracts the scaffolding into `primitive_harness.h` / `.cpp`: the struct layouts, the real-symbol externs, the pol_work filler **spies** (`Fill_Sphere`, `Line_A`, `Fill_Poly`), and a reset/assert helper. Each primitive is now a small test that compiles the real `AFF_OBJ.CPP`, links the real `3D` lib, sets up projected points, calls the real primitive, and reads the captured draw call. No framebuffer, palette, or game data.

## New coverage

- **`test_line_geometry`** - `Line()` forwards the projected endpoints to `Line_A` and drops the primitive when either endpoint is the projection clip sentinel `(-0x8000, -0x8000)`.
- **Sphere degenerate case** - a sphere point on the camera Z plane (`Zrot + PosZWr == 0`). The original `AFF_OBJ.ASM` guards this (`@@SkipSphere`); the C++ port divided by zero (latent `SIGFPE`). Adds the guard so the sphere is skipped, matching the ASM. This is the one code fix in the PR.
- **Sphere 3D characterisation** - pins that the `S32` multiply is safe at the shipping focal (600) across the full `U16` Rayon range, and records that the ASM keeps a 64-bit `imul`/`idiv` intermediate (a larger focal would need the 64-bit form).

## Verification

`test_sphere_radius` + `test_line_geometry` green; full host suite (36 tests) green.

## Follow-ups left as comments

- `Line()` 3D z-buffer branch: its `z1`/`z2` vs `P1`/`P2` pairing needs `Line_A`'s register convention decoded against the ASM (rarely-hit perspective + z-buffer path).
- Triangle/quad fillers: same harness shape, spy `Fill_Poly` and assert the assembled screen vertices.
