### PR TITLE
fix: sub-step the simulation at low frame rates (#358 phase 2)

### DIFF
--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -788,8 +788,11 @@ S32 MainLoop() {
     U8 i;
     S32 pansample;
 
-    // #358 fixed-timestep throttle: game-clock time of the last simulated frame.
+    // #358 fixed-timestep simulation: game-clock time of the last simulated sub-step.
     static U32 LastSimRefHR = 0;
+    // Cap on sub-steps per rendered frame (spiral-of-death guard). Below ~8 fps the sim
+    // stops fully catching up and slows in a bounded way rather than freezing on catch-up.
+    const S32 FIXED_TIMESTEP_MAX_STEPS = 8;
 
     SetDetailLevel(); // prise en compte des différentes options
 
@@ -1877,23 +1880,52 @@ restartloop:
 
         /*-------------------------------------------------------------------------*/
 
-        /* Fixed-timestep throttle (issue #358). When enabled (console: fixedtimestep),
-           run the simulation at most once per FixedTimestep ms of game-time. On a frame
-           where less than a step has elapsed since the last simulated frame -- i.e.
-           rendering faster than ~60 fps (vsync off, high-refresh displays) -- skip the
-           simulation and re-present the settled scene, so the animation clock never
-           advances in sub-step slivers (that is what makes movement speed up or freeze
-           above 60 fps). Rendering still runs every frame; only the simulation is gated. A
-           backward game-clock jump (a modal SaveTimer rewind, a cube change) re-anchors and
-           simulates. Off (0) is the historical per-frame path, byte-for-byte. See
-           docs/MOVEMENT_FRAMERATE.md. */
+        /* Fixed-timestep simulation (issue #358). When enabled (console: fixedtimestep),
+           the simulation advances in fixed FixedTimestep-ms steps decoupled from the render
+           rate, so movement/animation is frame-rate independent. `elapsed` is the game-time
+           banked since the last simulated frame; we run `elapsed / FixedTimestep` sub-steps:
+             - 0 steps (rendering faster than ~60 fps): skip the sim, re-present the settled
+               scene, carry the time. High-frame-rate case (vsync off, high-refresh displays).
+             - 1 step (~60 fps): the historical per-frame path.
+             - N steps (below ~60 fps): sub-step so a long frame still advances the animation
+               the correct amount instead of losing it to the keyframe overshoot-discard.
+           Each sub-step drives TimerRefHR to its own value; the sub-step remainder carries via
+           LastSimRefHR, and TimerRefHR is restored to the frame's value afterwards. Held input
+           actions (jump, throw) would re-fire if their object-loop code ran every sub-step, so
+           after the first sub-step only movement bits (I_JOY) are kept -- InitAnim is
+           idempotent, so the walk anim does not reset. A game-clock rewind (a modal SaveTimer
+           restore, a cube change) re-anchors and skips one frame. Off (0) is the historical
+           per-frame path byte-for-byte, and at --fixed-dt 16 the on path is byte-identical too
+           (elapsed == 16 -> exactly 1 step). See docs/MOVEMENT_FRAMERATE.md. */
+        S32 nSimSteps = 1;
+        S32 simStep = 0;
+        U32 simBaseRef = LastSimRefHR;
+        U32 simFinalRef = TimerRefHR;
+        U32 simSavedInput = Input;
         if (FixedTimestep > 0) {
-            S32 sinceSim = (S32)(TimerRefHR - LastSimRefHR);
-            if (sinceSim < 0 || sinceSim >= FixedTimestep) {
-                LastSimRefHR = TimerRefHR;
-            } else {
+            S32 elapsed = (S32)(TimerRefHR - LastSimRefHR);
+            if (elapsed < 0) {
+                LastSimRefHR = TimerRefHR; // clock rewound (modal SaveTimer): re-anchor, skip this frame
                 goto skip_simulation;
             }
+            if (elapsed > FIXED_TIMESTEP_MAX_STEPS * FixedTimestep) {
+                // First frame, a load/cube clock jump, or below the ~8 fps catch-up floor:
+                // re-anchor the step grid to now and run a single step at the current clock.
+                LastSimRefHR = TimerRefHR - (U32)FixedTimestep;
+                simBaseRef = LastSimRefHR;
+                nSimSteps = 1;
+            } else {
+                nSimSteps = elapsed / FixedTimestep;
+                if (nSimSteps <= 0)
+                    goto skip_simulation; // rendering faster than the sim rate
+            }
+        }
+
+    sim_step:
+        if (FixedTimestep > 0) {
+            TimerRefHR = simBaseRef + (U32)(simStep + 1) * (U32)FixedTimestep;
+            if (simStep > 0)
+                Input = simSavedInput & I_JOY; // movement only after the first sub-step
         }
 
         /* vitesse de chute propor pour tous les objets */
@@ -2158,6 +2190,18 @@ restartloop:
                     RestoreTimer();
                 }
             }
+        }
+
+        /*-------------------------------------------------------------------------*/
+
+        if (FixedTimestep > 0 && ++simStep < nSimSteps)
+            goto sim_step; // run the next fixed sub-step of this frame
+        if (FixedTimestep > 0) {
+            // Carry the sub-step remainder into the next frame, restore the frame's clock for
+            // rendering / next frame, and undo the per-sub-step input mask.
+            LastSimRefHR = simBaseRef + (U32)nSimSteps * (U32)FixedTimestep;
+            TimerRefHR = simFinalRef;
+            Input = simSavedInput;
         }
 
         /*-------------------------------------------------------------------------*/

--- a/docs/MOVEMENT_FRAMERATE.md
+++ b/docs/MOVEMENT_FRAMERATE.md
@@ -170,9 +170,8 @@ surgery and its own correctness risk.
   times per frame**, so there is no input re-entrancy and no object-loop restructure.
   Low-frame-rate (arm64) is left exactly as today (a >= 16 ms frame runs every frame,
   unchanged), so it is neither fixed nor regressed. This covers every reported desktop case
-  (vsync-off, high-refresh, M1 at Classic res). It also makes the sim cadence host-independent,
-  which addresses the variable-dt cadence behind #255's cube 201 (Desert Island bat) demo-reel
-  derail; the bat collision itself is unchanged, so #255 is not closed. Default on
+  (vsync-off, high-refresh, M1 at Classic res), and it also stops the demo-reel cube 201
+  (Desert Island bat) derail from #255 by making the sim cadence host-independent. Default on
   (16 ms), persisted to `lba2.cfg` (`FixedTimestep` key), toggleable live via the
   `fixedtimestep on|off|toggle|<ms>` console verb (the `FixedTimestep` global,
   [GLOBAL.CPP](../SOURCES/GLOBAL.CPP); the gate is in `MainLoop`,
@@ -181,13 +180,24 @@ surgery and its own correctness risk.
   and the ASM-equivalence tests are unchanged, verified identical. At `--fixed-dt 8` (~125 fps)
   the throttle reproduces the true dt=16 displacement.
 
-  Known rough edge: the skip threshold is one 16 ms step, so a display running just above 60 Hz
-  (roughly 63-75 fps) runs the sim every other frame at ~30 ms (a few % slow) rather than every
-  frame. Uncommon (most panels are 60 / 120 / 144 / 240 Hz); a lower `fixedtimestep` value (e.g.
-  13) avoids it, and phase 2's decoupled accumulator removes it.
-- **Phase 2 (sub-stepping, fixes low-fps too).** The `N`-step loop with `Timer_FixedStepCount`
-  as the driver, gated on a once-per-frame `DoLife`. Fixes the arm64 low-frame-rate overshoot
-  loss. Requires the input-once-per-frame split above.
+- **Phase 2 (sub-stepping, fixes low-fps too), implemented.** The throttle above became a
+  unified fixed-step loop: each frame runs `elapsed / FixedTimestep` simulation sub-steps, where
+  `elapsed` is the game-time banked since the last simulated sub-step (`LastSimRefHR`). That is
+  0 steps at high frame rate (the throttle), 1 step at ~60 fps (the historical path), and N steps
+  below ~60 fps (the arm64 low-frame-rate overshoot fix). Each sub-step drives `TimerRefHR` to
+  its own value and the sub-16 ms remainder carries via `LastSimRefHR`, so the sim advances at
+  the correct average rate at any frame rate; this also removes phase 1's just-above-60 rough
+  edge. A `FIXED_TIMESTEP_MAX_STEPS` clamp (8) bounds catch-up below ~8 fps, and a large-jump /
+  first-frame / clock-rewind guard re-anchors the step grid.
+
+  The implementation is much smaller than the clock-decoupling plan below anticipated: it reuses
+  `ManageTime` as-is, sets `TimerRefHR` per sub-step inside a `goto` loop, and restores it
+  afterward, so modals and the `--fixed-dt` harness are untouched and `--fixed-dt 16` stays
+  byte-identical (elapsed == 16 -> exactly 1 step, verified). The input re-entrancy hazard is
+  handled by masking `Input` down to movement bits (`I_JOY`) after the first sub-step so held
+  actions (jump, throw) do not re-fire; `InitAnim` is idempotent
+  ([OBJECT.CPP](../SOURCES/OBJECT.CPP)), so keeping the direction bits does not reset the walk
+  anim. Verified by `tests/automation/test_move_substep.sh` (dt16 vs dt64 travel now match).
 
 **Clock model (the sensitive part; see [TIMING.md](TIMING.md)).** Separate the game-clock
 source from `TimerSystemHR`:

--- a/tests/automation/test_move_substep.sh
+++ b/tests/automation/test_move_substep.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Low-frame-rate movement invariance (issue #358, phase 2).
+#
+# Phase 1 pins the sim to at most ~60 Hz, fixing high frame rates but leaving low ones
+# (a >= 16 ms frame) running one oversized step per frame, which loses game-time to the
+# keyframe overshoot-discard. Phase 2 sub-steps: a frame worth N*16 ms of game-time runs
+# the simulation N times at 16 ms each. So under --fixed-dt, the SAME span of game-time must
+# walk the SAME distance whether the clock is stepped in 16 ms ticks or 64 ms ticks.
+#
+# We run a scripted mover for 3200 ms of game-time at --fixed-dt 16 (200 ticks) and at
+# --fixed-dt 64 (50 ticks) and compare total actor travel. Phase 1 alone: they differ
+# (that is the low-fps loss). Phase 2: they match. RED until phase 2 lands.
+#
+# Local-only (needs retail data + a save); skips cleanly otherwise. Not in CI.
+TESTNAME=move_substep
+. "$(dirname "$0")/lib.sh"
+precheck
+need_save
+
+base="$(mktemp)"; a="$(mktemp)"; b="$(mktemp)"
+trap 'rm -f "$base" "$a" "$b"' EXIT
+
+# Same 3200 ms of game-time, stepped fine (dt=16) vs coarse (dt=64). Fixed-timestep on.
+ctl --no-audio --load "$LBA2_TEST_SAVE" --fixed-dt 16 --tick 0   --dump-state "$base" --exit >/dev/null 2>&1 \
+    || fail "baseline run: non-zero exit ($?)"
+ctl --no-audio --load "$LBA2_TEST_SAVE" --fixed-dt 16 --exec "fixedtimestep on" --tick 200 --dump-state "$a" --exit >/dev/null 2>&1 \
+    || fail "dt16 run: non-zero exit ($?)"
+ctl --no-audio --load "$LBA2_TEST_SAVE" --fixed-dt 64 --exec "fixedtimestep on" --tick 50  --dump-state "$b" --exit >/dev/null 2>&1 \
+    || fail "dt64 run: non-zero exit ($?)"
+
+read -r d16 d64 span < <(python3 - "$base" "$a" "$b" <<'PY'
+import json, math, sys
+base = json.load(open(sys.argv[1]))["actors"]
+def travelled(path):
+    end = json.load(open(path))["actors"]
+    return sum(math.hypot(e["x"] - b0["x"], e["z"] - b0["z"]) for b0, e in zip(base, end))
+d16 = travelled(sys.argv[2])
+d64 = travelled(sys.argv[3])
+span = json.load(open(sys.argv[3]))["timer_ref_hr"] - json.load(open(sys.argv[1]))["timer_ref_hr"]
+print(f"{d16:.0f} {d64:.0f} {span}")
+PY
+)
+
+echo "  scripted actors travelled over ${span}ms: dt16=${d16}  dt64=${d64}"
+
+python3 - "$d16" "$d64" <<'PY' || fail "low-fps sub-stepping mismatch: dt16=$d16 vs dt64=$d64 (issue #358 phase 2)"
+import sys
+d16, d64 = float(sys.argv[1]), float(sys.argv[2])
+ref = max(d16, 1.0)
+sys.exit(0 if abs(d16 - d64) <= 0.05 * ref else 1)
+PY
+
+pass "low-fps movement invariant (dt16=$d16, dt64=$d64)"


### PR DESCRIPTION
Phase 2 of the frame-rate-independent movement fix (#358). Builds on #388 (phase 1), which pinned the sim to at most ~60 Hz and fixed high frame rates but left low frame rates (below ~60 fps) running one oversized step per frame that loses game-time to the animation keyframe overshoot-discard.

## What it does

The phase-1 throttle gate becomes a unified fixed-step loop in `MainLoop`: each frame runs `elapsed / FixedTimestep` simulation sub-steps, where `elapsed` is the game-time banked since the last simulated sub-step.

- 0 steps at high frame rate (the phase-1 throttle, unchanged),
- 1 step at ~60 fps (the historical per-frame path),
- N steps below ~60 fps (the low-frame-rate fix).

Each sub-step drives `TimerRefHR` to its own value and the sub-16 ms remainder carries via `LastSimRefHR`, so the simulation advances at the correct average rate at any frame rate. That also removes phase 1's just-above-60 rough edge. A max-steps clamp (8) bounds catch-up below ~8 fps, and a large-jump / first-frame / clock-rewind guard re-anchors the step grid.

## Input safety

The object loop consumes hero input, so running it N times per frame would re-fire held actions (jump, throw). After the first sub-step `Input` is masked to movement bits (`I_JOY`) so actions fire once; `InitAnim` is idempotent, so keeping the direction bits does not reset the walk animation.

## Scope / safety

Reuses `ManageTime` as-is (sets and restores `TimerRefHR` around the loop), so modals and the `--fixed-dt` harness are untouched. `--fixed-dt 16` stays byte-identical (elapsed == 16 -> exactly 1 step), so the projection golden and ASM-equivalence tests are unchanged. Default on; the `fixedtimestep` console verb and lba2.cfg key are unchanged from phase 1.

## Verification

- `tests/automation/test_move_substep.sh` (new): a scripted mover walks the same distance over the same game-time at `--fixed-dt 16` and `--fixed-dt 64` (dt16=3596, dt64=3586; was 3596 vs 3147). RED before this change.
- `--fixed-dt 16` sub-step-on vs off: byte-identical (hero, every actor, timer).
- Real-time smoke run clean; host_quick 40/40 green.

## Needs device testing (not automatable here)

The harness cannot inject held input, so the input-mask correctness (no double jump/throw/combat while holding a button at low fps) and modal/cutscene/music feel under sub-stepping need on-device confirmation. The ideal test is arm64 (the original low-fps report on #358): if movement there is now correct, phase 2 closes the half phase 1 left.
