### PR TITLE
fix(music): play the current jingle out before the queued one (#406)

### DIFF
--- a/LIB386/AIL/SDL/STREAM.CPP
+++ b/LIB386/AIL/SDL/STREAM.CPP
@@ -136,6 +136,15 @@ static int SDLCALL DecodeThreadFunc(void *userdata) {
         totalShorts += chunkShorts;
     }
 
+    /* All of the track's PCM has been pushed. Signal end-of-input so SDL's
+       device-format converter emits its held tail; otherwise SDL_GetAudioStreamQueued
+       sticks a few bytes above 0 forever (the device format differs from the source,
+       so a converter sits in the path) and the stream never reports EOF -- which
+       stalls the deferred-music switch (#406). Only on a natural finish: if we were
+       stopped mid-decode the stream is being torn down anyway. */
+    if (!SDL_GetAtomicInt(&decodeStop) && stream)
+        SDL_FlushAudioStream(stream);
+
     stb_vorbis_close(d->vorbis);
 
     if (!SDL_GetAtomicInt(&decodeStop) && d->cacheResult && fullPcm && totalShorts > 0) {
@@ -343,6 +352,7 @@ static bool PlayOggFile(const char *oggPath, S32 startFrame) {
         Uint32 playBytes = oggCache.numBytes - offsetBytes;
         SDL_PutAudioStreamData(stream, oggCache.pcm + offsetBytes / sizeof(short), playBytes);
         SDL_AddAtomicInt(&streamPushedBytes, (int)playBytes);
+        SDL_FlushAudioStream(stream); // all input pushed -> let the converter drain to 0 at EOF (#406)
         return true;
     }
 
@@ -430,6 +440,7 @@ static bool SetupWavStream(const SDL_AudioSpec *spec, const Uint8 *wavData,
     }
     SDL_PutAudioStreamData(stream, wavData + offsetBytes, wavLen - offsetBytes);
     SDL_AddAtomicInt(&streamPushedBytes, (int)(wavLen - offsetBytes));
+    SDL_FlushAudioStream(stream); // all input pushed -> let the converter drain to 0 at EOF (#406)
     return true;
 }
 
@@ -740,6 +751,10 @@ S32 IsStreamPlaying() {
         return FALSE;
     if (SDL_GetAtomicInt(&decodeActive))
         return TRUE;
+    /* The stream is fully pushed and flushed (see PlayOggFile / SetupWavStream /
+       DecodeThreadFunc), so once the device has consumed everything the queue reaches
+       0 and the track is done. Without the flush the device-format converter would
+       hold a few bytes here forever and the stream would never report EOF (#406). */
     int queued = SDL_GetAudioStreamQueued(stream);
     if (queued <= 0) {
         StopStreamInternal();

--- a/SOURCES/MUSIC.CPP
+++ b/SOURCES/MUSIC.CPP
@@ -489,14 +489,29 @@ void FadeInVolumeMusic(void) {
 
 void CheckNextMusic(void) {
     if (NextMusic != -1) {
-        if (TimerRefHR > NextMusicTimer) {
-            // #355: force the switch (playit=TRUE) once the defer window has elapsed. A
-            // soft PlayMusic(FALSE) here re-defers whenever the current track is still
-            // playing, so with looping area music the queued track never gets to play.
-            // Forcing replaces the current track, matching the intent of the queue:
-            // defer briefly (TEST_MUSIC_TEMPO) so a quick pass-through doesn't cut the
-            // music, then take over.
-            PlayMusic(NextMusic, TRUE);
+        // Retail parity (#406): after the defer window elapses, don't hard-cut the
+        // current track -- let it play out and start the queued one only once it has
+        // finished. IsStreamPlaying() reports EOF (and detaches the spent stream), so
+        // the switch fires cleanly the moment the current track ends.
+        //
+        // Drain with playit=FALSE (soft), not TRUE. The gate already guarantees the
+        // current stream has ended, so GetMusic() is 0 and the soft path plays the
+        // queued track immediately instead of re-deferring -- it still takes over
+        // (the intent of #355). The point of FALSE is that it leaves StopLastMusic
+        // clear, marking the queued track as an ordinary (soft) cube jingle. That
+        // matters on the NEXT cube change: ChangeCube() does `if (StopLastMusic)
+        // StopMusic()` (OBJECT.CPP), so a forced (TRUE) drain would get the queued
+        // jingle hard-stopped almost immediately in the next area and the deferred
+        // "play out, then switch" chain would only ever work for the first hop.
+        //
+        // #355 forced here because a soft re-defer looped forever when GetMusic()
+        // could not observe EOF (the jingle-layout stale-StreamName bug: IsCDPlaying()
+        // short-circuits on cdPlaying==0, so the finished-stream teardown never ran and
+        // a spent jingle looked like it was still playing). The IsStreamPlaying() gate
+        // removes that reason, so FALSE is both sufficient (still plays) and correct
+        // (keeps the soft-jingle semantics ChangeCube depends on).
+        if (TimerRefHR > NextMusicTimer AND !IsStreamPlaying()) {
+            PlayMusic(NextMusic, FALSE);
         }
     }
 }

--- a/docs/MUSIC.md
+++ b/docs/MUSIC.md
@@ -84,21 +84,40 @@ is to ride out a quick pass-through of an area instead of chopping its music.
 `CheckNextMusic()` (called every frame from `PERSO.CPP`) drains it:
 
 ```
-if NextMusic != -1 AND now > NextMusicTimer:
-    PlayMusic(NextMusic, TRUE)   // force the switch
+if NextMusic != -1 AND now > NextMusicTimer AND !IsStreamPlaying():
+    PlayMusic(NextMusic, FALSE)   // current track has ended -> start the queued one (soft)
 ```
 
-The `TRUE` is the #355 fix. The original `FALSE` re-deferred whenever the current
-track was still playing, so with music that outlasts the 2 s window the queued
-track never played (you kept hearing the old one until a menu toggle nudged the
-stream). Forcing takes over once the window elapses.
+The switch waits for two things: the 2 s debounce window *and* the current track
+finishing. This is retail parity (#406): scene music plays the current track out
+and only then moves to the next, instead of hard-cutting. `IsStreamPlaying()`
+reports EOF (and detaches the spent stream), so by the time the drain runs there is
+silence to play into.
 
-**Consequence: scene-music switches lag by ~2 s.** On a cube change the old jingle
-keeps playing; the new one is queued and only takes over after the defer window.
-That delay is the queue, not the codec. Levers if it feels too long: lower
-`TEST_MUSIC_TEMPO`, or make the cube-entry call in `PERSO.CPP` force
-(`PlayMusic(CubeJingle, TRUE)`) at the cost of chopping music on quick
-pass-throughs.
+The drain is **soft** (`playit = FALSE`), and that matters. Because the gate has
+already established the current stream ended (`GetMusic()` is 0), the soft path plays
+the queued track immediately rather than re-deferring, so it still takes over. The
+point of `FALSE` is that it leaves `StopLastMusic` clear, marking the queued track as
+an ordinary cube jingle. `ChangeCube()` does `if (StopLastMusic) StopMusic()`, so a
+forced (`TRUE`) drain would get the queued jingle hard-stopped almost immediately on
+the next area change, and the "play out, then switch" behaviour would only ever work
+for the first hop. Soft keeps the chain going across areas.
+
+This supersedes #355, which forced the switch the moment the window elapsed and so
+cut the current track off. It forced because a soft `PlayMusic(FALSE)` re-deferred
+forever: for the jingle layout `GetMusic()` reads `StreamName()`, which is never
+cleared at natural EOF (`IsCDPlaying()` short-circuits on `cdPlaying == 0`, so
+`IsStreamPlaying()` -- the call that tears a finished stream down -- never runs), so
+a finished jingle looked like it was still playing. Gating `CheckNextMusic` on
+`IsStreamPlaying()` reads the real playback state, which removes the reason to force:
+the queued track still takes over (the #355 intent) without chopping the current one
+(the #406 intent), and stays soft so the chain survives the next `ChangeCube`.
+
+**Consequence: the new track starts when the current one ends** (plus up to the 2 s
+window). On a cube change the old jingle plays out; the new one is queued and takes
+over once the stream reaches EOF. Lever if you want a hard cut instead: make the
+cube-entry call in `PERSO.CPP` force (`PlayMusic(CubeJingle, TRUE)`), which bypasses
+the queue -- the same path cutscenes, FMVs, and chapter transitions already take.
 
 ## GetMusic, StopMusic, fades
 
@@ -151,7 +170,7 @@ cue audio. WAV and OGG then reach the stream very differently:
 | Cache | none | one-slot decoded-PCM cache (`oggCache`), keyed by path |
 | Seek/restore | byte offset into the loaded PCM | `stb_vorbis_seek_frame` (a seeked decode is not cached), or offset on a cache hit |
 
-Two consequences worth knowing:
+Three consequences worth knowing:
 
 - **Cold-OGG first-audio gap.** `FinishStream` resumes the device right after
   `PlayOggFile` launches the decode thread, so the device can run dry for tens of
@@ -164,6 +183,15 @@ Two consequences worth knowing:
   So the cache buys nothing on queue-driven area changes, and toggling between two
   adjacent areas re-decodes each time. This is an efficiency gap, not a bug (the
   cache is path-keyed; partial/seeked decodes are correctly not cached).
+- **EOF needs a flush.** `SDL_OpenAudioDeviceStream` opens the device at its native
+  format, so SDL sits a format converter in the path. The converter holds a small
+  tail of input it will not emit until told no more is coming, so
+  `SDL_GetAudioStreamQueued` sticks a few bytes above 0 forever and the stream never
+  reports end-of-track. Each source therefore calls `SDL_FlushAudioStream` once its
+  whole PCM has been pushed (OGG decode thread on natural finish, OGG cache-hit, WAV),
+  which lets the queue drain to 0 so `IsStreamPlaying()` can report EOF. This matters
+  for the deferred-switch queue (#406): the queued track waits on `IsStreamPlaying()`
+  going false, so without the flush it would wait forever.
 
 ## Testing
 
@@ -173,7 +201,8 @@ is SDL and library territory). Two targets under `tests/music/`:
 - **`test_music_pause_resume.cpp`** compiles the real `MUSIC.CPP` against a spy AIL
   backend (records ordered calls; a small model of "what is playing" that the test
   controls). Covers pause/resume-never-Stop (CD and jingle layouts), faded resume,
-  the #355 queue drain, the full decision matrix (nothing/same/different/force/
+  the #406/#355 deferred switch (the queue waits for the current track to end, then
+  the queued one takes over), the full decision matrix (nothing/same/different/force/
   `StopLastMusic`), `CheckNextMusic` timing and empty-queue edges, the `GetMusic`
   round-trip, and fade convergence.
 - **`test_music_stream_park.cpp`** unit-tests the pure `STREAM_PARK.H` decisions:

--- a/tests/music/test_music_pause_resume.cpp
+++ b/tests/music/test_music_pause_resume.cpp
@@ -49,6 +49,7 @@ void ResumeMusic(S32 fade);
 void InitJingle(void);
 S32 GetMusic(void);
 void CheckNextMusic(void);
+extern S32 StopLastMusic; // MUSIC.CPP global (declared in MUSIC.H), C++ linkage
 void FadeOutVolumeMusic(void);
 void FadeInVolumeMusic(void);
 S32 InitCD(char *name);
@@ -84,6 +85,16 @@ static char s_streamName[ADELINE_MAX_PATH] = "";
 static bool s_streamPaused = false;
 static S32 s_cdVol = 0;
 static S32 s_streamVol = 0;
+
+// Simulate the current stream reaching its natural end. The real SDL backend's
+// IsStreamPlaying() detaches a finished stream (clears StreamName) once the
+// device buffer drains, so model EOF the same way: the stream stops "playing"
+// and StreamName() goes empty. Used to exercise the deferred-switch queue
+// waiting for the current track to finish before starting the next one (#406).
+static void spy_end_stream() {
+    s_streamName[0] = '\0';
+    s_streamPaused = false;
+}
 
 // ── Spy AIL backend (matches the extern "C" decls pulled in above) ───────────
 
@@ -134,6 +145,7 @@ void ResumeStream() {
     rec("ResumeStream");
     s_streamPaused = false;
 }
+// A stream plays until it is stopped, paused, or reaches EOF (spy_end_stream).
 S32 IsStreamPlaying() { return (s_streamName[0] && !s_streamPaused) ? TRUE : FALSE; }
 void ChangeVolumeStream(S32 volume) { s_streamVol = volume; }
 S32 GetVolumeStream() { return s_streamVol; }
@@ -247,12 +259,12 @@ int main(void) {
     ResumeMusic(1);
     assert_resume_never_stops();
 
-    // ── Scenario 4: #355 - a queued track must take over, not defer forever ───
-    // Field repro: area music (jingle 16 / jadpcm09) keeps playing; a scene wants a
-    // DIFFERENT track; PlayMusic(FALSE) defers it into NextMusic; CheckNextMusic() (run
-    // every frame by PERSO's main loop) must eventually PLAY it instead of re-deferring
-    // while the looping track never ends. Before the fix these asserts fail: B is queued
-    // and never starts.
+    // ── Scenario 4: #406/#355 - the deferred switch waits for the current track ──
+    // Retail parity (#406): area music (jingle 16 / jadpcm09) is playing; a scene wants
+    // a DIFFERENT track; PlayMusic(FALSE) defers it into NextMusic. CheckNextMusic() (run
+    // every frame by PERSO's main loop) must NOT hard-cut the current track once the
+    // defer window elapses -- it lets the current track play out, then starts the queued
+    // one (#355: which must eventually play, not defer forever).
     DistribVersion = 3; // EU layout: TrackCD, every entry a jingle/stream
     InitCD(empty);
     InitJingle();
@@ -268,9 +280,21 @@ int main(void) {
 
     spy_clear();
     TimerRefHR += 5000; // elapse past the 2s (TEST_MUSIC_TEMPO) defer window
-    CheckNextMusic();   // the per-frame queue service
-    assert(called("PlayStream") && "queued track B must start once the defer elapses (#355)");
+    CheckNextMusic();   // window elapsed, but A is still playing -> must not cut it (#406)
+    assert(!called("PlayStream") && "the queued track must not cut the current one off (#406)");
+    assert(GetMusic() == 16 && "A keeps playing until it finishes on its own");
+
+    spy_clear();
+    spy_end_stream(); // A reaches its natural end (EOF detaches the stream)
+    CheckNextMusic(); // A has finished -> the queued track finally takes over
+    assert(called("PlayStream") && "queued track B starts once the current track ends (#355)");
     assert(GetMusic() == 7 && "B (jingle 7) is the current music after the queue drains");
+    // The queue must drain SOFT (playit=FALSE): the queued track is an ordinary cube
+    // jingle, so it must leave StopLastMusic clear. A forced drain would mark it as
+    // script/menu music, and ChangeCube's `if (StopLastMusic) StopMusic()` would then
+    // hard-cut it on the next area change -- the deferred chain would break after one
+    // hop (#406).
+    assert(StopLastMusic == FALSE && "the drained cube jingle stays soft so the next ChangeCube won't cut it");
 
     // ── Scenario 5: PlayMusic decision matrix - nothing / same / different (soft) ──
     DistribVersion = 3;
@@ -319,8 +343,11 @@ int main(void) {
     CheckNextMusic(); // still inside the defer window -> must not swap yet
     assert(!called("PlayStream") && GetMusic() == 16 && "the queue must not drain before the defer window");
     TimerRefHR += 5000;
-    CheckNextMusic(); // window elapsed -> B takes over
-    assert(GetMusic() == 7 && "B takes over once the defer window elapses");
+    CheckNextMusic(); // window elapsed, but A still playing -> queue waits for it (#406)
+    assert(!called("PlayStream") && GetMusic() == 16 && "the queue waits for the current track to finish");
+    spy_end_stream(); // A ends
+    CheckNextMusic(); // A finished -> B takes over
+    assert(GetMusic() == 7 && "B takes over once the current track finishes");
     spy_clear();
     CheckNextMusic(); // NextMusic is now -1
     assert(!called("PlayStream") && "CheckNextMusic with an empty queue does nothing");


### PR DESCRIPTION
## Summary

Scene-change music hard-cut to the next track instead of letting the current one play out, the way retail does. This was a regression from #376 (the #355 fix), which force-switched once the 2 s debounce elapsed.

There were three stacked causes, each of which had to be fixed:

1. **The hard cut.** `CheckNextMusic` force-switched on the defer timer alone. It is now gated on `!IsStreamPlaying()`, so the current jingle plays to its natural end before the queued one starts.

2. **EOF never fired.** `SDL_OpenAudioDeviceStream` opens the device at its native format, so a format converter sits in the path and holds a small tail of input. `SDL_GetAudioStreamQueued` therefore stuck a few bytes above 0 forever and `IsStreamPlaying()` never reported end-of-track — so the gate above could never open. Fixed by calling `SDL_FlushAudioStream` once each track's PCM has been fully pushed (OGG decode thread on a natural finish, OGG cache hit, WAV). This bug was invisible before because the old code force-cut on the timer and never consulted `IsStreamPlaying()`.

3. **The chain broke after one hop.** The drain force-played (`playit = TRUE`), which sets `StopLastMusic`, so `ChangeCube`'s `if (StopLastMusic) StopMusic()` hard-stopped the queued jingle on the next area change — the deferred switch only ever worked once. The drain is now soft (`FALSE`): the gate already guarantees the current track ended, so it still plays immediately, but it stays marked as an ordinary cube jingle and the "play out, then switch" chain continues across areas.

## Behaviour

On a cube-jingle change the current jingle now plays to completion (plus up to the 2 s debounce) and then the queued one takes over, matching retail. Scripted music (`LM_PLAY_MUSIC`), cutscenes, FMVs, and menus still switch immediately — they force and clear the queue — so interruptions are unaffected.

## Testing

- Host test `tests/music/test_music_pause_resume.cpp` grows the deferred-switch scenarios: no cut while the current track is still playing, the queued track takes over on EOF, and `StopLastMusic` stays clear after the drain. Each new assertion was checked to fail against the pre-fix behaviour.
- Live: OGG (Steam layout) and WAV (GOG, whose music lives inside the mounted disc image, exercising the WAV flush path) — jingles play fully and chain across areas with no cuts.

`docs/MUSIC.md` updated to match.

Fixes #406.
