### PR TITLE
fix(credits): drive the end-credits walk on the fixed-timestep clock (#403)

### DIFF
--- a/SOURCES/CREDITS.CPP
+++ b/SOURCES/CREDITS.CPP
@@ -338,6 +338,18 @@ S32 GamePlayCredits(const char *file_name, S32 mode) {
     timer = TimerRefHR;
     scrolltimer = TimerRefHR;
 
+    // #403: the credits run their own loop outside MainLoop's fixed-timestep
+    // simulation, so NPC locomotion (ObjectSetInterDep, driven by TimerRefHR) is
+    // otherwise coupled to the render frame rate -- too slow on high-refresh
+    // displays, exactly the coupling #358 removed everywhere else. We keep the
+    // real clock for input/music/scroll but drive the object loop off a game
+    // clock quantized to whole FixedTimestep steps, so ObjectSetInterDep never
+    // sees a sub-step delta (its <=/== guards make a held clock a no-op). Off
+    // (FixedTimestep == 0) leaves the historical per-frame path untouched.
+    U32 creditSimClock = TimerRefHR; // quantized game clock the objects advance on
+    U32 creditSimAcc = 0;            // banked real ms not yet applied as whole steps
+    U32 creditLastReal = TimerRefHR; // real clock at the previous iteration
+
     ManageSystem();
 
     Switch_Fillers(FILL_POLY_FOG_NZW);
@@ -370,7 +382,32 @@ S32 GamePlayCredits(const char *file_name, S32 mode) {
 
         InitTri();
 
-        if (NbMovingObj < 4) {
+        // #403: advance the credits object clock only in whole FixedTimestep
+        // quanta this frame. At high refresh most frames add 0 steps (the held
+        // clock no-ops ObjectSetInterDep, so walkers do not lose distance to
+        // per-frame rounding); ~60 fps adds one step (the historical path); a
+        // slow frame folds its backlog into a single clamped catch-up jump
+        // (FIXED_TIMESTEP_MAX_STEPS mirrors MainLoop's 8). The real clock is
+        // restored after the object loop so the scroll and music stay real-time.
+        U32 creditRealRef = TimerRefHR;
+        S32 creditSteps = 1; // throttle off: one step per frame, the historical path
+        if (FixedTimestep > 0) {
+            creditSteps = Timer_FixedStepCount(&creditSimAcc, creditRealRef - creditLastReal,
+                                               (U32)FixedTimestep, 8);
+            creditLastReal = creditRealRef;
+            creditSimClock += (U32)creditSteps * (U32)FixedTimestep;
+            TimerRefHR = creditSimClock;
+        }
+
+        // Spawn walkers at the sim cadence, not the render cadence. Every walker
+        // heads to the same "hello" spot, so spacing comes only from the stagger
+        // between spawns; spawning per render frame while travel advances per step
+        // (above) collapses that stagger at high fps and the walkers bunch up and
+        // clip through each other. One spawn per step (bounded by the four-slot
+        // cap) keeps the spawn-to-travel ratio frame-rate independent both ways:
+        // high refresh skips spawns on held-clock frames, and a slow frame that
+        // advances several steps spawns several so the crowd still fills up.
+        for (S32 s = 0; s < creditSteps AND NbMovingObj < 4; s++) {
             ptrobj = ptrcrdobj + nextobj;
             ptrobj->Flag = 1;
             NbMovingObj++;
@@ -506,6 +543,11 @@ S32 GamePlayCredits(const char *file_name, S32 mode) {
                 }
             }
         }
+
+        // #403: back to the real clock for the scroll, music, and ManageTime's
+        // wall-time accumulation on the next iteration.
+        if (FixedTimestep > 0)
+            TimerRefHR = creditRealRef;
 
         DoTri();
 

--- a/docs/MOVEMENT_FRAMERATE.md
+++ b/docs/MOVEMENT_FRAMERATE.md
@@ -270,6 +270,32 @@ cycle of field testing. This touches the game clock, which is the most bug-prone
 the port (see the `ManageTime` history in [TIMING.md](TIMING.md)), so a review of the clock
 model is warranted before the `TIMER.CPP`/`PERSO.CPP` change.
 
+## The end-credits loop (#403)
+
+The end credits run their own loop (`GamePlayCredits`,
+[SOURCES/CREDITS.CPP](../SOURCES/CREDITS.CPP)) outside `MainLoop`, so the same
+`ObjectSetInterDep` coupling survived the fix above: the credits walkers lost distance on
+high-refresh displays while the rest of the game was already frame-rate independent. Both
+the demo/attract credits (`Credits(FALSE)`) and the final "happy end" credits
+(`Credits(TRUE)`) share this loop; `mode` only branches scene setup, not the walk.
+
+The fix is a lighter variant of Phase 1: the credits object loop advances off a game clock
+quantized to whole `FixedTimestep` steps (via the same `Timer_FixedStepCount` core), while
+input, music, and the text scroll keep the real clock. On a held-clock frame
+`ObjectSetInterDep` is a no-op (its `TimerRefHR <= obj->Time` guards), so a high-refresh
+frame simply re-presents the settled walkers instead of advancing them a sub-step. No
+sub-stepping loop is needed: the credits scene never renders below 60 fps, so the
+low-frame-rate catch-up the main loop handles does not arise. Off (`FixedTimestep == 0`) is
+the historical per-frame path.
+
+One subtlety specific to this loop: every walker heads to the same central "hello" spot, so
+their on-screen spacing comes only from the stagger between spawns. The spawn is therefore
+gated on the same step count as the travel -- spawning per render frame while moving per
+step collapses the stagger at high fps and the walkers bunch up. Note the credits have no
+collision avoidance at all, so walkers that draw near-equal spawn angles already overlap in
+the unmodified engine at 60 fps; that is pre-existing behaviour, not a frame-rate artefact,
+and is tracked as a separate enhancement.
+
 ## Tests
 
 Test level must match the fix level. The fix is in the main loop, so:


### PR DESCRIPTION
## What

The end credits run their own loop (`GamePlayCredits`, `SOURCES/CREDITS.CPP`) outside `MainLoop`, so the `ObjectSetInterDep` frame-rate coupling that #358 removed everywhere else survived there. On high-refresh displays (or with vsync off) the credits walkers lose distance and move too slowly. It is the last unfixed instance of the #358 coupling, reported as #403.

Both the demo/attract credits and the final "happy end" credits share this loop (`mode` only branches scene setup, not the walk), so both are affected.

## Fix

Advance the credits object loop off a game clock quantized to whole `FixedTimestep` steps (reusing the tested `Timer_FixedStepCount` core), while input, music, and the text scroll keep the real clock. On a held-clock frame `ObjectSetInterDep` is a no-op (its `TimerRefHR <= obj->Time` guards), so a high-refresh frame re-presents the settled walkers instead of advancing them a sub-step.

This is a lighter variant of the main loop's Phase 1, with no sub-stepping loop: the credits scene never renders below 60 fps, so the low-frame-rate catch-up does not arise. Off (`FixedTimestep == 0`) is byte-for-byte the historical per-frame path.

The walker spawn is gated on the same step count as the travel. Every walker heads to the same central spot, so spacing comes only from the stagger between spawns; spawning per render frame while moving per step collapses that stagger and bunches the walkers at high fps.

## Verification

Measured with the `--fixed-dt` harness (emulating frame rate), driving the credits via the `credits` console command and tracing the lead walker's distance-to-goal at matched game-time (RNG-identical trajectory):

| game-time | 3000 | 5000 | 7000 | 9000 |
|---|---|---|---|---|
| fix, ~125 fps | 5371 | 3920 | 2479 | 839 |
| fix, ~62 fps | 5371 | 3920 | 2479 | 839 |
| unfixed, ~125 fps | 5391 | 4040 | 2472 | 1112 |
| unfixed, ~62 fps | 5371 | 3920 | 2479 | 839 |

With the fix the two frame rates are byte-identical; without it, ~125 fps leaves the walker ~270 units short at gt 9000. At 60 fps the fix is a no-op, identical to the current engine.

## Testing

Test-light, matching the other rendering-timing fixes in this area. The reusable core (`Timer_FixedStepCount`) is already unit-tested in CI (`tests/timer/test_fixed_step.cpp`), and the credits-loop wiring is documented with a repro in `docs/MOVEMENT_FRAMERATE.md` rather than shipping a permanent credit-object trace hook just to guard it.

## Not in scope

The credits have no collision avoidance, so walkers that draw near-equal random spawn angles already overlap in the unmodified engine at 60 fps. That is pre-existing behaviour, not a frame-rate artefact, and is tracked as a separate enhancement.
