### PR TITLE
fix(perso): don't let the throttle drop a hero input edge (#407)

### DIFF
--- a/SOURCES/INPUT.H
+++ b/SOURCES/INPUT.H
@@ -55,6 +55,15 @@
 #define I_FIRE (I_ACTION_M | I_INVENTORY | I_RETURN | I_THROW | I_COMPORTEMENT)
 #define I_ACTION (I_ACTION_M | I_ACTION_ALWAYS)
 
+// Hero discrete-action input bits that the throttled object loop (OBJECT.CPP MOVE_MANUAL)
+// consumes as EDGES, not held state: a melee/weapon attack starts on the press edge and weapon
+// fire stops on the release edge. Unlike movement (I_JOY) -- held state the fixed-timestep sim
+// throttle is correct to skip -- a dropped action/fire edge sticks: the blowgun keeps firing,
+// melee never starts (#407). So the throttle must not skip a frame whose input changed here (see
+// I_ACTION_EDGE use in PERSO.CPP MainLoop). I_FIRE is included because the object loop's stop/idle
+// reset also keys off an I_FIRE change (LastMyFire).
+#define I_ACTION_EDGE (I_ACTION | I_THROW | I_ESQUIVE | I_FIRE)
+
 #define ALL_INPUTS (0xFFFFFFFFL)
 
 // Input

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -1950,11 +1950,20 @@ restartloop:
                    while FirstTime == AFF_ALL_FLIP, then leaks over scene setup. Forcing the flip
                    frame to step keeps DoLife and AffScene on the same frame.
 
+                 - A hero action/fire input EDGE ((Input ^ LastInput) & I_ACTION_EDGE): melee,
+                   weapon fire and dodge are edge-triggered by the object loop -- a new attack
+                   starts on the press edge, weapon fire stops on the release edge -- but that loop
+                   runs only on simulated frames while LastInput advances every rendered frame
+                   (above). A press/release landing on a skipped frame is never seen, so the blowgun
+                   keeps firing on its own and melee never starts while moving (#407). Movement
+                   (I_JOY) is deliberately excluded: it is held state the throttle is correct to
+                   skip, and forcing a step on every walk change would defeat the frame-rate fix.
+
                Promotes a would-skip frame to a single step; a no-op when a step already runs or
                nothing is pending, so the throttle and its --fixed-dt 16 byte-for-byte guarantee are
                otherwise untouched. */
             nSimSteps = Timer_ForceStepIfPending(nSimSteps,
-                                                 (InventoryAction >= 0) || (FirstTime == AFF_ALL_FLIP),
+                                                 (InventoryAction >= 0) || (FirstTime == AFF_ALL_FLIP) || (((Input ^ LastInput) & I_ACTION_EDGE) != 0),
                                                  TimerRefHR, FixedTimestep, &simBaseRef, &nextLastSim);
             LastSimRefHR = nextLastSim;
             if (nSimSteps <= 0)

--- a/docs/MOVEMENT_FRAMERATE.md
+++ b/docs/MOVEMENT_FRAMERATE.md
@@ -199,10 +199,13 @@ surgery and its own correctness risk.
   ([OBJECT.CPP](../SOURCES/OBJECT.CPP)), so keeping the direction bits does not reset the walk
   anim. Verified by `tests/automation/test_move_substep.sh` (dt16 vs dt64 travel now match).
 
-**One-frame signals on a skipped frame.** A skip runs no simulation but still presents a frame,
-so anything that must be *read by the sim on the exact frame it is set* is lost when that frame
-skips. `Timer_ForceStepIfPending` promotes a would-skip frame to a single step when such a signal
-is pending, keeping the producer and consumer on the same frame. Two known signals:
+**One-frame signals on a skipped frame -- the invariant.** A skip runs no simulation but still
+presents a frame, so anything that must be *read/observed by the sim on the exact frame it changes*
+is lost when that frame skips. The rule that keeps this class from recurring: **the throttle may
+skip a frame only when it is a true no-op for the sim** -- nothing discrete happened on it.
+`Timer_ForceStepIfPending` enforces that by promoting a would-skip frame to a single step when a
+discrete signal is pending, keeping the producer and consumer on the same frame. The pending
+conditions:
 
 - **A one-frame inventory-use** (`InventoryAction`, set by `MenuInventory`, read by
   `LF_USE_INVENTORY` in `DoLife`). Without the promotion a quest item-use is wiped before any
@@ -215,8 +218,23 @@ is pending, keeping the producer and consumer on the same frame. Two known signa
   demo's behaviour menu (`LM_COMPORTEMENT_HERO`, suppressed while `FirstTime == AFF_ALL_FLIP`)
   popping over scene setup once the throttle defaulted on. Covered by
   `tests/automation/test_demo_behaviour_menu.sh`.
+- **A hero action/fire input edge** (`(Input ^ LastInput) & I_ACTION_EDGE`). The object loop that
+  drives the hero is edge-triggered on these bits -- a melee/weapon attack starts on the *press*
+  edge, weapon fire stops on the *release* edge -- but it runs only on simulated frames, while
+  `LastInput` advances every rendered frame. A press/release landing on a skipped frame is never
+  observed, so the blowgun keeps firing on its own and melee never starts while moving (#407,
+  same class, reported on keyboard and pad alike). Promoting the edge frame keeps the transition on
+  a simulated frame. Movement (`I_JOY`) is deliberately *excluded* from `I_ACTION_EDGE`: it is held
+  state the throttle is correct to skip, and forcing a step on every walk change would defeat the
+  frame-rate fix. Covered by `tests/automation/test_blowgun_release_throttle.sh`.
 
-Both are no-ops under `--fixed-dt 16` (that path never skips), so the goldens are untouched.
+All are no-ops under `--fixed-dt 16` (that path never skips), so the goldens are untouched.
+
+> A more robust structure -- running the sim at a fixed 60 Hz and *interpolating* skipped render
+> frames, with input latched across the gap (canonical "fix your timestep") -- would end this
+> dropped-signal class outright and remove the high-refresh stutter too, but it is not byte-exact
+> and needs its own re-baselining. Tracked in #412; the force-step promotion is the low-risk,
+> byte-exact containment.
 
 **Clock model (the sensitive part; see [TIMING.md](TIMING.md)).** Separate the game-clock
 source from `TimerSystemHR`:

--- a/tests/automation/test_blowgun_release_throttle.sh
+++ b/tests/automation/test_blowgun_release_throttle.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# #407 regression: the fixed-timestep throttle must not drop a hero input EDGE.
+#
+# The throttle (issue #358) skips the whole simulation on frames that render faster than one
+# step. Hero weapon fire is level-triggered on I_THROW and *stops* on a release edge:
+# `!(Input & I_THROW) && (LastInput & I_THROW)` (OBJECT.CPP, the weapon block's else branch).
+# LastInput advances every RENDERED frame (PERSO.CPP), but the object loop that reads the edge
+# only runs on SIMULATED frames. So when the release lands on a skipped frame, the edge is gone
+# by the next simulated frame and the ANIM_REPEAT blowgun animation never resets -- the hero
+# keeps firing on its own (issue #407 case 3). Same one-frame-signal-drop class as the item-use
+# (#392) and scene-flip (#411) throttle regressions; the fix forces a sim step on any frame whose
+# hero action/fire input changed (Timer_ForceStepIfPending input-edge case, PERSO.CPP).
+#
+# Test: fire the blowgun for a few frames then release, over the SAME window, with the throttle
+# off (per-frame sim, the ground truth) and on (forcing frame-skips). Toggling only the throttle
+# must not change the settled hero animation. --fixed-dt pins the cadence so the skip pattern is
+# deterministic. Before the fix the throttled run stays stuck on the firing anim (SARBACANE 35 /
+# SARBATRON 45) where the ground truth has returned to idle (RIEN 0).
+#
+# Local-only: needs retail data + a build + the tracked steam_classic_2023 corpus; skips cleanly
+# otherwise. The corpus saves are git-tracked, so each run works on a temp copy (a --load run
+# autosaves and must not mutate the fixture).
+TESTNAME=blowgun_release_throttle
+. "$(dirname "$0")/lib.sh"
+precheck
+
+CORPUS="$REPO/tests/savegame/corpus/saves/steam_classic_2023"
+# Saves with the blowgun (weapon 23) selected and the hero idle at load, so a fire+release is
+# the only thing that moves the animation off RIEN. Verified: idle (gen_anim 0) at load under
+# both throttle states, so the load state is not a confound.
+SAVES=("Bu" "DOS2" "Spaceship")
+
+is_firing_anim() { [ "$1" = "35" ] || [ "$1" = "45" ]; } # GEN_ANIM_SARBACANE / GEN_ANIM_SARBATRON
+
+# Fire the blowgun (hold I_THROW) for 6 frames, release, settle 40 frames, report hero gen_anim.
+gen_anim_after_fire() { # save-src fixedtimestep-ms
+    local src="$1" fts="$2" sv dump ga
+    sv="$(mktemp --suffix=.LBA)"; dump="$(mktemp)"
+    cp "$src" "$sv"
+    ctl_headless --load "$sv" --fixed-dt 8 --fixed-timestep "$fts" \
+        --exec "input throw 6" --tick 40 --dump-state "$dump" --exit >/dev/null 2>&1
+    ga="$(jget "$dump" "d['hero']['gen_anim']" 2>/dev/null)"
+    rm -f "$sv" "$dump"
+    echo "$ga"
+}
+
+tested=0
+fails=""
+for name in "${SAVES[@]}"; do
+    src="$CORPUS/$name.LBA"
+    [ -f "$src" ] || continue
+    off="$(gen_anim_after_fire "$src" 0)"   # ground truth: every frame simulates, no skips
+    on="$(gen_anim_after_fire "$src" 100)"  # throttle forcing frame-skips (the regression path)
+    [ -n "$off" ] && [ -n "$on" ] || { fails="$fails
+  $name: dump failed (off='$off' on='$on')"; continue; }
+    # Sanity: the ground-truth run must have stopped firing, else the fixture/observable is wrong.
+    if is_firing_anim "$off"; then
+        fails="$fails
+  $name: ground-truth (throttle off) is still firing (gen_anim=$off) -- bad fixture"
+        continue
+    fi
+    tested=$((tested + 1))
+    if [ "$on" != "$off" ]; then
+        fails="$fails
+  $name: throttle-off gen_anim=$off, throttle-on gen_anim=$on (blowgun stuck firing)"
+    fi
+done
+
+[ "$tested" -gt 0 ] || skip "no usable blowgun corpus save (steam_classic_2023 not present?)"
+[ -z "$fails" ] || fail "throttle changed the post-release hero animation (#407 input-edge drop):$fails"
+pass "blowgun stops firing on release with and without the throttle ($tested save(s))"


### PR DESCRIPTION
Fixes the input-handling half of #407.

## Symptom

Field-reported (#407, EPmager) on keyboard and controller alike, all resolutions, vsync-independent, none present before the fixed-timestep throttle (#358) defaulted on:

- The Blowgun keeps firing after Use weapon is released (stops only on a direction press).
- In Aggressive mode, holding Behaviour action while moving performs no melee, and releasing direction keeps the hero advancing.

## Root cause: an input edge dropped on a skipped frame

The throttle skips the whole simulation on frames that render faster than one step. The hero object loop is edge-triggered on its action/fire input: a melee or weapon attack starts on the *press* edge, weapon fire stops on the *release* edge ([OBJECT.CPP](../blob/main/SOURCES/OBJECT.CPP) `MOVE_MANUAL`). That loop runs only on simulated frames, but `LastInput` (its edge reference) advances every rendered frame ([PERSO.CPP](../blob/main/SOURCES/PERSO.CPP)). So a press/release that lands on a skipped frame is never observed and the edge is lost: the `ANIM_REPEAT` weapon anim never resets (blowgun keeps firing), and the anti-repeat guard swallows the melee start while walking.

Same one-frame-signal-drop class as the item-use (#392) and scene-flip (#411) throttle regressions, which is why it reproduces identically on keyboard and pad.

## Fix

Extend the existing `Timer_ForceStepIfPending` guard so a would-skip frame whose hero action/fire input changed (`(Input ^ LastInput) & I_ACTION_EDGE`) is promoted to a single step, keeping the transition on a simulated frame. Framed as the invariant the guard should enforce: the throttle skips a frame only when it is a true no-op for the sim.

Movement (`I_JOY`) is deliberately excluded from `I_ACTION_EDGE`: it is held state the throttle is correct to skip, and forcing a step on every walk change would defeat the frame-rate fix. A no-op when a step already runs or nothing changed, so `--fixed-dt 16` stays byte-for-byte identical and the throttle's decoupling is otherwise untouched.

## Verification

- **New regression test** `tests/automation/test_blowgun_release_throttle.sh`: fires the blowgun then releases over a fixed window with the throttle off (ground truth) and on (forcing skips); toggling only the throttle must not change the settled hero animation. Reproduced headlessly with the `input` harness command; RED without the fix (stuck on the firing anim across three corpus saves), GREEN with it.
- **Byte-exact:** the projection corpus hash is identical to the pre-fix binary (the guard is a literal no-op when a step already runs).
- **No regressions:** `test_item_use_throttle`, `test_demo_behaviour_menu`, `test_move_substep`, `test_input_injection` green; `host_quick` 43/43.
- **Confirmed in play** on-device: all three reported cases feel correct again.

Cases 1 and 2 (Aggressive melee / Discreet crouch) are not in the automated test: they need a walking + behaviour-switched state that is fiddly to stage deterministically headless. They ride the same `I_ACTION` edge through the same guard, so they are covered by construction and confirmed in play. Case 2 also carries a couple of cosmetic reporter suggestions (crouch rotation) that are behaviour-design questions beyond the drop and are left out of scope here.

## Follow-up

#412 tracks the structural fix (fixed-step sim + interpolated render + input latching) that would end this dropped-signal class outright and remove the high-refresh stutter, at the cost of byte-exactness and re-baselining. The force-step promotion here is the low-risk, byte-exact containment.

Docs in `docs/MOVEMENT_FRAMERATE.md`.
