### PR TITLE
feat(console): cubetrace -- log every cube transition (game flow map)

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -1570,6 +1570,14 @@ static void cmd_useitem(int argc, const char *argv[]) {
     }
 }
 
+/* cubetrace <0|1>: log every cube transition (island + from -> to cube) as it happens. Run a
+   playthrough (or the demo reel) with it on to trace out the game's cube-to-cube flow map. */
+static void cmd_cubetrace(int argc, const char *argv[]) {
+    if (argc >= 2)
+        DbgCubeTrace = atoi(argv[1]) ? 1 : 0;
+    Console_Print("cubetrace: %s", DbgCubeTrace ? "ON" : "OFF");
+}
+
 /*──────────────────────────────────────────────────────────────────────────*/
 /* Registration */
 /*──────────────────────────────────────────────────────────────────────────*/
@@ -1668,6 +1676,10 @@ void Console_RegisterAll(void) {
                               "useitem <n> [frames] [delay] | useitem trace <0|1>",
                               "Injects InventoryAction=n (drives LF_USE_INVENTORY without menu input); "
                               "'trace 1' logs each result.");
+    Console_RegisterCommandEx("cubetrace", cmd_cubetrace, "Log every cube transition",
+                              "cubetrace <0|1>",
+                              "Logs island + from -> to cube on each ChangeCube, tracing the game's "
+                              "cube-to-cube flow across a playthrough or the demo reel.");
 
     Console_RegisterCommandEx("perftrace", cmd_perftrace,
                               "Per-frame timing capture (ring buffer, no log spam)",

--- a/SOURCES/C_EXTERN.H
+++ b/SOURCES/C_EXTERN.H
@@ -360,6 +360,7 @@ extern S32 DbgUseItemInject;      // console `useitem`: item number to inject, -
 extern S32 DbgUseItemInjectN;     // console `useitem`: frames to inject over
 extern S32 DbgUseItemInjectDelay; // console `useitem`: frames to wait before injecting
 extern S32 DbgUseItemTrace;       // console `useitem trace`: log each LF_USE_INVENTORY result
+extern S32 DbgCubeTrace;          // console `cubetrace`: log every cube transition
 extern S32 MagicBall;
 extern U8 MagicBallType;
 extern U8 MagicBallCount;

--- a/SOURCES/GLOBAL.CPP
+++ b/SOURCES/GLOBAL.CPP
@@ -322,6 +322,9 @@ S32 DbgUseItemInject = -1;
 S32 DbgUseItemInjectN = 0;
 S32 DbgUseItemInjectDelay = 0;
 S32 DbgUseItemTrace = 0;
+// Console `cubetrace <0|1>`: log every cube transition (island + from -> to cube) as it happens,
+// so a playthrough or the demo reel traces out the game's cube-to-cube flow. No gameplay effect.
+S32 DbgCubeTrace = 0;
 S32 MagicBall = -1;
 U8 MagicBallType = 1;
 U8 MagicBallCount = 3;

--- a/SOURCES/OBJECT.CPP
+++ b/SOURCES/OBJECT.CPP
@@ -3,6 +3,8 @@
 #include "DEMO_SEED.H"
 #include "SAVEGAME.H"
 
+#include <SYSTEM/LOG.H> // cubetrace
+
 #include <stdio.h>
 
 #include "INPUT.H"
@@ -1167,6 +1169,12 @@ void ChangeCube() {
 
     oldcube = NumCube;
     NumCube = NewCube;
+
+    // cubetrace: log the cube-to-cube flow as it happens, so a playthrough (or the demo reel)
+    // traces out the game's progression map. `-1` old cube is a fresh load/new game.
+    if (DbgCubeTrace)
+        Log_Info("[cube] island %d: %d -> %d%s", (int)Island, (int)oldcube, (int)NumCube,
+                 FlagLoadGame ? " (load)" : "");
 
     // reinitialisation du générateur de nombres aléatoires.
     // Retail seeds from TimerRefHR (a wall-clock interval). In the attract reel

--- a/docs/CONSOLE.md
+++ b/docs/CONSOLE.md
@@ -70,6 +70,7 @@ These mirror the classic key-sequence cheats; you can type their name directly a
 | **vargame** &lt;n&gt; [value] | Read (no value) or set a game Life variable, `n` in `0..255`. Drives quest / inventory state. |
 | **lifetrace** &lt;objN&gt; \| off | Trace object N's Life script: its comportement/track/zone state each frame and every `LF_` condition it evaluates (with the branch `Value`). An NPC-script debugger: shows whether a script ever reaches a given check and what its gating conditions read. |
 | **useitem** &lt;n&gt; [frames] [delay] \| **useitem trace** &lt;0\|1&gt; | Inject a one-frame inventory item-use of var-game item `n` (as opening the inventory and using it would), so an NPC's give-item check (`LF_USE_INVENTORY`) can be driven headlessly. `frames` injects over N frames; `delay` waits N frames first (to land past a load's clock jump on a throttle-skip frame). `trace 1` logs each `LF_USE_INVENTORY` result. |
+| **cubetrace** &lt;0\|1&gt; | Log every cube transition (`island N: A -> B`) on each `ChangeCube`. Run a playthrough or the demo reel with it on to trace out the game's cube-to-cube flow map. |
 | **playvideo** &lt;name&gt; | Play ACF video by name. |
 | **listvideos** | List available ACF video names. |
 | **playjingle** &lt;1-26&gt; | Play jingle by number. |


### PR DESCRIPTION
First piece of the game-context tracer: log the game's cube-to-cube flow.

## What
`cubetrace <0|1>` logs each cube transition at the `ChangeCube` funnel (`SOURCES/OBJECT.CPP`):

```
[cube] island 2: 62 -> 63
```

Run a playthrough with it on and you get the game's progression map -- how one cube leads to the next -- which raw quest-var dumps don't convey. Console toggle, gated, no gameplay effect.

## Why
Following the thread from the quest-timeline discussion: variable indices aren't *context*; the useful context is the progression (cube flow) and what the Life scripts do. This is the cube-flow axis. The Life-script *event* layer (what a script does at each cube -- gives, dialogs, var sets) is the natural follow-up, building on `lifetrace` (#393).

## Notes
- Verified on a real cube change (`62 -> 63` via the `cube` console command). The headless `--demo` attract reel doesn't drive `ChangeCube`, so the map comes from an actual playthrough.
- Hook is at the single `ChangeCube` entry point, so it catches every transition (zone, door, script, load).