### PR TITLE
fix(input): recover from a config whose bindings are all unset

### DIFF
--- a/SOURCES/INPUT.CPP
+++ b/SOURCES/INPUT.CPP
@@ -6,6 +6,8 @@
 #include <SYSTEM/KEYBOARD_KEYS.H>
 
 #include "INPUT.H"
+
+#include <SYSTEM/LOG.H>
 #include "JOYSTICK.H"
 #include "FOLLOWCAM_CFG.H"
 
@@ -185,13 +187,35 @@ void ReadInputConfig(void) {
         for (n = 0; n < MAX_INPUT; n++) {
             snprintf(id, sizeof(id), "Input%d_1", n);
             DefKeys[n].Key1 = DefFileBufferReadValueDefault(id, DEFKEYSDEFAULT[n].Key1);
-            // Blindage si les Inputs sont configurés à 0
-            //			if( !DefKeys[n].Key1 )	DefKeys[n].Key1 = DEFKEYSDEFAULT[n].Key1 ;
 
             snprintf(id, sizeof(id), "Input%d_2", n);
             DefKeys[n].Key2 = DefFileBufferReadValueDefault(id, DEFKEYSDEFAULT[n].Key2);
-            // Blindage si les Inputs sont configurés à 0
-            //			if( !DefKeys[n].Key2 )	DefKeys[n].Key2 = DEFKEYSDEFAULT[n].Key2 ;
+
+            if (DefKeys[n].Key1 OR DefKeys[n].Key2)
+                initkeys = TRUE;
+        }
+
+        /* Blindage si les Inputs sont configurés à 0.
+           A cfg with no input bindings at all leaves the game unplayable: the
+           menu still opens, because its key is not in this table, but nothing
+           moves. Clearing every keyboard binding IS reachable from the remap
+           screen, so an empty keyboard table alone is not proof of corruption
+           -- a gamepad-only layout looks exactly like that. Requiring the
+           gamepad table to be empty as well distinguishes the two, and leaves
+           a partially customised layout untouched either way. */
+        if (!initkeys) {
+            for (n = 0; n < MAX_INPUT; n++) {
+                if (GamepadKeys[n].Key1 OR GamepadKeys[n].Key2) {
+                    initkeys = TRUE;
+                    break;
+                }
+            }
+        }
+
+        if (!initkeys) {
+            Log_Warn("Keyboard bindings in the config are all unset; "
+                     "restoring the default layout.");
+            RestoreInput();
         }
     }
 

--- a/SOURCES/INPUT.CPP
+++ b/SOURCES/INPUT.CPP
@@ -198,14 +198,23 @@ void ReadInputConfig(void) {
         /* Blindage si les Inputs sont configurés à 0.
            A cfg with no input bindings at all leaves the game unplayable: the
            menu still opens, because its key is not in this table, but nothing
-           moves. Clearing every keyboard binding IS reachable from the remap
-           screen, so an empty keyboard table alone is not proof of corruption
-           -- a gamepad-only layout looks exactly like that. Requiring the
-           gamepad table to be empty as well distinguishes the two, and leaves
-           a partially customised layout untouched either way. */
+           moves, and the remap screen needs the very bindings that are gone.
+
+           Clearing every keyboard binding IS reachable from the remap screen,
+           so an empty keyboard table alone is not proof of corruption -- a
+           gamepad-only layout looks exactly like that. The pad bindings decide
+           between the two, and they have to be read from the cfg here rather
+           than from GamepadKeys: ReadGamepadConfig runs after this function, so
+           the live table still holds whatever preceded it. */
         if (!initkeys) {
             for (n = 0; n < MAX_INPUT; n++) {
-                if (GamepadKeys[n].Key1 OR GamepadKeys[n].Key2) {
+                snprintf(id, sizeof(id), "Gamepad%d", n);
+                if (DefFileBufferReadValueDefault(id, 0)) {
+                    initkeys = TRUE;
+                    break;
+                }
+                snprintf(id, sizeof(id), "Gamepad%d_2", n);
+                if (DefFileBufferReadValueDefault(id, 0)) {
                     initkeys = TRUE;
                     break;
                 }

--- a/SOURCES/INPUT.CPP
+++ b/SOURCES/INPUT.CPP
@@ -208,13 +208,18 @@ void ReadInputConfig(void) {
            the live table still holds whatever preceded it. */
         if (!initkeys) {
             for (n = 0; n < MAX_INPUT; n++) {
+                /* Defaulted exactly as ReadGamepadConfig will default them, so
+                   the probe asks what the pad bindings are going to BE, not
+                   what the file happens to spell out. A cfg predating gamepad
+                   support has no Gamepad* keys at all and still ends up with
+                   the default pad layout. */
                 snprintf(id, sizeof(id), "Gamepad%d", n);
-                if (DefFileBufferReadValueDefault(id, 0)) {
+                if (DefFileBufferReadValueDefault(id, GamepadKeysDefault[n].Key1)) {
                     initkeys = TRUE;
                     break;
                 }
                 snprintf(id, sizeof(id), "Gamepad%d_2", n);
-                if (DefFileBufferReadValueDefault(id, 0)) {
+                if (DefFileBufferReadValueDefault(id, GamepadKeysDefault[n].Key2)) {
                     initkeys = TRUE;
                     break;
                 }
@@ -222,7 +227,7 @@ void ReadInputConfig(void) {
         }
 
         if (!initkeys) {
-            Log_Warn("Keyboard bindings in the config are all unset; "
+            Log_Warn("No usable keyboard or gamepad bindings in the config; "
                      "restoring the default layout.");
             RestoreInput();
         }


### PR DESCRIPTION
Thanks for this repo — I'm a big fan of this game :-)

## The state

`WinMode 1` makes `ReadInputConfig` trust the `Input*` block verbatim. A config
in which every keyboard and gamepad binding is zero therefore leaves the game
unplayable: the menu still opens, because its key is not in this table, but
nothing moves. There is no way out from inside the game either — reaching the
remap screen needs the very bindings that are missing — so the player has to
find and edit `lba2.cfg` by hand, or delete it and lose the rest of their
settings.

I hit this on my own install and could not work out afterwards which run
produced it. I could not reproduce it on `main` or with the shipped v0.12.0
AppImage in a normal headless run, so I am not claiming a specific trigger.
What is certain is that the state is unrecoverable once reached, and that the
engine already knows how it should behave.

## The fix

Adeline anticipated exactly this — the guard is in `ReadInputConfig`, written
and commented out, labelled *"Blindage si les Inputs sont configurés à 0"*.
Two changes make it safe to switch back on:

- **Test the table as a whole, not per entry.** A per-entry restore would
  overwrite a layout that deliberately leaves single bindings empty.
- **Require the gamepad table to be empty too.** Clearing every keyboard
  binding *is* reachable from the remap screen with Delete
  (`CONFIG.CPP` handles `K_SUPPR` for both slots), so a gamepad-only player
  produces an all-zero keyboard table on purpose. Only a configuration with no
  input at all is unambiguously broken.

The pad bindings are read from the cfg inside the check rather than from
`GamepadKeys`: `ReadGamepadConfig` runs *after* `ReadInputConfig`, so the live
table still holds whatever preceded it — zeros on a fresh boot — which would
have made the gamepad-only case look identical to a corrupt one.

One case stays ambiguous by nature: a layout with no keyboard *and* no gamepad
bindings is indistinguishable from corruption and will be restored. That
configuration cannot be played anyway, so I think restoring is the better of
the two behaviours, but it is a judgement call worth naming.

The recovery logs a warning, so a surprising remap is traceable rather than
mysterious.

## Testing

`make test` green (47/47), clang-format clean. Verified by hand against a
deliberately zeroed config: the engine logs
`Keyboard bindings in the config are all unset; restoring the default layout`,
plays normally, and writes real scancodes back at exit. A config with only
gamepad bindings is left alone.

First patch of mine here, so please point at anything that does not match house
style.
