### PR TITLE
fix(config): strip garbage lines from cfg and widen the boot read buffer

### DIFF
--- a/LIB386/SYSTEM/DEFFILE.CPP
+++ b/LIB386/SYSTEM/DEFFILE.CPP
@@ -130,6 +130,47 @@ S32 DefFileBufferInit(char *file, void *buffer, S32 maxsize) {
         buffersize = 0;
     }
 
+    /* Strip blatantly non-config lines: a run far longer than any real
+       "ident: value" pair with no ':' separator. Stale graphics bytes stamped
+       into the file by an interrupted write surface this way -- e.g. a long run
+       of one palette index left in the shared ScreenAux buffer. Such a line has
+       no ':' so the parser silently skips it on read and the writer copies it
+       back verbatim on every save: sticky corruption the NUL guard above misses
+       because the bytes are all printable. Excise only the offending line(s) and
+       compact in place, preserving every valid key, so reads are clean now and
+       the next write persists the healed file. Legitimate lines are short and
+       colon-delimited, so an over-long separator-less run can only be junk. */
+    if (buffersize > 0) {
+        const S32 maxLineLen = 512; // >> any real key:value line; << a graphics run
+        char *b = (char *)buffer;
+        S32 r = 0; // read cursor
+        S32 w = 0; // write cursor (compacted end)
+        S32 stripped = 0;
+        while (r < buffersize) {
+            const S32 lineStart = r;
+            S32 lineHasSep = FALSE;
+            while (r < buffersize && (U8)b[r] >= 32) { // a line is a run of printables
+                if (b[r] == ':')
+                    lineHasSep = TRUE;
+                r++;
+            }
+            const S32 lineLen = r - lineStart;
+            while (r < buffersize && (U8)b[r] < 32) // consume the trailing CR/LF/etc.
+                r++;
+            if (lineLen > maxLineLen && !lineHasSep) {
+                stripped++; // drop this line together with its terminator
+                continue;
+            }
+            if (w != lineStart) // keep: compact toward the front
+                memmove(b + w, b + lineStart, (size_t)(r - lineStart));
+            w += r - lineStart;
+        }
+        if (stripped) {
+            Log_Warn("DefFileBufferInit: stripped %d over-long separator-less line(s) (corrupt)", stripped);
+            buffersize = w;
+        }
+    }
+
     // Re-entry from DefFileBufferWriteString passes the module-static FileName
     // back in as `file`, which aliases the strcpy destination. Self-copy is UB
     // (ASan: strcpy-param-overlap); skip the copy when source and dest alias.

--- a/SOURCES/RES_SWITCH.CPP
+++ b/SOURCES/RES_SWITCH.CPP
@@ -52,6 +52,15 @@
 static bool g_resIsAutoDerived = false;
 bool Res_ResolutionIsAutoDerived(void) { return g_resIsAutoDerived; }
 
+/* Scratch-buffer size for the transient, heap-free boot reads of lba2.cfg
+   (Res_LoadBootDimensions / Res_LoadBootFullscreen). A fully-populated valid
+   cfg is already ~6 KB (72 keyboard + 72 gamepad bindings from MAX_INPUT, plus
+   ~70 settings/camera/audio keys), so the old 8 KB left almost no headroom and
+   any bloat -- a corrupt over-long line, future keys -- tips DefFileBufferInit
+   into its "buffer too small" reject, dropping the cfg's ResolutionX/Y and
+   silently falling back to auto-detect. 64 KB is generous and stays in BSS. */
+#define RES_BOOT_CFG_BUFSZ (64 * 1024)
+
 bool Res_ValidateDimensions(U32 w, U32 h) {
     if (w < RES_MIN_W || w > RES_MAX_W)
         return false;
@@ -286,9 +295,8 @@ void Res_LoadBootDimensions(U32 *outW, U32 *outH) {
        its own DefFileBufferInit against ScreenAux which fully resets the
        module state; nothing carries over from this transient init. */
     if (PathConfigFile[0] != '\0' && ExistsFileOrDir(PathConfigFile)) {
-        /* lba2.cfg is ~2.5KB at the time of writing; 8 KB is generous and
-           keeps the buffer in BSS rather than blowing main's stack. */
-        static char tmpCfgBuf[8192];
+        /* BSS scratch (see RES_BOOT_CFG_BUFSZ) rather than blowing main's stack. */
+        static char tmpCfgBuf[RES_BOOT_CFG_BUFSZ];
         if (DefFileBufferInit(PathConfigFile, tmpCfgBuf, (S32)sizeof tmpCfgBuf)) {
             const long w = DefFileBufferReadValueDefault("ResolutionX", 0);
             const long h = DefFileBufferReadValueDefault("ResolutionY", 0);
@@ -345,7 +353,7 @@ bool Res_LoadBootFullscreen(void) {
        Default windowed, matching ReadConfigFile's DisplayFullScreen default
        (FALSE) and its <0/>1 clamp — keep the two in sync. */
     if (PathConfigFile[0] != '\0' && ExistsFileOrDir(PathConfigFile)) {
-        static char tmpCfgBuf[8192];
+        static char tmpCfgBuf[RES_BOOT_CFG_BUFSZ];
         if (DefFileBufferInit(PathConfigFile, tmpCfgBuf, (S32)sizeof tmpCfgBuf)) {
             const long fs = DefFileBufferReadValueDefault("DisplayFullScreen", 0);
             return fs == 1;

--- a/tests/deffile/test_deffile_latin1.cpp
+++ b/tests/deffile/test_deffile_latin1.cpp
@@ -63,6 +63,12 @@ std::string ReadFile(const char *path) {
     return out;
 }
 
+// True iff key `ident` is present and reads back exactly as `expected`.
+bool ReadEq(const char *ident, const char *expected) {
+    char *v = DefFileBufferReadString(ident);
+    return v != NULL && std::strcmp(v, expected) == 0;
+}
+
 size_t CountOccurrences(const std::string &hay, const std::string &needle) {
     size_t count = 0;
     size_t pos = 0;
@@ -200,6 +206,151 @@ int main() {
         const std::string healed = ReadFile(path);
         CHECK(healed.find('\0') == std::string::npos);
         CHECK(healed.find("VoiceVolume: 100") != std::string::npos);
+    }
+
+    // ── Test 6: leading garbage line is stripped, every real key survives ────
+    // Real-world repro (Windows): a long run of one byte (0x4C 'L' -- a stale
+    // palette index from the shared ScreenAux buffer) got stamped as line 1 of
+    // lba2.cfg by an interrupted write. It has no ':' so the parser skips it and
+    // the writer copies it back on every save -- sticky corruption the NUL guard
+    // misses because the bytes are all printable. It also inflated the file past
+    // the boot reader's scratch buffer, silently dropping ResolutionX/Y.
+    // DefFileBufferInit must EXCISE only that line and keep every valid key, so
+    // the settings read correctly immediately (before any write) and the file
+    // heals to a clean, key-preserving state on the next write.
+    {
+        std::string corrupt(3000, 'L'); // stale-graphics run, no separator
+        corrupt += "\r\n";
+        corrupt += "FixedTimestep: 16\r\n";
+        corrupt += "Input0_1: 82\r\n";
+        corrupt += "VoiceVolume: 112\r\n";
+        corrupt += "Language: Français\r\n";
+        corrupt += "ResolutionX: 640\r\n";
+        corrupt += "ResolutionY: 480\r\n";
+        WriteFile(path, corrupt);
+
+        std::vector<char> buffer(65536, 0);
+        CHECK(DefFileBufferInit(path, &buffer[0], (S32)buffer.size()) == TRUE);
+
+        // Immediately readable -- no write needed. Every key preserved, verbatim.
+        CHECK(ReadEq("FixedTimestep", "16"));
+        CHECK(ReadEq("Input0_1", "82"));
+        CHECK(ReadEq("VoiceVolume", "112"));
+        CHECK(ReadEq("Language", "Français")); // non-ASCII value intact past the strip
+        CHECK(ReadEq("ResolutionX", "640"));   // the setting the boot read used to drop
+        CHECK(ReadEq("ResolutionY", "480"));
+
+        // A settings change persists a clean file: no 'L' run, all keys intact.
+        CHECK(DefFileBufferWriteString("ResolutionX", "1280") == TRUE);
+        const std::string healed = ReadFile(path);
+        CHECK(healed.find("LLLL") == std::string::npos);
+        CHECK(healed.find("ResolutionX: 1280") != std::string::npos);
+        CHECK(healed.find("FixedTimestep: 16") != std::string::npos);
+        CHECK(healed.find("VoiceVolume: 112") != std::string::npos);
+        CHECK(healed.find("Language: Français") != std::string::npos);
+        // Re-init the healed file: still clean, still complete.
+        CHECK(DefFileBufferInit(path, &buffer[0], (S32)buffer.size()) == TRUE);
+        CHECK(ReadEq("ResolutionX", "1280"));
+        CHECK(ReadEq("Input0_1", "82"));
+    }
+
+    // ── Test 7: garbage line in the MIDDLE -- keys on both sides survive ──────
+    // Also pins that the parser does not desync across the excised line (the
+    // Bug-A failure mode from Test 4, but for the strip path).
+    {
+        std::string corrupt = "FixedTimestep: 16\r\n";
+        corrupt += "Shadow: 3\r\n";
+        corrupt.append(2500, 'L'); // junk between two good blocks
+        corrupt += "\r\n";
+        corrupt += "MasterVolume: 127\r\n";
+        corrupt += "DetailLevel: 3\r\n";
+        WriteFile(path, corrupt);
+
+        std::vector<char> buffer(65536, 0);
+        CHECK(DefFileBufferInit(path, &buffer[0], (S32)buffer.size()) == TRUE);
+        CHECK(ReadEq("FixedTimestep", "16"));
+        CHECK(ReadEq("Shadow", "3"));
+        CHECK(ReadEq("MasterVolume", "127"));
+        CHECK(ReadEq("DetailLevel", "3"));
+    }
+
+    // ── Test 8: trailing garbage with no final newline -- prior keys survive ─
+    {
+        std::string corrupt = "MenuMouse: 1\r\nVSync: 0\r\n";
+        corrupt.append(1500, 'L'); // trailing junk, unterminated
+        WriteFile(path, corrupt);
+
+        std::vector<char> buffer(65536, 0);
+        CHECK(DefFileBufferInit(path, &buffer[0], (S32)buffer.size()) == TRUE);
+        CHECK(ReadEq("MenuMouse", "1"));
+        CHECK(ReadEq("VSync", "0"));
+
+        // Heals on write: junk gone, keys kept.
+        CHECK(DefFileBufferWriteString("VSync", "1") == TRUE);
+        const std::string healed = ReadFile(path);
+        CHECK(healed.find("LLLL") == std::string::npos);
+        CHECK(healed.find("MenuMouse: 1") != std::string::npos);
+        CHECK(healed.find("VSync: 1") != std::string::npos);
+    }
+
+    // ── Test 9: several garbage lines are all stripped, all keys survive ────
+    {
+        std::string corrupt(700, 'L');
+        corrupt += "\r\n";
+        corrupt += "AllCameras: 1\r\n";
+        corrupt.append(900, 'X'); // a second junk run, different byte
+        corrupt += "\r\n";
+        corrupt += "ReverseStereo: 0\r\n";
+        corrupt.append(600, 'Z');
+        corrupt += "\r\n";
+        WriteFile(path, corrupt);
+
+        std::vector<char> buffer(65536, 0);
+        CHECK(DefFileBufferInit(path, &buffer[0], (S32)buffer.size()) == TRUE);
+        CHECK(ReadEq("AllCameras", "1"));
+        CHECK(ReadEq("ReverseStereo", "0"));
+    }
+
+    // ── Test 10: false-positive guard -- a long value WITH a ':' is kept ──────
+    // Long lines are only junk when they lack a separator. A legitimate
+    // "ident: <long value>" has its ':' up front, so even one past the 512-char
+    // strip threshold must be kept. (Read-back can't verify the full value --
+    // DefFileBufferReadString caps at DefString's 256 bytes -- so this checks the
+    // line survives on disk and the following key still parses, i.e. no strip,
+    // no desync.)
+    {
+        const std::string longval(600, 'x'); // line length 610 > 512, but has ':'
+        std::string original = "LastSave: " + longval + "\r\nShadow: 3\r\n";
+        WriteFile(path, original);
+
+        std::vector<char> buffer(65536, 0);
+        CHECK(DefFileBufferInit(path, &buffer[0], (S32)buffer.size()) == TRUE);
+        CHECK(ReadEq("Shadow", "3")); // key after the long line still parses
+
+        // Rewriting a *different* key copies the buffer verbatim; the long
+        // colon-bearing line must still be there -- proof it was never stripped.
+        CHECK(DefFileBufferWriteString("Shadow", "3") == TRUE);
+        CHECK(ReadFile(path).find(longval) != std::string::npos);
+    }
+
+    // ── Test 11: threshold boundary -- 512 no-':' chars kept, 513 stripped ────
+    // Guards against both a too-eager strip (eating a merely-longish odd line)
+    // and a too-lax one. 512 is the largest run treated as tolerable.
+    {
+        std::string keep = std::string(512, 'q') + "\r\nShadow: 2\r\n";
+        WriteFile(path, keep);
+        std::vector<char> buffer(65536, 0);
+        CHECK(DefFileBufferInit(path, &buffer[0], (S32)buffer.size()) == TRUE);
+        CHECK(ReadEq("Shadow", "2"));
+        CHECK(DefFileBufferWriteString("Shadow", "2") == TRUE);
+        CHECK(ReadFile(path).find(std::string(512, 'q')) != std::string::npos); // kept
+
+        std::string strip = std::string(513, 'q') + "\r\nShadow: 5\r\n";
+        WriteFile(path, strip);
+        CHECK(DefFileBufferInit(path, &buffer[0], (S32)buffer.size()) == TRUE);
+        CHECK(ReadEq("Shadow", "5"));
+        CHECK(DefFileBufferWriteString("Shadow", "5") == TRUE);
+        CHECK(ReadFile(path).find(std::string(513, 'q')) == std::string::npos); // stripped
     }
 
     std::remove(path);


### PR DESCRIPTION
## What

A corrupt `lba2.cfg` on Windows produced three `DefFileBufferInit: buffer too small` lines at boot, and the display came up at the auto-detected size despite a saved `ResolutionX`/`ResolutionY`.

The cause was a long run of stale bytes (a `0x4C` graphics fill) sitting as the file's first line. The runtime cfg buffer aliases `ScreenAux`, the shared graphics/asset scratch buffer, so an interrupted write can stamp graphics data into the file. That produced two failures on load:

- **Sticky corruption.** The junk line has no `:` separator, so the parser skips it and the writer copies it back verbatim on every save. The existing guard only discards NUL-corrupted blobs, so an all-printable run persisted forever.
- **Boot reads dropped.** The bloat pushed the file past the 8 KB scratch buffer that `Res_LoadBootDimensions` / `Res_LoadBootFullscreen` use, so `DefFileBufferInit` rejected it and the saved resolution silently fell back to auto-detect.

No user setting is lost in this state: the values are intact below the junk line, they just aren't read.

## Change

- `DefFileBufferInit` excises over-long (>512 char) separator-less lines in place, preserving every valid key. Reads are clean immediately and the next write persists the healed file.
- The two boot scratch buffers grow to 64 KB (BSS) via `RES_BOOT_CFG_BUFSZ`. A fully-populated valid cfg is already ~6 KB, so 8 KB left almost no headroom regardless of corruption.

## Tests

`test_deffile_latin1` gains cases for leading / middle / trailing / multiple junk runs, immediate-read and heal-on-write key preservation, and false-positive guards (a long colon-bearing value is kept; a 512-char separator-less line is kept, 513 is stripped). Both deffile host tests pass; `lba2cc` compiles clean.

## Follow-up (not in this PR)

The deeper hazard is that a config file shares memory with the frame scratch buffer. Decoupling the cfg buffer from `ScreenAux` would remove the injection vector entirely.
