### PR TITLE
feat(present): let the present scale filter be chosen

### DIFF
--- a/LIB386/SYSTEM/WINDOW.CPP
+++ b/LIB386/SYSTEM/WINDOW.CPP
@@ -34,6 +34,51 @@ static void ApplyGameWindowHideSystemCursor(void) {
     SDL_SetCursor(NULL);
 }
 
+/* Scale filter applied when the framebuffer is stretched to the window,
+   selected with LBA2_SCALE_MODE=nearest|linear|pixelart.
+
+   NEAREST stays the default: it is the historical output exactly. It is also
+   uneven at a non-integer window scale -- 1728x1080 shown on 3840x2400 is 20/9,
+   so a source pixel becomes two output pixels here and three there, and that
+   irregularity is what reads as chunkiness. LINEAR removes it by softening the
+   fixed-pixel 2D layer along with everything else. PIXELART keeps texel
+   interiors crisp and interpolates only across the texel seam.
+
+   PIXELART needs SDL 3.4 at both compile and run time and degrades to NEAREST
+   rather than failing, which is why the two guards differ: the compile one
+   keeps older SDL building, the runtime one catches headers and runtime
+   disagreeing -- SDL_SetTextureScaleMode simply returns false there and would
+   otherwise leave the texture on a mode nobody chose. */
+static SDL_ScaleMode ResolveScaleMode(void) {
+    const char *mode = SDL_getenv("LBA2_SCALE_MODE");
+    if (mode == NULL) {
+        return SDL_SCALEMODE_NEAREST;
+    }
+    if (SDL_strcasecmp(mode, "linear") == 0) {
+        return SDL_SCALEMODE_LINEAR;
+    }
+#if SDL_VERSION_ATLEAST(3, 4, 0)
+    if (SDL_strcasecmp(mode, "pixelart") == 0) {
+        if (SDL_GetVersion() >= SDL_VERSIONNUM(3, 4, 0)) {
+            return SDL_SCALEMODE_PIXELART;
+        }
+        Log_Warn("The pixelart scale mode needs SDL 3.4 at runtime; this "
+                 "build is linked against an older one. Using nearest.");
+    }
+#endif
+    return SDL_SCALEMODE_NEAREST;
+}
+
+/* Apply the chosen filter and say so if the runtime refused it, rather than
+   leaving the texture on a mode nobody asked for. */
+static void ApplyScaleMode(SDL_Texture *texture) {
+    const SDL_ScaleMode mode = ResolveScaleMode();
+    if (!SDL_SetTextureScaleMode(texture, mode)) {
+        Log_Warn("Unable to set texture scale mode.\n\tSDL message: %s",
+                 SDL_GetError());
+    }
+}
+
 /* Tell SDL to present the framebuffer centered and aspect-fit (letterbox /
    pillarbox) at the given logical size. Applied whenever the renderer or
    texture is (re)created. SDL then owns both the on-screen present rect and the
@@ -173,7 +218,7 @@ bool CreateWindowSurface(U32 resX, U32 resY, bool fullscreen) {
         return false;
     }
 
-    SDL_SetTextureScaleMode(sdlTexture, SDL_SCALEMODE_NEAREST);
+    ApplyScaleMode(sdlTexture);
     windowSurfaceResX = resX;
     windowSurfaceResY = resY;
     SetLogicalPresentation(resX, resY);
@@ -261,7 +306,7 @@ bool ResizeWindowSurface(U32 newW, U32 newH) {
                   newW, newH, errorMsg);
         return false;
     }
-    SDL_SetTextureScaleMode(sdlTexture, SDL_SCALEMODE_NEAREST);
+    ApplyScaleMode(sdlTexture);
 
     windowSurfaceResX = newW;
     windowSurfaceResY = newH;


### PR DESCRIPTION
Thanks for this repo — I'm a big fan of this game :-)

## Why

The streaming texture is pinned to `SDL_SCALEMODE_NEAREST`. That is the right
default at an integer scale, but not at every window size: 1728x1080 presented
to a 3840x2400 display is 20/9, so each source pixel becomes either two or
three output pixels in a repeating 9-source/20-destination pattern. That
unevenness is a presentation artefact sitting on top of the genuinely low-res
content, and on a large display it is what reads as "chunky".

`LBA2_SCALE_MODE` offers the two alternatives:

- `linear` — removes the unevenness, at the cost of softening the fixed-pixel
  2D layer (HUD, fonts, dialogue) along with everything else.
- `pixelart` — SDL 3.4's sharp-bilinear: texel interiors stay crisp, only the
  ~1px seam interpolates.

`nearest` stays the default, so nothing changes for anyone who does not ask.

## The two guards

Pixelart is guarded at compile *and* run time because the failure modes differ.
The compile guard keeps SDL 3.2 builds working — CI pins `release-3.2.16`, so
without it this would not build. The runtime `SDL_GetVersion()` check catches
headers and runtime disagreeing, which is a real configuration (an AppImage
bundling 3.4 next to a system 3.2): there `SDL_SetTextureScaleMode` simply
returns false and the texture silently keeps whatever mode it had. The apply
path now reports a refusal rather than swallowing it.

## Testing

`make test` green (47/47), clang-format clean. Built and run against both SDL
3.2.16 (pixelart correctly falls back to nearest, warning logged) and SDL 3.4.0
(pixelart active). Compared the three modes on identical frames by replaying
SDL's own shader maths (`GetPixelArtUV` in `src/render/opengl/SDL_shaders_gl.c`)
over a captured framebuffer: pixelart keeps the texture detail nearest has and
loses the stair-stepping linear removes.

Would a cfg key and an entry in the Display submenu be welcome alongside the
environment variable? Happy to add both — I kept the first cut to one variable.