### PR TITLE
fix(holomap): time-scale the manual globe rotation (#358)

### DIFF
--- a/SOURCES/HOLOGLOB.CPP
+++ b/SOURCES/HOLOGLOB.CPP
@@ -980,6 +980,9 @@ void Holo_RequestCapture(const char *path) {
 void HoloGlobe(S32 planet) {
     S32 testnofire = TRUE;
     U32 memotime;
+    /* #358: game-clock time of the previous loop iteration, used to time-scale the manual
+       globe rotation so it spins at the same rate regardless of the frame rate. */
+    U32 holoRotTime;
 
     InitHoloGlobe(planet);
 
@@ -997,6 +1000,7 @@ void HoloGlobe(S32 planet) {
     HoloBeta = DestBeta;
 
     memotime = TimerRefHR;
+    holoRotTime = TimerRefHR;
 
     ZBufYMin = 0;
     ZBufYMax = (S32)ModeDesiredY - 1;
@@ -1004,6 +1008,18 @@ void HoloGlobe(S32 planet) {
     while (!FlagHoloEnd) {
         ManageTime();
         MyGetInput();
+
+        /* #358: game-time elapsed since the previous frame, normalised to the 16 ms
+           (~60 fps) reference, so the manual globe rotation below spins at a constant rate
+           instead of a fixed step per frame (which spun fast at high frame rates). Clamp a
+           stutter so a dropped frame does not jump the globe. */
+        S32 holoDt = (S32)(TimerRefHR - holoRotTime);
+        holoRotTime = TimerRefHR;
+        if (holoDt < 0)
+            holoDt = 0;
+        else if (holoDt > 100)
+            holoDt = 100;
+        S32 holoRotStep = 32 * holoDt / 16;
 
         // Clear une bande du ZBuffer. The Z-buffer is sized RESOLUTION_X *
         // RESOLUTION_Y per PR #205 and addressed Y*ModeDesiredX+X, so the
@@ -1029,13 +1045,13 @@ void HoloGlobe(S32 planet) {
         } else {
             if (FlagMap != 1) {
                 if (Input & I_LEFT)
-                    HoloBeta = (HoloBeta + 32) & 4095;
+                    HoloBeta = (HoloBeta + holoRotStep) & 4095;
                 if (Input & I_RIGHT)
-                    HoloBeta = (HoloBeta - 32) & 4095;
+                    HoloBeta = (HoloBeta - holoRotStep) & 4095;
                 if (Input & I_UP)
-                    HoloAlpha = (HoloAlpha - 32) & 4095;
+                    HoloAlpha = (HoloAlpha - holoRotStep) & 4095;
                 if (Input & I_DOWN)
-                    HoloAlpha = (HoloAlpha + 32) & 4095;
+                    HoloAlpha = (HoloAlpha + holoRotStep) & 4095;
 
                 if (((Input == I_ACTION_M) OR(Input == I_RETURN)) // espace
                     AND(!FlagMap)) {


### PR DESCRIPTION
A small follow-up to the #358 frame-rate work. The main-loop fix (fixed-timestep) covers the simulation block, but modal loops run their own loop and are not covered. An audit of the modals found they are almost all already time-based (`TimerRefHR`), with one straggler: the **holomap globe's manual rotation**.

## The bug

While a direction is held, the holomap modal adds a fixed `+/-32` to `HoloBeta`/`HoloAlpha` **per rendered frame** ([HOLOGLOB.CPP](SOURCES/HOLOGLOB.CPP)), so the globe spins proportional to the frame rate: fast on high-refresh / vsync-off displays. The automatic animations right next to it (arrow goto/bob, palette rotation) already scale by `TimerRefHR`, so this brings the manual rotation in line with them.

## The fix

Scale the step by the game-time elapsed since the previous frame, normalised to the 16 ms (~60 fps) reference:

```c
S32 holoDt = TimerRefHR - holoRotTime;  holoRotTime = TimerRefHR;  // clamped for stutters
S32 holoRotStep = 32 * holoDt / 16;     // 32 units per 16 ms
```

At the reference rate (`dt == 16`) the step is exactly 32, so the feel is unchanged at 60 fps and now constant at any frame rate. `32 * dt / 16` is exact (`= 2 * dt`), so there's no per-frame rounding loss. A stutter is clamped so a dropped frame doesn't jump the globe.

## Verified

The holomap still opens, renders, and exits cleanly (`ui holomap` capture produces a valid frame). The held-input rotation rate itself can't be exercised headlessly (the harness can't inject held input), so the rate change is confirmed by the arithmetic and needs a quick on-device eyeball.

## Scope

Same class as the #358 movement coupling (per-frame step vs game-time), isolated to this one modal. The rest of the modal surface (inventory rotation/zoom, credits scroll, menu timeouts) was audited and is already time-based.
