### PR TITLE
fix(perso): deliver an inventory item-use on a throttle-skip frame (#358)

### DIFF
--- a/LIB386/H/SYSTEM/TIMER.H
+++ b/LIB386/H/SYSTEM/TIMER.H
@@ -83,6 +83,18 @@ S32 Timer_FixedStepCount(U32 *accMs, U32 elapsedMs, U32 dt, S32 maxSteps);
 // per-frame path, byte-for-byte). dt <= 0 (throttle off) returns 1 and leaves lastSim alone.
 S32 Timer_PlanSimSteps(U32 now, U32 lastSim, S32 dt, S32 maxSteps, U32 *baseRefOut, U32 *lastSimOut);
 
+// Promote a throttle-skip into a single delivered step when a one-frame game event is pending
+// this frame (issue #358). `plannedSteps` is Timer_PlanSimSteps' result; `pending` is non-zero
+// when the caller has a discrete event that the object loop must consume this frame (an inventory
+// item used this frame, consumed by LF_USE_INVENTORY in DoLife). If the frame already runs a step
+// (plannedSteps > 0) or nothing is pending, the plan is returned untouched. Otherwise the skip is
+// promoted to one step at `now`: the sub-step grid is re-anchored to `now - dt` (so the step runs
+// at `now`) and `*lastSimOut` to `now`, so the event is delivered without the throttle swallowing
+// it on high-refresh displays. Pure and unit-tested; the main loop's event-delivery guard lives
+// here rather than in the throttle math. See SOURCES/PERSO.CPP and docs/MOVEMENT_FRAMERATE.md.
+S32 Timer_ForceStepIfPending(S32 plannedSteps, S32 pending, U32 now, S32 dt, U32 *baseRefOut,
+                             U32 *lastSimOut);
+
 void ManageTime();
 void HandleEventsTimer(const void *event);
 

--- a/LIB386/SYSTEM/TIMER.CPP
+++ b/LIB386/SYSTEM/TIMER.CPP
@@ -204,6 +204,24 @@ S32 Timer_PlanSimSteps(U32 now, U32 lastSim, S32 dt, S32 maxSteps, U32 *baseRefO
     return nSteps;
 }
 
+S32 Timer_ForceStepIfPending(S32 plannedSteps, S32 pending, U32 now, S32 dt, U32 *baseRefOut,
+                             U32 *lastSimOut) {
+    // A frame that already runs a step consumes the pending event then; nothing pending means the
+    // throttle stands (keeps the high-fps movement decoupling untouched). Only a would-skip frame
+    // with a pending event needs promoting.
+    if (plannedSteps > 0 || !pending) {
+        return plannedSteps;
+    }
+
+    // Promote the skip to a single step at `now`: anchor the sub-step grid to now - dt (so the one
+    // step runs at `now`, like a normal ~60 Hz frame) and lastSim to `now`, re-anchoring the grid
+    // so the next frame throttles cleanly from here. This is what stops the fixed-timestep throttle
+    // from swallowing a one-frame inventory-use on high-refresh displays (issue #358).
+    *baseRefOut = now - (U32)dt;
+    *lastSimOut = now;
+    return 1;
+}
+
 void ManageTime() {
     TimerSystemHR = FixedDtActive ? FixedDtNow : SDL_GetTicks();
 

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -1911,6 +1911,16 @@ restartloop:
             U32 nextLastSim;
             nSimSteps = Timer_PlanSimSteps(TimerRefHR, LastSimRefHR, FixedTimestep,
                                            FIXED_TIMESTEP_MAX_STEPS, &simBaseRef, &nextLastSim);
+            /* Deliver a one-frame inventory-use event even on a throttle-skip frame. InventoryAction
+               is set above this frame by MenuInventory, cleared at the top of every loop, and
+               consumed by LF_USE_INVENTORY in DoLife below. On high-refresh displays most frames
+               skip the sim, so without this the event is wiped before any simulated frame reads it
+               and a quest item-use (the ferry ticket, the Balsam flower, the Wizard Diploma)
+               silently fails (#358 regression, softlocks the Peddler). Promotes a would-skip frame
+               to a single step; a no-op when a step already runs or nothing is pending, so the
+               throttle and its --fixed-dt 16 byte-for-byte guarantee are otherwise untouched. */
+            nSimSteps = Timer_ForceStepIfPending(nSimSteps, InventoryAction >= 0, TimerRefHR,
+                                                 FixedTimestep, &simBaseRef, &nextLastSim);
             LastSimRefHR = nextLastSim;
             if (nSimSteps <= 0)
                 goto skip_simulation; // high-fps skip (remainder carries) or clock rewind (re-anchored)

--- a/tests/timer/test_fixed_step.cpp
+++ b/tests/timer/test_fixed_step.cpp
@@ -198,6 +198,55 @@ static void test_plan_sim_steps_frame_invariance(void) {
     }
 }
 
+/* Timer_ForceStepIfPending is the item-use regression fix (#358). The fixed-timestep throttle
+ * skips the whole simulation on frames that render faster than one step (high-refresh displays),
+ * but a one-frame inventory-use event (InventoryAction, consumed by LF_USE_INVENTORY in DoLife
+ * and cleared every frame) is lost if its frame is skipped -- quest item-uses (ferry ticket,
+ * Balsam flower, Wizard Diploma) then fail. This promotes a skip into a single step at `now`
+ * when an event is pending, so the object loop still runs and consumes it. A frame that already
+ * runs >= 1 step needs no help -- the event is consumed then. */
+static void test_force_step_if_pending(void) {
+    const S32 DT = 16;
+    U32 base, next;
+
+    /* No event pending: a skip stays a skip. The throttle is unchanged when nothing is pending
+     * -- this is what keeps the high-fps movement decoupling (and #391's byte-for-byte gate). */
+    base = next = 0xDEAD;
+    ASSERT_EQ_INT(0, Timer_ForceStepIfPending(0, /*pending=*/0, 108, DT, &base, &next));
+    ASSERT_EQ_UINT(0xDEAD, base); /* untouched: caller keeps the planner's carry anchor */
+    ASSERT_EQ_UINT(0xDEAD, next);
+
+    /* Event pending on a skip frame: promote to one step at `now`. Re-anchor the grid to now-dt
+     * (so sub-step 0 runs at `now`) and lastSim to `now`. THIS is the fix. */
+    base = next = 0xDEAD;
+    ASSERT_EQ_INT(1, Timer_ForceStepIfPending(0, /*pending=*/1, 108, DT, &base, &next));
+    ASSERT_EQ_UINT(108 - 16, base); /* sub-step 0 at base + dt == 108 == now */
+    ASSERT_EQ_UINT(108, next);
+
+    /* Rewind skip (the planner returned 0 with a re-anchor) with an event pending is promoted the
+     * same way -- the helper is agnostic to WHY the frame was going to skip. */
+    base = next = 0xDEAD;
+    ASSERT_EQ_INT(1, Timer_ForceStepIfPending(0, /*pending=*/1, 90, DT, &base, &next));
+    ASSERT_EQ_UINT(90 - 16, base);
+    ASSERT_EQ_UINT(90, next);
+
+    /* Frame already runs steps: the pending event is consumed by the planned step(s), so no
+     * override -- return the count unchanged and leave the planner's anchors alone. */
+    base = 100;
+    next = 148;
+    ASSERT_EQ_INT(3, Timer_ForceStepIfPending(3, /*pending=*/1, 150, DT, &base, &next));
+    ASSERT_EQ_UINT(100, base);
+    ASSERT_EQ_UINT(148, next);
+
+    /* One planned step with an event pending is likewise unchanged (plannedSteps > 0 short-
+     * circuits): the historical ~60 fps path already delivers the event. */
+    base = 100;
+    next = 116;
+    ASSERT_EQ_INT(1, Timer_ForceStepIfPending(1, /*pending=*/1, 116, DT, &base, &next));
+    ASSERT_EQ_UINT(100, base);
+    ASSERT_EQ_UINT(116, next);
+}
+
 /* --- Modal clock steppers under fixed-dt ---------------------------------------------
  * Timer_FixedDtPresent()/Pump() keep the virtual clock moving inside modal inner loops so a
  * wait on a TimerRefHR deadline cannot deadlock. They mutate the private FixedDtNow;
@@ -275,6 +324,7 @@ int main(void) {
     RUN_TEST(test_zero_dt_guard);
     RUN_TEST(test_plan_sim_steps_cases);
     RUN_TEST(test_plan_sim_steps_frame_invariance);
+    RUN_TEST(test_force_step_if_pending);
     RUN_TEST(test_fixed_dt_present_first_free_then_steps);
     RUN_TEST(test_fixed_dt_pump_steps_every_call);
     TEST_SUMMARY();


### PR DESCRIPTION
Follow-up to #391 (stacked on its branch; retarget to main once #391 lands).

## The bug

The #358 fixed-timestep throttle (default on) skips the whole simulation on frames that render faster than one step — high-refresh displays, vsync off. A quest item-use is a **one-frame signal**: `InventoryAction` is set by `MenuInventory`, cleared at the top of every loop, and read by `LF_USE_INVENTORY` inside `DoLife`. If the frame the item is used on is a skipped frame, the event is wiped before any simulated frame reads it, so the interaction silently fails:

- Mr. Paul won't take the ferry ticket except right up against him
- the Magic School headmaster won't take the Balsam flower
- the Travelling Peddler can't be given the Wizard Diploma at all (his collision box is larger than the shrunken effective zone) — a softlock

Field-confirmed by a playtester: switching `fixedtimestep off` (per-frame sim, no skips) makes it work again. It was invisible before the throttle was defaulted on.

## The fix

`Timer_ForceStepIfPending()`: when the planner would skip this frame but a discrete one-frame event is pending, promote the skip to a single step at the current clock, so the object loop runs and `DoLife` consumes the event. A no-op when a step already runs or nothing is pending — so the throttle and its `--fixed-dt 16` byte-for-byte guarantee are otherwise untouched. `MainLoop` passes `InventoryAction >= 0`. The event-delivery guard lives in the caller, not in the throttle math (`Timer_PlanSimSteps` stays a pure timing function).

## Tests

- `test_fixed_step`: new `test_force_step_if_pending` pins all four cases — promote-on-skip, promote-on-rewind, and the already-stepping / nothing-pending no-ops. Written test-first (RED on a stub, GREEN after).
- `ctest -L host_quick`: 40/40.
- Boots and ticks clean at `--fixed-dt 16` and `--fixed-dt 8`.

## Testing it by hand

No headless input-injection, so item-use isn't scriptable — it's a manual check. To make the skip near-certain at any refresh rate, widen the window with `fixedtimestep 100`, then give a quest item to an NPC:

- base build (#391 / this branch's parent) at `fixedtimestep 100`: fails almost every attempt
- this branch at `fixedtimestep 100`: works every time
