### PR TITLE
fix(render): track the render mode in the background-object on-screen test (#424)

### DIFF
--- a/SOURCES/COMMON.H
+++ b/SOURCES/COMMON.H
@@ -190,10 +190,15 @@ typedef	struct	{
 #define DEMI_BRICK_XZ   256
 #define DEMI_BRICK_Y    128
 
+/* "Is this projected point on screen?", screen rect plus the original slack.
+   The max bounds track the render mode: hardcoded 680/580 is 640x480 + that slack,
+   so at wider modes they rejected points that were plainly on screen.
+   The (S32) casts matter: ModeDesiredX/Y are unsigned, and a negative Xp/Yp
+   (legal, that is what the VIEW_X0/Y0 slack is for) would wrap past the max. */
 #define VIEW_X0         -50
 #define VIEW_Y0         -30
-#define VIEW_X1         680
-#define VIEW_Y1         580
+#define VIEW_X1         ((S32)ModeDesiredX + 40)
+#define VIEW_Y1         ((S32)ModeDesiredY + 100)
 
 // Type de cube
 #define CUBE_INTERIEUR	0

--- a/SOURCES/DEFINES.H
+++ b/SOURCES/DEFINES.H
@@ -227,10 +227,11 @@
 
 /*---------------- FENETRE ------------------*/
 
+/* Mirrors COMMON.H (included above); see the note there on the mode-relative bounds. */
 #define VIEW_X0 -50
 #define VIEW_Y0 -30
-#define VIEW_X1 680
-#define VIEW_Y1 580
+#define VIEW_X1 ((S32)ModeDesiredX + 40)
+#define VIEW_Y1 ((S32)ModeDesiredY + 100)
 
 /*──────────────────────────────────────────────────────────────────────────*/
 /* type objet pour affscene */

--- a/SOURCES/OBJECT.CPP
+++ b/SOURCES/OBJECT.CPP
@@ -5483,6 +5483,10 @@ startaffscene:
                         OR(flagflip == AFF_OBJETS_NO_FLIP))) {
             // rustine: renseigne qd meme moteur presence sprite
             // pour obj_back si dans l'écran
+            //
+            // WAS_DRAWN is what LM_BACKGROUND / TM_BACKGROUND OFF reads to decide it must
+            // force a full redraw: the object is baked into the decor while flagged, so
+            // without that redraw the baked copy is never erased and a ghost stays behind.
             PtrProjectPoint(ptrobj->Obj.X, ptrobj->Obj.Y, ptrobj->Obj.Z);
             if ((Xp > VIEW_X0) AND(Xp < VIEW_X1) AND(Yp > VIEW_Y0) AND(Yp < VIEW_Y1)) {
                 ptrobj->WorkFlags |= WAS_DRAWN;


### PR DESCRIPTION
## What

Fixes #424: a sliding door leaves a duplicate copy of itself in its original doorway, with no collision, until a menu or camera refresh scrubs it.

Root cause is a hardcoded 640x480 bound, so this only bites at widescreen resolutions. The screenshots below are the same game state at two resolutions.

## Why

An object flagged `OBJ_BACKGROUND` is baked into the decor (`COMMON.H`: *"s'incruste dans le decor la 1er fois"*). On a full-flip frame `AffScene` copies its pixels from `Log` into `Screen` (`OBJECT.CPP:5175`), and partial frames then skip drawing it entirely. A closed door is scenery, cheaply.

When the door opens, its script clears the flag (`LM_BACKGROUND` / `TM_BACKGROUND` OFF). The baked copy is erased by the full redraw those opcodes force, `FirstTime = AFF_ALL_FLIP; /* :-( */`. **That redraw is gated on `WAS_DRAWN`**, and for a baked object `WAS_DRAWN` is set only by the on-screen test in `AffScene`:

```c
if ((Xp > VIEW_X0) AND (Xp < VIEW_X1) AND (Yp > VIEW_Y0) AND (Yp < VIEW_Y1))
    ptrobj->WorkFlags |= WAS_DRAWN;
```

`VIEW_X0/Y0/X1/Y1` were `-50/-30/680/580`: the 640x480 screen rect plus slack. At 640x480 every on-screen point passes, which is why retail never hit this. At 1280x720 the palace door projects to `Xp=787`, fails the `680` bound, leaves `WAS_DRAWN` clear, and the un-bake never fires. The baked pixels stay in `Screen`, every `BoxClean` faithfully restores them, and you get a pixel-perfect ghost door that only a later full redraw removes.

The dead zone is a fixed screen rectangle, so it grows with resolution: nothing at 640x480, the right ~20% of the width at 848x480, the right ~47% plus the bottom ~19% at 1280x720. That matches the field reports, where the bug was palace-only on a narrower mode and then appeared from the early game onward at 720p.

## How

Take the max bounds from `ModeDesiredX/Y` and keep the original slack. `640+40` and `480+100` are exactly the old literals, so 640x480 is unchanged by construction.

The `(S32)` casts are load-bearing: `ModeDesiredX/Y` are unsigned, and the `VIEW_X0/Y0` slack means a negative `Xp`/`Yp` is legal, so without the cast it would wrap past the max bound and invert the test.

## Testing

Repro is deterministic and headless (cube 154, Emperor's Palace):

```bash
lba2cc --resolution 1280x720 --fixed-dt 16 --load "021 Palace.LBA" \
       --exec "teleport 5120 256 1800 2048; input up 200" \
       --tick 320 --screenshot ghost.png --exit
```

The hero has to *walk* into the door rather than be teleported onto it: frame 1 after a load is a full flip, which sets `WAS_DRAWN` the legitimate way and hides the bug. This is also why it is intermittent in play, since walking to a door often triggers a camera recentre that scrubs the ghost before you notice it.

- **1280x720:** before, the doorway stays filled with a door texture while the real door has slid 1024 units clear. After, the doorway is empty.
- **640x480:** the captured frame is **byte-identical** before and after (md5, `--fixed-dt 16` to pin the clock).
- 46/46 host tests pass; `make format-check` clean.

No new test: the fix is four lines, and the guard that matters is the resolution A/B capture above rather than a permanent scaffold. Instrumentation used to find it (a `Log_Debug` on both gates) was stripped before commit.

## Note

`VIEW_*` is not listed in `WIDESCREEN_HARDCODED_DIMS_AUDIT.md`, so this is a genuine gap in that sweep. #356 (interior block textures going black near the screen edge, recovering on recenter) is plausibly the same family and worth a look next.
