### PR TITLE
test(render): triangle/quad + Line z-buffer geometry coverage

### DIFF
--- a/LIB386/OBJECT/AFF_OBJ.CPP
+++ b/LIB386/OBJECT/AFF_OBJ.CPP
@@ -1034,7 +1034,8 @@ S32 Line(U32 typePoly, void *poly) {
         T_OBJ_POINT rotatedP1 = Obj_ListRotatedPoints[line->P1];
         T_OBJ_POINT rotatedP2 = Obj_ListRotatedPoints[line->P2];
 
-        // For some reason, z1 is calculated with p2 and z2 with p1
+        // z1/z2 are the z-buffer depths of P1/P2 (matches AFF_OBJ.ASM: esi<-P1,
+        // edi<-P2). `~z - (PosZWr-1)` is the ASM's obfuscated `-z - PosZWr`.
         z1 = Fill_ZBuffer_Factor * (~rotatedP1.Z - (PosZWr - 1)) >> 16;
         z2 = Fill_ZBuffer_Factor * (~rotatedP2.Z - (PosZWr - 1)) >> 16;
     }

--- a/tests/render/CMakeLists.txt
+++ b/tests/render/CMakeLists.txt
@@ -24,3 +24,4 @@ endfunction()
 
 add_render_primitive_test(test_sphere_radius)
 add_render_primitive_test(test_line_geometry)
+add_render_primitive_test(test_poly_geometry)

--- a/tests/render/primitive_harness.cpp
+++ b/tests/render/primitive_harness.cpp
@@ -33,13 +33,15 @@ void Fill_Sphere(S32 type, S32 col, S32 cx, S32 cy, S32 rayon, S32 /*z*/) {
     g_spy.sphere_radius = rayon;
 }
 
-void Line_A(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 /*z1*/, S32 /*z2*/) {
+void Line_A(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
     g_spy.line_calls++;
     g_spy.line_x0 = x0;
     g_spy.line_y0 = y0;
     g_spy.line_x1 = x1;
     g_spy.line_y1 = y1;
     g_spy.line_col = col;
+    g_spy.line_z1 = z1;
+    g_spy.line_z2 = z2;
 }
 
 S32 Fill_Poly(S32 type, S32 color, S32 nb, Struc_Point *) {

--- a/tests/render/primitive_harness.cpp
+++ b/tests/render/primitive_harness.cpp
@@ -23,7 +23,6 @@ SpyCapture g_spy;
 int g_failures = 0;
 
 // The pol_work fillers have C linkage (POLY.H wraps them in extern "C").
-struct Struc_Point;
 extern "C" {
 void Fill_Sphere(S32 type, S32 col, S32 cx, S32 cy, S32 rayon, S32 /*z*/) {
     g_spy.sphere_calls++;
@@ -43,8 +42,11 @@ void Line_A(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 /*z1*/, S32 /*z2*/) {
     g_spy.line_col = col;
 }
 
-S32 Fill_Poly(S32, S32, S32, Struc_Point *) {
+S32 Fill_Poly(S32 type, S32 color, S32 nb, Struc_Point *) {
     g_spy.poly_calls++;
+    g_spy.poly_type = type;
+    g_spy.poly_color = color;
+    g_spy.poly_nb = nb;
     return 0;
 }
 }

--- a/tests/render/primitive_harness.h
+++ b/tests/render/primitive_harness.h
@@ -91,7 +91,7 @@ struct SpyCapture {
     int sphere_calls;
     S32 sphere_radius, sphere_cx, sphere_cy, sphere_type, sphere_col;
     int line_calls;
-    S32 line_x0, line_y0, line_x1, line_y1, line_col;
+    S32 line_x0, line_y0, line_x1, line_y1, line_col, line_z1, line_z2;
     int poly_calls;
     S32 poly_type, poly_color, poly_nb;
 };

--- a/tests/render/primitive_harness.h
+++ b/tests/render/primitive_harness.h
@@ -45,6 +45,20 @@ struct T_OBJ_SPHERE {
 struct T_OBJ_LINE {
     U16 Type, Coul, P1, P2;
 };
+struct Struc_Point {
+    S16 Pt_XE, Pt_YE;
+    U16 Pt_MapU, Pt_MapV, Pt_Light, Pt_ZO;
+    S32 Pt_W;
+};
+struct STRUC_POLY3_LIGHT {
+    U16 P1, P2, P3, __padding, Couleur, Normale;
+};
+struct STRUC_POLY4_LIGHT {
+    U16 P1, P2, P3, P4, Couleur, Normale;
+};
+struct STRUC_POLY3_ENV {
+    U16 P1, P2, P3, HandleEnv, Couleur, Normale, Scale, __padding;
+};
 #pragma pack(pop)
 
 enum { TYPE_3D = 0,
@@ -54,8 +68,14 @@ enum { TYPE_3D = 0,
 extern S32 Sphere(U32 typePoly, void *poly);
 extern S32 Sphere_Transp(U32 typePoly, void *poly);
 extern S32 Line(U32 typePoly, void *poly);
+extern S32 Triangle_Solid(U32 typePoly, void *poly);
+extern S32 Triangle_Flat(U32 typePoly, void *poly);
+extern S32 Quad_Solid(U32 typePoly, void *poly);
+extern bool TestVisible(STRUC_POLY3_ENV *poly);
 extern T_OBJ_POINT Obj_ListRotatedPoints[];
 extern TYPE_PT Obj_ListProjectedPoints[];
+extern Struc_Point ListFillPoly[]; // AFF_OBJ.CPP scratch: assembled poly vertices
+extern U16 ListLights[];           // per-normal light intensities
 extern S32 PosZWr;
 
 // ── Real 3D library (linked) ─────────────────────────────────────────────────
@@ -73,6 +93,7 @@ struct SpyCapture {
     int line_calls;
     S32 line_x0, line_y0, line_x1, line_y1, line_col;
     int poly_calls;
+    S32 poly_type, poly_color, poly_nb;
 };
 extern SpyCapture g_spy;
 

--- a/tests/render/test_line_geometry.cpp
+++ b/tests/render/test_line_geometry.cpp
@@ -8,9 +8,11 @@
 // otherwise emits Line_A(x0, y0, x1, y1, colour, ...). This pins the common path
 // on the host: correct endpoints forwarded, and the clip-skip honoured.
 //
-// The 3D z-buffer branch (Line's z1/z2 derivation) is deliberately not asserted
-// yet: it is only reached for perspective + z-buffer lines and its z1/z2 vs P1/P2
-// pairing needs Line_A's register convention decoded against the ASM. Follow-up.
+// The 3D z-buffer branch derives per-endpoint depths z1 (from P1) and z2 (from
+// P2). AFF_OBJ.ASM loads P1's z into esi and P2's z into edi before Line_A
+// (whose convention is eax=x0, ebx=y0, ecx=x1, edx=y1, ebp=col, esi=z1, edi=z2),
+// so z1 pairs with P1. A stale comment in Line() claimed the opposite; this test
+// pins the correct pairing.
 //
 // See primitive_harness.h for the harness design.
 // ─────────────────────────────────────────────────────────────────────────────
@@ -23,6 +25,12 @@ static void set_point(int i, S16 px, S16 py, S16 pz) {
     Obj_ListProjectedPoints[i].Y = py;
     Obj_ListRotatedPoints[i].Z = pz;
     Obj_ListRotatedPoints[i].Group = 0;
+}
+
+// ASM Line z-buffer depth: (Fill_ZBuffer_Factor * (-rotatedZ - PosZWr)) >> 16.
+static S32 asm_line_z(S32 rotatedZ, S32 poszwr, U32 factor) {
+    U32 depth = (U32)(-rotatedZ - poszwr);
+    return (S32)((factor * depth) >> 16);
 }
 
 int main() {
@@ -74,6 +82,27 @@ int main() {
         spy_reset();
         Line(0, &l);
         check("clipped P2 suppresses draw", g_spy.line_calls, 0);
+    }
+
+    // ── 3D z-buffer: per-endpoint depths, z1 from P1 and z2 from P2 ──────────
+    printf("\n[3D z-buffer: z1<-P1, z2<-P2 (not swapped)]\n");
+    TypeProj = TYPE_3D;
+    {
+        T_OBJ_LINE l;
+        l.Type = 0;
+        l.Coul = 7;
+        l.P1 = 0;
+        l.P2 = 1;
+        set_point(0, 10, 20, /*rotZ*/ -100);
+        set_point(1, 100, 120, /*rotZ*/ -50);
+        PosZWr = -200;
+        spy_reset();
+        Fill_Flag_ZBuffer = 1;         // enable the z-buffer branch (after reset)
+        Fill_ZBuffer_Factor = 0x20000; // 2.0 in 16.16
+        Line(0, &l);
+        check("line emitted", g_spy.line_calls, 1);
+        check("z1 depth from P1", g_spy.line_z1, asm_line_z(-100, -200, 0x20000));
+        check("z2 depth from P2", g_spy.line_z2, asm_line_z(-50, -200, 0x20000));
     }
 
     printf("\n%s (%d failure%s)\n", g_failures ? "FAILED" : "PASSED", g_failures,

--- a/tests/render/test_poly_geometry.cpp
+++ b/tests/render/test_poly_geometry.cpp
@@ -1,0 +1,115 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// tests/render/test_poly_geometry.cpp
+//
+// Body-primitive geometry: the triangle/quad path.
+//
+//   TestVisible   - backface culling. The cross product
+//                   (x2-x1)*(y1-y3) - (y2-y1)*(x1-x3) decides front vs back
+//                   (visible when its sign bit is clear); a clipped vertex culls.
+//                   Verified against AFF_OBJ.ASM TestVisibleI (same formula, same
+//                   sign convention). A flip here drops or double-draws faces.
+//   Triangle_Solid - vertex assembly: the projected points are copied into
+//                   ListFillPoly and forwarded to Fill_Poly with type = typePoly>>2
+//                   and colour = Couleur & 0xFF.
+//   Triangle_Flat  - flat shading: colour = (Couleur + (ListLights[Normale]>>8)) & 0xFF,
+//                   emitted with poly type 1.
+//
+// See primitive_harness.h for the harness design.
+// ─────────────────────────────────────────────────────────────────────────────
+#include "primitive_harness.h"
+
+#include <cstdio>
+
+static void set_proj(int i, S16 x, S16 y) {
+    Obj_ListProjectedPoints[i].X = x;
+    Obj_ListProjectedPoints[i].Y = y;
+}
+
+// Reference cross product, matching TestVisible / AFF_OBJ.ASM TestVisibleI.
+static bool ref_visible(S16 x1, S16 y1, S16 x2, S16 y2, S16 x3, S16 y3) {
+    S32 value = (x2 - x1) * (y1 - y3) - (y2 - y1) * (x1 - x3);
+    return (value & 0x80000000) == 0;
+}
+
+int main() {
+    printf("=== body primitive: triangle / quad ===\n");
+    TypeProj = TYPE_ISO; // z-buffer branch off; endpoints forward verbatim
+
+    // ── Backface culling ────────────────────────────────────────────────────
+    printf("\n[TestVisible: winding + clip]\n");
+    STRUC_POLY3_ENV tri;
+    tri.P1 = 0;
+    tri.P2 = 1;
+    tri.P3 = 2;
+
+    // Front-facing: cross product >= 0.
+    set_proj(0, 0, 0);
+    set_proj(1, 0, 10);
+    set_proj(2, 10, 0);
+    check("front-facing visible", (S32)TestVisible(&tri), 1);
+    check("  matches ref cross product", (S32)ref_visible(0, 0, 0, 10, 10, 0), 1);
+
+    // Back-facing: reversed winding, cross product < 0.
+    set_proj(0, 0, 0);
+    set_proj(1, 10, 0);
+    set_proj(2, 0, 10);
+    check("back-facing culled", (S32)TestVisible(&tri), 0);
+    check("  matches ref cross product", (S32)ref_visible(0, 0, 10, 0, 0, 10), 0);
+
+    // Any clipped vertex culls, regardless of winding.
+    set_proj(0, 0, 0);
+    set_proj(1, 0, 10);
+    set_proj(2, (S16)-0x8000, (S16)-0x8000);
+    check("clipped vertex culled", (S32)TestVisible(&tri), 0);
+
+    // ── Triangle_Solid: vertex assembly + type/colour ───────────────────────
+    printf("\n[Triangle_Solid: assembly]\n");
+    {
+        set_proj(0, 11, 22);
+        set_proj(1, 33, 44);
+        set_proj(2, 55, 66);
+        STRUC_POLY3_LIGHT p;
+        p.P1 = 0;
+        p.P2 = 1;
+        p.P3 = 2;
+        p.__padding = 0;
+        p.Couleur = 0x1234; // & 0xFF -> 0x34
+        p.Normale = 0;
+        spy_reset();
+        Triangle_Solid(/*typePoly*/ 8, &p); // type = 8 >> 2 = 2
+        check("poly emitted", g_spy.poly_calls, 1);
+        check("poly type (typePoly>>2)", g_spy.poly_type, 2);
+        check("poly colour (Couleur & 0xFF)", g_spy.poly_color, 0x34);
+        check("poly vertex count", g_spy.poly_nb, 3);
+        check("v0.x", ListFillPoly[0].Pt_XE, 11);
+        check("v0.y", ListFillPoly[0].Pt_YE, 22);
+        check("v1.x", ListFillPoly[1].Pt_XE, 33);
+        check("v1.y", ListFillPoly[1].Pt_YE, 44);
+        check("v2.x", ListFillPoly[2].Pt_XE, 55);
+        check("v2.y", ListFillPoly[2].Pt_YE, 66);
+    }
+
+    // ── Triangle_Flat: flat shade colour ────────────────────────────────────
+    printf("\n[Triangle_Flat: colour = (Couleur + light) & 0xFF]\n");
+    {
+        set_proj(0, 1, 2);
+        set_proj(1, 3, 4);
+        set_proj(2, 5, 6);
+        ListLights[3] = 0x0500; // >> 8 -> 5
+        STRUC_POLY3_LIGHT p;
+        p.P1 = 0;
+        p.P2 = 1;
+        p.P3 = 2;
+        p.__padding = 0;
+        p.Couleur = 16;
+        p.Normale = 3;
+        spy_reset();
+        Triangle_Flat(/*typePoly*/ 0, &p);
+        check("flat poly type", g_spy.poly_type, 1);
+        check("flat colour (16 + 5)", g_spy.poly_color, 21);
+    }
+
+    printf("\n%s (%d failure%s)\n", g_failures ? "FAILED" : "PASSED", g_failures,
+           g_failures == 1 ? "" : "s");
+    return g_failures ? 1 : 0;
+}


### PR DESCRIPTION
Follow-up to #380 (the #357 fix) and #381 (the primitive-geometry harness). Adds triangle/quad and Line z-buffer coverage, continuing to pin the class of ASM-to-C++ geometry mistranslations that the 32-bit-Docker filler-equivalence tests never check on a 64-bit host.

## Triangle / quad (`test_poly_geometry`)

- **`TestVisible`** - backface culling by the cross product `(x2-x1)*(y1-y3) - (y2-y1)*(x1-x3)` (front vs back by its sign bit, and a clipped vertex culls). Verified against the original `AFF_OBJ.ASM` `TestVisibleI` (same formula and sign convention). A flip here silently drops or double-draws faces.
- **`Triangle_Solid`** - vertex assembly: the projected points are copied into `ListFillPoly` and forwarded to `Fill_Poly` with `type = typePoly>>2` and `colour = Couleur & 0xFF`.
- **`Triangle_Flat`** - flat shading: `colour = (Couleur + (ListLights[Normale]>>8)) & 0xFF`, emitted with poly type 1.

No divergence: the poly path matches the ASM.

## Line z-buffer (`test_line_geometry`)

`Line()` derives per-endpoint z-buffer depths `z1` (from P1) and `z2` (from P2). A comment claimed *"z1 is calculated with p2 and z2 with p1"*, but the code and the ASM agree: the ASM loads P1's z into `esi` and P2's z into `edi` before `Line_A` (`eax=x0, ebx=y0, ecx=x1, edx=y1, ebp=col, esi=z1, edi=z2`), so `z1` pairs with P1. This corrects the misleading comment and adds a test asserting both depths against the ASM formula - proving they are not swapped.

## Also (from earlier in this branch, now confirmed)

The textured/Gouraud perspective term `Pt_W = W_NORM / (Z + PosZWr)` uses a bare `idiv` in the ASM (no `@@Skip` guard, unlike the sphere), so `z==0` cannot occur there and the C++ bare division is faithful - not another divide-by-zero.

## Result

Full host suite (38 tests) green. The one live bug in this class (interior sphere radius) shipped in #380; this is coverage that locks the rest of the geometry down.
