### PR TITLE
fix(fmv): scene no longer pops in at FMV/scene transitions

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -320,9 +320,11 @@ static void cmd_ui_dispatch(int argc, const char *argv[]) {
         /* PlayAcf opens an ACF / Smacker cinematic by name and runs the
            playback loop until end-of-file, ESC, or I_MENUS input.
            Video_RequestCapture arms a one-shot SavePNG inside the loop
-           after the first composited frame, then exits via PlayAcf's
-           fin_play cleanup (which restores Log + palette).  Useful for
-           regression-testing widescreen centring of cutscenes. */
+           after the first composited frame; the PNG is written from Log
+           before PlayAcf's tail, so the capture is unaffected by it.
+           PlayAcf leaves the screen black on exit (its contract) -- fine
+           for this headless capture verb. Useful for regression-testing
+           widescreen centring of cutscenes. */
         Video_RequestCapture(argv[3]);
         PlayAcf(argv[2]);
         Console_Print("ui video %s -> %s", argv[2], argv[3]);
@@ -590,14 +592,36 @@ static void cmd_give(int argc, const char *argv[]) {
 
 static void cmd_playvideo(int argc, const char *argv[]) {
     if (argc < 2) {
-        Console_Print("Usage: playvideo <name>");
+        Console_Print("Usage: playvideo <name>  (a video name -- see listvideos)");
         return;
     }
+    // Validate the name up front (PlayAcf returns 0 for both "not found" and normal
+    // completion, so its return can't distinguish them).
+    if (GetNumAcf(argv[1]) < 0) {
+        Console_Print("playvideo: no video named '%s' (run listvideos for names)", argv[1]);
+        return;
+    }
+    /* Preview: PlayAcf leaves the screen black on return (its contract -- callers
+       reveal via their own fade-in). A bare preview has no such caller, so it
+       snapshots the pre-video screen and fades it back, like cmd_credits. Refuse if we
+       can't snapshot rather than run PlayAcf's Cls and strand the screen on black. */
+    if (!Log) {
+        Console_Print("playvideo: no framebuffer");
+        return;
+    }
+    const U32 bufSize = (U32)(ModeDesiredX * ModeDesiredY);
+    U8 *savedLog = (U8 *)malloc(bufSize);
+    if (!savedLog) {
+        Console_Print("playvideo: out of memory for screen snapshot");
+        return;
+    }
+    memcpy(savedLog, Log, bufSize);
     Console_Close();
-    if (PlayAcf(argv[1]) >= 0)
-        Console_Print("Playing video: %s", argv[1]);
-    else
-        Console_Print("Video not found: %s", argv[1]);
+    PlayAcf(argv[1]);
+    memcpy(Log, savedLog, bufSize);
+    free(savedLog);
+    FadeToPal(PtrPal); // PtrPal is unchanged by a bare PlayAcf; fade the screen back in
+    Console_Print("Playing video: %s", argv[1]);
 }
 
 static void cmd_credits(int argc, const char *argv[]) {

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -4001,7 +4001,11 @@ S32 MainGameMenu(S32 load) {
                 PlayAcf("BABY");
                 Image_LoadStretched(tmpFilePathScreen, Screen, PCR_MENU);
                 CopyScreen(Screen, Log);
-                BoxStaticFullflip();
+                // PlayAcf now leaves the screen black (original contract). Reveal the
+                // win screen with its palette, the same PtrPalNormal the menu is drawn
+                // with above; without this the composited image would present black.
+                PtrPal = PtrPalNormal;
+                FadeToPal(PtrPalNormal);
                 EscTimer = 0;
 #endif
                 break;

--- a/SOURCES/PLAYACF.CPP
+++ b/SOURCES/PLAYACF.CPP
@@ -386,23 +386,6 @@ S32 PlayAcf(const char *name) {
         StopMusic();
         HQ_PauseSamples();
 
-        /* Save current screen and palette so we can restore after playback (fix black screen). */
-        const U32 logSize = (U32)(ModeDesiredX * ModeDesiredY);
-        const U32 palSize = 768;
-        U8 *savedLog = (U8 *)malloc(logSize + palSize);
-        if (!savedLog) {
-            if (VideoLogIsEnabled())
-                SDL_Log("[VIDEO] PlayAcf: malloc failed for screen save");
-            HQ_ResumeSamples();
-            s_playacf_playing = 0;
-            return 0;
-        }
-        U8 *savedPal = savedLog + logSize;
-        if (Log && PtrPal) {
-            memcpy(savedLog, Log, logSize);
-            memcpy(savedPal, PtrPal, palSize);
-        }
-
         U8 *decompbuf = (U8 *)LoadMalloc_HQR(PathAcf, n);
         U32 size = LoadMallocFileSize;
         if (!size) {
@@ -550,15 +533,21 @@ S32 PlayAcf(const char *name) {
             }
 
             ReadNextVideoFrame(smkObject, cineOrigin, ModeDesiredX, &pal);
-            if (pal)
+            if (pal) {
+                // The video is on screen with its own palette; clear FlagBlackPal so
+                // the engine state matches (SetBlackPal at entry left it TRUE). The
+                // tail FadeToBlack() below early-returns when FlagBlackPal is set, so
+                // without this the video would cut, not fade, at its end.
+                FlagBlackPal = FALSE;
                 PaletteSync(pal);
+            }
 
             /* Harness one-shot capture — saves a composited frame past the
                cinematic's initial fade-in (frame 0 is uniformly black for the
                INTRO smk; we pick a later frame so the golden is meaningful
-               regardless of whether audio init / pre-fill is enabled). The
-               cleanup at fin_play restores Log from savedLog, but the on-disk
-               PNG already holds the cinematic frame. */
+               regardless of whether audio init / pre-fill is enabled). The PNG is
+               written here from Log, so the fade-to-black at fin_play doesn't
+               affect it. */
             if (s_video_capture_path[0] && c >= 25u) {
                 SavePNG(s_video_capture_path, Log, (S32)ModeDesiredX,
                         (S32)ModeDesiredY, pal ? pal : PtrPal);
@@ -621,19 +610,27 @@ S32 PlayAcf(const char *name) {
 
     fin_play:
         StopVideoAudio();
+
+        /* `pal` points into the smk struct (smk_get_palette returns an inline member),
+           so copy it out before smk_close frees that struct -- FadeToBlack below reads
+           all 768 bytes. Fall back to PtrPal if the first frame never decoded. */
+        U8 lastFramePal[768];
+        memcpy(lastFramePal, pal ? pal : PtrPal, sizeof(lastFramePal));
+
         smk_close(smkObject);
         Free(decompbuf);
 
-        /* Restore screen and palette so we don't leave a black screen. */
-        if (savedLog && Log && PtrPal) {
-            memcpy(Log, savedLog, logSize);
-            memcpy(PtrPal, savedLog + logSize, palSize);
-            PaletteSync(PtrPal);
-        }
-        if (savedLog)
-            free(savedLog);
-
+        /* Original contract: fade the video out to black and leave the screen black,
+           so the scene load stays hidden and the caller's fade-in (FlagFade) reveals
+           the next scene. The port used to restore the pre-video scene bright here
+           ("so we don't leave a black screen"), which un-blacked the screen under
+           every LM_PLAY_ACF / TM_PLAY_ACF / menu-FMV caller and flashed the scene one
+           frame before the fade-in (#404). */
+        FadeToBlack(lastFramePal);
+        Cls();
         BoxStaticFullflip();
+        SetBlackPal();
+
         HQ_ResumeSamples();
         InitWaitNoKey();
         InitWaitNoInput(I_MENUS);

--- a/SOURCES/PLAYACF.H
+++ b/SOURCES/PLAYACF.H
@@ -40,6 +40,11 @@ extern S32 GetNumAcf(const char *name);
 //▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
 extern void PlayAllAcf(void);
 //▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+/* Contract: PlayAcf fades the video out and leaves the screen BLACK on return
+   (SetBlackPal, FlagBlackPal=TRUE). The caller must reveal the next screen --
+   in-game via FlagFade + AffScene (LM_PLAY_ACF / TM_PLAY_ACF etc.), or by its own
+   FadeToPal (menu win-screen, console preview). A caller that neither fades in nor
+   restores will sit on black. */
 extern S32 PlayAcf(const char *name);
 /* Harness hook: arm a one-shot screenshot inside the next PlayAcf call.
    PlayAcf saves the Log buffer to <path> on the first composited cinema


### PR DESCRIPTION
Fixes #404.

## The bug

At an FMV that precedes a scene change, the new scene flashes for one frame at full brightness before the fade-in, and the video no longer fades out at its tail. The effect scales with frame rate (worse the higher the fps).

## Cause

`PlayAcf`'s exit was changed (in `a322185b`, the debug-console PR #24) from the original *fade the video out, leave the screen black* to *restore the pre-video screen bright*. Every in-game caller (`LM_PLAY_ACF`, `TM_PLAY_ACF`, the menu FMVs) fades the current scene to black, plays the video, then arms `FlagFade` and expects the black to persist until its fade-in reveals the loaded scene. Un-blacking the screen at `PlayAcf`'s exit meant the caller's `AffScene` composited and presented the new scene bright one frame *before* `FadeToPalAndSamples` forced it black — the pop. It is a timing race (the Smacker decode runs on its own clock), which is why it is worse the higher the frame rate.

## The fix

Restore the original contract: fade the video out (`FadeToBlack`) and leave the screen black (`SetBlackPal`). The caller's fade-in does the reveal, so the scene load is hidden on both sides.

- `FlagBlackPal` is cleared during playback so the tail `FadeToBlack` ramps instead of early-returning.
- The last-frame palette is copied out before `smk_close` frees the struct it points into (that palette is an inline struct member, so reading it after close was a use-after-free).
- `BABY` (the win screen) is the one caller with no fade-in loop; it now reveals with `FadeToPal(PtrPalNormal)`.
- `PlayAcf`'s leave-black contract is documented at its declaration so the next caller does not re-hit the black screen.
- `playvideo` (bare console preview) now snapshots the screen and fades it back, since `PlayAcf` leaves it black; it also validates the video name up front (`PlayAcf` returns 0 for both "not found" and success, so the old check never reported a bad name).

## Testing

Test-light by nature: this is a structural revert of rendering-timing behaviour that is not meaningfully unit-testable without game assets (same class as #353 / #374). Verified by inspecting the present stream (the new scene now composites at luma 0, not full brightness, before the fade-in) and in-game by the original reporter. Builds clean; existing host tests pass.
