### PR TITLE
fix(perso): force a sim step on a scene-flip frame so the throttle cannot skip it (#358)

### DIFF
--- a/SOURCES/GERELIFE.CPP
+++ b/SOURCES/GERELIFE.CPP
@@ -831,8 +831,18 @@ void DoLife(U8 numobj) {
             InitAnim(GEN_ANIM_RIEN, ANIM_REPEAT, NUM_PERSO);
             SetComportement(*PtrPrg++);
 
-            if (DemoSlide AND(FirstTime != AFF_ALL_FLIP))
-                MenuComportement(2 * 1000);
+            // In the attract demo, a scripted behaviour change flashes the behaviour menu, except
+            // during a full-scene flip (AFF_ALL_FLIP) so it does not pop over scene setup / a
+            // cutscene. That suppression depends on reading FirstTime on the same frame AffScene
+            // consumes it, so the fixed-timestep throttle must not skip the flip frame (see the
+            // Timer_ForceStepIfPending scene-flip case in PERSO.CPP, #358).
+            if (DemoSlide) {
+                S32 showmenu = (FirstTime != AFF_ALL_FLIP);
+                Log_Debug("[demo] LM_COMPORTEMENT_HERO cube=%d FirstTime=%d menu=%d", (int)NumCube,
+                          (int)FirstTime, (int)showmenu);
+                if (showmenu)
+                    MenuComportement(2 * 1000);
+            }
             break;
 
             //---------------------------------------------------------------------------

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -1933,16 +1933,29 @@ restartloop:
             U32 nextLastSim;
             nSimSteps = Timer_PlanSimSteps(TimerRefHR, LastSimRefHR, FixedTimestep,
                                            FIXED_TIMESTEP_MAX_STEPS, &simBaseRef, &nextLastSim);
-            /* Deliver a one-frame inventory-use event even on a throttle-skip frame. InventoryAction
-               is set above this frame by MenuInventory, cleared at the top of every loop, and
-               consumed by LF_USE_INVENTORY in DoLife below. On high-refresh displays most frames
-               skip the sim, so without this the event is wiped before any simulated frame reads it
-               and a quest item-use (the ferry ticket, the Balsam flower, the Wizard Diploma)
-               silently fails (#358 regression, softlocks the Peddler). Promotes a would-skip frame
-               to a single step; a no-op when a step already runs or nothing is pending, so the
-               throttle and its --fixed-dt 16 byte-for-byte guarantee are otherwise untouched. */
-            nSimSteps = Timer_ForceStepIfPending(nSimSteps, InventoryAction >= 0, TimerRefHR,
-                                                 FixedTimestep, &simBaseRef, &nextLastSim);
+            /* Force a real sim step on a would-skip frame when it carries a one-frame signal that a
+               later, non-skipped frame cannot recover:
+
+                 - InventoryAction: a quest item-use set by MenuInventory, cleared at the top of
+                   every loop and consumed by LF_USE_INVENTORY in DoLife below. On high-refresh
+                   displays most frames skip the sim, so without this the event is wiped before any
+                   simulated frame reads it and a quest item-use (the ferry ticket, the Balsam
+                   flower, the Wizard Diploma) silently fails (#358 regression, softlocks the Peddler).
+
+                 - FirstTime == AFF_ALL_FLIP: a full-scene flip (scene load / CAM_FOLLOW). DoLife
+                   runs this frame and reads FirstTime; AffScene(FirstTime) below then consumes it and
+                   the tail resets FirstTime to AFF_OBJETS_FLIP. If the flip frame is skipped, AffScene
+                   still runs and resets FirstTime, so the deferred DoLife reads the stale value a
+                   frame later -- e.g. the demo behaviour menu (LM_COMPORTEMENT_HERO), suppressed
+                   while FirstTime == AFF_ALL_FLIP, then leaks over scene setup. Forcing the flip
+                   frame to step keeps DoLife and AffScene on the same frame.
+
+               Promotes a would-skip frame to a single step; a no-op when a step already runs or
+               nothing is pending, so the throttle and its --fixed-dt 16 byte-for-byte guarantee are
+               otherwise untouched. */
+            nSimSteps = Timer_ForceStepIfPending(nSimSteps,
+                                                 (InventoryAction >= 0) || (FirstTime == AFF_ALL_FLIP),
+                                                 TimerRefHR, FixedTimestep, &simBaseRef, &nextLastSim);
             LastSimRefHR = nextLastSim;
             if (nSimSteps <= 0)
                 goto skip_simulation; // high-fps skip (remainder carries) or clock rewind (re-anchored)

--- a/docs/MOVEMENT_FRAMERATE.md
+++ b/docs/MOVEMENT_FRAMERATE.md
@@ -199,6 +199,25 @@ surgery and its own correctness risk.
   ([OBJECT.CPP](../SOURCES/OBJECT.CPP)), so keeping the direction bits does not reset the walk
   anim. Verified by `tests/automation/test_move_substep.sh` (dt16 vs dt64 travel now match).
 
+**One-frame signals on a skipped frame.** A skip runs no simulation but still presents a frame,
+so anything that must be *read by the sim on the exact frame it is set* is lost when that frame
+skips. `Timer_ForceStepIfPending` promotes a would-skip frame to a single step when such a signal
+is pending, keeping the producer and consumer on the same frame. Two known signals:
+
+- **A one-frame inventory-use** (`InventoryAction`, set by `MenuInventory`, read by
+  `LF_USE_INVENTORY` in `DoLife`). Without the promotion a quest item-use is wiped before any
+  simulated frame reads it (#358, softlocks the Peddler). Covered by
+  `tests/automation/test_item_use_throttle.sh`.
+- **A full-scene flip** (`FirstTime == AFF_ALL_FLIP`, set on scene load / `LM_CAM_FOLLOW`).
+  `DoLife` reads `FirstTime` this frame; `AffScene(FirstTime)` then consumes it and the loop tail
+  resets it to `AFF_OBJETS_FLIP`. If the flip frame skips, `AffScene` still resets it, so a
+  `DoLife` deferred to the next frame reads the stale value. The visible symptom was the attract
+  demo's behaviour menu (`LM_COMPORTEMENT_HERO`, suppressed while `FirstTime == AFF_ALL_FLIP`)
+  popping over scene setup once the throttle defaulted on. Covered by
+  `tests/automation/test_demo_behaviour_menu.sh`.
+
+Both are no-ops under `--fixed-dt 16` (that path never skips), so the goldens are untouched.
+
 **Clock model (the sensitive part; see [TIMING.md](TIMING.md)).** Separate the game-clock
 source from `TimerSystemHR`:
 

--- a/tests/automation/test_demo_behaviour_menu.sh
+++ b/tests/automation/test_demo_behaviour_menu.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# #358 regression: the fixed-timestep throttle must not skip a full-scene-flip frame.
+#
+# In the attract demo a scripted behaviour change (LM_COMPORTEMENT_HERO) flashes the behaviour
+# menu, suppressed during a scene flip (FirstTime == AFF_ALL_FLIP) so it does not pop over scene
+# setup / a cutscene. That suppression reads FirstTime on the same frame AffScene consumes it. If
+# the throttle skips the flip frame, AffScene still resets FirstTime, the deferred read a frame
+# later sees the stale value, and the menu leaks over every scene start (the reported symptom).
+# The fix forces a flip frame to simulate (Timer_ForceStepIfPending scene-flip case, PERSO.CPP).
+#
+# Test: run the SAME demo window (same --fixed-dt, same --tick) with the throttle off and with it
+# on forcing frame-skips; toggling only the throttle must not change WHICH scenes show the menu.
+# Before the fix the throttled run leaked the menu into many extra scene-start cubes.
+#
+# The [demo] line is a Log_Debug at the guard, so the run needs --log-level debug. Local-only:
+# needs retail data + a build; skips cleanly otherwise.
+TESTNAME=demo_behaviour_menu
+. "$(dirname "$0")/lib.sh"
+precheck
+
+base="$(mktemp)"; thr="$(mktemp)"
+trap 'rm -f "$base" "$thr"' EXIT
+
+# Unique cubes where the behaviour menu was SHOWN over a fixed demo window. --fixed-dt makes it
+# deterministic; the extra arg toggles only the throttle (FixedTimestep).
+shown() {
+    ctl_headless --log-level debug --exec "cube 193" --demo --fixed-dt 40 --tick 8000 "$@" --exit 2>&1 1>/dev/null \
+        | sed -n 's/.*\[demo\] LM_COMPORTEMENT_HERO cube=\([0-9]*\).*menu=1/\1/p' | sort -un
+}
+
+shown --fixed-timestep 0   > "$base"   # no throttle: every frame simulates (ground truth)
+shown --fixed-timestep 100 > "$thr"    # throttle forcing frame-skips (the regression path)
+
+[ -s "$base" ] || fail "no behaviour-menu events in the no-throttle run: demo did not run or the trace is missing"
+
+if ! diff -q "$base" "$thr" >/dev/null; then
+    fail "throttle changed which scenes show the behaviour menu (leaks over scene setup, #358):
+  no-throttle: $(tr '\n' ' ' < "$base")
+  throttle   : $(tr '\n' ' ' < "$thr")"
+fi
+
+pass "behaviour-menu scenes identical with/without the throttle: $(tr '\n' ' ' < "$base")"


### PR DESCRIPTION
## Symptom

Since the fixed-timestep throttle defaulted on, the attract demo's **behaviour menu pops up over scene setup and cutscenes** (fine during actual gameplay). Reported in review; confirmed not caused by the zonelist/walkthrough work (#401/#402) — reproduced and cured by toggling *only* the throttle.

## Root cause: a one-frame signal dropped on a skipped frame

The throttle skips the simulation on a frame that renders faster than one step. A full-scene flip (`FirstTime == AFF_ALL_FLIP`, set on scene load / `LM_CAM_FOLLOW`) is a one-frame signal:

1. `DoLife` runs this frame and reads `FirstTime`;
2. `AffScene(FirstTime)` ([PERSO.CPP:2238](../blob/main/SOURCES/PERSO.CPP)) then consumes it and the loop tail resets it to `AFF_OBJETS_FLIP`.

When the throttle **skips** the flip frame, `AffScene` still runs and resets `FirstTime`, so a `DoLife` deferred to the next frame reads the stale value. The demo behaviour menu (`LM_COMPORTEMENT_HERO`), which is suppressed while `FirstTime == AFF_ALL_FLIP`, then leaks over scene setup. Same class as the #358 inventory-use drop.

## Fix

Extend the existing `Timer_ForceStepIfPending` guard so a pending scene flip, like a pending item-use, promotes a would-skip frame to a single step — keeping `DoLife` and `AffScene` on the same frame. No-op when a step already runs or nothing is pending, so the throttle and its `--fixed-dt 16` byte-for-byte guarantee are untouched.

## Verification

- **Reproduced and fixed:** with the throttle forcing skips, scene-flip cubes 198/199/200/207 leaked the menu before; after the fix the set of scenes showing the menu is identical to the no-throttle baseline (`{194,195,196,203,206}`, the legitimate mid-gameplay changes).
- **New regression test** `tests/automation/test_demo_behaviour_menu.sh` toggles only the throttle over a fixed demo window and asserts the menu-shown set is unchanged. **Fails without the fix** (leaks 198/199/200/207), passes with it.
- **No regressions:** projection corpus (50 saves, `--fixed-dt 16`) still matches golden; `test_item_use_throttle.sh` still passes; timer/movement host tests green.

Docs in `docs/MOVEMENT_FRAMERATE.md`.