### PR TITLE
refactor(perso): route the fixed-timestep loop through a tested core, with planner + modal-stepper tests (#358)

### DIFF
--- a/LIB386/H/SYSTEM/TIMER.H
+++ b/LIB386/H/SYSTEM/TIMER.H
@@ -64,6 +64,25 @@ void Timer_FixedDtPump();
 // keeping only the sub-dt remainder. Post-condition: `*accMs < dt`. Unit-tested directly.
 S32 Timer_FixedStepCount(U32 *accMs, U32 elapsedMs, U32 dt, S32 maxSteps);
 
+// Plan one rendered frame of the production sub-step loop (SOURCES/PERSO.CPP MainLoop). Pure:
+// no clock read, no globals. Given the frame's game clock `now` (TimerRefHR) and the game-time
+// `lastSim` of the last simulated sub-step, return how many fixed `dt`-ms sub-steps to run this
+// frame and, via the out-params, the anchor and the next `lastSim`:
+//   *baseRefOut  -- sub-step k (0-based) runs at clock *baseRefOut + (k+1)*dt.
+//   *lastSimOut  -- the caller writes this back to LastSimRefHR (carries the sub-dt remainder).
+// Cases (the whole point of the fixed-timestep fix, issue #358):
+//   0 steps, lastSim unchanged  -- rendering faster than the sim rate (elapsed < dt): skip and
+//                                  re-present, the remainder carries in the lastSim gap.
+//   0 steps, lastSim = now      -- the game clock rewound (a modal SaveTimer restore): re-anchor.
+//   1 step,  grid re-anchored   -- elapsed > maxSteps*dt (first frame / load / cube jump / below
+//                                  the catch-up floor): drop the backlog, step once at `now`.
+//   N steps                     -- elapsed = N*dt (+remainder): sub-step so a long frame advances
+//                                  the animation the correct amount instead of losing it.
+// The normal-path count+carry delegates to Timer_FixedStepCount, so that tested core is the
+// engine here. At dt == 16 and elapsed == 16 this returns exactly 1 step (the historical
+// per-frame path, byte-for-byte). dt <= 0 (throttle off) returns 1 and leaves lastSim alone.
+S32 Timer_PlanSimSteps(U32 now, U32 lastSim, S32 dt, S32 maxSteps, U32 *baseRefOut, U32 *lastSimOut);
+
 void ManageTime();
 void HandleEventsTimer(const void *event);
 

--- a/LIB386/SYSTEM/TIMER.CPP
+++ b/LIB386/SYSTEM/TIMER.CPP
@@ -168,6 +168,42 @@ S32 Timer_FixedStepCount(U32 *accMs, U32 elapsedMs, U32 dt, S32 maxSteps) {
     return steps;
 }
 
+S32 Timer_PlanSimSteps(U32 now, U32 lastSim, S32 dt, S32 maxSteps, U32 *baseRefOut, U32 *lastSimOut) {
+    // Default: a single step anchored at the frame start (the throttle-off / per-frame path).
+    *baseRefOut = lastSim;
+    *lastSimOut = lastSim;
+    if (dt <= 0) {
+        return 1;
+    }
+
+    // Signed so a backward game-clock jump (a modal SaveTimer restore, a cube change) reads
+    // negative rather than wrapping to a huge positive gap.
+    S32 elapsed = (S32)(now - lastSim);
+    if (elapsed < 0) {
+        *lastSimOut = now; // rewind: re-anchor the step grid, run no sub-step this frame
+        return 0;
+    }
+    if (elapsed > maxSteps * dt) {
+        // First frame, a load/cube clock jump, or below the catch-up floor: drop the backlog
+        // and run a single step at the current clock (grid re-anchored to now - dt).
+        *baseRefOut = now - (U32)dt;
+        *lastSimOut = now;
+        return 1;
+    }
+
+    // Normal path. Fold the whole elapsed span through the tested accumulator: with acc seeded
+    // to 0 it returns elapsed/dt and leaves the sub-dt remainder in acc (elapsed <= maxSteps*dt
+    // here, so the clamp never fires -- the large-jump guard above owns that). lastSim advances
+    // by nSteps*dt == now - remainder, which carries the remainder into the next frame.
+    U32 acc = 0;
+    S32 nSteps = Timer_FixedStepCount(&acc, (U32)elapsed, (U32)dt, -1);
+    if (nSteps <= 0) {
+        return 0; // rendering faster than the sim rate: skip, remainder carries in the gap
+    }
+    *lastSimOut = now - acc;
+    return nSteps;
+}
+
 void ManageTime() {
     TimerSystemHR = FixedDtActive ? FixedDtNow : SDL_GetTicks();
 

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -1903,22 +1903,17 @@ restartloop:
         U32 simFinalRef = TimerRefHR;
         U32 simSavedInput = Input;
         if (FixedTimestep > 0) {
-            S32 elapsed = (S32)(TimerRefHR - LastSimRefHR);
-            if (elapsed < 0) {
-                LastSimRefHR = TimerRefHR; // clock rewound (modal SaveTimer): re-anchor, skip this frame
-                goto skip_simulation;
-            }
-            if (elapsed > FIXED_TIMESTEP_MAX_STEPS * FixedTimestep) {
-                // First frame, a load/cube clock jump, or below the ~8 fps catch-up floor:
-                // re-anchor the step grid to now and run a single step at the current clock.
-                LastSimRefHR = TimerRefHR - (U32)FixedTimestep;
-                simBaseRef = LastSimRefHR;
-                nSimSteps = 1;
-            } else {
-                nSimSteps = elapsed / FixedTimestep;
-                if (nSimSteps <= 0)
-                    goto skip_simulation; // rendering faster than the sim rate
-            }
+            // Plan this frame's sub-steps (count + sub-step clock anchor + the next-frame carry).
+            // Timer_PlanSimSteps is the pure, unit-tested core (LIB386/SYSTEM/TIMER.CPP): it
+            // delegates the normal-path count/carry to Timer_FixedStepCount and owns the rewind
+            // and large-jump re-anchors. LastSimRefHR is advanced here (the carry), so the tail
+            // below no longer touches it.
+            U32 nextLastSim;
+            nSimSteps = Timer_PlanSimSteps(TimerRefHR, LastSimRefHR, FixedTimestep,
+                                           FIXED_TIMESTEP_MAX_STEPS, &simBaseRef, &nextLastSim);
+            LastSimRefHR = nextLastSim;
+            if (nSimSteps <= 0)
+                goto skip_simulation; // high-fps skip (remainder carries) or clock rewind (re-anchored)
         }
 
     sim_step:
@@ -2197,9 +2192,8 @@ restartloop:
         if (FixedTimestep > 0 && ++simStep < nSimSteps)
             goto sim_step; // run the next fixed sub-step of this frame
         if (FixedTimestep > 0) {
-            // Carry the sub-step remainder into the next frame, restore the frame's clock for
-            // rendering / next frame, and undo the per-sub-step input mask.
-            LastSimRefHR = simBaseRef + (U32)nSimSteps * (U32)FixedTimestep;
+            // Restore the frame's clock for rendering / the next frame and undo the per-sub-step
+            // input mask. LastSimRefHR was already advanced by Timer_PlanSimSteps (the carry).
             TimerRefHR = simFinalRef;
             Input = simSavedInput;
         }

--- a/tests/automation/test_move_framerate.sh
+++ b/tests/automation/test_move_framerate.sh
@@ -1,62 +1,72 @@
 #!/usr/bin/env bash
-# Movement is frame-rate dependent (issue #358): end-to-end repro.
+# High-frame-rate movement invariance (issue #358).
 #
-# Character/NPC locomotion is baked into animation keyframe translations delivered
-# once per rendered frame (ObjectSetInterDep), so the distance a scripted actor walks
-# over a fixed span of *game-time* must not depend on the frame rate. --fixed-dt N
-# pins the per-tick game-clock step to N ms, i.e. emulates ~1000/N fps deterministically.
-# We run the SAME save for the SAME game-time (3200 ms) at dt=16 (~60 fps) and dt=64
-# (~16 fps) and compare how far the scene's scripted movers travel.
+# Locomotion is baked into animation keyframe translations delivered once per SIMULATED frame
+# (ObjectSetInterDep). Above ~60 fps the animation clock would otherwise advance in sub-step
+# slivers and movement speeds up or freezes. The fixed-timestep simulation (SOURCES/PERSO.CPP
+# -> Timer_PlanSimSteps) runs `elapsed / FixedTimestep` sub-steps per frame: at high frame
+# rates that is 0 (skip the sim, re-present, carry the time), so the distance a scripted actor
+# walks over a fixed span of game-time does not depend on how fast we render above the cap.
 #
-# Today the two totals differ well beyond tolerance, which is the bug (RED). See
-# docs/MOVEMENT_FRAMERATE.md for the mechanism and the fixed-timestep fix.
+# --fixed-dt N pins the per-tick game-clock step to N ms (~1000/N fps, deterministic). We walk
+# the SAME 3200 ms of game-time at two rates and compare how far the scene's movers travel:
+#     ~120 fps: --fixed-dt 8  --tick 400   the planner runs 0 sub-steps on every other frame,
+#                                          so this is the ONLY test that exercises the skip/carry
+#                                          branch (Timer_PlanSimSteps returning 0 with a carry)
+#     ~60 fps:  --fixed-dt 16 --tick 200   the planner runs exactly one sub-step per frame
+# Both collapse to a 16 ms effective sim step, so the movers travel the same distance. Disable
+# the throttle and the ~120 fps run reverts to the per-frame path and over-walks -- that
+# regression is what this gates. The low-fps counterpart (dt16 vs dt64) is test_move_substep.sh.
 #
-# NOTE: --fixed-dt drives the *simulation* step directly, so this exercises the
-# unit-level coupling end-to-end. Once the fixed-timestep fix lands, the simulation
-# is pinned to a constant step regardless of render rate; a follow-up will re-point
-# this test at the render-rate knob so it becomes the GREEN gate. For now it is the
-# executable, real-data proof of the coupling.
-#
-# Local-only (needs retail data + a save); skips cleanly otherwise. Not in CI.
+# Assumes the default throttle (FixedTimestep=16); the run does not touch it, so it neither
+# depends on nor rewrites lba2.cfg. Local-only (needs retail data + a save); skips cleanly
+# otherwise. Not in CI.
 TESTNAME=move_framerate
 . "$(dirname "$0")/lib.sh"
 precheck
 need_save
 
-base="$(mktemp)"; a="$(mktemp)"; b="$(mktemp)"
-trap 'rm -f "$base" "$a" "$b"' EXIT
+base="$(mktemp)"; a="$(mktemp)"; c="$(mktemp)"
+trap 'rm -f "$base" "$a" "$c"' EXIT
 
-# Same total game-time (3200 ms) at two frame rates.
+# Same total game-time (3200 ms) at ~60 fps and ~120 fps. Each run reloads the same save.
 ctl --no-audio --load "$LBA2_TEST_SAVE" --fixed-dt 16 --tick 0   --dump-state "$base" --exit >/dev/null 2>&1 \
     || fail "baseline run: non-zero exit ($?)"
 ctl --no-audio --load "$LBA2_TEST_SAVE" --fixed-dt 16 --tick 200 --dump-state "$a"    --exit >/dev/null 2>&1 \
-    || fail "60fps run: non-zero exit ($?)"
-ctl --no-audio --load "$LBA2_TEST_SAVE" --fixed-dt 64 --tick 50  --dump-state "$b"    --exit >/dev/null 2>&1 \
-    || fail "16fps run: non-zero exit ($?)"
+    || fail "~60fps run: non-zero exit ($?)"
+ctl --no-audio --load "$LBA2_TEST_SAVE" --fixed-dt 8  --tick 400 --dump-state "$c"    --exit >/dev/null 2>&1 \
+    || fail "~120fps run: non-zero exit ($?)"
 
-# Total distance all actors travelled from the baseline, at each frame rate.
-read -r d60 d16 span < <(python3 - "$base" "$a" "$b" <<'PY'
+read -r d60 d120 span < <(python3 - "$base" "$a" "$c" <<'PY'
 import json, math, sys
 base = json.load(open(sys.argv[1]))["actors"]
 def travelled(path):
     end = json.load(open(path))["actors"]
     return sum(math.hypot(e["x"] - b0["x"], e["z"] - b0["z"]) for b0, e in zip(base, end))
-d60 = travelled(sys.argv[2])
-d16 = travelled(sys.argv[3])
-# Both runs cover the same game-time; report it so a failure is self-explanatory.
-span = json.load(open(sys.argv[3]))["timer_ref_hr"] - json.load(open(sys.argv[1]))["timer_ref_hr"]
-print(f"{d60:.0f} {d16:.0f} {span}")
+d60  = travelled(sys.argv[2])
+d120 = travelled(sys.argv[3])
+span = json.load(open(sys.argv[2]))["timer_ref_hr"] - json.load(open(sys.argv[1]))["timer_ref_hr"]
+print(f"{d60:.0f} {d120:.0f} {span}")
 PY
 )
 
-echo "  scripted actors travelled over ${span}ms of game-time: ~60fps=${d60}  ~16fps=${d16}"
+echo "  scripted actors travelled over ${span}ms of game-time: ~60fps=${d60}  ~120fps=${d120}"
 
-# Same game-time must walk the same distance. Fails today (that is #358).
-python3 - "$d60" "$d16" <<'PY' || fail "frame-rate dependent movement: 60fps=$d60 vs 16fps=$d16 (issue #358)"
+# Measuring invariance needs actual movement; a static scene walks 0 at every rate and would
+# pass trivially, hiding a regression -- skip instead of green-washing.
+python3 - "$d60" <<'PY' || skip "loaded scene has no scripted movement (d60=$d60); use a save with movers"
 import sys
-d60, d16 = float(sys.argv[1]), float(sys.argv[2])
-ref = max(d60, 1.0)
-sys.exit(0 if abs(d60 - d16) <= 0.05 * ref else 1)
+sys.exit(0 if float(sys.argv[1]) >= 100.0 else 1)
 PY
 
-pass "movement frame-rate invariant (60fps=$d60, 16fps=$d16)"
+# GREEN gate: above the cap the sim step is pinned, so ~120 fps must track ~60 fps. Tolerance
+# 10%: the residual is a few % (per-frame sub-effects the sim throttle does not gate); a
+# throttle regression reverts ~120 fps to the per-frame path (~14% over-walk) and trips this.
+python3 - "$d60" "$d120" <<'PY' || fail "high-fps movement not invariant: ~60fps=$d60 vs ~120fps=$d120 (issue #358)"
+import sys
+d60, d120 = float(sys.argv[1]), float(sys.argv[2])
+ref = max(d60, 1.0)
+sys.exit(0 if abs(d60 - d120) <= 0.10 * ref else 1)
+PY
+
+pass "high-fps movement invariant (~60fps=$d60, ~120fps=$d120)"

--- a/tests/automation/test_move_substep.sh
+++ b/tests/automation/test_move_substep.sh
@@ -9,9 +9,12 @@
 #
 # We run a scripted mover for 3200 ms of game-time at --fixed-dt 16 (200 ticks) and at
 # --fixed-dt 64 (50 ticks) and compare total actor travel. Phase 1 alone: they differ
-# (that is the low-fps loss). Phase 2: they match. RED until phase 2 lands.
+# (that is the low-fps loss). Phase 2: they match. The high-fps counterpart (dt8 vs dt16) is
+# test_move_framerate.sh.
 #
-# Local-only (needs retail data + a save); skips cleanly otherwise. Not in CI.
+# Assumes the default throttle (FixedTimestep=16); the run does not touch it, so it neither
+# depends on nor rewrites lba2.cfg. Local-only (needs retail data + a save); skips cleanly
+# otherwise. Not in CI.
 TESTNAME=move_substep
 . "$(dirname "$0")/lib.sh"
 precheck
@@ -20,12 +23,12 @@ need_save
 base="$(mktemp)"; a="$(mktemp)"; b="$(mktemp)"
 trap 'rm -f "$base" "$a" "$b"' EXIT
 
-# Same 3200 ms of game-time, stepped fine (dt=16) vs coarse (dt=64). Fixed-timestep on.
+# Same 3200 ms of game-time, stepped fine (dt=16) vs coarse (dt=64), throttle at its default.
 ctl --no-audio --load "$LBA2_TEST_SAVE" --fixed-dt 16 --tick 0   --dump-state "$base" --exit >/dev/null 2>&1 \
     || fail "baseline run: non-zero exit ($?)"
-ctl --no-audio --load "$LBA2_TEST_SAVE" --fixed-dt 16 --exec "fixedtimestep on" --tick 200 --dump-state "$a" --exit >/dev/null 2>&1 \
+ctl --no-audio --load "$LBA2_TEST_SAVE" --fixed-dt 16 --tick 200 --dump-state "$a" --exit >/dev/null 2>&1 \
     || fail "dt16 run: non-zero exit ($?)"
-ctl --no-audio --load "$LBA2_TEST_SAVE" --fixed-dt 64 --exec "fixedtimestep on" --tick 50  --dump-state "$b" --exit >/dev/null 2>&1 \
+ctl --no-audio --load "$LBA2_TEST_SAVE" --fixed-dt 64 --tick 50  --dump-state "$b" --exit >/dev/null 2>&1 \
     || fail "dt64 run: non-zero exit ($?)"
 
 read -r d16 d64 span < <(python3 - "$base" "$a" "$b" <<'PY'
@@ -42,6 +45,13 @@ PY
 )
 
 echo "  scripted actors travelled over ${span}ms: dt16=${d16}  dt64=${d64}"
+
+# Measuring invariance needs actual movement; a static scene walks 0 at both rates and would
+# pass trivially, hiding a regression -- skip instead of green-washing.
+python3 - "$d16" <<'PY' || skip "loaded scene has no scripted movement (d16=$d16); use a save with movers"
+import sys
+sys.exit(0 if float(sys.argv[1]) >= 100.0 else 1)
+PY
 
 python3 - "$d16" "$d64" <<'PY' || fail "low-fps sub-stepping mismatch: dt16=$d16 vs dt64=$d64 (issue #358 phase 2)"
 import sys

--- a/tests/timer/test_fixed_step.cpp
+++ b/tests/timer/test_fixed_step.cpp
@@ -103,11 +103,180 @@ static void test_zero_dt_guard(void) {
     ASSERT_EQ_UINT(123, acc);
 }
 
+/* Timer_PlanSimSteps is the SHIPPED per-frame planner (SOURCES/PERSO.CPP MainLoop routes
+ * through it). It layers the rewind and large-jump re-anchors over the Timer_FixedStepCount
+ * core above. `base` anchors the sub-step clocks (sub-step k runs at base + (k+1)*dt); `next`
+ * is written back to LastSimRefHR and carries the sub-dt remainder as (now - next). Pin every
+ * branch. */
+static void test_plan_sim_steps_cases(void) {
+    const S32 DT = 16, MAX = 8;
+    U32 base, next;
+
+    /* ~60 fps: exactly one step, grid advances by dt, the step runs at `now`. This is the
+     * historical per-frame path -- byte-identical to pre-throttle. */
+    ASSERT_EQ_INT(1, Timer_PlanSimSteps(116, 100, DT, MAX, &base, &next));
+    ASSERT_EQ_UINT(100, base); /* sub-step 0 at base + dt == 116 == now */
+    ASSERT_EQ_UINT(116, next);
+
+    /* High frame rate: less than a step has elapsed -> 0 steps, lastSim unchanged, the
+     * remainder carries in the (now - next) gap. */
+    ASSERT_EQ_INT(0, Timer_PlanSimSteps(108, 100, DT, MAX, &base, &next));
+    ASSERT_EQ_UINT(100, next);
+
+    /* Low frame rate, exact: elapsed = 4*dt -> 4 sub-steps, no remainder. */
+    ASSERT_EQ_INT(4, Timer_PlanSimSteps(164, 100, DT, MAX, &base, &next));
+    ASSERT_EQ_UINT(100, base);
+    ASSERT_EQ_UINT(164, next);
+
+    /* Low frame rate with remainder: elapsed = 50 -> 3 steps (48 ms), 2 ms carries. */
+    ASSERT_EQ_INT(3, Timer_PlanSimSteps(150, 100, DT, MAX, &base, &next));
+    ASSERT_EQ_UINT(100, base);
+    ASSERT_EQ_UINT(148, next); /* 100 + 3*16; the 2 ms remainder is (150 - 148) */
+
+    /* Boundary: elapsed == maxSteps*dt (128) is still the NORMAL path, not the large-jump
+     * clamp -> 8 steps, full catch-up. */
+    ASSERT_EQ_INT(8, Timer_PlanSimSteps(228, 100, DT, MAX, &base, &next));
+    ASSERT_EQ_UINT(100, base);
+    ASSERT_EQ_UINT(228, next);
+
+    /* Just past the boundary (129 > 128): large jump -> drop the backlog, run one step, and
+     * re-anchor the grid to now - dt so the single step runs at `now`. */
+    ASSERT_EQ_INT(1, Timer_PlanSimSteps(229, 100, DT, MAX, &base, &next));
+    ASSERT_EQ_UINT(229 - 16, base);
+    ASSERT_EQ_UINT(229, next);
+
+    /* First frame (lastSim seeded 0, now = a loaded save's large clock) is the large-jump
+     * path: one step at `now`, NOT thousands of catch-up steps. */
+    ASSERT_EQ_INT(1, Timer_PlanSimSteps(5351037, 0, DT, MAX, &base, &next));
+    ASSERT_EQ_UINT(5351037 - 16, base);
+    ASSERT_EQ_UINT(5351037, next);
+
+    /* Rewind (now < lastSim: a modal SaveTimer restore / cube change): 0 steps, re-anchor
+     * lastSim to now, skip the frame. */
+    ASSERT_EQ_INT(0, Timer_PlanSimSteps(90, 100, DT, MAX, &base, &next));
+    ASSERT_EQ_UINT(90, next);
+
+    /* Throttle off (dt <= 0): one step, lastSim untouched (per-frame path). */
+    ASSERT_EQ_INT(1, Timer_PlanSimSteps(200, 100, 0, MAX, &base, &next));
+    ASSERT_EQ_UINT(100, next);
+}
+
+/* Drive the planner like the main loop does -- TimerRefHR advances by `frameDelta` each
+ * rendered frame -- over a fixed span of game-time. Two invariants below the catch-up floor:
+ *   (1) total sub-steps == span/dt regardless of the frame pacing (frame-rate independence);
+ *   (2) the sub-step clocks tile the span contiguously -- each is exactly dt after the last
+ *       one that ran, across frame boundaries, with no gap or overlap. */
+static long plan_total_steps(U32 frameDelta, U32 span, S32 dt, S32 maxSteps) {
+    U32 lastSim = 0, prevSubClock = 0;
+    long steps = 0;
+    for (U32 now = frameDelta; now <= span; now += frameDelta) {
+        U32 base, next;
+        S32 n = Timer_PlanSimSteps(now, lastSim, dt, maxSteps, &base, &next);
+        for (S32 k = 0; k < n; k++) {
+            U32 subClock = base + (U32)(k + 1) * (U32)dt;
+            ASSERT_EQ_UINT(prevSubClock + (U32)dt, subClock); /* contiguous, exactly dt apart */
+            prevSubClock = subClock;
+        }
+        lastSim = next;
+        steps += n;
+    }
+    return steps;
+}
+
+static void test_plan_sim_steps_frame_invariance(void) {
+    const U32 SPAN = 1600; /* whole number of 16 ms steps and divisible by every frameDelta below */
+    const S32 DT = 16, MAX = 8;
+    const long IDEAL = 1600 / 16; /* 100 */
+
+    /* ~1000 / ~120 / ~60 / ~15 fps -- all at or below the ~8 fps catch-up floor. */
+    const U32 rates[] = {1, 8, 16, 64};
+    for (int i = 0; i < 4; i++) {
+        long steps = plan_total_steps(rates[i], SPAN, DT, MAX);
+        printf("  frameDelta=%2u ms -> %ld sub-steps over %u ms (ideal %ld)\n",
+               rates[i], steps, SPAN, IDEAL);
+        ASSERT_EQ_INT(IDEAL, steps);
+    }
+}
+
+/* --- Modal clock steppers under fixed-dt ---------------------------------------------
+ * Timer_FixedDtPresent()/Pump() keep the virtual clock moving inside modal inner loops so a
+ * wait on a TimerRefHR deadline cannot deadlock. They mutate the private FixedDtNow;
+ * ManageTime() copies that into the observable TimerSystemHR. Absolute values carry over
+ * between tests (Timer_EnableFixedDt seeds FixedDtNow from the current TimerSystemHR), so
+ * assert deltas against a captured base rather than literal zeros. */
+
+static void test_fixed_dt_present_first_free_then_steps(void) {
+    Timer_EnableFixedDt(16);
+    ManageTime();
+    U32 base = TimerSystemHR;
+
+    /* Before the first tick advance the present is inert: boot/load presents must not move
+     * the clock. */
+    Timer_FixedDtPresent();
+    ManageTime();
+    ASSERT_EQ_UINT(base, TimerSystemHR);
+
+    Timer_FixedDtAdvance(); /* one tick: +16, arms ticking, arms the free present */
+    ManageTime();
+    ASSERT_EQ_UINT(base + 16, TimerSystemHR);
+
+    /* First present after the advance is free -- it is the main-loop render the tick already
+     * paid for. */
+    Timer_FixedDtPresent();
+    ManageTime();
+    ASSERT_EQ_UINT(base + 16, TimerSystemHR);
+
+    /* Every additional present in the same tick steps the clock (modal inner-loop frames). */
+    Timer_FixedDtPresent();
+    ManageTime();
+    ASSERT_EQ_UINT(base + 32, TimerSystemHR);
+    Timer_FixedDtPresent();
+    ManageTime();
+    ASSERT_EQ_UINT(base + 48, TimerSystemHR);
+
+    /* A fresh tick re-arms the free present. */
+    Timer_FixedDtAdvance();
+    ManageTime();
+    ASSERT_EQ_UINT(base + 64, TimerSystemHR);
+    Timer_FixedDtPresent();
+    ManageTime();
+    ASSERT_EQ_UINT(base + 64, TimerSystemHR);
+}
+
+static void test_fixed_dt_pump_steps_every_call(void) {
+    Timer_EnableFixedDt(16);
+    ManageTime();
+    U32 base = TimerSystemHR;
+
+    /* Inert before the first tick advance, same as present. */
+    Timer_FixedDtPump();
+    ManageTime();
+    ASSERT_EQ_UINT(base, TimerSystemHR);
+
+    Timer_FixedDtAdvance(); /* +16, arms ticking (and the free-present flag, which Pump ignores) */
+    ManageTime();
+    ASSERT_EQ_UINT(base + 16, TimerSystemHR);
+
+    /* No free first step: a non-presenting busy-wait owns every iteration's time, so each Pump
+     * advances the clock (this is what stops the MUSIC/AMBIANCE fade loops spinning forever on
+     * a TimerRefHR deadline under fixed-dt). */
+    Timer_FixedDtPump();
+    ManageTime();
+    ASSERT_EQ_UINT(base + 32, TimerSystemHR);
+    Timer_FixedDtPump();
+    ManageTime();
+    ASSERT_EQ_UINT(base + 48, TimerSystemHR);
+}
+
 int main(void) {
     RUN_TEST(test_step_count_is_pacing_invariant);
     RUN_TEST(test_high_and_low_frame_rate);
     RUN_TEST(test_clamp_drops_backlog);
     RUN_TEST(test_zero_dt_guard);
+    RUN_TEST(test_plan_sim_steps_cases);
+    RUN_TEST(test_plan_sim_steps_frame_invariance);
+    RUN_TEST(test_fixed_dt_present_first_free_then_steps);
+    RUN_TEST(test_fixed_dt_pump_steps_every_call);
     TEST_SUMMARY();
     return test_failures != 0;
 }


### PR DESCRIPTION
## Why

The #358 fixed-timestep work (phase 1 throttle, phase 2 sub-stepping) is now load-bearing for `TimerRefHR` and all movement. But two gaps remained:

- The phase 2 sub-step loop hand-rolled its `elapsed / FixedTimestep` step count **inline** in `MainLoop`, so `Timer_FixedStepCount` (the pure, fully unit-tested accumulator) was dead code while the shipping math had no unit coverage.
- `Timer_FixedDtPresent` / `Timer_FixedDtPump` (the modal clock steppers that keep a fixed-dt wait loop from deadlocking on a `TimerRefHR` deadline) had no tests at all.

## What

**Production refactor (behavior-identical):**
- Extract the per-frame decision into a pure `Timer_PlanSimSteps()` in `TIMER.CPP`. Its normal path delegates the count and remainder-carry to `Timer_FixedStepCount`, so that tested function is now the engine of the shipping loop; the rewind and large-jump re-anchors stay as guards around it.
- `PERSO.CPP` calls the planner instead of the inline math (20 lines down to a call). `LastSimRefHR` is advanced by the planner, so the loop tail no longer carries it.

Verified byte-for-byte: the simulation dump (`actors`, `timer_ref_hr`, `hero`, `vars`) is identical at `--fixed-dt` 8/16/64 before and after, so `--fixed-dt 16` and the throttle-off path are unchanged.

**Tests:**
- `test_fixed_step`: unit-test `Timer_PlanSimSteps` across every branch (skip / 1-step / N-step / remainder-carry / rewind / large-jump / boundary / off) plus a multi-frame contiguity + invariance property, and first coverage of `Timer_FixedDtPresent`/`Pump`.
- `test_move_framerate`: repurposed to the high-fps gate (dt8 vs dt16) — the only test that exercises the planner's skip/carry branch — with a no-movement skip guard.
- `test_move_substep`: dropped the `--exec "fixedtimestep on"` that persisted `FixedTimestep` to the user's `lba2.cfg`; added the same skip guard. It now owns the low-fps gate (dt16 vs dt64), de-duplicated from `test_move_framerate`.

## Testing

- `ctest -L host_quick`: 40/40 pass.
- Both shell gates pass end to end on retail data (Desert Island): high-fps dt8 vs dt16 within 0.25%, low-fps dt16 vs dt64 within 0.3%.
- Confirmed `lba2.cfg` sha is unchanged after a shell-test run (de-persist).