### PR TITLE
fix(discovery): don't boot a different install than the one asked for (#433)

### DIFF
--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2933,11 +2933,18 @@ int main(int argc, char *argv[]) {
         atexit(Log_Shutdown);
 
         if (!ResolveGameDataDir(resFolderPath, ADELINE_MAX_PATH, &argc, argv)) {
-            /* Auto-discovery exhausted. Last fallback before exit: in a
-             * windowed environment, prompt the user with a folder dialog
-             * and persist their pick for next launch. Headless / no-display
-             * environments fall through to exit (PromptForResDir returns
-             * false when SDL_INIT_VIDEO can't be brought up). */
+            /* A batch or headless run must not reach the folder picker: it is modal, and
+             * --headless still brings SDL up on the dummy video driver, so the dialog does
+             * open and then waits forever for an answer nobody can give. Exit with the fix
+             * in the message instead. */
+            if (Control_IsActive() || Control_IsHeadless()) {
+                Log_Error("Game data not found. Pass --game-dir <folder containing "
+                          "LBA2.HQR> (often Common/), or set LBA2_GAME_DIR.");
+                exit(EXIT_FAILURE);
+            }
+
+            /* Interactive last fallback: prompt with a folder dialog and persist the pick
+             * for next launch. */
             if (!PromptForResDir(resFolderPath, ADELINE_MAX_PATH)) {
                 /* Do not SDL_Quit() here: SDL3 can double-free in
                  * SDL_QuitFilesystem when shutting down after early

--- a/SOURCES/RES_DISCOVERY.CPP
+++ b/SOURCES/RES_DISCOVERY.CPP
@@ -107,8 +107,13 @@ void LogFailure(const char tried[][ADELINE_MAX_PATH], int triedCount) {
     for (int i = 0; i < triedCount; i++) {
         Log_Error("  - %s", tried[i]);
     }
-    Log_Error("Hints: set LBA2_GAME_DIR to your install folder, or use --game-dir <path>.");
-    Log_Error("See docs/GAME_DATA.md. Retail game files are not included in this repository.");
+    /* This message reaches the reader who has the binary and no game data, which is exactly
+       the reader who cannot open a file in the source tree. Say the thing, and point at the
+       README that ships beside the binary. */
+    Log_Error("Hints: set LBA2_GAME_DIR to your install folder, or pass --game-dir <path>.");
+    Log_Error("The path is the folder holding the HQR files, often Common/.");
+    Log_Error("This is a source port: it needs the retail game files, which it does not ship. "
+              "See README.txt.");
 }
 
 void StripGameDirArgs(int *argc, char **argv) {
@@ -337,9 +342,25 @@ bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv) {
     const bool forcePicker = ExtractPickGameDirFlag(*argc, argv);
     StripGameDirArgs(argc, argv);
 
-    if (cliPath[0] != '\0' &&
-        NormalizeAndTry(cliPath, outDir, outMax, tried, &triedCount)) {
-        return true;
+    if (cliPath[0] != '\0') {
+        /* The path itself, then the subfolder a retail install keeps its data in: people
+           point this at the install root (README says so, and the Makefile forwards
+           GAME_DIR straight through), and the HQRs live one level down in Common/. */
+        if (NormalizeAndTry(cliPath, outDir, outMax, tried, &triedCount) ||
+            TryJoinBaseSub(cliPath, "Common", outDir, outMax, tried, &triedCount)) {
+            return true;
+        }
+
+        /* Neither worked, so the path is a mistake, not a hint. Falling through to the env /
+           persisted / auto-discovery probes below would boot a DIFFERENT install than the one
+           asked for and say so only in the banner: a run against assets nobody asked for that
+           still exits 0. */
+        Log_Error("RES_DISCOVERY: --game-dir '%s' does not hold the game data: no LBA2.HQR "
+                  "in it, nor in a Common/ inside it.",
+                  cliPath);
+        Log_Error("Point it at the folder with the HQR files, or at the install that "
+                  "contains it. Refusing to boot a different install instead.");
+        return false;
     }
 
     const char *env = getenv("LBA2_GAME_DIR");

--- a/tests/automation/test_cli_contract.sh
+++ b/tests/automation/test_cli_contract.sh
@@ -9,6 +9,8 @@
 #                   not parse cmds="--tick", eat the 30, and tick zero times)
 #   --exec-at       runs a command after a scene change has settled, which --exec cannot
 #   unfired exec-at exits non-zero: a command the run never reached did not happen
+#   --game-dir      an unusable path fails instead of booting some other install
+#   picker          a headless run exits instead of hanging on the modal folder dialog
 #   --no-autosave   blocks autosaves but NOT an explicit save: the console's `savebug`
 #                   writes to the bugs dir and must keep working
 TESTNAME=cli_contract
@@ -48,6 +50,30 @@ if timeout 60 "$LBA2_BIN" --headless --no-autosave --exec-at 500 "cube 100" --ti
     >/dev/null 2>&1; then
     fail "an --exec-at that never fired still exited 0"
 fi
+
+# --- a --game-dir that doesn't hold the data must fail, not boot another install --------
+# Discovery falls back to the persisted / auto-discovered path, so an unusable --game-dir
+# would boot a DIFFERENT install and say so only in the banner: an A/B against assets you
+# never asked for, exiting 0.
+if timeout 30 "$LBA2_BIN" --game-dir /nonexistent/path --headless --tick 1 --exit >/dev/null 2>&1; then
+    fail "an unusable --game-dir was accepted; the run booted some other install"
+fi
+
+# --- an install root works, since that is what the Makefile and README tell you to pass --
+# Only meaningful on a Common/ layout: a GOG tree keeps the HQRs at the root, so its parent
+# holds no game data and refusing it is correct.
+if [ "$(basename "$LBA2_GAME_DIR")" = "Common" ]; then
+    if ! timeout 45 "$LBA2_BIN" --game-dir "$(dirname "$LBA2_GAME_DIR")" --headless --tick 1 \
+        --exit >/dev/null 2>&1; then
+        fail "--game-dir <install root> rejected; it must probe <root>/Common before refusing"
+    fi
+fi
+
+# --- a batch run must never block on the folder picker ------------------------------
+# --headless brings SDL up on the dummy video driver, so SDL_INIT_VIDEO succeeds and the
+# modal picker really does open, with nobody to answer it.
+timeout 30 "$LBA2_BIN" --pick-game-dir --headless --tick 1 --exit >/dev/null 2>&1
+[ $? -eq 124 ] && fail "--pick-game-dir hung a headless run on the modal folder picker"
 
 need_save
 


### PR DESCRIPTION
**Stack 3 of 3 for #433.** Base: #436 (review #435 and #436 first).

This one is not really harness ergonomics, which is why it is on its own: it changes what the engine does with a `--game-dir` you got wrong, and that is user-visible.

## The bug

An explicit `--game-dir` that didn't hold the game data was **silently discarded**. Discovery fell through to the env var, then a persisted path, then auto-discovery, so the run booted a **different install** and mentioned it only in the banner. Every artifact came from assets nobody asked for, and it exited 0.

I found this by driving the harness and reading the banner: every run in the session that produced the #424 fix had been reading a different tree than the one on its own command line. It didn't change those conclusions (both are valid retail trees, and the bug was in code), but an A/B between two data trees would have compared neither.

## The fix, and why it isn't just "refuse"

Refusing outright would break the documented workflow: [Makefile:56](../blob/main/Makefile#L56) forwards `GAME_DIR` straight through and [README.md:79](../blob/main/README.md#L79) tells you to point it at the *install*, while the HQRs live one level down in `Common/`.

So an explicit path now probes itself, then a `Common/` inside it — exactly as auto-discovery already probes `data/` and `game/`. Only if neither holds the data does it say so and refuse, rather than substituting an install of its own choice.

Verified against both trees on this machine:

| Layout | `--game-dir` | Result |
| --- | --- | --- |
| Steam/hand-assembled | install root (holds `Common/`) | resolves to `Common/` |
| Steam/hand-assembled | the `Common/` folder itself | resolves |
| **GOG** (HQRs at the root) | install root | resolves |
| any | a path with no game data anywhere | **refuses**, names what it wanted |

## The picker hang

A batch or headless run could hang **forever** on the game-data folder picker. The code assumed headless meant no video subsystem, but `--headless` brings SDL up on the *dummy* driver, so `SDL_INIT_VIDEO` succeeds and the modal dialog really does open, with nobody to answer it. It now exits with the fix in the message.

## The message

It pointed at `docs/GAME_DATA.md` — a file in a source tree — for the one reader who has the binary and no game data, i.e. exactly the reader who cannot open it. It now names what the flag wants and points at `README.txt`, which a release ships beside the binary.

## Testing

Both cases are pinned in `test_cli_contract.sh`; the hang case asserts on the timeout exit code, since a regression there would otherwise present as a hung suite rather than a failure.

Host tests 47/47. Automation 30 passed / 2 skipped / 3 failed on **both** game-data trees, the 3 identical on `main`.
