### PR TITLE
feat(control): add --fixed-timestep, useitem inject, and #392 throttle test

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -1546,6 +1546,30 @@ static void cmd_lifetrace(int argc, const char *argv[]) {
         Console_Print("lifetrace: off");
 }
 
+/* useitem <n> [frames] [delay] | useitem trace <0|1>: inject a one-frame inventory item-use of
+   var-game item n (as MenuInventory would), so an NPC's give-item check (LF_USE_INVENTORY) can be
+   driven headlessly. `frames` injects over N frames, `delay` waits N frames first (land past a load
+   large-jump on a throttle-skip frame). `trace 1` logs each LF_USE_INVENTORY result. */
+static void cmd_useitem(int argc, const char *argv[]) {
+    if (argc >= 2 && !strcasecmp(argv[1], "trace")) {
+        if (argc >= 3)
+            DbgUseItemTrace = atoi(argv[2]) ? 1 : 0;
+        Console_Print("useitem trace: %s", DbgUseItemTrace ? "ON" : "OFF");
+        return;
+    }
+    if (argc >= 2) {
+        DbgUseItemInject = atoi(argv[1]);
+        DbgUseItemInjectN = (argc >= 3) ? atoi(argv[2]) : 1;
+        DbgUseItemInjectDelay = (argc >= 4) ? atoi(argv[3]) : 0;
+        if (DbgUseItemInjectN < 1)
+            DbgUseItemInjectN = 1;
+        Console_Print("useitem: inject InventoryAction=%d over %d frame(s), after %d-frame delay",
+                      DbgUseItemInject, DbgUseItemInjectN, DbgUseItemInjectDelay);
+    } else {
+        Console_Print("Usage: useitem <n> [frames] [delay] | useitem trace <0|1>");
+    }
+}
+
 /*──────────────────────────────────────────────────────────────────────────*/
 /* Registration */
 /*──────────────────────────────────────────────────────────────────────────*/
@@ -1640,6 +1664,10 @@ void Console_RegisterAll(void) {
                               "lifetrace <objN> | lifetrace off",
                               "Logs the object's comportement/track/zone each frame and every LF_ "
                               "condition it evaluates.");
+    Console_RegisterCommandEx("useitem", cmd_useitem, "Inject an inventory item-use (headless)",
+                              "useitem <n> [frames] [delay] | useitem trace <0|1>",
+                              "Injects InventoryAction=n (drives LF_USE_INVENTORY without menu input); "
+                              "'trace 1' logs each result.");
 
     Console_RegisterCommandEx("perftrace", cmd_perftrace,
                               "Per-frame timing capture (ring buffer, no log spam)",

--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -40,6 +40,8 @@ static int s_have_tick = 0;
 static long s_tick = 0;
 static int s_have_fixed_dt = 0;
 static long s_fixed_dt = 0;
+static int s_have_fixed_timestep = 0;
+static long s_fixed_timestep = 0;
 static int s_have_dump = 0;
 static char s_dump_path[ADELINE_MAX_PATH];
 static int s_have_shot = 0;
@@ -156,6 +158,23 @@ void Control_ParseArgs(int *argc, char *argv[]) {
             } else {
                 s_fixed_dt = v;
                 s_have_fixed_dt = 1;
+            }
+            s_active = 1;
+            read += 2;
+            continue;
+        }
+        if (!strcmp(a, "--fixed-timestep") && has_val) {
+            /* Set the fixed-timestep throttle (FixedTimestep) for this run only, without
+               persisting to lba2.cfg (unlike the `fixedtimestep` console verb). Lets a test
+               force the throttle on/off + a step size regardless of the local cfg. 0 = off. */
+            char *end = NULL;
+            long v = strtol(argv[read + 1], &end, 0);
+            if (end == argv[read + 1] || *end != '\0' || v < 0 || v > 100) {
+                fprintf(stderr, "[control] --fixed-timestep: invalid value '%s' (want 0..100, ignoring)\n",
+                        argv[read + 1]);
+            } else {
+                s_fixed_timestep = v;
+                s_have_fixed_timestep = 1;
             }
             s_active = 1;
             read += 2;
@@ -691,6 +710,11 @@ void Control_TickHook(void) {
     if (!s_armed)
         return;
     s_hook_calls++;
+    /* Apply --fixed-timestep once, on the first tick: it must land after ReadConfigFile (which
+       set FixedTimestep from lba2.cfg during boot) so the flag overrides the cfg for this run
+       only, without persisting. */
+    if (s_have_fixed_timestep && s_hook_calls == 1)
+        FixedTimestep = (S32)s_fixed_timestep;
     /* Advance the deterministic clock one fixed step per tick. The hook runs exactly once
        per loop-body iteration, before this tick's ManageTime() banks the step. */
     if (s_have_fixed_dt)

--- a/SOURCES/C_EXTERN.H
+++ b/SOURCES/C_EXTERN.H
@@ -355,7 +355,11 @@ extern U8 Weapon;
 extern U8 Bulle;
 extern U8 ActionNormal;
 extern S32 InventoryAction;
-extern S32 DbgLifeTraceObj; // console `lifetrace`: Life-script trace target object, -1 = off
+extern S32 DbgLifeTraceObj;       // console `lifetrace`: Life-script trace target object, -1 = off
+extern S32 DbgUseItemInject;      // console `useitem`: item number to inject, -1 = none
+extern S32 DbgUseItemInjectN;     // console `useitem`: frames to inject over
+extern S32 DbgUseItemInjectDelay; // console `useitem`: frames to wait before injecting
+extern S32 DbgUseItemTrace;       // console `useitem trace`: log each LF_USE_INVENTORY result
 extern S32 MagicBall;
 extern U8 MagicBallType;
 extern U8 MagicBallCount;

--- a/SOURCES/GERELIFE.CPP
+++ b/SOURCES/GERELIFE.CPP
@@ -277,6 +277,13 @@ void DoFuncLife(T_OBJET *ptrobj) {
             }
         }
 
+        // Console `useitem trace`: which object checked which item, and why it answered.
+        if (DbgUseItemTrace)
+            Log_Info("[useinv] LF_USE_INVENTORY obj=%d num=%d InvAct=%d used=%d var=%d -> %s",
+                     (int)(ptrobj - ListObjet), (int)num, (int)InventoryAction,
+                     (TabInv[num].FlagInv & FLAG_INV_USED) ? 1 : 0, (int)ListVarGame[num],
+                     Value ? "TRUE" : "false");
+
         if (DemoSlide) {
             Value = TRUE;
             InvSelect = TabInv[num].Box;

--- a/SOURCES/GLOBAL.CPP
+++ b/SOURCES/GLOBAL.CPP
@@ -314,6 +314,14 @@ S32 InventoryAction = -1;
 // Console `lifetrace <objN>`: object index whose Life script to trace (comportement/track/zone state
 // each frame + every condition it evaluates), or -1 for off. Headless-debug aid, no gameplay effect.
 S32 DbgLifeTraceObj = -1;
+// Console `useitem`: inject a one-frame inventory item-use headlessly (mimics what MenuInventory
+// sets), so the give-item path (LF_USE_INVENTORY) can be driven and tested without menu input.
+// Inject = item number, InjectN = frames to inject over, InjectDelay = frames to wait first (settle
+// past the load large-jump onto a throttle-skip frame). Trace logs each LF_USE_INVENTORY result.
+S32 DbgUseItemInject = -1;
+S32 DbgUseItemInjectN = 0;
+S32 DbgUseItemInjectDelay = 0;
+S32 DbgUseItemTrace = 0;
 S32 MagicBall = -1;
 U8 MagicBallType = 1;
 U8 MagicBallCount = 3;

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -1449,6 +1449,19 @@ restartloop:
 
             InventoryAction = -1;
 
+            // Console `useitem`: inject a one-frame inventory item-use (as MenuInventory would),
+            // before the throttle gate, so it exercises the exact drop/deliver path a real use hits.
+            // Optional delay lets the injection land past the load large-jump on a settled skip frame.
+            if (DbgUseItemInject >= 0 && DbgUseItemInjectN > 0) {
+                if (DbgUseItemInjectDelay > 0) {
+                    DbgUseItemInjectDelay--;
+                } else {
+                    InventoryAction = DbgUseItemInject;
+                    if (--DbgUseItemInjectN <= 0)
+                        DbgUseItemInject = -1;
+                }
+            }
+
             if ((Input & I_INVENTORY)
                     AND(PtrComportement->Flags & CF_INVENTORY)
                         AND(ptrobj->Obj.Body.Num != -1)

--- a/docs/CONSOLE.md
+++ b/docs/CONSOLE.md
@@ -69,6 +69,7 @@ These mirror the classic key-sequence cheats; you can type their name directly a
 | **varcube** &lt;n&gt; [value] | Read (no value) or set a scene (cube) Life variable, `n` in `0..79`. Drives quest state, e.g. arm the flag an NPC's script waits on. |
 | **vargame** &lt;n&gt; [value] | Read (no value) or set a game Life variable, `n` in `0..255`. Drives quest / inventory state. |
 | **lifetrace** &lt;objN&gt; \| off | Trace object N's Life script: its comportement/track/zone state each frame and every `LF_` condition it evaluates (with the branch `Value`). An NPC-script debugger: shows whether a script ever reaches a given check and what its gating conditions read. |
+| **useitem** &lt;n&gt; [frames] [delay] \| **useitem trace** &lt;0\|1&gt; | Inject a one-frame inventory item-use of var-game item `n` (as opening the inventory and using it would), so an NPC's give-item check (`LF_USE_INVENTORY`) can be driven headlessly. `frames` injects over N frames; `delay` waits N frames first (to land past a load's clock jump on a throttle-skip frame). `trace 1` logs each `LF_USE_INVENTORY` result. |
 | **playvideo** &lt;name&gt; | Play ACF video by name. |
 | **listvideos** | List available ACF video names. |
 | **playjingle** &lt;1-26&gt; | Play jingle by number. |

--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -26,6 +26,8 @@ lba2cc --load <slot>          restore a save before the loop starts
        --exec "<cmd>;<cmd>"   run console commands (';'-separated) on the first tick
        --tick <N>             advance N simulation ticks
        --fixed-dt <ms>        advance the clock by a constant <ms> per tick (deterministic)
+       --fixed-timestep <ms>  set the sim throttle (FixedTimestep) for this run only, no cfg
+                              persist (0 = off); combine with a small --fixed-dt to force skips
        --language <name>      override Language at boot (English | Français | Deutsch |
                               Español | Italiano | Portugues; or EN | FR | DE | SP | IT | PO)
        --no-audio             skip InitAIL() and InitSampleDriver() at boot — bypasses

--- a/tests/automation/test_item_use_throttle.sh
+++ b/tests/automation/test_item_use_throttle.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# #392 regression: the fixed-timestep throttle must not drop a one-frame inventory item-use.
+#
+# A quest item-use is a one-frame signal (InventoryAction, consumed by LF_USE_INVENTORY inside
+# DoLife). The throttle skips the whole simulation on frames that render faster than one step, so a
+# use landing on a skipped frame would be lost before any simulated frame reads it. #392
+# (Timer_ForceStepIfPending) forces a would-skip frame to simulate when a use is pending, so the
+# NPC's poll still sees it.
+#
+# Driven end-to-end on a tracked save where NPC obj 2 polls LF_USE_INVENTORY for item 18 (the hero
+# holds it). Throttle on at 100 ms with a fast clock (--fixed-dt 8) makes frames 2..13 all skip; the
+# use is injected on frame 6 (delay 5) -- a guaranteed skip frame. With #392 that frame is forced
+# and the poll returns TRUE; without it the use is dropped and the poll never returns TRUE. The give
+# then triggers a blocking dialog (no clean --exit), so the run is SIGKILLed and the flushed
+# adeline.log is read (Log_Info fflushes per line; stdout is block-buffered and lost on the kill).
+#
+# Local-only (needs retail data + the tracked corpus save). Not in host_quick CI.
+TESTNAME=item_use_throttle
+. "$(dirname "$0")/lib.sh"
+precheck
+
+FIX="$(dirname "$0")/../savegame/corpus/saves/steam_classic_2023/Wannies fragment.LBA"
+[ -f "$FIX" ] || skip "fixture missing: $FIX"
+
+# Isolate the log + cfg in a temp XDG dir: no stale runs, no touching the real adeline.log.
+xdg="$(mktemp -d)"
+trap 'rm -rf "$xdg"' EXIT
+log="$xdg/Twinsen/LBA2/adeline.log"
+
+# The give-dialog blocks the tick loop, so the run never exits cleanly: bound it and SIGKILL.
+XDG_DATA_HOME="$xdg" SDL_AUDIODRIVER=dummy SDL_VIDEODRIVER=dummy \
+    timeout -s KILL 20 "$LBA2_BIN" \
+    --language English --no-audio --resolution 640x480 --load "$FIX" \
+    --fixed-timestep 100 --fixed-dt 8 --exec "useitem trace 1; useitem 18 1 5" --tick 20 --exit \
+    >/dev/null 2>&1
+
+[ -f "$log" ] || fail "no log written ($log) -- run did not boot?"
+grep -q "num=18 .*InvAct=18.* -> TRUE" "$log" \
+    || fail "item-use dropped on a throttle-skip frame -- #392 regression (log: $log)"
+
+pass "item-use survived the throttle (registered on a forced skip frame)"


### PR DESCRIPTION
Completes the headless item-use tooling and adds the end-to-end regression test #392 was missing (it currently only has the `Timer_ForceStepIfPending` unit test).

## What
- **`--fixed-timestep <ms>`** — set the sim throttle (`FixedTimestep`) for one run only, *without* persisting to `lba2.cfg` (unlike the `fixedtimestep` console verb). Lets a test force the throttle regardless of the local cfg. Applied on the first tick, after `ReadConfigFile`.
- **`useitem <n> [frames] [delay]` / `useitem trace <0|1>`** — inject a one-frame inventory item-use headlessly (as `MenuInventory` would set it), so an NPC's give-item check (`LF_USE_INVENTORY`) can be driven without menu input; `trace` logs each result.
- **`tests/automation/test_item_use_throttle.sh`** — the guard.

## The test
On a git-tracked corpus save (`Wannies fragment.LBA`) where NPC obj 2 polls `LF_USE_INVENTORY` for item 18 (the hero holds it): throttle on at 100 ms with `--fixed-dt 8` makes frames 2–13 all skip; the use is injected on frame 6 (a guaranteed skip). With #392 that frame is forced and the poll returns TRUE; **without #392 the use is dropped and the poll never returns TRUE**, so the test fails — a real regression guard.

Local-only (needs retail data; the fixture is tracked). It reads the flushed `adeline.log` in an isolated `XDG_DATA_HOME` dir because the give's dialog blocks a clean `--exit`, so the run is SIGKILLed (stdout is block-buffered and lost; the log is fflushed per line).

## Verification
- Built; the new automation test passes locally (item-use registers on the forced skip frame).
- No new em-dashes (local guard).

Depends conceptually on the docs in #394 (also touches CONSOLE.md/CONTROL.md — trivial adjacent additions).
