### PR TITLE
docs(widescreen): reconcile HD-phase status across the three docs

### DIFF
--- a/docs/RUNTIME_RESOLUTION.md
+++ b/docs/RUNTIME_RESOLUTION.md
@@ -29,7 +29,7 @@ The widescreen render path (Phases 1–3 in `WIDESCREEN.md`) is already runtime-
 
 - **Resolution-independent UI.** The 4:3 UI is C1-centred or C2-re-anchored case by case — that work belongs to the audit, not this doc.
 - **Per-display preferences.** A single global resolution stored in `lba2.cfg`; if the player moves their laptop to a 4K monitor, they pick a new one. Multi-display memory is a future enhancement.
-- **Cinematic upscale.** Smacker source is 320×200; at higher render resolutions it stays letterboxed inside the 640×480 image area (see `PLAYACF.CPP`). Render resolution does not change cinematic source quality.
+- **Cinematic upscale.** Smacker source is 320×200. `VideoFullScreen` selects the upscale policy (`Video_ComputeCineRect` in `PLAYACF.CPP`): fit-to-screen (default, aspect-preserving pillar/letterbox) or the classic centred 2× letterbox (PR #430). Render resolution does not change cinematic source quality either way.
 - **Display-mode switching.** This is the *render* resolution. SDL scales the framebuffer to the window/display. We don't change the OS display mode.
 
 ## Existing infrastructure
@@ -165,7 +165,7 @@ Display in the form `<W>x<H> (<aspect>, <tag>)`:
 | `320 ≤ W ≤ 1920` | Matches `--resolution` CLI validator. |
 | `200 ≤ H ≤ 1024` | Same. |
 | `W ≤ display_W` and `H ≤ display_H` | Don't offer modes larger than the display; SDL would still scale, but it's misleading. |
-| `Y > 480` flagged `experimental` | Until A4 (terrain horizon) and A5 (holomap Z-buffer Y bounds) are fixed (audit row in `WIDESCREEN_HARDCODED_DIMS_AUDIT.md` — task #99 / HD pass), tall modes glitch on the holomap. The player can still pick them; we tell them what to expect. |
+| `Y > 480` flagged `experimental` | A4 (terrain horizon) and A5 (holomap Z-buffer Y bounds) are now fixed (routed through `ModeDesiredY-1`, PR #262), as is the actor-shadow cull (#443). Tall modes stay flagged `experimental` for the remaining Phase 7 polish rather than correctness bugs: HUD and menu fonts blit 1:1 (tiny at 1080p), and the `ui holoplan` tall-res path is still unverified. The player can still pick them; we tell them what to expect. |
 
 ### SDL discovery
 

--- a/docs/WIDESCREEN.md
+++ b/docs/WIDESCREEN.md
@@ -167,6 +167,12 @@ With the Y-axis clamps and the save-clip pin fixed, the exterior 3D view fills
 the full framebuffer height. That immediately raises a composition question we
 have *not* resolved — captured here to revisit.
 
+**Update (2026-07).** Two pieces of the recompose lever have since landed:
+`fix/exterior-near-clip-hd` (#342) scales the exterior near-clip with render
+height, and `feat/autocam-hd-recompose` (#343) gives the auto-camera HD
+world-awareness (the recompose direction of option 2). The framing decision
+below is still open, but option 2 is no longer hypothetical.
+
 **The mechanism.** The projection (`LPROJ3DF.CPP`) is square-pixel with a fixed
 field constant: `Xp = ModeDesiredX/2 + (x-cam)·ChampX/Z`, `Yp = ModeDesiredY/2 +
 (y-cam)·ChampZ/Z`, with `ChampX`/`ChampZ` constant. So growing the framebuffer
@@ -274,7 +280,7 @@ Widescreen shipped without true high resolution: the framebuffer grows horizonta
 
 1. **Bitmap fonts (open, highest player impact).** `LIB386/SVGA/FONT.CPP` and `AFFSTR.CPP` blit glyphs 1:1, so HUD, dialogue, and menu text is tiny at 1080p. Pixel-scale the 8×N glyphs by an integer factor derived from `ModeDesiredY`, scaling advance widths and line spacing with them. Nothing is in flight, so it is a clean slate.
 2. **Iso interior sharpness (experimental).** The isometric brick layer is a 640-class blit; at HD it wants scaling or edge-upscaling (xBR / EPX) so interiors stay crisp. Five unmerged branches explore this: `feat/iso-xbr-optimized` (furthest along), `feat/iso-xbr-bricks`, `feat/iso-brick-scale`, `feat/iso-scale`, and `feat/iso-zoom-screenspace`. Findings live on-branch in `ISO_SCALE_FINDINGS.md`; the on-main groundwork is [`ISO_SPACE_AUDIT.md`](ISO_SPACE_AUDIT.md). Needs triage down to one mergeable approach.
-3. **Holomap at Y > 480 (blocked).** The A4/A5 Z-buffer-bounds fix is correct and 640-identical but cannot be verified at tall resolution: `ui holoplan` at 1024×768 times out on a cinema-mode rendering bug. Resolve that, then add `test_ui_holoplan_768x768.sh`.
+3. **Holomap at Y > 480 (needs re-verification).** The A4/A5 Z-buffer-bounds fix is correct and 640-identical. It was flagged unverified at tall resolution because `ui holoplan` at 1024×768 reportedly timed out on a cinema-mode rendering bug. A 2026-07 code sweep found no dimension-based timeout (the zoom loop is time-driven and image-centred), so re-test `ui holoplan` at 1024×768 before assuming it is still blocked, then add `test_ui_holoplan_768x768.sh`.
 4. **Vertical framing (decision pending).** A taller frame reveals more vertical field of view, exposing the sky edge and map seams. The levers and the current leaning are in [Vertical framing at HD](#vertical-framing-at-hd--open-question). Cheap to A/B with the polyrec harness.
 5. **Watch-items.** The 16-bit Z-buffer plus `Fill_ZBuffer_Factor` may Z-fight on distant geometry at HD aspect; filler precision is de-risked (swept at 1920, 0.006% sub-pixel edge drift, no overflow). Smacker upscale is now a player option (fit-to-screen default, aspect-preserving) and 1:1 mouse coords need no action.
 
@@ -351,6 +357,6 @@ LBA2_BIN=build-wide/SOURCES/lba2cc \
 | 4 – fullscreen + runtime resolution | Done. Explicit player choice (`--resolution` / `lba2.cfg` / Display submenu / `resolution` verb) plus first-launch widescreen auto-detect; precedence CLI > cfg > auto > 640×480. Fullscreen defaults on via the cfg template. See [Phase 4](#phase-4-fullscreen-and-runtime-resolution). |
 | 5 – UI (C2) | Done for the menu/UI surfaces (#213–#228 re-anchor campaign, plus #260, #289, #291, #310). HD-only concerns split out to Phase 7. |
 | 6 – regression | Ongoing per-PR (projrec corpus, `host_quick`, and `ui_*` capture tests gate the 640×480 contract). No final lock-in pass yet. |
-| 7 – native HD | Not started. Fonts blit 1:1, iso interior sharpness (experiment branches), holomap tall-res timeout, vertical-framing decision. See [Phase 7](#phase-7-native-hd). |
+| 7 – native HD | In progress. HD-height render *correctness* is done: Y-clamps (#262), exterior near-clip scaling (#342), and actor shadows (#443) all route through `ModeDesiredY`, and auto-camera HD recompose landed (#343). Remaining is legibility and sharpness: bitmap fonts blit 1:1, iso interior sharpness (experiment branches), holomap tall-res verification, and the vertical-framing decision. See [Phase 7](#phase-7-native-hd). |
 
 Foundation already in place: PR #134 (`RESOLUTION_X` / `RESOLUTION_Y` constants, and most render-space literals routed through them).

--- a/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
+++ b/docs/WIDESCREEN_HARDCODED_DIMS_AUDIT.md
@@ -262,17 +262,26 @@ width.)*
 
 ### A4. Terrain horizon polygons clamped to Y=479
 
-[`SOURCES/3DEXT/TERRAIN.CPP:570-641`](../SOURCES/3DEXT/TERRAIN.CPP) — six
-sites set `Tab_Points[N].Pt_YE = (S16)479` as the bottom edge of the
+[`SOURCES/3DEXT/TERRAIN.CPP:570-641`](../SOURCES/3DEXT/TERRAIN.CPP) set eight
+sites to `Tab_Points[N].Pt_YE = (S16)479` as the bottom edge of the
 horizon polygons. If render height ever moves above 480 (future HD), the
 horizon stops at row 479. (At the current 480 height this is fine; flag
 for the Phase 5 HD pass.)
 
+*(Resolved: all eight sites now set `Pt_YE = (S16)((S32)ModeDesiredY - 1)`
+(`TERRAIN.CPP:570, 572, 593, 595, 616, 618, 639, 641`), landed in
+fix/widescreen-y-clamp, PR #262. Behavior-preserving at 480; the horizon
+reaches the true frame bottom at any height.)*
+
 ### A5. Holomap Z-buffer Y bounds
 
-[`SOURCES/HOLOGLOB.CPP:141, 152, 153, 995`](../SOURCES/HOLOGLOB.CPP) —
+[`SOURCES/HOLOGLOB.CPP:141, 152, 153, 995`](../SOURCES/HOLOGLOB.CPP) had
 `ZBufYMin/Max = 479` clamps. Same situation as A4: fine at the current
 height, breaks at HD.
+
+*(Resolved: the bounds now clamp to `(S32)ModeDesiredY - 1`
+(`HOLOGLOB.CPP:148, 159-160, 1005-1006`), same PR #262. Behavior-preserving
+at 480.)*
 
 ### A6. Save-thumbnail buffer
 
@@ -393,15 +402,16 @@ to black first so sidebars are clean. The B4-routed corner brackets +
 brackets all line up with the centred bitmap. `BoxStaticAdd` for the
 full-screen dirty marker stays at framebuffer corners so the sidebars
 are still painted on each repaint. No-op at 640×480; X-axis widening
-verified at 768 and 1024. Y>480 still subject to the wider HD-pass — A4
-/ A5 still flag the Y-axis sites.)*
+verified at 768 and 1024. The Y-axis is now handled too: A4 / A5 route
+through `ModeDesiredY - 1` (PR #262), so the holoplan image centres and
+clips correctly at tall heights.)*
 
 ### A10. Misc full-framebuffer allocations + sizes
 
 | Site | What | Status |
 |---|---|---|
 | [`SOURCES/PERSO.CPP:2008`](../SOURCES/PERSO.CPP) | `DefFileBufferInit(PathConfigFile, ScreenAux, (640 * 480 + RECOVER_AREA))` | **Functional, low priority.** Tells `DefFileBufferInit` the scratch buffer is `640*480 + RECOVER_AREA` bytes; the actual `ScreenAux` is `MDX*MDY + RECOVER_AREA`. Under-declares the buffer but doesn't corrupt — `LBA2.CFG` is a small text file, never approaches 307K. Worth tightening to `ModeDesiredX * ModeDesiredY + RECOVER_AREA`. |
-| [`SOURCES/PLAYACF.CPP:222-456`](../SOURCES/PLAYACF.CPP) + [`:504`](../SOURCES/PLAYACF.CPP) | Cinematic video upscaled into a 640×480 dest buffer, then `CopyBlock(0, 0, 640, 480, dest, 0, 0, Log)` to the framebuffer. | **Open — real bug at wider widths.** The 640×480 buffer lands in the left 640 columns of Log; columns `[640, ModeDesiredX)` keep whatever Log held before the cutscene started. Visible as garbage / stale UI to the right of the Smacker frame at 768/1024. Fix shape: clear Log to black + `CopyBlock(0, 0, 640, 480, dest, (MDX-640)/2, (MDY-480)/2, Log)` for letterbox-centred cinematic. |
+| [`SOURCES/PLAYACF.CPP:519-536`](../SOURCES/PLAYACF.CPP) | Cinematic video decoded into the framebuffer for display. | **Resolved** (PR #430, feat/fmv-widescreen-fit). Rewritten to pre-clear `Log` with `memset` and write the decoded frame directly at the centred origin with `ModeDesiredX` row stride (`Video_ComputeCineRect` + `cineOrigin`, `PLAYACF.CPP:519-536`); no intermediate 640-stride buffer and no `CopyBlock`. `VideoFullScreen` selects fit-to-screen (default, aspect-preserving) vs the classic centred letterbox. Byte-identical at 640×480. |
 | [`SOURCES/DEFINES.H:211`](../SOURCES/DEFINES.H) | `#define MAX_PLAYER ((640 * 480) / …)` | **Intentionally fixed** per [`WIDESCREEN.md`](WIDESCREEN.md#what-does-not-need-to-change) — partitions `BufSpeak`, and a silent slot-count change would walk off the end of it. Save format depends on this staying at 640*480. Do not change. |
 | [`SOURCES/CONFIG/MAIN.CPP:90`](../SOURCES/CONFIG/MAIN.CPP) | `#define ibuffersize (640 * 480 + RECOVER_AREA)` | **Not built.** `SOURCES/CONFIG/` is the original Adeline standalone config tool; it isn't referenced by any active `CMakeLists.txt`. Dormant code, not in the shipping binary. |
 
@@ -590,14 +600,16 @@ copy stride for a specific intermediate buffer. Audit independently
 if the BlitBox path ever widens; for now, it's specific to that buffer's
 size.
 
-### C6. Currently-fine 479 references (HD-only concern)
+### C6. 479 references (HD-Y class, now resolved)
 
-A4, A5 above (`Tab_Points[N].Pt_YE = 479`, `ZBufYMin/Max = 479`) work
-at the current 480 render height. They become bugs only when render
-*height* changes, i.e. the Phase 5 HD work. A11 was the first of this
-HD-Y class to actually surface in the field (actor shadows, once 1080p
-shipped); A4 / A5 are the same shape and should be expected to bite as
-vertical HD sees more field use.
+A4, A5 above (`Tab_Points[N].Pt_YE = 479`, `ZBufYMin/Max = 479`) worked
+at the native 480 height and would have broken above it. A11 (actor
+shadows) was the first of this HD-Y class to surface in the field, once
+1080p shipped. All three are now routed through `ModeDesiredY` (A4/A5 in
+PR #262, A11 in PR #443), so the class this row warned about is closed.
+A fresh HD-height sweep (2026-07) found no remaining live instance; the
+only residual literals are benign (an untriggered `CopyBlockShade` size
+guard, dead initializers, editor-only debug rects).
 
 ## Recommended fix ordering
 
@@ -617,8 +629,9 @@ in this priority:
 4. **Tier 2 — UI layout per the chosen strategy.** Category B sites.
    Under C1: build a 4:3-render-into-wider-Log compositor. Under C2:
    route the literals.
-5. **Tier 4 — HD-only.** A4 (terrain horizon Y=479), A5 (holomap
-   ZBufYMax=479), C6. Fine at 480 height; defer.
+5. **Tier 4, HD-only (done).** A4 (terrain horizon Y=479), A5 (holomap
+   ZBufYMax=479), and A11 (actor shadows) all route through `ModeDesiredY`
+   now (#262, #443); C6 closed.
 
 The author's intuition that "the inventory is 4:3 and should stay that
 way" maps cleanly to C1 — and is consistent with the SCREEN.HQR


### PR DESCRIPTION
Docs-only. The widescreen docs had drifted behind the code on the HD-height items — several fixes that landed months ago were still catalogued as open, which actively misleads anyone picking up Phase 7 work (e.g. `RUNTIME_RESOLUTION.md` says tall modes are blocked on A4/A5, both long fixed). This squares the three docs with current `main`. No code changes.

Verified each claim against the source before writing it (PR merges + literal greps + a fresh HD-height sweep).

## WIDESCREEN_HARDCODED_DIMS_AUDIT.md
- **A4** (terrain horizon Y=479): marked Resolved — all eight sites now `Pt_YE = (S16)((S32)ModeDesiredY - 1)` (PR #262). Also corrects the site count (eight, not six).
- **A5** (holomap Z-buffer Y bounds): marked Resolved — clamps to `ModeDesiredY - 1` (PR #262).
- **A10 PLAYACF**: was "Open — real bug"; now Resolved — rewritten to pre-clear `Log` and write the decoded frame directly at the centred origin with `ModeDesiredX` stride (`Video_ComputeCineRect`/`cineOrigin`, PR #430); no `CopyBlock`.
- **C6** and **Tier-4 fix-ordering**: the HD-Y class (A4/A5/A11) is closed; a fresh 2026-07 sweep found no remaining live instance (residual literals are all benign).
- Fixed the stale **A9** tail that still flagged A4/A5 as open.

## RUNTIME_RESOLUTION.md
- The `Y > 480` experimental gate no longer hinges on A4/A5 (both fixed). Reframed around what actually remains: 1:1 fonts and the unverified `ui holoplan` tall-res path.
- Smacker non-goal updated: fit-to-screen shipped (PR #430), not fixed letterbox.

## WIDESCREEN.md
- Phase 7 status row: **Not started → In progress**. HD-height render *correctness* is done (#262 Y-clamps, #342 exterior near-clip, #443 actor shadows, #343 autocam HD recompose); remaining is legibility/sharpness (fonts, iso, framing decision).
- Vertical-framing section: noted the recompose lever partly landed (#342 near-clip scaling, #343 autocam HD recompose) — option 2 is no longer hypothetical.
- Holomap Phase 7 item reframed as **needs re-verification**: the cited tall-res timeout wasn't found in a code sweep (the zoom loop is time-driven), so it should be re-tested at 1024×768 rather than assumed blocked.

### Note left for a follow-up (not in this PR)
The holomap timeout claim needs a live `ui holoplan 1024×768` re-test to confirm it's actually unblocked; flagged in-doc rather than asserted.