### PR TITLE
chore(format): pin clang-format to 18 with a single source of truth

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,7 +14,9 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install clang-format
-        run: sudo apt-get update && sudo apt-get install -y clang-format-17
+        # Keep this major version in sync with CLANG_FORMAT_MAJOR in
+        # scripts/ci/clang-format-select.sh (the single source of truth).
+        run: sudo apt-get update && sudo apt-get install -y clang-format-18
 
       - name: Check formatting
         run: bash ./scripts/ci/check-format.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ Style rules and rationale (language dialect, indentation, types, C++98, preserva
 Formatting mechanics (agent-operational):
 
 - Formatting: clang-format with checked-in `.clang-format`; exclusions live in `.clang-format-ignore` (ASM, `LIB386/libsmacker/`, vendored `stb_*`, and a handful of legacy lookup-table files). When adding vendored third-party code or generated/hand-tuned lookup tables, add the path to `.clang-format-ignore` in the same commit — single source of truth for local scripts, CI, and the pre-commit hook.
+- clang-format version: pinned once in `scripts/ci/clang-format-select.sh` (`CLANG_FORMAT_MAJOR`, currently 18). Install that exact version (`clang-format-18`) so local formatting matches CI; the scripts refuse to run a different major rather than silently disagreeing with CI.
 - Pre-commit hook (optional, recommended): `git config core.hooksPath scripts/git-hooks` once per clone. It runs clang-format `--dry-run` on staged C/C++ files (respecting `.clang-format-ignore`) and blocks commits with violations. Fix with `bash ./scripts/ci/apply-format.sh && git add -u`. Bypass with `git commit --no-verify` or `SKIP_FORMAT=1` when warranted.
 
 ## Logging

--- a/scripts/ci/apply-format.sh
+++ b/scripts/ci/apply-format.sh
@@ -6,14 +6,11 @@ set -euo pipefail
 # The file list is filtered through .clang-format-ignore so local formatting
 # and CI checks stay aligned on what is intentionally excluded.
 
-if command -v clang-format-17 >/dev/null 2>&1; then
-    clang_format=clang-format-17
-elif command -v clang-format >/dev/null 2>&1; then
-    clang_format=clang-format
-elif command -v xcrun >/dev/null 2>&1; then
-    clang_format="$(xcrun --find clang-format)"
-else
-    echo "clang-format is required to apply formatting." >&2
+# shellcheck source=scripts/ci/clang-format-select.sh
+. "$(dirname "${BASH_SOURCE[0]}")/clang-format-select.sh"
+if [ -z "$clang_format" ]; then
+    echo "clang-format ${CLANG_FORMAT_MAJOR} is required to apply formatting." >&2
+    echo "  Debian/Ubuntu: apt-get install clang-format-${CLANG_FORMAT_MAJOR}   macOS: brew install clang-format" >&2
     exit 1
 fi
 

--- a/scripts/ci/check-format.sh
+++ b/scripts/ci/check-format.sh
@@ -6,14 +6,11 @@ set -euo pipefail
 # Like apply-format.sh, this reads exclusions from .clang-format-ignore so the
 # local check and CI are evaluating the same file set.
 
-if command -v clang-format-17 >/dev/null 2>&1; then
-    clang_format=clang-format-17
-elif command -v clang-format >/dev/null 2>&1; then
-    clang_format=clang-format
-elif command -v xcrun >/dev/null 2>&1; then
-    clang_format="$(xcrun --find clang-format)"
-else
-    echo "clang-format is required to run the format check." >&2
+# shellcheck source=scripts/ci/clang-format-select.sh
+. "$(dirname "${BASH_SOURCE[0]}")/clang-format-select.sh"
+if [ -z "$clang_format" ]; then
+    echo "clang-format ${CLANG_FORMAT_MAJOR} is required to run the format check." >&2
+    echo "  Debian/Ubuntu: apt-get install clang-format-${CLANG_FORMAT_MAJOR}   macOS: brew install clang-format" >&2
     exit 1
 fi
 

--- a/scripts/ci/clang-format-select.sh
+++ b/scripts/ci/clang-format-select.sh
@@ -1,0 +1,33 @@
+# shellcheck shell=bash
+#
+# Single source of truth for the clang-format version used by CI
+# (check-format.sh), local formatting (apply-format.sh), and the pre-commit
+# hook. Bump CLANG_FORMAT_MAJOR here to move the whole project to a new
+# clang-format in one place.
+#
+# Source this fragment (do not execute it). It sets:
+#   CLANG_FORMAT_MAJOR - the required major version
+#   clang_format       - path/name of a clang-format whose major version
+#                        matches, or "" if none is installed.
+#
+# It never falls back to a different major version. Silently formatting with a
+# clang-format that disagrees with CI is worse than not formatting at all, so
+# callers decide what an empty result means: CI and apply-format fail; the
+# pre-commit hook skips with a warning.
+
+CLANG_FORMAT_MAJOR=18
+
+clang_format=""
+for _cf_cand in \
+    "clang-format-${CLANG_FORMAT_MAJOR}" \
+    "clang-format" \
+    "$( (command -v xcrun >/dev/null 2>&1 && xcrun --find clang-format 2>/dev/null) || true)"; do
+    [ -n "${_cf_cand}" ] || continue
+    command -v "${_cf_cand}" >/dev/null 2>&1 || continue
+    _cf_ver="$({ "${_cf_cand}" --version 2>/dev/null || true; } | grep -oE '[0-9]+' | head -n1 || true)"
+    if [ "${_cf_ver}" = "${CLANG_FORMAT_MAJOR}" ]; then
+        clang_format="${_cf_cand}"
+        break
+    fi
+done
+unset _cf_cand _cf_ver

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -14,20 +14,16 @@ if [ "${SKIP_FORMAT:-0}" = "1" ]; then
     exit 0
 fi
 
-if command -v clang-format-17 >/dev/null 2>&1; then
-    clang_format=clang-format-17
-elif command -v clang-format >/dev/null 2>&1; then
-    clang_format=clang-format
-elif command -v xcrun >/dev/null 2>&1; then
-    clang_format="$(xcrun --find clang-format)"
-else
-    echo "pre-commit: clang-format not found; skipping format check." >&2
-    echo "            install clang-format-17, or set SKIP_FORMAT=1 to silence." >&2
-    exit 0
-fi
-
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
+
+# shellcheck source=scripts/ci/clang-format-select.sh
+. scripts/ci/clang-format-select.sh
+if [ -z "$clang_format" ]; then
+    echo "pre-commit: clang-format ${CLANG_FORMAT_MAJOR} not found; skipping format check." >&2
+    echo "            install clang-format-${CLANG_FORMAT_MAJOR}, or set SKIP_FORMAT=1 to silence." >&2
+    exit 0
+fi
 
 # Staged, added/copied/modified/renamed files only (skip deletes).
 mapfile -d '' -t staged < <(


### PR DESCRIPTION
Closes #442.

### Problem

clang-format was pinned to major **17** in four places (`.github/workflows/format.yml`, `scripts/ci/check-format.sh`, `scripts/ci/apply-format.sh`, `scripts/git-hooks/pre-commit`), each with a **silent fallback** to unversioned `clang-format`. On a current toolchain (Ubuntu 24.04, recent Homebrew) that default is 18+, so a contributor without `clang-format-17` formatted with a different major, passed their local hook, then failed CI's 17 check (or the reverse). 17 is no longer the default anywhere, so the fallback path was the common one. This cost real time more than once.

### Change

- **`scripts/ci/clang-format-select.sh`** (new): a shared resolver sourced by all three call sites. `CLANG_FORMAT_MAJOR` is pinned in one place (now **18**); it resolves a `clang-format` whose major version actually matches and leaves the selection empty otherwise. It never falls back to a different major.
- **`check-format.sh` / `apply-format.sh`**: fail loudly with an actionable install hint when no matching version is found.
- **pre-commit hook**: keeps its non-blocking skip-with-warning behaviour when the version is absent, but is now version-aware (won't silently run a mismatched major).
- **`format.yml`**: installs `clang-format-18`, with a comment pointing at the single source of truth.
- **AGENTS.md**: documents the pinned version.

### Why 18 is safe here

The whole tree is already clean under clang-format-18 — **655 files checked, zero would change** — so this is a tooling-only change with no reformatting churn.

### Testing

- Resolver selects `clang-format-18`; with only a wrong-major binary on `PATH`, `check-format.sh` fails with exit 1 and the install hint (no silent fallback).
- Pre-commit hook: rejects a deliberately misformatted staged file, passes once formatted.
- `check-format.sh` over the full tree: clean, exit 0.
- This PR's own commit passed through the restructured hook.
