### PR TITLE
fix(fade): present the lit-to-lit palette crossfade so it ramps under SDL

### DIFF
--- a/SOURCES/AMBIANCE.CPP
+++ b/SOURCES/AMBIANCE.CPP
@@ -717,7 +717,7 @@ void FadePalToPal(U8 *ptrpal, U8 *ptrpal1) {
     do {
         S32 n;
 
-        Timer_FixedDtPump(); // non-presenting palette-fade wait: step the virtual clock under fixed-dt
+        Timer_FixedDtPump(); // step the virtual clock under fixed-dt (as the other fade loops do)
         ManageTime();
 
         delta = TimerSystemHR - starttime;
@@ -731,7 +731,14 @@ void FadePalToPal(U8 *ptrpal, U8 *ptrpal1) {
             workpal[n * 3 + 2] = (U8)RegleTrois(ptrpal[n * 3 + 2], ptrpal1[n * 3 + 2], FADE_DELAY, delta);
         }
 
+        // Present each ramp step, like FadePal. PaletteSync alone only rebuilds the
+        // palette LUT; under SDL nothing repaints until the next BoxBlit, so without
+        // this the lit-to-lit crossfade is invisible and snaps to the target palette
+        // on the next unrelated present. BoxBlit (present only, no BoxClean) keeps the
+        // composited Log intact, matching the DOS palette-write behaviour.
         PaletteSync(workpal);
+        BoxStaticAdd(0, 0, (S32)(ModeDesiredX - 1), (S32)(ModeDesiredY - 1));
+        BoxBlit();
     } while (delta != FADE_DELAY);
 
     RestoreTimer();


### PR DESCRIPTION
## The bug

Some scene scripts fire a lit-to-lit palette crossfade (the `LM_FADE_TO_PAL`
opcode with a non-black target, from a lit palette). Under SDL that crossfade is
invisible: it snaps straight to the target palette instead of ramping.

About 10 shipped scenes hit this on entry, mostly island-arrival exteriors
(Citadel harbor, White Leaf Desert city center, Otringal harbor, Francos
arrival, ...), so it is visible in the title-screen attract reel.

## Cause

`FadePalToPal` (the lit-to-lit crossfade behind `FadeToPalIndex`) only called
`PaletteSync` per ramp step. On DOS a palette write re-tinted the live
framebuffer so the ramp was visible; under SDL `PaletteSync` only rebuilds the
palette LUT and nothing repaints until the next unrelated `BoxBlit`, so the ramp
uploaded 0 frames.

The rest of the fade family already presents each step (`FadeToBlack` /
`FadeToPal` / ... run `FadePal`, which does a per-step `BoxBlit`); `FadePalToPal`
was the one that was missed.

## The fix

Present each ramp step with `BoxStaticAdd` + `BoxBlit`, exactly like `FadePal`.
`BoxBlit` is present-only (no `BoxClean`), so it re-uploads the composited `Log`
at the ramping palette without wiping the object layer (the same reason #417 uses
`BoxBlit`). The loop already pumps the fixed-dt clock and is bracketed by
`SaveTimer`/`RestoreTimer`, so the fade's timing and determinism are unchanged.

## Repro

The failure has no still-frame signature (a before/after screenshot shows the
same final palette), so it is observed by watching the ramp: the attract reel
(`--demo --exec "cube 193"`) walks the arrival scenes, and the lighting
crossfades snap before this change and ramp after.

Follow-up to #417 (same subsystem, same present-only `BoxBlit` rule).