### PR TITLE
fix: frame-rate-independent movement via a fixed-timestep sim throttle (#358)

### DIFF
--- a/LIB386/H/SYSTEM/TIMER.H
+++ b/LIB386/H/SYSTEM/TIMER.H
@@ -50,6 +50,20 @@ void Timer_FixedDtPresent();
 // Unlike Timer_FixedDtPresent() there is no free first step. Inert outside fixed-dt.
 void Timer_FixedDtPump();
 
+// --- Fixed simulation timestep (production, issue #358) ----------------------
+// Movement/animation is only correct near ~60 fps because locomotion is baked into
+// animation keyframes advanced once per rendered frame (see docs/MOVEMENT_FRAMERATE.md).
+// This scheduler decouples the simulation rate from the render rate: given the real
+// wall-clock elapsed since the last rendered frame, it returns how many fixed dt-sized
+// simulation steps to run this frame, carrying the sub-step remainder so movement over
+// game-time is invariant to the frame rate.
+//
+// Timer_FixedStepCount is the pure core (no clock, no globals): fold `elapsedMs` into
+// `*accMs` and return the step count, clamped to `maxSteps` (a spiral-of-death guard;
+// pass a negative value for no clamp). On clamp the backlog beyond the clamp is dropped,
+// keeping only the sub-dt remainder. Post-condition: `*accMs < dt`. Unit-tested directly.
+S32 Timer_FixedStepCount(U32 *accMs, U32 elapsedMs, U32 dt, S32 maxSteps);
+
 void ManageTime();
 void HandleEventsTimer(const void *event);
 

--- a/LIB386/SYSTEM/TIMER.CPP
+++ b/LIB386/SYSTEM/TIMER.CPP
@@ -141,6 +141,33 @@ S32 Timer_FixedDtActive() {
     return FixedDtActive;
 }
 
+S32 Timer_FixedStepCount(U32 *accMs, U32 elapsedMs, U32 dt, S32 maxSteps) {
+    // Pure accumulator (issue #358). No clock read, no globals: fold the elapsed
+    // real time into the carry and hand back how many fixed dt-steps of simulation
+    // are due. The remainder stays in *accMs, so over any span of wall-time the total
+    // step count is span/dt regardless of how the elapsed time was chunked -- that is
+    // what makes movement frame-rate independent. See docs/MOVEMENT_FRAMERATE.md.
+    if (dt == 0) {
+        return 0; // guard: a zero step would divide by zero and never advance
+    }
+
+    *accMs += elapsedMs;
+
+    S32 steps = (S32)(*accMs / dt);
+
+    if (maxSteps >= 0 && steps > maxSteps) {
+        // Behind by more than we will run this frame (a long stall, or a modal that
+        // banked real time while the game clock was frozen). Run the clamp and drop
+        // the backlog so we do not spiral trying to catch up; keep the sub-dt remainder.
+        steps = maxSteps;
+        *accMs %= dt;
+    } else {
+        *accMs -= (U32)steps * dt;
+    }
+
+    return steps;
+}
+
 void ManageTime() {
     TimerSystemHR = FixedDtActive ? FixedDtNow : SDL_GetTicks();
 

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -1534,7 +1534,7 @@ void Console_RegisterAll(void) {
                               "Caps the frame rate to the display refresh. Persists to lba2.cfg (VSync key).");
 
     Console_RegisterCommandEx("fixedtimestep", cmd_fixedtimestep,
-                              "Throttle the sim to ~60 Hz so movement is frame-rate independent (#358)",
+                              "Throttle the sim to ~60 Hz so movement is frame-rate independent",
                               "fixedtimestep [on|off|toggle|MS]",
                               "Runs the simulation at most once per MS ms of game-time (on = 16). Fixes "
                               "movement speeding up or freezing above 60 fps (vsync off, high-refresh). "

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -1426,6 +1426,39 @@ static void cmd_vsync(int argc, const char *argv[]) {
     Console_Print("Vsync: %s", DisplayVSync ? "ON" : "OFF");
 }
 
+/* fixedtimestep [on|off|toggle|<ms>]: issue #358. Throttle the simulation to advance at
+   most once per <ms> of game-time (on = 16 = ~60 Hz) so movement/animation stops speeding
+   up or freezing above 60 fps (vsync off, high-refresh). off/0 restores per-frame sim.
+   Console-only, not persisted. See docs/MOVEMENT_FRAMERATE.md. */
+static void cmd_fixedtimestep(int argc, const char *argv[]) {
+    if (argc >= 2) {
+        const char *arg = argv[1];
+        if (!strcasecmp(arg, "on")) {
+            FixedTimestep = 16;
+        } else if (!strcasecmp(arg, "off") || !strcmp(arg, "0")) {
+            FixedTimestep = 0;
+        } else if (!strcasecmp(arg, "toggle")) {
+            FixedTimestep = FixedTimestep > 0 ? 0 : 16;
+        } else {
+            int ms = atoi(arg);
+            if (ms < 1 || ms > 100) {
+                Console_Print("fixedtimestep: bad arg '%s' (use on|off|toggle|1..100).", arg);
+                return;
+            }
+            FixedTimestep = ms;
+        }
+    }
+
+    if (FixedTimestep > 0) {
+        Console_Print("FixedTimestep: ON (%d ms, sim <= ~%d fps)", FixedTimestep, 1000 / FixedTimestep);
+    } else {
+        Console_Print("FixedTimestep: OFF (per-frame simulation)");
+    }
+    if (argc < 2) {
+        Console_Print("Usage: fixedtimestep <on|off|toggle|MS>");
+    }
+}
+
 /*──────────────────────────────────────────────────────────────────────────*/
 /* Registration */
 /*──────────────────────────────────────────────────────────────────────────*/
@@ -1498,6 +1531,13 @@ void Console_RegisterAll(void) {
                               "Toggle vertical sync (no args = show state)",
                               "vsync [on|off|toggle]",
                               "Caps the frame rate to the display refresh. Persists to lba2.cfg (VSync key).");
+
+    Console_RegisterCommandEx("fixedtimestep", cmd_fixedtimestep,
+                              "Throttle the sim to ~60 Hz so movement is frame-rate independent (#358)",
+                              "fixedtimestep [on|off|toggle|MS]",
+                              "Runs the simulation at most once per MS ms of game-time (on = 16). Fixes "
+                              "movement speeding up or freezing above 60 fps (vsync off, high-refresh). "
+                              "Console-only, not persisted.");
 
     Console_RegisterCommandEx("perftrace", cmd_perftrace,
                               "Per-frame timing capture (ring buffer, no log spam)",

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -1429,7 +1429,7 @@ static void cmd_vsync(int argc, const char *argv[]) {
 /* fixedtimestep [on|off|toggle|<ms>]: issue #358. Throttle the simulation to advance at
    most once per <ms> of game-time (on = 16 = ~60 Hz) so movement/animation stops speeding
    up or freezing above 60 fps (vsync off, high-refresh). off/0 restores per-frame sim.
-   Console-only, not persisted. See docs/MOVEMENT_FRAMERATE.md. */
+   Default is on (16); persists to lba2.cfg (FixedTimestep key). See docs/MOVEMENT_FRAMERATE.md. */
 static void cmd_fixedtimestep(int argc, const char *argv[]) {
     if (argc >= 2) {
         const char *arg = argv[1];
@@ -1447,6 +1447,7 @@ static void cmd_fixedtimestep(int argc, const char *argv[]) {
             }
             FixedTimestep = ms;
         }
+        DefFileBufferWriteValue("FixedTimestep", FixedTimestep);
     }
 
     if (FixedTimestep > 0) {
@@ -1537,7 +1538,7 @@ void Console_RegisterAll(void) {
                               "fixedtimestep [on|off|toggle|MS]",
                               "Runs the simulation at most once per MS ms of game-time (on = 16). Fixes "
                               "movement speeding up or freezing above 60 fps (vsync off, high-refresh). "
-                              "Console-only, not persisted.");
+                              "Default on; persists to lba2.cfg (FixedTimestep key).");
 
     Console_RegisterCommandEx("perftrace", cmd_perftrace,
                               "Per-frame timing capture (ring buffer, no log spam)",

--- a/SOURCES/C_EXTERN.H
+++ b/SOURCES/C_EXTERN.H
@@ -115,6 +115,7 @@ extern S32 DetailLevel;
 extern S32 VideoFullScreen;
 extern S32 DisplayFullScreen;
 extern S32 DisplayVSync;
+extern S32 FixedTimestep; ///< #358: min ms of game-time per sim step (0 = off). See docs/MOVEMENT_FRAMERATE.md.
 
 /// 1 = mouse hover / click / wheel in plasma menus (see docs/MENU.md). Read from lba2.cfg `MenuMouse`.
 extern S32 FlagMenuMouse;

--- a/SOURCES/GLOBAL.CPP
+++ b/SOURCES/GLOBAL.CPP
@@ -88,6 +88,12 @@ S32 VideoFullScreen = TRUE;
 S32 DisplayFullScreen = FALSE;
 S32 DisplayVSync = TRUE;
 
+// #358: min ms of game-time between simulation steps (0 = off, per-frame sim as before).
+// When > 0 the main loop runs the simulation at most once per this many ms of game clock,
+// so movement/animation stops speeding up or freezing above ~60 fps (vsync off, high-refresh
+// displays). Opt-in, console-only via the `fixedtimestep` verb. See docs/MOVEMENT_FRAMERATE.md.
+S32 FixedTimestep = 0;
+
 S32 FlagMenuMouse = TRUE;
 
 //S32	FlagPalettePcx = FALSE ;

--- a/SOURCES/GLOBAL.CPP
+++ b/SOURCES/GLOBAL.CPP
@@ -91,8 +91,9 @@ S32 DisplayVSync = TRUE;
 // #358: min ms of game-time between simulation steps (0 = off, per-frame sim as before).
 // When > 0 the main loop runs the simulation at most once per this many ms of game clock,
 // so movement/animation stops speeding up or freezing above ~60 fps (vsync off, high-refresh
-// displays). Opt-in, console-only via the `fixedtimestep` verb. See docs/MOVEMENT_FRAMERATE.md.
-S32 FixedTimestep = 0;
+// displays). Default 16 (~60 Hz sim). Persisted to lba2.cfg (FixedTimestep key) and toggleable
+// live via the `fixedtimestep` console verb. See docs/MOVEMENT_FRAMERATE.md.
+S32 FixedTimestep = 16;
 
 S32 FlagMenuMouse = TRUE;
 

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -788,6 +788,9 @@ S32 MainLoop() {
     U8 i;
     S32 pansample;
 
+    // #358 fixed-timestep throttle: game-clock time of the last simulated frame.
+    static U32 LastSimRefHR = 0;
+
     SetDetailLevel(); // prise en compte des différentes options
 
 restartloop:
@@ -1874,6 +1877,25 @@ restartloop:
 
         /*-------------------------------------------------------------------------*/
 
+        /* Fixed-timestep throttle (issue #358). When enabled (console: fixedtimestep),
+           run the simulation at most once per FixedTimestep ms of game-time. On a frame
+           where less than a step has elapsed since the last simulated frame -- i.e.
+           rendering faster than ~60 fps (vsync off, high-refresh displays) -- skip the
+           simulation and re-present the settled scene, so the animation clock never
+           advances in sub-step slivers (that is what makes movement speed up or freeze
+           above 60 fps). Rendering still runs every frame; only the simulation is gated. A
+           backward game-clock jump (a modal SaveTimer rewind, a cube change) re-anchors and
+           simulates. Off (0) is the historical per-frame path, byte-for-byte. See
+           docs/MOVEMENT_FRAMERATE.md. */
+        if (FixedTimestep > 0) {
+            S32 sinceSim = (S32)(TimerRefHR - LastSimRefHR);
+            if (sinceSim < 0 || sinceSim >= FixedTimestep) {
+                LastSimRefHR = TimerRefHR;
+            } else {
+                goto skip_simulation;
+            }
+        }
+
         /* vitesse de chute propor pour tous les objets */
         StepFalling = GetDeltaMove(&RealFalling);
         /* vitesse de decalage propor pour tous les objets */
@@ -2141,6 +2163,7 @@ restartloop:
         /*-------------------------------------------------------------------------*/
         /* affiche tout */
 
+    skip_simulation:
         Perftrace_PhaseBegin(PERFTRACE_PHASE_SCENE);
         AffScene(FirstTime);
         Perftrace_PhaseEnd(PERFTRACE_PHASE_SCENE);

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2270,6 +2270,13 @@ void ReadConfigFile(void) {
        Res_LoadBoot* pre-read is needed. */
     Window_SetVSync(DisplayVSync);
 
+    /* #358 fixed-timestep throttle. Default 16 ms (~60 Hz sim) so movement is frame-rate
+       independent above 60 fps; 0 restores the historical per-frame simulation. Clamp to a
+       sane range (a value near a frame time; 0 = off). See docs/MOVEMENT_FRAMERATE.md. */
+    FixedTimestep = DefFileBufferReadValueDefault("FixedTimestep", 16);
+    if (FixedTimestep < 0 OR FixedTimestep > 100)
+        FixedTimestep = 16;
+
     /* Console toggle scancode (SDL scancode integer); invalid values fall back to F12 in console module. */
     Console_SetToggleScancode(DefFileBufferReadValueDefault("ConsoleToggleKey", K_F12));
 
@@ -2392,6 +2399,7 @@ void WriteConfigFile(void) {
     DefFileBufferWriteValue("FullScreen", VideoFullScreen);
     DefFileBufferWriteValue("DisplayFullScreen", DisplayFullScreen);
     DefFileBufferWriteValue("VSync", DisplayVSync);
+    DefFileBufferWriteValue("FixedTimestep", FixedTimestep);
     DefFileBufferWriteValue("ConsoleToggleKey", Console_GetToggleScancode());
     /* Render resolution. Read at boot by Res_LoadBootDimensions (CLI > cfg >
        auto-detect > compile-time default). Persist it only when the player

--- a/docs/MOVEMENT_FRAMERATE.md
+++ b/docs/MOVEMENT_FRAMERATE.md
@@ -151,6 +151,30 @@ sees `dt=16`. So the block from ~1877 to ~2139 runs inside
 `for (step = 0; step < nSteps; step++)`, with the render and the frame-level UI outside it.
 `nSteps == 0` (render faster than 60 fps) skips the sim and re-presents the settled frame.
 
+**The catch: input re-entrancy (found during wiring).** The sim block's per-object loop
+mixes animation advancement (which we want to run `N` times) with `DoLife`, which processes
+hero input. Hero actions are level-triggered off the held input: e.g. the jump path at
+[OBJECT.CPP:4056-4090](../SOURCES/OBJECT.CPP) falls into `InitAnim(GEN_ANIM_SAUTE)` whenever
+it runs with the action button held. Running the object loop `N` times per frame re-fires
+the jump (and combat, throw) `N` times. So `N`-step sub-stepping is only safe once `DoLife`
+input/action processing is made once-per-frame (split from the per-object anim/physics
+advance, or the momentary-action input bits are masked after the first step). That is real
+surgery and its own correctness risk.
+
+**Phased delivery.**
+
+- **Phase 1 (throttle, safe, fixes the high-fps cases).** Run the sim block at most once per
+  ~16 ms of game-time: skip the sim on frames where `TimerRefHR` has advanced less than one
+  step since the last sim run (still render). The sim then sees a >= 16 ms delta instead of a
+  tiny one, so the high-frame-rate rounding loss is gone. The sim runs **0 or 1 times per
+  frame**, so there is no input re-entrancy and no object-loop restructure. Low-frame-rate
+  (arm64) is left exactly as today (a >= 16 ms frame runs every frame, unchanged), so it is
+  neither fixed nor regressed. This covers every reported desktop case (vsync-off,
+  high-refresh, M1 at Classic res).
+- **Phase 2 (sub-stepping, fixes low-fps too).** The `N`-step loop with `Timer_FixedStepCount`
+  as the driver, gated on a once-per-frame `DoLife`. Fixes the arm64 low-frame-rate overshoot
+  loss. Requires the input-once-per-frame split above.
+
 **Clock model (the sensitive part; see [TIMING.md](TIMING.md)).** Separate the game-clock
 source from `TimerSystemHR`:
 

--- a/docs/MOVEMENT_FRAMERATE.md
+++ b/docs/MOVEMENT_FRAMERATE.md
@@ -1,0 +1,153 @@
+# Movement is frame-rate dependent (#358)
+
+Reduced and inconsistent movement speed (NPC walk/patrol, hero walk/sneak, jump
+length, scripted crawl-throughs) reported first on Android arm64, then reproduced on
+desktop: an Apple M1 at Classic 640×480, and anywhere vsync is off or the display runs
+above 60 Hz. This documents the root cause, the evidence, and the fix.
+
+Companion to [TIMING.md](TIMING.md) (the clocks) and [CONTROL.md](CONTROL.md) (the
+`--fixed-dt` harness used to measure this).
+
+## The short version
+
+Hero/NPC horizontal movement is not `velocity × dt`. Pressing a direction just selects
+a walk/run/jump animation; the actual displacement is baked into the animation's
+keyframe translations and applied by `ObjectSetInterDep`
+([LIB386/ANIM/INTERDEP.CPP](../LIB386/ANIM/INTERDEP.CPP)), which the main loop calls
+once per rendered frame per object (`GereObjAnim`,
+[SOURCES/OBJECT.CPP](../SOURCES/OBJECT.CPP), no catch-up loop). So how far an actor
+walks in a given span of *game-time* depends on the frame rate. It is only correct in a
+narrow band around 60 fps; both slower and faster frame rates lose distance, and the
+slowest-moving NPCs are hit hardest. The engine has no frame-rate limiter other than
+vsync, so movement quietly rides on vsync actually capping at 60 Hz or below.
+
+By contrast, everything that *is* `velocity × dt` (gravity/falling via `StepFalling`,
+conveyor belts via `StepShifting`, turning via `Beta`, projectiles, vehicles) goes
+through the `MOVE` accumulator ([LIB386/3D/MOVE.CPP](../LIB386/3D/MOVE.CPP)), which
+carries its sub-unit remainder and is frame-rate independent. Those are not affected.
+
+## Evidence
+
+Measured deterministically with `--fixed-dt N`, which pins the per-tick game-clock step
+to N ms (so it emulates ~1000/N fps). Same "Desert Island" save, same 3200 ms of
+game-time, per-actor displacement of a scripted mover and a slow mover, as a percentage
+of their 60-fps distance:
+
+| ~FPS | 1000 | 500 | 250 | 125 | **62** | 31 | 16 |
+|---|---|---|---|---|---|---|---|
+| scripted mover | 47% | 80% | 93% | 94% | **100%** | 92% | 88% |
+| slow mover | **0%** | 26% | 80% | 104% | **100%** | 86% | 71% |
+
+A sweet spot at ~60 fps, falling off both ways. At 1000 fps the slow mover is frozen
+(0%); at 16 fps everything is 12 to 29% short. It reproduces on x86_64 (WSL) via
+`--fixed-dt` alone, so it is not ARM `long double` arithmetic: it is frame timing. This
+matches every field observation. "Vsync off is worse, on is better" (off is uncapped
+high fps). "Slower on a high-refresh monitor" (above 60 Hz). "Happens on the M1 at
+Classic res" (a fast machine exceeding 60 fps). "Slowest NPCs most affected."
+
+The unit test `tests/movement/test_move_framerate.cpp` reproduces the same shape on a
+synthetic 4-keyframe walk with no game data: 100% of ideal at high fps, plateauing at
+78% from ~60 fps down.
+
+## Mechanism
+
+Two frame-rate couplings, both in `ObjectSetInterDep`, pulling opposite ways.
+
+1. **Low frame rate: overshoot discard.** When a keyframe completes, the next
+   keyframe's window is re-anchored to the current clock
+   (`obj->LastTimer = obj->Time; obj->NextTimer = obj->Time + dur` in INTERDEP.CPP). Any
+   game-time by which `obj->Time` overshot the keyframe's intended end is thrown away,
+   so the animation (and the locomotion baked into it) falls behind real game-time. The
+   bigger the frame (lower fps), the more is discarded per boundary. The existing
+   `test_cpp_frame_advance` in `tests/ANIM/test_interdep.cpp` even asserts this discard
+   as correct, because the original ASM does the same: it is inherent, not a port bug.
+
+2. **High frame rate: per-frame rounding.** The per-frame local delta is rotated to
+   world space and `fistp`-rounded to integer coordinates with no fractional remainder
+   carried (`obj->X += X0` in INTERDEP.CPP, via `LongRotatePointF`). At high fps each
+   per-frame delta is sub-unit; rounding a stream of them drifts, toward zero for a slow
+   mover, which is how a slow NPC freezes at 1000 fps. The pre-rotation telescoping
+   (`LastAnimStep*`) only cancels the *local*-space truncation; the post-rotation
+   rounding is not carried.
+
+Between them the animation clock only tracks real game-time near ~60 fps, which is
+where period hardware ran the in-scene loop.
+
+## Why it looks like a recent regression
+
+It is inherent to the 1997 engine, invisible on DOS at a stable ~60 fps. The movement
+math (`INTERDEP.CPP`, `MOVE.CPP`, `ANIM.CPP`, `FRAME.CPP`) has had no behavioural change
+in the port, only reformatting and warning fixes, and `--fixed-dt 16` displacement is
+bit-identical across recent commits. What changed is the *exposure*:
+
+- The game's only frame cap is vsync (`SDL_SetRenderVSync`,
+  [LIB386/SYSTEM/WINDOW.CPP](../LIB386/SYSTEM/WINDOW.CPP)); `DisplayVSync` defaults on
+  ([SOURCES/GLOBAL.CPP](../SOURCES/GLOBAL.CPP)). Turning it off, or a backend where SDL
+  vsync does not hard-block, runs uncapped into the high-fps loss.
+- The `ManageTime` fix (`ed0e7a64`, see [TIMING.md](TIMING.md)) made `TimerRefHR` track
+  true wall-time honestly; before it, a lagging game clock masked the coupling behind
+  uniform slowness.
+- Higher default render cost (HD-resolution auto-detect) drops weak or arm hardware into
+  the low-fps loss; high-refresh displays sit above 60 Hz with vsync on.
+
+## Fix: fixed simulation timestep
+
+Chosen 2026-07-07. Drive the simulation at a constant 16 ms step regardless of render
+rate, so every user sits at the ~60 fps behaviour the animator assumed, and
+`ObjectSetInterDep`'s per-step math runs exactly as it does under `--fixed-dt 16`
+today. That keeps the ASM-equivalence tests and the projection-corpus determinism
+golden green: this pins the function to a constant dt in production rather than changing
+its arithmetic (which would diverge from the ASM oracle).
+
+Shape (the standard "fix your timestep"):
+
+- Accumulate real elapsed wall-time each loop iteration.
+- Step the simulation in fixed 16 ms quanta (each advancing the game clock by 16),
+  reusing the existing `Timer_EnableFixedDt` / `Timer_FixedDtAdvance` primitives
+  ([LIB386/SYSTEM/TIMER.CPP](../LIB386/SYSTEM/TIMER.CPP)), and render once per iteration.
+- Clamp the catch-up steps per render (a spiral-of-death guard for weak or arm
+  hardware): if the accumulator is many steps behind, run a bounded number and drop the
+  rest.
+- Poll input once per rendered frame.
+
+Add a real frame-rate limiter as a backstop (sleep to 16 ms when vsync does not block),
+so correctness never depends on SDL vsync behaving identically across Metal, GL, and
+Android. Both belong in the same change, behind a config flag initially so it can be
+A/B'd against current behaviour.
+
+The delicate part is not the anim math. It is separating the simulation block from the
+render (`AffScene`) and the input poll in `MainLoop`
+([SOURCES/PERSO.CPP](../SOURCES/PERSO.CPP)) so the sim can run 0 to N times per rendered
+frame. That split gets its own design note before implementation.
+
+Trade-off (accepted): pinning to 16 ms locks in the ~60 fps reference behaviour, giving
+consistency and the intended feel at any render rate, not a theoretical keyframe-ideal.
+Rejected alternatives: (a) making `ObjectSetInterDep` itself frame-rate independent,
+which is the most surgical fix but diverges from the ASM oracle and breaks the
+equivalence tests plus the golden; (b) a 60 fps frame cap only, a band-aid that still
+leaves sub-60-fps (arm64) slow and does nothing below 60.
+
+## Tests
+
+Test level must match the fix level. The fix is in the main loop, so:
+
+- **Characterization (CI, `tests/movement/test_move_framerate.cpp`).** Drives the real
+  `ObjectSetInterDep` over a fixed game-time span at several dt and asserts the walked
+  distance matches. CPP-only, deterministic, no game data. RED today; pins the coupling
+  as an executable fact. It is not the merge gate (a main-loop fix does not change this
+  function's per-call dt sensitivity), it is the root-cause proof.
+- **End-to-end (local, `tests/automation/test_move_framerate.sh`).** Loads a save and
+  compares how far the scene's scripted movers travel over the same game-time at ~60 fps
+  vs ~16 fps. RED today (~12% gap on Desert Island). Needs retail data, so it is
+  local-only, not CI.
+- **To come with the fix.** A unit test of the fixed-timestep scheduler (given a
+  sequence of real frame times, assert the number of 16 ms sim steps and the clamp),
+  which is the clean CI GREEN gate; and re-pointing the end-to-end test at a render-rate
+  knob (varying render fps with the sim pinned) so it verifies movement invariance.
+
+## Related
+
+- [TIMING.md](TIMING.md): the two clocks, `ManageTime`, and the fixed-dt primitives this
+  fix promotes to a gameplay mode.
+- [FIXED_DT_PLAN.md](FIXED_DT_PLAN.md): the harness-only virtual clock the fix builds on.
+- [CONTROL.md](CONTROL.md): `--fixed-dt`, `--tick`, `--dump-state`.

--- a/docs/MOVEMENT_FRAMERATE.md
+++ b/docs/MOVEMENT_FRAMERATE.md
@@ -170,8 +170,9 @@ surgery and its own correctness risk.
   times per frame**, so there is no input re-entrancy and no object-loop restructure.
   Low-frame-rate (arm64) is left exactly as today (a >= 16 ms frame runs every frame,
   unchanged), so it is neither fixed nor regressed. This covers every reported desktop case
-  (vsync-off, high-refresh, M1 at Classic res), and it also stops the demo-reel cube 201
-  (Desert Island bat) derail from #255 by making the sim cadence host-independent. Default on
+  (vsync-off, high-refresh, M1 at Classic res). It also makes the sim cadence host-independent,
+  which addresses the variable-dt cadence behind #255's cube 201 (Desert Island bat) demo-reel
+  derail; the bat collision itself is unchanged, so #255 is not closed. Default on
   (16 ms), persisted to `lba2.cfg` (`FixedTimestep` key), toggleable live via the
   `fixedtimestep on|off|toggle|<ms>` console verb (the `FixedTimestep` global,
   [GLOBAL.CPP](../SOURCES/GLOBAL.CPP); the gate is in `MainLoop`,

--- a/docs/MOVEMENT_FRAMERATE.md
+++ b/docs/MOVEMENT_FRAMERATE.md
@@ -163,14 +163,18 @@ surgery and its own correctness risk.
 
 **Phased delivery.**
 
-- **Phase 1 (throttle, safe, fixes the high-fps cases).** Run the sim block at most once per
-  ~16 ms of game-time: skip the sim on frames where `TimerRefHR` has advanced less than one
-  step since the last sim run (still render). The sim then sees a >= 16 ms delta instead of a
-  tiny one, so the high-frame-rate rounding loss is gone. The sim runs **0 or 1 times per
-  frame**, so there is no input re-entrancy and no object-loop restructure. Low-frame-rate
-  (arm64) is left exactly as today (a >= 16 ms frame runs every frame, unchanged), so it is
-  neither fixed nor regressed. This covers every reported desktop case (vsync-off,
-  high-refresh, M1 at Classic res).
+- **Phase 1 (throttle, safe, fixes the high-fps cases), implemented.** Run the sim block at
+  most once per ~16 ms of game-time: skip the sim on frames where `TimerRefHR` has advanced
+  less than one step since the last sim run (still render). The sim then sees a >= 16 ms delta
+  instead of a tiny one, so the high-frame-rate rounding loss is gone. The sim runs **0 or 1
+  times per frame**, so there is no input re-entrancy and no object-loop restructure.
+  Low-frame-rate (arm64) is left exactly as today (a >= 16 ms frame runs every frame,
+  unchanged), so it is neither fixed nor regressed. This covers every reported desktop case
+  (vsync-off, high-refresh, M1 at Classic res). Opt-in and console-only (no cfg persistence):
+  `fixedtimestep on|off|toggle|<ms>` (the `FixedTimestep` global, [GLOBAL.CPP](../SOURCES/GLOBAL.CPP);
+  the gate is in `MainLoop`, [PERSO.CPP](../SOURCES/PERSO.CPP)). Off (0) is byte-for-byte the
+  historical per-frame path, verified identical to the `--fixed-dt 16` golden; at `--fixed-dt 8`
+  (~125 fps) the throttle reproduces the true dt=16 displacement.
 - **Phase 2 (sub-stepping, fixes low-fps too).** The `N`-step loop with `Timer_FixedStepCount`
   as the driver, gated on a once-per-frame `DoLife`. Fixes the arm64 low-frame-rate overshoot
   loss. Requires the input-once-per-frame split above.

--- a/docs/MOVEMENT_FRAMERATE.md
+++ b/docs/MOVEMENT_FRAMERATE.md
@@ -127,6 +127,64 @@ which is the most surgical fix but diverges from the ASM oracle and breaks the
 equivalence tests plus the golden; (b) a 60 fps frame cap only, a band-aid that still
 leaves sub-60-fps (arm64) slow and does nothing below 60.
 
+## Implementation plan (the MainLoop split)
+
+The scheduler core landed first as a pure, unit-tested function (`Timer_FixedStepCount`,
+[LIB386/SYSTEM/TIMER.CPP](../LIB386/SYSTEM/TIMER.CPP)): fold real elapsed into a carry,
+return how many fixed dt-steps are due, clamp runaway backlog. It has no caller yet. The
+rest is wiring it into `MainLoop` ([SOURCES/PERSO.CPP](../SOURCES/PERSO.CPP):785).
+
+**The loop today**, per `while(TRUE)` iteration:
+
+| lines | role | cadence under the fix |
+|---|---|---|
+| 918 `Control_TickHook` | harness seam | once per frame |
+| 944-945 `MyGetInput(); ManageTime()` | input poll + game-clock advance | input once per frame; clock becomes the step driver |
+| 947-1836 | UI, menus, pause, demo watchdog, camera setup | once per frame (input sampled once, applied to every sub-step) |
+| ~1877-2139 | simulation: global movers, `GereAmbiance`/`CheckNextMusic`, `GereExtras`, `AnimAllFlow`, the per-object physics/AI/collision/anim loop, camera centering | run 0..N times per frame |
+| 2145 `AffScene` | render | once per frame |
+
+**Why the sim block must loop.** Advancing the game clock by `N*dt` and running the sim
+once would just feed `ObjectSetInterDep` one big dt, which is the overshoot bug again. The
+sim block has to run `N` times, each after a single `dt` advance, so every animation step
+sees `dt=16`. So the block from ~1877 to ~2139 runs inside
+`for (step = 0; step < nSteps; step++)`, with the render and the frame-level UI outside it.
+`nSteps == 0` (render faster than 60 fps) skips the sim and re-presents the settled frame.
+
+**Clock model (the sensitive part; see [TIMING.md](TIMING.md)).** Separate the game-clock
+source from `TimerSystemHR`:
+
+- `TimerSystemHR` stays real (`SDL_GetTicks`) so the FPS counter, audio/sample fades
+  ([AMBIANCE.CPP](../SOURCES/AMBIANCE.CPP)), texture animation
+  ([ANIMTEX.CPP](../SOURCES/ANIMTEX.CPP)), and the HQR LRU keep real-time behaviour.
+- `TimerRefHR` (the game clock the simulation reads) advances only by explicit `dt` bumps:
+  once per sim-step in the main step-loop, and once per iteration in the modal subloops that
+  already pump the clock for the harness (`Timer_FixedDtPresent`/`Timer_FixedDtPump`, the
+  `SaveTimer`/`RestoreTimer` modals in `MESSAGE.CPP`/`INVENT.CPP`/`AMBIANCE.CPP`).
+
+This generalizes the existing fixed-dt overlay ([FIXED_DT_PLAN.md](FIXED_DT_PLAN.md)): the
+harness case is this same model with `TimerSystemHR` *also* virtual for determinism. Because
+the harness path is unchanged, `--fixed-dt 16` stays bit-identical and the projection golden
+and ASM-equivalence tests are untouched. The refactor is contained to `TIMER.CPP` (a
+game-clock source distinct from `TimerSystemHR`, banked in `ManageTime`) plus the step-loop
+in `PERSO.CPP`.
+
+**Backstops and rollout.**
+
+- Clamp catch-up steps per frame (`Timer_FixedStepCount`'s `maxSteps`) so weak/arm hardware
+  that renders slower than the sim rate cannot spiral; the dropped backlog is bounded slow-mo
+  under overload, not a freeze.
+- Add a real frame-rate limiter (sleep toward 16 ms when vsync does not block) so we do not
+  busy-render thousands of duplicate frames at very high fps, and so correctness never depends
+  on SDL vsync behaving across Metal/GL/Android.
+- Land behind a config flag (default off first), so it can be A/B'd on real hardware at 60 /
+  144 / vsync-off before becoming the default.
+
+**Open decision:** whether to enable by default in the first release or ship it opt-in for one
+cycle of field testing. This touches the game clock, which is the most bug-prone surface in
+the port (see the `ManageTime` history in [TIMING.md](TIMING.md)), so a review of the clock
+model is warranted before the `TIMER.CPP`/`PERSO.CPP` change.
+
 ## Tests
 
 Test level must match the fix level. The fix is in the main loop, so:
@@ -140,10 +198,14 @@ Test level must match the fix level. The fix is in the main loop, so:
   compares how far the scene's scripted movers travel over the same game-time at ~60 fps
   vs ~16 fps. RED today (~12% gap on Desert Island). Needs retail data, so it is
   local-only, not CI.
-- **To come with the fix.** A unit test of the fixed-timestep scheduler (given a
-  sequence of real frame times, assert the number of 16 ms sim steps and the clamp),
-  which is the clean CI GREEN gate; and re-pointing the end-to-end test at a render-rate
-  knob (varying render fps with the sim pinned) so it verifies movement invariance.
+- **Scheduler core (CI, `tests/timer/test_fixed_step.cpp`).** Drives the pure
+  `Timer_FixedStepCount` and asserts the step count over a fixed span of wall-time is
+  identical across steady / fine / coarse / jittery frame pacing (exactly 1000 steps over
+  16000 ms at dt=16), plus the clamp and guards. GREEN. This is the clean CI gate for the
+  fix's core logic.
+- **To come with the wiring.** Re-point the end-to-end test at a render-rate knob (vary
+  render fps with the sim pinned) so it verifies movement invariance after the MainLoop
+  split, rather than the `--fixed-dt` sweep (which drives the sim step directly).
 
 ## Related
 

--- a/docs/MOVEMENT_FRAMERATE.md
+++ b/docs/MOVEMENT_FRAMERATE.md
@@ -170,11 +170,20 @@ surgery and its own correctness risk.
   times per frame**, so there is no input re-entrancy and no object-loop restructure.
   Low-frame-rate (arm64) is left exactly as today (a >= 16 ms frame runs every frame,
   unchanged), so it is neither fixed nor regressed. This covers every reported desktop case
-  (vsync-off, high-refresh, M1 at Classic res). Opt-in and console-only (no cfg persistence):
-  `fixedtimestep on|off|toggle|<ms>` (the `FixedTimestep` global, [GLOBAL.CPP](../SOURCES/GLOBAL.CPP);
-  the gate is in `MainLoop`, [PERSO.CPP](../SOURCES/PERSO.CPP)). Off (0) is byte-for-byte the
-  historical per-frame path, verified identical to the `--fixed-dt 16` golden; at `--fixed-dt 8`
-  (~125 fps) the throttle reproduces the true dt=16 displacement.
+  (vsync-off, high-refresh, M1 at Classic res), and it also stops the demo-reel cube 201
+  (Desert Island bat) derail from #255 by making the sim cadence host-independent. Default on
+  (16 ms), persisted to `lba2.cfg` (`FixedTimestep` key), toggleable live via the
+  `fixedtimestep on|off|toggle|<ms>` console verb (the `FixedTimestep` global,
+  [GLOBAL.CPP](../SOURCES/GLOBAL.CPP); the gate is in `MainLoop`,
+  [PERSO.CPP](../SOURCES/PERSO.CPP)). Off (0) is byte-for-byte the historical per-frame path;
+  the throttle is a no-op under `--fixed-dt 16` (16 >= 16 never skips), so the projection golden
+  and the ASM-equivalence tests are unchanged, verified identical. At `--fixed-dt 8` (~125 fps)
+  the throttle reproduces the true dt=16 displacement.
+
+  Known rough edge: the skip threshold is one 16 ms step, so a display running just above 60 Hz
+  (roughly 63-75 fps) runs the sim every other frame at ~30 ms (a few % slow) rather than every
+  frame. Uncommon (most panels are 60 / 120 / 144 / 240 Hz); a lower `fixedtimestep` value (e.g.
+  13) avoids it, and phase 2's decoupled accumulator removes it.
 - **Phase 2 (sub-stepping, fixes low-fps too).** The `N`-step loop with `Timer_FixedStepCount`
   as the driver, gated on a once-per-frame `DoLife`. Fixes the arm64 low-frame-rate overshoot
   loss. Requires the input-once-per-frame split above.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Index of documentation in this repository.
 | [SAVEGAME.md](SAVEGAME.md) | .lba save format: lifecycle, binary layout, version compatibility, save editors, LBALab tools. |
 | [CAMERA.md](CAMERA.md) | Camera system: interior (iso) vs exterior (perspective), CameraCenter, Auto camera (`FollowCamera`, community addition). |
 | [TIMING.md](TIMING.md) | Engine timing: TimerSystemHR vs TimerRefHR, LockTimer vs SaveTimer semantics, ManageTime call sites, fixed-dt overlay, and the 1997 `ManageTime` bug history. |
+| [MOVEMENT_FRAMERATE.md](MOVEMENT_FRAMERATE.md) | Why movement speed is frame-rate dependent (#358): animation-baked locomotion, the two couplings in `ObjectSetInterDep`, evidence, and the fixed-simulation-timestep fix. |
 | [SPRITES.md](SPRITES.md) | Sprite system: UI / world-extra / 3D-anim lanes, `ScaleSprite` vs `ScaleSpriteTransp`, perspective scale (`CalculeScaleFactorSprite`), sort-tree integration. Magic-ball case study. |
 | [LBA_EDITOR.md](LBA_EDITOR.md) | What `LBA_EDITOR`/`PERSO` paths still do: editor capabilities, runtime hooks, and likely missing pieces. |
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ add_subdirectory(iso9660)
 add_subdirectory(disc_image)
 add_subdirectory(cue)
 add_subdirectory(render)
+add_subdirectory(movement)
 
 if(LBA2_BUILD_ASM_EQUIV_TESTS)
 include(cmake/asm_test_helpers.cmake)

--- a/tests/automation/test_move_framerate.sh
+++ b/tests/automation/test_move_framerate.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Movement is frame-rate dependent (issue #358): end-to-end repro.
+#
+# Character/NPC locomotion is baked into animation keyframe translations delivered
+# once per rendered frame (ObjectSetInterDep), so the distance a scripted actor walks
+# over a fixed span of *game-time* must not depend on the frame rate. --fixed-dt N
+# pins the per-tick game-clock step to N ms, i.e. emulates ~1000/N fps deterministically.
+# We run the SAME save for the SAME game-time (3200 ms) at dt=16 (~60 fps) and dt=64
+# (~16 fps) and compare how far the scene's scripted movers travel.
+#
+# Today the two totals differ well beyond tolerance, which is the bug (RED). See
+# docs/MOVEMENT_FRAMERATE.md for the mechanism and the fixed-timestep fix.
+#
+# NOTE: --fixed-dt drives the *simulation* step directly, so this exercises the
+# unit-level coupling end-to-end. Once the fixed-timestep fix lands, the simulation
+# is pinned to a constant step regardless of render rate; a follow-up will re-point
+# this test at the render-rate knob so it becomes the GREEN gate. For now it is the
+# executable, real-data proof of the coupling.
+#
+# Local-only (needs retail data + a save); skips cleanly otherwise. Not in CI.
+TESTNAME=move_framerate
+. "$(dirname "$0")/lib.sh"
+precheck
+need_save
+
+base="$(mktemp)"; a="$(mktemp)"; b="$(mktemp)"
+trap 'rm -f "$base" "$a" "$b"' EXIT
+
+# Same total game-time (3200 ms) at two frame rates.
+ctl --no-audio --load "$LBA2_TEST_SAVE" --fixed-dt 16 --tick 0   --dump-state "$base" --exit >/dev/null 2>&1 \
+    || fail "baseline run: non-zero exit ($?)"
+ctl --no-audio --load "$LBA2_TEST_SAVE" --fixed-dt 16 --tick 200 --dump-state "$a"    --exit >/dev/null 2>&1 \
+    || fail "60fps run: non-zero exit ($?)"
+ctl --no-audio --load "$LBA2_TEST_SAVE" --fixed-dt 64 --tick 50  --dump-state "$b"    --exit >/dev/null 2>&1 \
+    || fail "16fps run: non-zero exit ($?)"
+
+# Total distance all actors travelled from the baseline, at each frame rate.
+read -r d60 d16 span < <(python3 - "$base" "$a" "$b" <<'PY'
+import json, math, sys
+base = json.load(open(sys.argv[1]))["actors"]
+def travelled(path):
+    end = json.load(open(path))["actors"]
+    return sum(math.hypot(e["x"] - b0["x"], e["z"] - b0["z"]) for b0, e in zip(base, end))
+d60 = travelled(sys.argv[2])
+d16 = travelled(sys.argv[3])
+# Both runs cover the same game-time; report it so a failure is self-explanatory.
+span = json.load(open(sys.argv[3]))["timer_ref_hr"] - json.load(open(sys.argv[1]))["timer_ref_hr"]
+print(f"{d60:.0f} {d16:.0f} {span}")
+PY
+)
+
+echo "  scripted actors travelled over ${span}ms of game-time: ~60fps=${d60}  ~16fps=${d16}"
+
+# Same game-time must walk the same distance. Fails today (that is #358).
+python3 - "$d60" "$d16" <<'PY' || fail "frame-rate dependent movement: 60fps=$d60 vs 16fps=$d16 (issue #358)"
+import sys
+d60, d16 = float(sys.argv[1]), float(sys.argv[2])
+ref = max(d60, 1.0)
+sys.exit(0 if abs(d60 - d16) <= 0.05 * ref else 1)
+PY
+
+pass "movement frame-rate invariant (60fps=$d60, 16fps=$d16)"

--- a/tests/movement/CMakeLists.txt
+++ b/tests/movement/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Host regression: character/NPC locomotion must be frame-rate independent (#358).
+#
+# Drives the real C ObjectSetInterDep over a fixed span of game-time at several
+# frame rates and asserts the walked distance matches. CPP-only (no ASM, no
+# Docker, no game assets), so it runs in host_quick CI on every platform. The
+# anim fixture is shared with the ANIM equivalence tests.
+add_executable(test_move_framerate
+    test_move_framerate.cpp
+)
+target_include_directories(test_move_framerate PRIVATE
+    ${CMAKE_SOURCE_DIR}/LIB386/H
+    ${CMAKE_SOURCE_DIR}/tests
+    ${CMAKE_SOURCE_DIR}/tests/ANIM
+    ${CMAKE_BINARY_DIR}
+)
+target_link_libraries(test_move_framerate PRIVATE ani obj 3D poly svg sys SDL3::SDL3)
+set_target_properties(test_move_framerate PROPERTIES CXX_STANDARD 11)
+add_test(NAME test_move_framerate COMMAND test_move_framerate)
+register_host_test(test_move_framerate)

--- a/tests/movement/test_move_framerate.cpp
+++ b/tests/movement/test_move_framerate.cpp
@@ -1,0 +1,133 @@
+/* Root-cause characterization: animation-driven locomotion is frame-rate
+ * dependent (issue #358).
+ *
+ * In LBA2 there is no "walk speed * dt": hero/NPC horizontal displacement is baked
+ * into the animation keyframe translations and delivered by ObjectSetInterDep
+ * (LIB386/ANIM/INTERDEP.CPP), which the main loop calls exactly ONCE per rendered
+ * frame per object (SOURCES/OBJECT.CPP GereObjAnim, no catch-up loop). So the
+ * distance walked over a fixed span of *game-time* should not depend on how finely
+ * that span is sampled, i.e. on the frame rate. It does.
+ *
+ * This test drives the real C ObjectSetInterDep over the SAME span of game-time at
+ * several dt granularities and prints/asserts the walked distance. It FAILS on the
+ * current engine (that is the bug) and pins the coupling as an executable,
+ * platform-independent fact, the same shape measured end-to-end with the
+ * --fixed-dt harness sweep (see docs/MOVEMENT_FRAMERATE.md).
+ *
+ * The dominant effect here is the LOW-frame-rate overshoot-discard: when a keyframe
+ * completes, ObjectSetInterDep re-anchors the next window to obj->Time
+ * (NextTimer = obj->Time + dur, INTERDEP.CPP), throwing away the overshoot past the
+ * keyframe's intended end, so the animation falls behind real game-time. With a
+ * 50 ms keyframe the distance is ideal at high frame rates and plateaus ~22% short
+ * from ~60 fps down. (The opposing HIGH-frame-rate rounding loss needs sub-unit
+ * per-frame deltas and is angle-dependent; it is characterized against the real
+ * game in the doc rather than asserted here.)
+ *
+ * NOTE ON THE FIX LEVEL: the chosen fix is a fixed simulation timestep in the main
+ * loop, which pins this function to a constant dt in production rather than changing
+ * its arithmetic (that would diverge from the ASM oracle the equivalence tests hold
+ * it to). So this unit-level invariance is not itself the merge gate; it is the
+ * characterization. The end-to-end gate is the render-rate sweep in
+ * tests/automation/test_move_framerate.sh.
+ *
+ * CPP-only: drives the real C ObjectSetInterDep, links the real 3D math. No ASM,
+ * no Docker, no game assets. Runs in host_quick CI.
+ */
+#include "test_harness.h"
+#include <ANIM/INTERDEP.H>
+#include <ANIM/ANIM.H>
+#include <ANIM/LIBINIT.H>
+#include <ANIM/CLEAR.H>
+#include <ANIM.H>
+#include <OBJECT/AFF_OBJ.H>
+#include <math.h>
+
+#include "anim_test_fixture.h"
+
+extern "C" U32 TimerRefHR;
+
+/* Total span of game-time each run integrates over (ms). */
+#define WALK_MS 3200
+/* Frame-rate-independent target: 3200 ms / (4 keyframes * 50 ms) = 16 cycles,
+ * 4 * 300 units of forward Z per cycle. */
+#define WALK_IDEAL (16 * 4 * 300)
+/* Walked distance must match across frame rates within this fraction. */
+#define WALK_TOL 0.02
+
+static U8 g_walk_anim[512];
+
+/* A looping "walk": 4 keyframes, 50 ms each, a fixed forward Z step per frame.
+ * Translation lives in the frame-header slots [1..3] (X,Y,Z) that ObjectSetInterDep
+ * reads; Master stays 0 so there is no angle animation and the object keeps facing
+ * whatever Beta we point it at. */
+static void build_walk_anim(void) {
+    build_anim_header(g_walk_anim, /*nbFrames*/ 4, /*nbGroups*/ 2,
+                      /*loopFrame*/ 0, /*deltaTime*/ 50);
+    for (U16 f = 0; f < 4; f++) {
+        S16 *fp = anim_frame_ptr(g_walk_anim, 2, f);
+        fp[1] = 0;   /* X translation */
+        fp[2] = 0;   /* Y translation (override the fixture's NextBody = -1) */
+        fp[3] = 300; /* Z translation: a forward step per keyframe */
+    }
+}
+
+/* Walk for WALK_MS of game-time in dt-ms steps facing `beta`; return the net world
+ * displacement magnitude in the XZ plane. */
+static double run_walk(U16 dt, S32 beta) {
+    build_walk_anim();
+
+    T_OBJ_3D obj;
+    init_test_obj(&obj);
+    init_anim_buffer();
+    TransFctAnim = NULL;
+    /* Anchor the clock at 0 BEFORE ObjectInitAnim: it seeds obj->Time from
+     * TimerRefHR, and a stale (larger) value would send the first step down
+     * ObjectSetInterDep's rewind branch and corrupt the timers. */
+    TimerRefHR = 0;
+    ObjectInitAnim(&obj, g_walk_anim);
+    obj.Status = FLAG_CHANGE;
+    obj.LastFrame = 0;
+    obj.NextFrame = 1;
+    obj.LastOfsFrame = (PTR_U32)anim_frame_offset(2, 0);
+    obj.NextOfsFrame = (PTR_U32)anim_frame_offset(2, 1);
+    obj.LastOfsIsPtr = 0;
+    obj.LastTimer = 0;
+    obj.NextTimer = 50;
+    obj.Alpha = 0;
+    obj.Beta = beta;
+    obj.Gamma = 0;
+    obj.X = 0;
+    obj.Y = 0;
+    obj.Z = 0;
+
+    for (U32 t = dt; t <= WALK_MS; t += dt) {
+        TimerRefHR = t;
+        ObjectSetInterDep(&obj);
+    }
+    return sqrt((double)obj.X * obj.X + (double)obj.Z * obj.Z);
+}
+
+/* The property under test: same game-time walks the same distance regardless of the
+ * frame rate it is sampled at. Beta=0 isolates the low-frame-rate overshoot-discard
+ * (no rotation rounding), so the failure is clean and deterministic. */
+static void test_framerate_invariance(void) {
+    const int fps_dt[] = {1, 2, 4, 8, 16, 32, 64};
+    double d[7];
+    printf("  walked over %d ms of game-time (ideal = %d):\n", WALK_MS, WALK_IDEAL);
+    for (int i = 0; i < 7; i++) {
+        d[i] = run_walk((U16)fps_dt[i], 0);
+        printf("    ~%4d fps (dt=%2d): %.0f  (%.0f%% of ideal)\n",
+               1000 / fps_dt[i], fps_dt[i], d[i], 100.0 * d[i] / WALK_IDEAL);
+    }
+    /* High frame rate (dt=1) vs 60 fps (dt=16) vs low frame rate (dt=64): all
+     * should walk the same distance. They do not today. */
+    double ref = d[4];                               /* dt=16, ~60 fps */
+    ASSERT_TRUE(fabs(d[0] - ref) <= WALK_TOL * ref); /* dt=1  vs dt=16 */
+    ASSERT_TRUE(fabs(d[6] - ref) <= WALK_TOL * ref); /* dt=64 vs dt=16 */
+}
+
+int main(void) {
+    RUN_TEST(test_framerate_invariance);
+    TEST_SUMMARY();
+    return test_failures != 0;
+}

--- a/tests/movement/test_move_framerate.cpp
+++ b/tests/movement/test_move_framerate.cpp
@@ -9,10 +9,12 @@
  * that span is sampled, i.e. on the frame rate. It does.
  *
  * This test drives the real C ObjectSetInterDep over the SAME span of game-time at
- * several dt granularities and prints/asserts the walked distance. It FAILS on the
- * current engine (that is the bug) and pins the coupling as an executable,
- * platform-independent fact, the same shape measured end-to-end with the
- * --fixed-dt harness sweep (see docs/MOVEMENT_FRAMERATE.md).
+ * several dt granularities and asserts the walked distance materially DIFFERS across
+ * them, pinning the coupling as an executable, platform-independent fact (the same
+ * shape measured end-to-end with the --fixed-dt harness sweep, see
+ * docs/MOVEMENT_FRAMERATE.md). It is a characterization, not a bug that flips green:
+ * the fix (the main-loop throttle) works around this at the loop level without changing
+ * this function; its logic is gated by tests/timer/test_fixed_step.cpp.
  *
  * The dominant effect here is the LOW-frame-rate overshoot-discard: when a keyframe
  * completes, ObjectSetInterDep re-anchors the next window to obj->Time
@@ -22,13 +24,6 @@
  * from ~60 fps down. (The opposing HIGH-frame-rate rounding loss needs sub-unit
  * per-frame deltas and is angle-dependent; it is characterized against the real
  * game in the doc rather than asserted here.)
- *
- * NOTE ON THE FIX LEVEL: the chosen fix is a fixed simulation timestep in the main
- * loop, which pins this function to a constant dt in production rather than changing
- * its arithmetic (that would diverge from the ASM oracle the equivalence tests hold
- * it to). So this unit-level invariance is not itself the merge gate; it is the
- * characterization. The end-to-end gate is the render-rate sweep in
- * tests/automation/test_move_framerate.sh.
  *
  * CPP-only: drives the real C ObjectSetInterDep, links the real 3D math. No ASM,
  * no Docker, no game assets. Runs in host_quick CI.
@@ -51,8 +46,6 @@ extern "C" U32 TimerRefHR;
 /* Frame-rate-independent target: 3200 ms / (4 keyframes * 50 ms) = 16 cycles,
  * 4 * 300 units of forward Z per cycle. */
 #define WALK_IDEAL (16 * 4 * 300)
-/* Walked distance must match across frame rates within this fraction. */
-#define WALK_TOL 0.02
 
 static U8 g_walk_anim[512];
 
@@ -110,24 +103,31 @@ static double run_walk(U16 dt, S32 beta) {
 /* The property under test: same game-time walks the same distance regardless of the
  * frame rate it is sampled at. Beta=0 isolates the low-frame-rate overshoot-discard
  * (no rotation rounding), so the failure is clean and deterministic. */
-static void test_framerate_invariance(void) {
+static void test_framerate_coupling_present(void) {
     const int fps_dt[] = {1, 2, 4, 8, 16, 32, 64};
-    double d[7];
+    double d[7], lo = 1e18, hi = 0.0;
     printf("  walked over %d ms of game-time (ideal = %d):\n", WALK_MS, WALK_IDEAL);
     for (int i = 0; i < 7; i++) {
         d[i] = run_walk((U16)fps_dt[i], 0);
+        if (d[i] < lo)
+            lo = d[i];
+        if (d[i] > hi)
+            hi = d[i];
         printf("    ~%4d fps (dt=%2d): %.0f  (%.0f%% of ideal)\n",
                1000 / fps_dt[i], fps_dt[i], d[i], 100.0 * d[i] / WALK_IDEAL);
     }
-    /* High frame rate (dt=1) vs 60 fps (dt=16) vs low frame rate (dt=64): all
-     * should walk the same distance. They do not today. */
-    double ref = d[4];                               /* dt=16, ~60 fps */
-    ASSERT_TRUE(fabs(d[0] - ref) <= WALK_TOL * ref); /* dt=1  vs dt=16 */
-    ASSERT_TRUE(fabs(d[6] - ref) <= WALK_TOL * ref); /* dt=64 vs dt=16 */
+    /* Characterization: the same game-time walks a materially DIFFERENT distance at
+     * different dt (here ~22%: 100% of ideal at dt=1 down to a 78% plateau from dt=16).
+     * That is the root-cause coupling issue #358 is about. The fix does not change this
+     * function (that would diverge from the ASM oracle); it is the main-loop throttle that
+     * pins the effective sim dt near 16 ms, whose logic is gated by
+     * tests/timer/test_fixed_step.cpp. If this coupling ever disappears here, the throttle's
+     * premise changed -- revisit the fix. */
+    ASSERT_TRUE((hi - lo) > 0.1 * hi);
 }
 
 int main(void) {
-    RUN_TEST(test_framerate_invariance);
+    RUN_TEST(test_framerate_coupling_present);
     TEST_SUMMARY();
     return test_failures != 0;
 }

--- a/tests/timer/CMakeLists.txt
+++ b/tests/timer/CMakeLists.txt
@@ -12,3 +12,19 @@ set_target_properties(test_timer_lock_window PROPERTIES CXX_STANDARD 11)
 add_test(NAME test_timer_lock_window COMMAND test_timer_lock_window)
 
 register_host_test(test_timer_lock_window)
+
+# Fixed simulation-timestep scheduler (issue #358).
+add_executable(test_fixed_step test_fixed_step.cpp
+    ${CMAKE_SOURCE_DIR}/LIB386/SYSTEM/TIMER.CPP)
+
+target_include_directories(test_fixed_step PRIVATE
+    ${CMAKE_SOURCE_DIR}/LIB386/H
+)
+
+target_link_libraries(test_fixed_step PRIVATE SDL3::SDL3)
+
+set_target_properties(test_fixed_step PROPERTIES CXX_STANDARD 11)
+
+add_test(NAME test_fixed_step COMMAND test_fixed_step)
+
+register_host_test(test_fixed_step)

--- a/tests/timer/test_fixed_step.cpp
+++ b/tests/timer/test_fixed_step.cpp
@@ -1,0 +1,113 @@
+/* Fixed simulation-timestep scheduler (issue #358).
+ *
+ * Timer_FixedStepCount is the pure core of the fixed-timestep fix: fold the real
+ * wall-clock elapsed since the last rendered frame into a carry, and return how many
+ * fixed dt-sized simulation steps are due. The property that makes movement frame-rate
+ * independent is that over any span of wall-time the TOTAL number of steps is span/dt,
+ * no matter how the elapsed time was chunked across frames. These tests assert exactly
+ * that, plus the spiral-of-death clamp and the sub-dt remainder carry.
+ *
+ * CPP-only host test; compiles the real TIMER.CPP. See docs/MOVEMENT_FRAMERATE.md.
+ */
+#include "../test_harness.h"
+#include <SYSTEM/TIMER.H>
+
+/* Stub for WINDOW.H AppActive (referenced by TIMER.CPP::HandleEventsTimer, which the
+ * whole-file compile pulls in even though this test only exercises the scheduler). */
+bool AppActive = true;
+
+/* Feed a per-frame elapsed pattern through the scheduler and return the total steps. */
+static long total_steps(const U32 *elapsed, int nFrames, U32 dt, S32 maxSteps) {
+    U32 acc = 0;
+    long steps = 0;
+    for (int i = 0; i < nFrames; i++) {
+        S32 n = Timer_FixedStepCount(&acc, elapsed[i], dt, maxSteps);
+        steps += n;
+        /* Post-condition: the carry never holds a whole step. */
+        ASSERT_TRUE(acc < dt);
+    }
+    return steps;
+}
+
+/* Same total wall-time, different frame pacing, must yield the same number of 16 ms
+ * simulation steps. 16000 ms is a whole number of 16 ms steps, so with no clamp the
+ * count is exactly 1000 regardless of pacing. */
+static void test_step_count_is_pacing_invariant(void) {
+    const U32 DT = 16;
+    const S32 NOCLAMP = -1;
+    const long IDEAL = 16000 / 16; /* 1000 */
+
+    U32 steady[1000];
+    for (int i = 0; i < 1000; i++)
+        steady[i] = 16; /* ~60 fps */
+
+    static U32 fine[16000];
+    for (int i = 0; i < 16000; i++)
+        fine[i] = 1; /* ~1000 fps */
+
+    U32 coarse[320];
+    for (int i = 0; i < 320; i++)
+        coarse[i] = 50; /* ~20 fps */
+
+    /* Irregular but summing to 16000: alternate 8 and 24 ms frames. */
+    U32 jittery[1000];
+    for (int i = 0; i < 1000; i++)
+        jittery[i] = (i & 1) ? 24 : 8;
+
+    long s_steady = total_steps(steady, 1000, DT, NOCLAMP);
+    long s_fine = total_steps(fine, 16000, DT, NOCLAMP);
+    long s_coarse = total_steps(coarse, 320, DT, NOCLAMP);
+    long s_jittery = total_steps(jittery, 1000, DT, NOCLAMP);
+
+    printf("  steps over 16000 ms: steady=%ld fine=%ld coarse=%ld jittery=%ld (ideal %ld)\n",
+           s_steady, s_fine, s_coarse, s_jittery, IDEAL);
+
+    ASSERT_EQ_INT(IDEAL, s_steady);
+    ASSERT_EQ_INT(IDEAL, s_fine);
+    ASSERT_EQ_INT(IDEAL, s_coarse);
+    ASSERT_EQ_INT(IDEAL, s_jittery);
+}
+
+/* High frame rate (elapsed < dt) runs the sim only every few frames; low frame rate
+ * runs it several times per frame. */
+static void test_high_and_low_frame_rate(void) {
+    U32 acc = 0;
+    /* ~250 fps: 4 ms frames, 16 ms step -> a step every 4th frame. */
+    int nonzero = 0;
+    for (int i = 0; i < 40; i++)
+        if (Timer_FixedStepCount(&acc, 4, 16, -1) > 0)
+            nonzero++;
+    ASSERT_EQ_INT(10, nonzero); /* 40 frames * 4 ms / 16 ms */
+
+    /* ~15 fps: one 66 ms frame owes 4 steps (66/16), carrying 2 ms. */
+    acc = 0;
+    ASSERT_EQ_INT(4, Timer_FixedStepCount(&acc, 66, 16, -1));
+    ASSERT_EQ_UINT(2, acc);
+}
+
+/* A long stall (or a modal that banked real time while the game clock was frozen) is
+ * clamped so the sim does not spiral trying to catch up; the backlog is dropped and only
+ * the sub-dt remainder is kept. */
+static void test_clamp_drops_backlog(void) {
+    U32 acc = 0;
+    /* 100003 ms of backlog, 16 ms step, at most 5 steps per frame. */
+    S32 n = Timer_FixedStepCount(&acc, 100003, 16, 5);
+    ASSERT_EQ_INT(5, n);
+    ASSERT_EQ_UINT(100003 % 16, acc); /* remainder kept, backlog dropped */
+}
+
+/* A zero step size is a no-op guard, not a divide-by-zero, and does not consume time. */
+static void test_zero_dt_guard(void) {
+    U32 acc = 123;
+    ASSERT_EQ_INT(0, Timer_FixedStepCount(&acc, 50, 0, 5));
+    ASSERT_EQ_UINT(123, acc);
+}
+
+int main(void) {
+    RUN_TEST(test_step_count_is_pacing_invariant);
+    RUN_TEST(test_high_and_low_frame_rate);
+    RUN_TEST(test_clamp_drops_backlog);
+    RUN_TEST(test_zero_dt_guard);
+    TEST_SUMMARY();
+    return test_failures != 0;
+}


### PR DESCRIPTION
## Problem

Movement speed (hero walk/sneak/jump and NPC patrols) is reduced and inconsistent above ~60 fps: worse with vsync off, on high-refresh displays, and on fast machines even at Classic 640x480. Confirmed on both keyboard and gamepad, and on NPCs (which read no input), so it is not the gamepad.

## Root cause

Hero/NPC locomotion is not `velocity * dt`; it is baked into animation keyframe translations delivered by `ObjectSetInterDep` once per rendered frame (no catch-up loop). So the distance walked over a fixed span of *game-time* depends on the frame rate, and it is only correct in a narrow band around 60 fps. Measured deterministically with `--fixed-dt`: a scripted mover walks 100% of the ideal at ~1000 fps down to a plateau ~78% from 60 fps down, and slow movers can freeze entirely at very high fps. It reproduces on x86_64 via `--fixed-dt` alone, so it is timing, not ARM `long double` arithmetic. Full write-up and evidence in [`docs/MOVEMENT_FRAMERATE.md`](docs/MOVEMENT_FRAMERATE.md).

## Fix (phase 1: throttle)

Gate the main-loop simulation so it advances at most once per `FixedTimestep` ms of game-time: on a frame where less than a step has elapsed since the last simulated frame, skip the sim (still render). The animation clock then never advances in sub-step slivers. The sim runs 0-or-1 times per frame, so there is no input re-entrancy (`DoLife` stays once-per-frame; running the object loop N times would re-fire held actions like jump) and no object-loop restructure.

- Default on (16 ms, ~60 Hz sim), persisted to `lba2.cfg` (`FixedTimestep` key), toggleable live: `fixedtimestep on|off|toggle|<ms>`.
- Low frame rates (a >= 16 ms frame runs every frame) are unchanged, neither fixed nor regressed. The arm64 low-fps overshoot half is phase 2 (needs a `DoLife`-once-per-frame split to allow safe sub-stepping).

## Verification

- Byte-for-byte identical to the historical per-frame path under `--fixed-dt 16` (16 >= 16 never skips), verified against the pre-throttle baseline, so the projection golden and ASM-equivalence tests are unchanged.
- At `--fixed-dt 8` (~125 fps) the throttle reproduces the true dt=16 displacement (821 lossy -> 845, matching the dt=16 reference of 845).
- New CI test `tests/timer/test_fixed_step.cpp` proves the scheduler core delivers a frame-rate-invariant step count; `tests/movement/test_move_framerate.cpp` characterizes the coupling. All 40 host_quick tests pass.

## Related: #255

Pinning the sim cadence makes it host-independent, which addresses the variable-dt cadence hypothesis behind #255's Desert Island bat-scene (cube 201) demo-reel derail and stops the timing-related stuck hero. It does not touch collision: the bat can still collide with Twinsen, so #255 is not closed by this and its #251 watchdog stays as the safety net.

## Caveat

The skip threshold is one 16 ms step, so a display running just above 60 Hz (roughly 63-75 fps) runs the sim every other frame at ~30 ms (a few % slow). Uncommon (most panels are 60 / 120 / 144 / 240 Hz); a lower `fixedtimestep` value avoids it, and phase 2's decoupled accumulator removes it.

## Try it

F12 console, `vsync off`, then toggle `fixedtimestep off` / `on` while moving to feel the difference at high fps.
