### PR TITLE
test(aff_obj): expand body-render coverage (ISO entries + randomised fuzz)

### DIFF
--- a/tests/OBJECT/test_aff_obj.cpp
+++ b/tests/OBJECT/test_aff_obj.cpp
@@ -1951,6 +1951,70 @@ static void test_objectdisplay_visible_iso_render(void) {
                                      0, 0, 0, 64, 96, 32, 1, -1, 1);
 }
 
+// Randomised ObjectDisplay render: the fixed cases always centre the object, so
+// clipping and off-centre positions are barely exercised. This walks random
+// positions, rotations, and projection modes and asserts the CPP and ASM render
+// agree on everything (framebuffer, projected points, sort, screen box, ...).
+// The general body fixture is Solid/Flat polys - no z-buffer or perspective W
+// term - so there is no division to trip a degenerate position. A divergence at
+// any input is a real bug the centred fixtures would miss.
+static void render_fuzz_one(const char *label, void *fixture, S32 x, S32 y, S32 z,
+                            S32 alpha, S32 beta, S32 gamma, int iso) {
+    T_OBJ_3D cpp_object;
+    T_OBJ_3D asm_object;
+    RENDER_SNAPSHOT cpp_snapshot;
+    RENDER_SNAPSHOT asm_snapshot;
+    AffObjEnvironmentSetupFn setup =
+        iso ? setup_iso_aff_obj_environment : setup_common_aff_obj_environment;
+
+    build_test_object_fixture(&cpp_object, fixture, x, y, z, alpha, beta, gamma, 1, NULL);
+    build_test_object_fixture(&asm_object, fixture, x, y, z, alpha, beta, gamma, 1, NULL);
+
+    restore_cpp_3d_callbacks();
+    setup();
+    seed_cpp_aff_obj_state();
+    cpp_snapshot.Result = ObjectDisplay(&cpp_object);
+    capture_cpp_snapshot(&cpp_snapshot);
+
+    setup();
+    install_asm_compatible_3d_callbacks();
+    seed_asm_aff_obj_state();
+    asm_snapshot.Result = asm_ObjectDisplay(&asm_object);
+    capture_asm_snapshot(&asm_snapshot);
+
+    compare_render_snapshots(label, &asm_snapshot, &cpp_snapshot);
+}
+
+static void test_objectdisplay_random_stress(void) {
+    TEST_BODY_FIXTURE body_fixture;
+    TEST_SPHERE_BODY_FIXTURE sphere_fixture;
+
+    build_test_body_fixture(&body_fixture);
+    build_sphere_test_body_fixture(&sphere_fixture, 0);
+
+    rng_seed(0x357A11u);
+    for (int i = 0; i < 500; i++) {
+        S32 x = (S32)(rng_next() % 1600) - 800;
+        S32 y = (S32)(rng_next() % 1600) - 800;
+        S32 z = (S32)(rng_next() % 1600) - 800;
+        S32 alpha = (S32)(rng_next() % 4096);
+        S32 beta = (S32)(rng_next() % 4096);
+        S32 gamma = (S32)(rng_next() % 4096);
+        int iso = (int)(rng_next() & 1u);
+        // Alternate the body (Solid/Flat polys) with the sphere fixture, so the
+        // fuzz also drives the sphere-radius division (the #357 primitive) across
+        // random depths in both projection modes.
+        int use_sphere = (int)(rng_next() & 1u);
+        void *fixture = use_sphere ? (void *)&sphere_fixture : (void *)&body_fixture;
+        char label[128];
+        snprintf(label, sizeof(label),
+                 "render fuzz #%d %s %s x=%d y=%d z=%d a=%d b=%d g=%d", i,
+                 use_sphere ? "sphere" : "body", iso ? "ISO" : "3D", x, y, z, alpha,
+                 beta, gamma);
+        render_fuzz_one(label, fixture, x, y, z, alpha, beta, gamma, iso);
+    }
+}
+
 static void test_bodydisplay_visible_render(void) {
     ASSERT_EQ_INT(96, (int)sizeof(T_BODY_HEADER));
     ASSERT_EQ_INT(180, (int)sizeof(TEST_BODY_FIXTURE));
@@ -2656,6 +2720,7 @@ int main(void) {
     RUN_TEST(test_objectdisplay_sphere_transp_iso_render);
     RUN_TEST(test_objectdisplay_line_iso_render);
     RUN_TEST(test_objectdisplay_visible_iso_render);
+    RUN_TEST(test_objectdisplay_random_stress);
     RUN_TEST(test_testvisible_fixed_cases);
     RUN_TEST(test_testvisible_edge_cases);
     RUN_TEST(test_testvisible_random_stress);

--- a/tests/OBJECT/test_aff_obj.cpp
+++ b/tests/OBJECT/test_aff_obj.cpp
@@ -1661,9 +1661,10 @@ static S32 expected_nonzero_pixels_for_label(const char *label) {
     return -1;
 }
 
-static void run_bodydisplay_render_case(const char *label, S32 x, S32 y, S32 z,
-                                        S32 alpha, S32 beta, S32 gamma,
-                                        S32 expected_result, int expect_pixels) {
+static void run_bodydisplay_render_case_ex(const char *label, S32 x, S32 y, S32 z,
+                                           S32 alpha, S32 beta, S32 gamma,
+                                           AffObjEnvironmentSetupFn setup_environment,
+                                           S32 expected_result, int expect_pixels) {
     TEST_BODY_FIXTURE fixture;
     RENDER_SNAPSHOT cpp_snapshot;
     RENDER_SNAPSHOT asm_snapshot;
@@ -1671,15 +1672,67 @@ static void run_bodydisplay_render_case(const char *label, S32 x, S32 y, S32 z,
     build_test_body_fixture(&fixture);
 
     restore_cpp_3d_callbacks();
-    setup_common_aff_obj_environment();
+    setup_environment();
     seed_cpp_aff_obj_state();
     cpp_snapshot.Result = BodyDisplay(x, y, z, alpha, beta, gamma, &fixture);
     capture_cpp_snapshot(&cpp_snapshot);
 
-    setup_common_aff_obj_environment();
+    setup_environment();
     install_asm_compatible_3d_callbacks();
     seed_asm_aff_obj_state();
     asm_snapshot.Result = asm_BodyDisplay(x, y, z, alpha, beta, gamma, &fixture);
+    capture_asm_snapshot(&asm_snapshot);
+
+    compare_render_snapshots(label, &asm_snapshot, &cpp_snapshot);
+    ASSERT_EQ_INT(expected_result, cpp_snapshot.Result);
+    ASSERT_EQ_INT(expected_result, asm_snapshot.Result);
+    ASSERT_EQ_INT(cpp_snapshot.NonZeroPixels, asm_snapshot.NonZeroPixels);
+
+    if (expect_pixels) {
+        S32 expected_nonzero = expected_nonzero_pixels_for_label(label);
+        if (expected_nonzero >= 0) {
+            ASSERT_EQ_INT(expected_nonzero, cpp_snapshot.NonZeroPixels);
+            ASSERT_EQ_INT(expected_nonzero, asm_snapshot.NonZeroPixels);
+        } else {
+            ASSERT_TRUE(cpp_snapshot.NonZeroPixels > 0);
+            ASSERT_TRUE(asm_snapshot.NonZeroPixels > 0);
+        }
+        ASSERT_EQ_INT(1, cpp_snapshot.NbSortValue);
+        ASSERT_EQ_INT(1, asm_snapshot.NbSortValue);
+    } else {
+        ASSERT_EQ_INT(0, cpp_snapshot.NonZeroPixels);
+        ASSERT_EQ_INT(0, asm_snapshot.NonZeroPixels);
+    }
+}
+
+static void run_bodydisplay_render_case(const char *label, S32 x, S32 y, S32 z,
+                                        S32 alpha, S32 beta, S32 gamma,
+                                        S32 expected_result, int expect_pixels) {
+    run_bodydisplay_render_case_ex(label, x, y, z, alpha, beta, gamma,
+                                   setup_common_aff_obj_environment,
+                                   expected_result, expect_pixels);
+}
+
+static void run_bodydisplay_alphabeta_render_case_ex(
+    const char *label, S32 x, S32 y, S32 z, S32 alpha, S32 beta, S32 gamma,
+    AffObjEnvironmentSetupFn setup_environment, S32 expected_result,
+    int expect_pixels) {
+    TEST_BODY_FIXTURE fixture;
+    RENDER_SNAPSHOT cpp_snapshot;
+    RENDER_SNAPSHOT asm_snapshot;
+
+    build_test_body_fixture(&fixture);
+
+    restore_cpp_3d_callbacks();
+    setup_environment();
+    seed_cpp_aff_obj_state();
+    cpp_snapshot.Result = BodyDisplay_AlphaBeta(x, y, z, alpha, beta, gamma, &fixture);
+    capture_cpp_snapshot(&cpp_snapshot);
+
+    setup_environment();
+    install_asm_compatible_3d_callbacks();
+    seed_asm_aff_obj_state();
+    asm_snapshot.Result = asm_BodyDisplay_AlphaBeta(x, y, z, alpha, beta, gamma, &fixture);
     capture_asm_snapshot(&asm_snapshot);
 
     compare_render_snapshots(label, &asm_snapshot, &cpp_snapshot);
@@ -1708,44 +1761,9 @@ static void run_bodydisplay_alphabeta_render_case(const char *label, S32 x, S32 
                                                   S32 z, S32 alpha, S32 beta,
                                                   S32 gamma, S32 expected_result,
                                                   int expect_pixels) {
-    TEST_BODY_FIXTURE fixture;
-    RENDER_SNAPSHOT cpp_snapshot;
-    RENDER_SNAPSHOT asm_snapshot;
-
-    build_test_body_fixture(&fixture);
-
-    restore_cpp_3d_callbacks();
-    setup_common_aff_obj_environment();
-    seed_cpp_aff_obj_state();
-    cpp_snapshot.Result = BodyDisplay_AlphaBeta(x, y, z, alpha, beta, gamma, &fixture);
-    capture_cpp_snapshot(&cpp_snapshot);
-
-    setup_common_aff_obj_environment();
-    install_asm_compatible_3d_callbacks();
-    seed_asm_aff_obj_state();
-    asm_snapshot.Result = asm_BodyDisplay_AlphaBeta(x, y, z, alpha, beta, gamma, &fixture);
-    capture_asm_snapshot(&asm_snapshot);
-
-    compare_render_snapshots(label, &asm_snapshot, &cpp_snapshot);
-    ASSERT_EQ_INT(expected_result, cpp_snapshot.Result);
-    ASSERT_EQ_INT(expected_result, asm_snapshot.Result);
-    ASSERT_EQ_INT(cpp_snapshot.NonZeroPixels, asm_snapshot.NonZeroPixels);
-
-    if (expect_pixels) {
-        S32 expected_nonzero = expected_nonzero_pixels_for_label(label);
-        if (expected_nonzero >= 0) {
-            ASSERT_EQ_INT(expected_nonzero, cpp_snapshot.NonZeroPixels);
-            ASSERT_EQ_INT(expected_nonzero, asm_snapshot.NonZeroPixels);
-        } else {
-            ASSERT_TRUE(cpp_snapshot.NonZeroPixels > 0);
-            ASSERT_TRUE(asm_snapshot.NonZeroPixels > 0);
-        }
-        ASSERT_EQ_INT(1, cpp_snapshot.NbSortValue);
-        ASSERT_EQ_INT(1, asm_snapshot.NbSortValue);
-    } else {
-        ASSERT_EQ_INT(0, cpp_snapshot.NonZeroPixels);
-        ASSERT_EQ_INT(0, asm_snapshot.NonZeroPixels);
-    }
+    run_bodydisplay_alphabeta_render_case_ex(label, x, y, z, alpha, beta, gamma,
+                                             setup_common_aff_obj_environment,
+                                             expected_result, expect_pixels);
 }
 
 static void run_objectdisplay_render_case_ex(const char *label, void *fixture,
@@ -1948,6 +1966,21 @@ static void test_bodydisplay_hidden_render(void) {
 static void test_bodydisplay_alphabeta_visible_render(void) {
     run_bodydisplay_alphabeta_render_case("BodyDisplay_AlphaBeta visible render",
                                           0, 0, 0, 96, 128, 64, 1, 1);
+}
+
+// ISO variants of the two remaining body-render entry points, so all three
+// (BodyDisplay, BodyDisplay_AlphaBeta, ObjectDisplay) are compared ASM-vs-CPP in
+// interior mode - not just 3D. Drives the ISO object-position branch and the ISO
+// primitive paths end to end.
+static void test_bodydisplay_visible_iso_render(void) {
+    run_bodydisplay_render_case_ex("BodyDisplay visible ISO render", 0, 0, 0,
+                                   64, 96, 32, setup_iso_aff_obj_environment, 1, 1);
+}
+
+static void test_bodydisplay_alphabeta_visible_iso_render(void) {
+    run_bodydisplay_alphabeta_render_case_ex("BodyDisplay_AlphaBeta visible ISO render",
+                                             0, 0, 0, 96, 128, 64,
+                                             setup_iso_aff_obj_environment, 1, 1);
 }
 
 static void test_objectdisplay_visible_render(void) {
@@ -2556,6 +2589,8 @@ int main(void) {
     RUN_TEST(test_bodydisplay_visible_render);
     RUN_TEST(test_bodydisplay_hidden_render);
     RUN_TEST(test_bodydisplay_alphabeta_visible_render);
+    RUN_TEST(test_bodydisplay_visible_iso_render);
+    RUN_TEST(test_bodydisplay_alphabeta_visible_iso_render);
     RUN_TEST(test_objectdisplay_visible_render);
     RUN_TEST(test_objectdisplay_transparent_render);
     RUN_TEST(test_objectdisplay_trame_render);


### PR DESCRIPTION
Two additions that expand `test_aff_obj`'s coverage of the body-render pipeline, following the ISO-gap audit behind #383.

## 1. ISO coverage for the remaining body-render entry points

#383 added interior/ISO render coverage for `ObjectDisplay`, but `BodyDisplay` and `BodyDisplay_AlphaBeta` still rendered only in 3D (their runners hardcoded the perspective environment), leaving their ISO object-position branch (`AFF_OBJ.CPP` ~1734/1778) uncompared. Parameterizes both runners with a setup function (backward-compatible wrappers keep the 3D callers unchanged) and adds ISO variants, so all three body-render entries are compared ASM-vs-CPP in both projection modes.

## 2. Randomised ObjectDisplay render stress

The fixed fixtures always centre the object, so off-centre positions and the clipping paths are barely exercised. `test_objectdisplay_random_stress` walks 500 random positions, rotations, and projection modes (3D + ISO), asserting the CPP and ASM render agree on everything `compare_render_snapshots` checks - framebuffer, projected/rotated points, sort output, screen box. The general body fixture is Solid/Flat polys (no z-buffer, no perspective W term), so no position can trip a division. It passes: the render is faithful across the fuzzed domain, and a future position/rotation/mode-dependent divergence - the class the centred fixtures miss - now fails here.

## Verification

Full Docker ASM-equivalence suite green: 79 tests, 19586 assertions, 0 failures.

## Audit note

While here I confirmed the rest of the equiv-tested render surface has no analogous single-mode gap: projection is covered per mode (`test_prli3df`/`prliiso`, `test_lproj3df`/`lprojiso`), fillers are mode-agnostic (polyrec), and `CAMERA.CPP`'s ISO/3D branches have no `CAMERA.ASM` to test against.
