### PR TITLE
feat(control): emit cube vars (vars_cube) in --dump-state

### DIFF
--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -621,6 +621,20 @@ static void control_dump_state(const char *path) {
     }
     fprintf(f, " } },\n");
 
+    /* Scene (cube) Life variables. Together with the game vars above these are the quest state,
+       so a corpus of saves dumped through this is a timeline of quest progression. */
+    fprintf(f, "  \"vars_cube\": { \"count\": %d, \"nonzero\": {", (int)MAX_VARS_CUBE);
+    {
+        int i, first = 1;
+        for (i = 0; i < MAX_VARS_CUBE; i++) {
+            if (ListVarCube[i] != 0) {
+                fprintf(f, "%s \"%d\": %d", first ? "" : ",", i, (int)ListVarCube[i]);
+                first = 0;
+            }
+        }
+    }
+    fprintf(f, " } },\n");
+
     fprintf(f, "  \"log\": [");
     {
         const char *lines[16];

--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -173,6 +173,7 @@ Schema-versioned, hand-written, all-integer fields:
   "actors": [ { "index": 0, "x": 5926, "y": 256, "z": 4935, "beta": 2337,
                 "life": 250, "body": 2, "anim": 66, "move": 1, "flags": 2119 } ],
   "vars": { "count": 256, "nonzero": { "0": 1, "14": 5, "88": 25 } },
+  "vars_cube": { "count": 80, "nonzero": { "0": 1 } },
   "log": [ "Cube 100 (change on next frame)" ]
 }
 ```
@@ -191,6 +192,9 @@ Schema-versioned, hand-written, all-integer fields:
 - `actors` — every live object (`0..num_objects-1`); the hero is also `actors[0]`.
 - `vars` — `ListVarGame[]` (the saved script-variable array), emitted sparsely as
   `{count, nonzero}` to keep the file small.
+- `vars_cube`: `ListVarCube[]`, the scene/cube script-variable array, same sparse shape.
+  Together `vars` + `vars_cube` are the full quest state, so dumping a save exposes which
+  quest flags it has set (e.g. a gate an NPC's script is waiting on).
 - `log` — recent console scrollback lines.
 
 ### Seeing the log in a harness run


### PR DESCRIPTION
Adds a `vars_cube` field to `--dump-state`: `ListVarCube[]` (the scene/cube Life variables), beside the existing game `vars`. Together they are the full quest state, so dumping a save exposes which quest flags it has set (e.g. a gate an NPC's script is waiting on).

Small, standalone plumbing. (Scoped down from an earlier version that also shipped a var-table timeline doc/script; raw variable indices are not the right abstraction for a game-context timeline. A progression tracer -- cube transitions + Life-script events -- is the better direction, tracked separately.)