### PR TITLE
feat(console): headless game-state control + Life-script tracing

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -16,6 +16,7 @@
 #include "../JOYSTICK.H"
 /* HOLO.H lacks include guards and is pulled in transitively by DEFINES.H. */
 #include "../INVENT.H"
+#include "../OBJECT.H" // SetAnim (teleport stops the hero's carried animation)
 #include "../RES_CATALOG.H"
 #include "../RES_SWITCH.H"
 #include "../PERFTRACE.H"
@@ -1460,6 +1461,91 @@ static void cmd_fixedtimestep(int argc, const char *argv[]) {
     }
 }
 
+/* teleport <x> <y> <z> [beta] | teleport actor <n>: reposition the hero in the current cube.
+   Sets ListObjet[NUM_PERSO].Obj coords directly; the next simulated frame re-runs zone detection and
+   collision from the new spot. `teleport actor <n>` jumps onto actor n -- the quick way to reach a
+   zone-gated interaction without walking. Within-cube only (cross-cube needs ChangeCube). */
+static void cmd_teleport(int argc, const char *argv[]) {
+    T_OBJET *hero = &ListObjet[NUM_PERSO];
+
+    if (argc >= 3 && !strcasecmp(argv[1], "actor")) {
+        int n = atoi(argv[2]);
+        if (n < 0 || n >= (int)NbObjets) {
+            Console_Print("teleport: actor %d out of range (0..%d)", n, (int)NbObjets - 1);
+            return;
+        }
+        T_OBJET *t = &ListObjet[n];
+        hero->Obj.X = t->Obj.X;
+        hero->Obj.Y = t->Obj.Y;
+        hero->Obj.Z = t->Obj.Z;
+        SetAnim(NUM_PERSO, GEN_ANIM_RIEN); // stop the carried walk anim
+        Console_Print("teleport: hero -> actor %d at (%d,%d,%d)", n, (int)hero->Obj.X, (int)hero->Obj.Y,
+                      (int)hero->Obj.Z);
+        return;
+    }
+
+    if (argc >= 4) {
+        hero->Obj.X = atoi(argv[1]);
+        hero->Obj.Y = atoi(argv[2]);
+        hero->Obj.Z = atoi(argv[3]);
+        if (argc >= 5)
+            hero->Obj.Beta = (S16)atoi(argv[4]);
+        SetAnim(NUM_PERSO, GEN_ANIM_RIEN);
+        Console_Print("teleport: hero -> (%d,%d,%d) beta=%d", (int)hero->Obj.X, (int)hero->Obj.Y,
+                      (int)hero->Obj.Z, (int)hero->Obj.Beta);
+        return;
+    }
+
+    Console_Print("Usage: teleport <x> <y> <z> [beta] | teleport actor <n>");
+}
+
+/* varcube <n> [value] / vargame <n> [value]: read or set a scene (cube) or game Life variable.
+   With no value, prints the current one; with a value, sets it. Lets a console/harness session drive
+   quest state directly -- e.g. arm the flag an NPC's script waits on to reach an interaction stage. */
+static void cmd_varcube(int argc, const char *argv[]) {
+    if (argc < 2) {
+        Console_Print("Usage: varcube <n> [value]  (n = 0..%d)", MAX_VARS_CUBE - 1);
+        return;
+    }
+    S32 n = atoi(argv[1]);
+    if (n < 0 || n >= MAX_VARS_CUBE) {
+        Console_Print("varcube: index %d out of range (0..%d)", n, MAX_VARS_CUBE - 1);
+        return;
+    }
+    if (argc >= 3)
+        ListVarCube[n] = (U8)atoi(argv[2]);
+    Console_Print("varcube[%d] = %d", n, (int)ListVarCube[n]);
+}
+
+static void cmd_vargame(int argc, const char *argv[]) {
+    if (argc < 2) {
+        Console_Print("Usage: vargame <n> [value]  (n = 0..%d)", MAX_VARS_GAME - 1);
+        return;
+    }
+    S32 n = atoi(argv[1]);
+    if (n < 0 || n >= MAX_VARS_GAME) {
+        Console_Print("vargame: index %d out of range (0..%d)", n, MAX_VARS_GAME - 1);
+        return;
+    }
+    if (argc >= 3)
+        ListVarGame[n] = (S16)atoi(argv[2]);
+    Console_Print("vargame[%d] = %d", n, (int)ListVarGame[n]);
+}
+
+/* lifetrace <objN> | off: trace object N's Life script -- its comportement/track/zone state each
+   frame and every condition (LF_*) it evaluates. Reveals whether an NPC's script ever reaches a
+   given check and what its gating conditions read. */
+static void cmd_lifetrace(int argc, const char *argv[]) {
+    if (argc >= 2 && !strcasecmp(argv[1], "off"))
+        DbgLifeTraceObj = -1;
+    else if (argc >= 2)
+        DbgLifeTraceObj = atoi(argv[1]);
+    if (DbgLifeTraceObj >= 0)
+        Console_Print("lifetrace: object %d", DbgLifeTraceObj);
+    else
+        Console_Print("lifetrace: off");
+}
+
 /*──────────────────────────────────────────────────────────────────────────*/
 /* Registration */
 /*──────────────────────────────────────────────────────────────────────────*/
@@ -1539,6 +1625,21 @@ void Console_RegisterAll(void) {
                               "Runs the simulation at most once per MS ms of game-time (on = 16). Fixes "
                               "movement speeding up or freezing above 60 fps (vsync off, high-refresh). "
                               "Default on; persists to lba2.cfg (FixedTimestep key).");
+
+    Console_RegisterCommandEx("teleport", cmd_teleport, "Reposition the hero in the current cube",
+                              "teleport <x> <y> <z> [beta] | teleport actor <n>",
+                              "Sets the hero's coords directly; next frame re-runs zones/collision. "
+                              "'actor <n>' jumps onto actor n. Within-cube only.");
+    Console_RegisterCommandEx("varcube", cmd_varcube, "Read/set a scene (cube) Life variable",
+                              "varcube <n> [value]",
+                              "Reads the cube var, or sets it with a value. Drives quest state.");
+    Console_RegisterCommandEx("vargame", cmd_vargame, "Read/set a game Life variable",
+                              "vargame <n> [value]",
+                              "Reads the game var, or sets it with a value. Drives quest/inventory state.");
+    Console_RegisterCommandEx("lifetrace", cmd_lifetrace, "Trace an object's Life script",
+                              "lifetrace <objN> | lifetrace off",
+                              "Logs the object's comportement/track/zone each frame and every LF_ "
+                              "condition it evaluates.");
 
     Console_RegisterCommandEx("perftrace", cmd_perftrace,
                               "Per-frame timing capture (ring buffer, no log spam)",

--- a/SOURCES/C_EXTERN.H
+++ b/SOURCES/C_EXTERN.H
@@ -355,6 +355,7 @@ extern U8 Weapon;
 extern U8 Bulle;
 extern U8 ActionNormal;
 extern S32 InventoryAction;
+extern S32 DbgLifeTraceObj; // console `lifetrace`: Life-script trace target object, -1 = off
 extern S32 MagicBall;
 extern U8 MagicBallType;
 extern U8 MagicBallCount;

--- a/SOURCES/GERELIFE.CPP
+++ b/SOURCES/GERELIFE.CPP
@@ -4,6 +4,7 @@
 #include <SVGA/SCREEN.H>
 #include <SVGA/VIDEO.H>
 #include <SYSTEM/KEYBOARD_KEYS.H>
+#include <SYSTEM/LOG.H> // lifetrace
 
 U8 *PtrPrg;
 U8 TypeAnswer;
@@ -34,6 +35,10 @@ void DoFuncLife(T_OBJET *ptrobj) {
     T_ZONE *ptrz;
 
     TypeAnswer = RET_S8;
+
+    // lifetrace: log every Life condition (LF_* opcode) the traced object evaluates.
+    if (DbgLifeTraceObj >= 0 && (S32)(ptrobj - ListObjet) == DbgLifeTraceObj)
+        Log_Info("[life]   obj=%d checks LF=%d", (int)(ptrobj - ListObjet), (int)*PtrPrg);
 
     switch (*PtrPrg++) /* func */
     {
@@ -242,10 +247,14 @@ void DoFuncLife(T_OBJET *ptrobj) {
         break;
 
         //---------------------------------------------------------------------------
-    case LF_VAR_CUBE:
-        Value = ListVarCube[*PtrPrg++];
+    case LF_VAR_CUBE: {
+        S32 vidx = *PtrPrg++;
+        Value = ListVarCube[vidx];
+        if (DbgLifeTraceObj >= 0 && (S32)(ptrobj - ListObjet) == DbgLifeTraceObj)
+            Log_Info("[life]   LF_VAR_CUBE[%d] = %d", (int)vidx, (int)Value); // which quest flag it reads
         TypeAnswer = RET_U8;
         break;
+    }
 
         //---------------------------------------------------------------------------
     case LF_VAR_GAME:
@@ -754,6 +763,12 @@ void DoLife(U8 numobj) {
 
     PtrPrg = ptrobj->PtrLife + ptrobj->OffsetLife;
 
+    // lifetrace: log this object's Life-script state each DoLife call.
+    if (DbgLifeTraceObj >= 0 && numobj == DbgLifeTraceObj)
+        Log_Info("[life] obj=%d DoLife off=%d comport=%d track=%d zone_sce=%d", (int)numobj,
+                 (int)ptrobj->OffsetLife, (int)ptrobj->MemoComportement, (int)ptrobj->LabelTrack,
+                 (int)ptrobj->ZoneSce);
+
     while (flag != -1) {
         ptrmacro = PtrPrg;
         switch (*PtrPrg++) {
@@ -1066,6 +1081,8 @@ void DoLife(U8 numobj) {
         case LM_IF:
         case LM_AND_IF:
             DoFuncLife(ptrobj);
+            if (DbgLifeTraceObj >= 0 && numobj == DbgLifeTraceObj)
+                Log_Info("[life]     IF -> Value=%d", (int)Value);
             if (!DoTest()) {
                 PtrPrg = ptrobj->PtrLife + *(S16 *)PtrPrg;
             } else {

--- a/SOURCES/GLOBAL.CPP
+++ b/SOURCES/GLOBAL.CPP
@@ -311,6 +311,9 @@ U8 Weapon = FLAG_BALLE_MAGIQUE; // magicball
 U8 Bulle = TRUE;
 U8 ActionNormal = FALSE;
 S32 InventoryAction = -1;
+// Console `lifetrace <objN>`: object index whose Life script to trace (comportement/track/zone state
+// each frame + every condition it evaluates), or -1 for off. Headless-debug aid, no gameplay effect.
+S32 DbgLifeTraceObj = -1;
 S32 MagicBall = -1;
 U8 MagicBallType = 1;
 U8 MagicBallCount = 3;


### PR DESCRIPTION
Console commands to drive and inspect game state in headless / control-harness runs, so state- and quest-gated interactions are reproducible via `--exec` without needing a specific save.

## Commands
- `teleport <x> <y> <z> [beta]` / `teleport actor <n>` — reposition the hero (within-cube; `actor <n>` jumps onto an actor to reach a zone-gated NPC without walking).
- `varcube <n> [value]` / `vargame <n> [value]` — read or set a scene (cube) / game Life variable.
- `lifetrace <objN> | off` — log an object's comportement/track/zone each frame and every `LF_` condition it evaluates.

## Why
These came out of debugging the fixed-timestep item-use issue. `lifetrace` is what revealed an NPC's give-item gate chain (proximity → cube-var flags → the inventory check), and `varcube` let us drive quest flags to reach a polling state. They generalise: position, quest state, and Life-script observability cover the gates behind most LBA interactions — which the headless harness previously couldn't touch (no movement input).

## Scope
Code-only, no gameplay effect (the trace is silent unless enabled). Built and smoke-tested on a save (var get/set, teleport, and a peddler `lifetrace` all verified). Docs and an automation test can follow.
