### PR TITLE
fix(fade): stop the palette fade from wiping actors out of the frame

### DIFF
--- a/SOURCES/AMBIANCE.CPP
+++ b/SOURCES/AMBIANCE.CPP
@@ -501,8 +501,16 @@ void FadePal(U8 r, U8 v, U8 b, U8 *ptrpal, S32 scale) {
     }
 
     PaletteSync(workpal);
+    // Re-present the composited Log at the ramped palette. On DOS the palette
+    // write alone re-tinted the live framebuffer, so the fade acted on whatever
+    // was on screen (terrain + actors). Under SDL PaletteSync does not repaint,
+    // so we re-blit the whole frame. Use BoxBlit (present only), NOT BoxUpdate:
+    // BoxUpdate also runs BoxClean, whose Screen->Log restore wipes the moving
+    // (actor/object) boxes out of Log, so every fade would drop the object layer
+    // and only fade the terrain -- actors vanish at fade-out start and pop in
+    // after fade-in. The next real AffScene recycles the box lists as usual.
     BoxStaticAdd(0, 0, (S32)(ModeDesiredX - 1), (S32)(ModeDesiredY - 1));
-    BoxUpdate();
+    BoxBlit();
 }
 
 //──────────────────────────────────────────────────────────────────────────

--- a/SOURCES/DISKFUNC.CPP
+++ b/SOURCES/DISKFUNC.CPP
@@ -88,6 +88,13 @@ S32 LoadScene(S32 numscene) {
         FadeToBlackAndSamples(PtrPal);
         HQ_StopSample();
 
+        // The fade is now a pure presenter (it no longer recycles the moving
+        // box list), so it leaves the old cube's actor boxes in pBoxMovingList.
+        // Cls() blacks Log but does not touch that list, so the BoxUpdate below
+        // would BoxClean stale old-cube rects (a Screen->Log restore at bogus
+        // coordinates). Reset the lists first: Log is about to be all black, so
+        // there is nothing dirty to preserve.
+        BoxReset();
         Cls();
         BoxUpdate();
     }


### PR DESCRIPTION
## The bug

On any scene load, the models and movable sprites (actors, NPCs, doors, item
drops) are not part of the fade. On the way out they vanish the instant the
fade-out begins, before the scene darkens; on the way in the scene fades up
without them and they pop in at full brightness a frame after the fade
finishes. Visible on classic-res iso interiors and on exteriors alike.

The fade is meant to hide the scene load on both sides. Instead only the
terrain fades, and the actor layer snaps.

## Cause

`FadePal` (the one-step palette ramp every fade loops on) re-presents the frame
with `BoxUpdate()`. `BoxUpdate` is `BoxBlit` (present) **plus** `BoxClean`, and
`BoxClean` restores the clean, actor-less `Screen` backdrop back into `Log`
over every moving (actor/object) box. So the first fade step erases the actor
layer out of `Log`; the rest of the ramp presents terrain only.

The actors really are composited on the reveal frame (hero `work_flags` shows
`WAS_DRAWN`); they are wiped after compositing, before the frame is shown. The
tell is that even the static cell-bar objects disappear, which no animation
theory explains but a whole-object-layer wipe does.

This is a regression from `a7653e2a` ("Fix video and fade issues", #33), which
added the `BoxStaticAdd + BoxUpdate` re-present to `FadePal` because, unlike a
DOS VGA palette write, SDL's `PaletteSync` does not repaint the window. The
re-present was needed; pulling in `BoxClean` was the mistake.

## The fix

`FadePal` re-presents with `BoxBlit` (present only) instead of `BoxUpdate`, so
the ramping palette acts on the composited scene, matching the original DOS
behaviour. Every black-fade primitive funnels through `FadePal`, so this covers
scene loads, FMV reveals, menu fades and white flashes in one place.

Because the fade no longer recycles the moving-box list, it leaves the pre-fade
actor boxes in `pBoxMovingList`. Every real consumer redraws before the next
lit present except the cube-load path in `LoadScene`, where the following
`Cls() + BoxUpdate()` would `BoxClean` those stale rects into the black `Log`
(invisible today, but a latent wrong-region restore). A `BoxReset()` before the
`Cls()` there keeps the load starting clean.

`FadePalToPal` (the lit-to-lit crossfade) has the same never-repaints-under-SDL
shape but is a separate function that does not go through `FadePal`; left for a
follow-up to keep this focused.

## Testing

Render-only change, no game logic / RNG / timers / geometry touched, so
determinism and the projection corpus are unaffected.

- Host suite: 44/44 pass.
- Control-harness automation: identical result with and without the change
  (same pre-existing data-tree failures; `ui_display` capture hash byte-identical).
- Deterministic repro (headless), warp into a busy iso interior and screenshot
  the reveal frame:

  ```
  cp "SAVE/007 In prison.LBA" /tmp/p.lba
  SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy \
    lba2cc --game-dir <data> --load /tmp/p.lba \
    --exec "cube 84" --fixed-dt 16 --fixed-timestep 0 --tick 2 \
    --screenshot reveal.png --exit
  ```

  Before: `reveal.png` shows terrain only, no hero / guard / prisoner / cell
  bars. After: the full scene is present on the reveal frame.

No committed pixel baseline: screenshot goldens are sensitive to the local game
data tree (the corpus and `ui_display` baselines already diverge in this
checkout), so the repro is documented here rather than pinned to a brittle
golden, matching how #353 / #404 shipped.
