### PR TITLE
fix(perso): hold hero input across fixed-timestep sub-steps (#456)

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -1558,6 +1558,31 @@ static void cmd_vargame(int argc, const char *argv[]) {
     Console_Print("vargame[%d] = %d", n, (int)ListVarGame[n]);
 }
 
+/* behaviour [n] | comportement [n]: read or set the hero behaviour (0=Normal 1=Sportif 2=Aggressive
+   3=Discreet 4=Protopack ...). Routes through SetComportement so the weapon/body side-effects match a
+   real in-game switch. Lets a headless test reach the melee (Aggressive), jump (Sportif) and hide
+   (Discreet) input paths without a save fixture in that behaviour. */
+static void cmd_behaviour(int argc, const char *argv[]) {
+    if (argc >= 2) {
+        S32 n = atoi(argv[1]);
+        if (n < 0 || n >= MAX_COMPORTEMENTS) {
+            Console_Print("behaviour: %d out of range (0..%d)", n, MAX_COMPORTEMENTS - 1);
+            return;
+        }
+        SetComportement((U8)n);
+    }
+    Console_Print("behaviour = %d", (int)Comportement);
+}
+
+/* weapon [n]: read or set the hero's active weapon global (FLAG_BALLE_MAGIQUE=1, FLAG_SABRE, FLAG_DART,
+   FLAG_SARBACANE, ...). Sets Weapon only; a weapon that is ammo- or inventory-gated may also need its
+   ListVarGame flag (use `vargame`). For reaching the various fire paths in a headless test. */
+static void cmd_weapon(int argc, const char *argv[]) {
+    if (argc >= 2)
+        Weapon = (U8)atoi(argv[1]);
+    Console_Print("weapon = %d", (int)Weapon);
+}
+
 /* lifetrace <objN> | off: trace object N's Life script -- its comportement/track/zone state each
    frame and every condition (LF_*) it evaluates. Reveals whether an NPC's script ever reaches a
    given check and what its gating conditions read. */
@@ -1906,6 +1931,10 @@ void Console_RegisterAll(void) {
                               "teleport <x> <y> <z> [beta] | teleport actor <n>",
                               "Sets the hero's coords directly; next frame re-runs zones/collision. "
                               "'actor <n>' jumps onto actor n. Within-cube only.");
+    Console_RegisterCommandEx("behaviour", cmd_behaviour, "Read/set hero behaviour (comportement)",
+                              "behaviour [0..13]", "0=Normal 1=Sportif 2=Aggressive 3=Discreet 4=Protopack. Routes through SetComportement.");
+    Console_RegisterCommandEx("weapon", cmd_weapon, "Read/set hero active weapon",
+                              "weapon [n]", "Sets the Weapon global (1=magic ball). Ammo/inventory may need vargame.");
     Console_RegisterCommandEx("varcube", cmd_varcube, "Read/set a scene (cube) Life variable",
                               "varcube <n> [value]",
                               "Reads the cube var, or sets it with a value. Drives quest state.");

--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -710,6 +710,8 @@ static void control_dump_state(const char *path) {
     fprintf(f, "  \"tick\": %ld,\n", ticks_done);
     fprintf(f, "  \"timer_ref_hr\": %u,\n", (unsigned int)TimerRefHR);
     fprintf(f, "  \"fps\": %d,\n", (int)NbFramePerSecond);
+    fprintf(f, "  \"throws\": %d,\n", (int)DbgHeroThrows);
+    fprintf(f, "  \"action_resets\": %d,\n", (int)DbgHeroActionResets);
 
     fprintf(f,
             "  \"scene\": { \"island\": %d, \"cube\": %d, \"cube_mode\": \"%s\", "

--- a/SOURCES/C_EXTERN.H
+++ b/SOURCES/C_EXTERN.H
@@ -362,6 +362,8 @@ extern S32 DbgUseItemInjectDelay; // console `useitem`: frames to wait before in
 extern S32 DbgUseItemTrace;       // console `useitem trace`: log each LF_USE_INVENTORY result
 extern S32 DbgCubeTrace;          // console `cubetrace`: log every cube transition
 extern S32 DbgSkipModals;         // console `skipmodals`: abort dialogue modals headlessly
+extern S32 DbgHeroThrows;         // harness: count of hero projectile spawns (magic ball + ThrowExtra); re-fire tests
+extern S32 DbgHeroActionResets;   // harness: hero action-anim resets by the momentary-action release/idle paths (MOVE_MANUAL); #456 tests
 extern S32 MagicBall;
 extern U8 MagicBallType;
 extern U8 MagicBallCount;

--- a/SOURCES/EXTRA.CPP
+++ b/SOURCES/EXTRA.CPP
@@ -974,6 +974,8 @@ S32	ThrowExtra(	U8 owner,
 	{
 		if( ptrextra->Sprite != -1 ) 	continue ;	/* slot libre */
 
+		if( owner == NUM_PERSO )	DbgHeroThrows++ ;	/* harness re-fire counter (#456) */
+
 		ptrextra->Sprite = num ;
 		ptrextra->Scale  = -1 ;
 

--- a/SOURCES/GLOBAL.CPP
+++ b/SOURCES/GLOBAL.CPP
@@ -328,6 +328,17 @@ S32 DbgCubeTrace = 0;
 // Console `skipmodals <0|1>`: abort dialogue modals immediately (as if Esc) so a headless run does
 // not hang on a give/talk dialog. The script continues past the dialog; no quest-state change.
 S32 DbgSkipModals = 0;
+// Harness re-fire observability: incremented once per hero projectile spawn (ThrowMagicBall and
+// ThrowExtra with owner == NUM_PERSO), surfaced in --dump-state as "throws". A held throw over one
+// animation cycle must spawn exactly one at every frame rate; a value that climbs with sub-step
+// count is the #456 re-fire regression. No gameplay effect.
+S32 DbgHeroThrows = 0;
+// Harness observability for the #456 input/frame-rate tests: counts the times the hero's
+// in-progress action animation (throw/attack) is reset to idle by a momentary-action release/idle
+// path in OBJECT.CPP MOVE_MANUAL. During a HELD action with no real release this must stay 0; a
+// value that climbs at low frame rates is the sub-step phantom-release regression. Surfaced in
+// --dump-state as "action_resets". No gameplay effect.
+S32 DbgHeroActionResets = 0;
 S32 MagicBall = -1;
 U8 MagicBallType = 1;
 U8 MagicBallCount = 3;

--- a/SOURCES/OBJECT.CPP
+++ b/SOURCES/OBJECT.CPP
@@ -4343,6 +4343,8 @@ void DoDir(U8 numobj) {
                     }
 
                     if (LastInput & I_THROW) {
+                        if (numobj == NUM_PERSO && ptrobj->GenAnim != GEN_ANIM_RIEN)
+                            DbgHeroActionResets++;
                         InitAnim(GEN_ANIM_RIEN, ANIM_REPEAT, numobj);
                     }
 
@@ -4405,6 +4407,8 @@ void DoDir(U8 numobj) {
             if ((LastJoyFlag)
                     AND(((Input & I_JOY) != LastMyJoy)
                             OR((Input & I_FIRE) != LastMyFire))) {
+                if (numobj == NUM_PERSO && ptrobj->GenAnim != GEN_ANIM_RIEN)
+                    DbgHeroActionResets++;
                 InitAnim(GEN_ANIM_RIEN, ANIM_REPEAT, numobj);
                 Pushing = FALSE;
             }

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -1930,6 +1930,7 @@ restartloop:
         U32 simBaseRef = LastSimRefHR;
         U32 simFinalRef = TimerRefHR;
         U32 simSavedInput = Input;
+        U32 simSavedLastInput = LastInput; // restored after the sub-step loop (see below)
         if (FixedTimestep > 0) {
             // Plan this frame's sub-steps (count + sub-step clock anchor + the next-frame carry).
             // Timer_PlanSimSteps is the pure, unit-tested core (LIB386/SYSTEM/TIMER.CPP): it
@@ -1985,8 +1986,26 @@ restartloop:
     sim_step:
         if (FixedTimestep > 0) {
             TimerRefHR = simBaseRef + (U32)(simStep + 1) * (U32)FixedTimestep;
-            if (simStep > 0)
-                Input = simSavedInput & I_JOY; // movement only after the first sub-step
+            if (simStep > 0) {
+                /* Input is sampled once per rendered frame; a frame's sub-steps advance sim TIME, not
+                   input. So every sub-step sees the frame's held input, and the press/release EDGE is
+                   consumed once -- on the first sub-step, where LastInput is still the previous frame's
+                   real sample. On later sub-steps we hold BOTH Input and LastInput at that sample so the
+                   held bits read as steady state: no phantom press (Input == LastInput, so the object
+                   loop's edge-guarded actions like the C_AGRESSIF MyRnd combo do not re-select) and no
+                   phantom release (the held bits are still present, so the momentary-action reset paths
+                   -- `if (LastInput & I_THROW) InitAnim(GEN_ANIM_RIEN)` and the LastMyFire idle reset in
+                   OBJECT.CPP MOVE_MANUAL -- stay put instead of cancelling an in-flight throw/attack anim
+                   before it reaches its action frame). The earlier `& I_JOY` mask dropped the held action
+                   bits, which the loop read as a release and reset the anim every sub-step, so below
+                   ~60 fps a held throw/attack never advanced to its throw/hit frame (#456). InitAnim is
+                   idempotent and projectile spawns are animation-frame-gated, so re-presenting the held
+                   input each sub-step does not re-fire. LastInput is restored after the loop.
+                   At FixedTimestep == 0 or nSimSteps == 1 (>= ~60 fps) this branch never runs, so the
+                   per-frame path is byte-for-byte unchanged. */
+                Input = simSavedInput;
+                LastInput = simSavedInput;
+            }
         }
 
         /* vitesse de chute propor pour tous les objets */
@@ -2259,9 +2278,10 @@ restartloop:
             goto sim_step; // run the next fixed sub-step of this frame
         if (FixedTimestep > 0) {
             // Restore the frame's clock for rendering / the next frame and undo the per-sub-step
-            // input mask. LastSimRefHR was already advanced by Timer_PlanSimSteps (the carry).
+            // input hold. LastSimRefHR was already advanced by Timer_PlanSimSteps (the carry).
             TimerRefHR = simFinalRef;
             Input = simSavedInput;
+            LastInput = simSavedLastInput; // undo the sub-step hold so the next frame's edge is real
         }
 
         /*-------------------------------------------------------------------------*/

--- a/docs/MOVEMENT_FRAMERATE.md
+++ b/docs/MOVEMENT_FRAMERATE.md
@@ -194,10 +194,23 @@ surgery and its own correctness risk.
   `ManageTime` as-is, sets `TimerRefHR` per sub-step inside a `goto` loop, and restores it
   afterward, so modals and the `--fixed-dt` harness are untouched and `--fixed-dt 16` stays
   byte-identical (elapsed == 16 -> exactly 1 step, verified). The input re-entrancy hazard is
-  handled by masking `Input` down to movement bits (`I_JOY`) after the first sub-step so held
-  actions (jump, throw) do not re-fire; `InitAnim` is idempotent
-  ([OBJECT.CPP](../SOURCES/OBJECT.CPP)), so keeping the direction bits does not reset the walk
-  anim. Verified by `tests/automation/test_move_substep.sh` (dt16 vs dt64 travel now match).
+  handled by holding the frame's input sample across the sub-steps: input is sampled once per
+  rendered frame, and a frame's sub-steps advance sim *time*, not input. Sub-step 0 sees the real
+  press/release *edge* (`LastInput` is still the previous frame's sample); sub-steps 1..N hold
+  **both** `Input` and `LastInput` at the frame's sample, so a held action reads as steady state --
+  no phantom press (`Input == LastInput`, so edge-guarded actions like the aggressive-mode combo
+  do not re-select) and no phantom release. `InitAnim` is idempotent and projectile spawns are
+  animation-frame-gated ([OBJECT.CPP](../SOURCES/OBJECT.CPP)), so re-presenting the held input each
+  sub-step does not re-fire. `LastInput` is restored after the loop.
+
+  The first cut instead *masked* `Input` down to movement bits (`I_JOY`) on sub-steps > 0. That
+  dropped the held action bits, which the hero object loop's momentary-action paths read as a
+  *release* -- `if (LastInput & I_THROW) InitAnim(GEN_ANIM_RIEN)` and the `LastMyFire` idle reset
+  in `MOVE_MANUAL` -- so below ~60 fps a held throw/attack was reset to idle every sub-step and
+  never reached its throw/hit frame: the magic ball never left Twinsen's hand and the sword combo
+  broke (#456). Verified by `tests/automation/test_move_substep.sh` (dt16 vs dt64 travel match)
+  and `tests/automation/test_action_substep.sh` (throw fires and melee holds across the rate
+  range; 60 fps unchanged).
 
 **One-frame signals on a skipped frame -- the invariant.** A skip runs no simulation but still
 presents a frame, so anything that must be *read/observed by the sim on the exact frame it changes*

--- a/tests/automation/test_action_substep.sh
+++ b/tests/automation/test_action_substep.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Hero action input is frame-rate independent under fixed-timestep sub-stepping (issue #456).
+#
+# The #358 sub-step loop advances the simulation N times for one input sample when a frame runs
+# below ~60 fps. Its first cut masked Input down to movement bits (I_JOY) on every sub-step after
+# the first, to stop held actions re-firing. But the hero object loop (OBJECT.CPP MOVE_MANUAL) reads
+# a *release* off the momentary-action bits (`if (LastInput & I_THROW) InitAnim(GEN_ANIM_RIEN)`, plus
+# the LastMyFire idle reset), so dropping I_THROW/I_ACTION_M mid-frame looked like the player let go:
+# the throw/attack animation was reset to idle every sub-step and never reached its throw/hit frame.
+# Below ~60 fps the magic ball never left Twinsen's hand and the sword combo broke (#456).
+#
+# The fix holds BOTH Input and LastInput at the frame's sample on sub-steps > 0, so a held action is
+# steady state (no phantom press, no phantom release). This test drives a held throw and a held melee
+# across the frame-rate range and asserts the action still fires and its animation is not spuriously
+# reset. The reference is --fixed-dt 16 (~60 fps, one sub-step, the historical path); the low-fps
+# lanes must match it.
+#
+# Observables (harness-only, no gameplay effect): --dump-state "throws" counts hero projectile spawns
+# (ThrowExtra / ThrowMagicBall); "action_resets" counts times an in-progress hero action animation was
+# reset to idle by a MOVE_MANUAL release/idle path — during a HELD action with no real release this
+# must stay ~0. Both are driven headlessly by the `input`, `behaviour`, `weapon`, `vargame` verbs.
+#
+# --fixed-timestep 16 is passed explicitly: the throttle only sub-steps when on, and a developer's
+# lba2.cfg may have FixedTimestep:0 (throttle off), under which every lane runs one step and the bug
+# cannot appear. Local-only (needs retail data + a save); skips cleanly otherwise. Not in CI.
+TESTNAME=action_substep
+. "$(dirname "$0")/lib.sh"
+precheck
+
+# Git-tracked corpus save (reproducible on any machine), same fixture test_melee_throttle uses.
+SAVE="$REPO/tests/savegame/corpus/saves/steam_classic_2023/Desert Island.LBA"
+[ -f "$SAVE" ] || skip "no Desert Island corpus save (steam_classic_2023 not present?)"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Isolate the cfg/save dir: each run passes --fixed-timestep 16 explicitly, and a fresh
+# XDG_DATA_HOME keeps that (and any config write) out of the developer's shared lba2.cfg, so this
+# test neither depends on nor mutates the cfg FixedTimestep other suites read.
+export XDG_DATA_HOME="$tmp/xdg"
+mkdir -p "$XDG_DATA_HOME"
+
+# throws_and_resets <dt> <ticks> <exec> -> echoes "<throws> <action_resets> <gen_anim>"
+run_probe() {
+    local dt="$1" ticks="$2" ex="$3"
+    local out="$tmp/s_${dt}_$RANDOM.json"
+    ctl --fixed-timestep 16 --fixed-dt "$dt" --load "$SAVE" \
+        --exec "$ex" --tick "$ticks" --dump-state "$out" --exit >/dev/null 2>&1 \
+        || fail "run (dt=$dt) returned non-zero exit"
+    jget "$out" "'%d %d %d' % (d['throws'], d['action_resets'], d['hero']['gen_anim'])"
+}
+
+# Equal game-time (~3200 ms) at each rate: ticks = 3200 / dt.
+declare -A TICKS=( [16]=200 [40]=80 [64]=50 [128]=25 )
+LOW_LANES="40 64 128"
+
+# ── 1. Held throw: the magic ball must leave Twinsen's hand at every frame rate ──────────────────
+# Arm the magic ball explicitly (behaviour + weapon + inventory flag) so the test does not depend on
+# what the fixture save had equipped.
+ARM="behaviour 0; weapon 1; vargame 1 1"
+read -r t_ref r_ref _ < <(run_probe 16 "${TICKS[16]}" "$ARM; input throw 220")
+[ "$t_ref" -ge 1 ] || skip "fixture can't throw a magic ball at 60 fps (throws=$t_ref) — needs a save where the hero can act"
+[ "$r_ref" -eq 0 ] || fail "60 fps reference already resets the throw anim (action_resets=$r_ref) — unexpected"
+
+for dt in $LOW_LANES; do
+    read -r t r _ < <(run_probe "$dt" "${TICKS[$dt]}" "$ARM; input throw 220")
+    # fires the same number of times as 60 fps: < ref is the #456 drop, > ref is a sub-step re-fire.
+    [ "$t" -eq "$t_ref" ] || fail "held throw at dt=$dt fired $t times, 60fps fired $t_ref (issue #456 sub-step input drop)"
+    [ "$r" -eq 0 ] || fail "held throw at dt=$dt reset the throw anim $r times mid-hold (issue #456 phantom release)"
+done
+echo "  throw: fires ${t_ref}x at 16/40/64/128 ms steps, 0 spurious resets"
+
+# ── 2. Held melee: the sword combo must keep swinging, not collapse to idle ──────────────────────
+# Aggressive behaviour, action held. A cancelled combo shows as action_resets climbing and the hero
+# settling on GEN_ANIM_RIEN (0) instead of a COUP animation. Allow a small slack: the combo naturally
+# cycles COUP -> brief idle -> COUP, and one such boundary can coincide with a sub-step edge.
+read -r _ mr_ref mg_ref < <(run_probe 16 "${TICKS[16]}" "behaviour 2; input action 220")
+MELEE_SLACK=5
+for dt in $LOW_LANES; do
+    read -r _ mr _ < <(run_probe "$dt" "${TICKS[$dt]}" "behaviour 2; input action 220")
+    [ "$mr" -le "$MELEE_SLACK" ] || fail "held melee at dt=$dt reset the attack anim $mr times (60fps=$mr_ref; issue #456)"
+done
+echo "  melee: attack anim resets <= $MELEE_SLACK at 40/64/128 ms steps (60fps=$mr_ref)"
+
+# ── 3. 60 fps is untouched: one sub-step must equal the throttle-off historical path ─────────────
+# The fix only changes the simStep > 0 branch, which never runs at dt=16 (one step). Guard that the
+# throttled 60 fps path is byte-identical to the throttle-off path over the same input.
+on="$tmp/on.json"; off="$tmp/off.json"
+ctl --fixed-timestep 16 --fixed-dt 16 --load "$SAVE" \
+    --exec "$ARM; input throw 60" --tick 40 --dump-state "$on" --exit >/dev/null 2>&1 || fail "throttle-on run failed"
+ctl --fixed-timestep 0  --fixed-dt 16 --load "$SAVE" \
+    --exec "$ARM; input throw 60" --tick 40 --dump-state "$off" --exit >/dev/null 2>&1 || fail "throttle-off run failed"
+if ! python3 -c "
+import json,sys
+a=json.load(open('$on'))['hero']; b=json.load(open('$off'))['hero']
+sys.exit(0 if a==b else 1)"; then
+    fail "60 fps throttled path diverges from the historical (throttle-off) path — the fix perturbed the reference"
+fi
+echo "  60fps: throttled path == throttle-off path (fix is a no-op at one sub-step)"
+
+pass "hero action input frame-rate independent (throw fires ${t_ref}x, melee holds, 60fps unchanged)"


### PR DESCRIPTION
## The bug

Below ~60 fps the fixed-timestep throttle (#358) sub-steps the simulation. Its first cut masked `Input` down to movement bits (`I_JOY`) on sub-steps after the first, to stop held actions re-firing. But the hero object loop reads a *release* off the momentary-action bits (`if (LastInput & I_THROW) InitAnim(GEN_ANIM_RIEN)`, plus the `LastMyFire` idle reset in `MOVE_MANUAL`), so dropping `I_THROW`/`I_ACTION_M` mid-frame looked like the player let go. The throw/attack animation was reset to idle every sub-step and never reached its throw/hit frame: the magic ball never left Twinsen's hand and the sword combo broke.

## The fix

Input is sampled once per rendered frame; a frame's sub-steps advance sim *time*, not input. Hold **both** `Input` and `LastInput` at the frame's sample on sub-steps after the first, so a held action reads as steady state: no phantom press (`Input == LastInput`, so edge-guarded actions like the aggressive-mode combo do not re-select) and no phantom release. `LastInput` is restored after the loop. At one sub-step (>= ~60 fps) or `FixedTimestep == 0` the branch never runs, so the per-frame path is byte-for-byte unchanged.

## Commits

1. `feat(control)` -- headless hooks to drive/observe hero actions: `behaviour`/`weapon` console verbs and `throws`/`action_resets` dump-state fields. Used by the test.
2. `fix(perso)` -- the fix plus `docs/MOVEMENT_FRAMERATE.md`.
3. `test(automation)` -- `test_action_substep.sh`.

## Reproduce

`fixedtimestep 4` in the F12 console forces sub-stepping at 60 fps without needing real low fps. Hold throw, or mash the sword combo. Before: the throw animation never even starts. After: fires normally. (Confirmed the same way at low fps with `--fixed-dt`.)

## Verification

- New `test_action_substep.sh`: held throw fires and melee holds across 16/40/64/128 ms steps; **fails on the pre-fix binary** (throw fires 0 times where 60 fps fires once), passes after.
- Unchanged and green: `test_move_substep`, `test_move_framerate`, `test_melee_throttle`, `test_blowgun_release_throttle`, `test_input_hold_throttle`, `test_item_use_throttle`, `test_input_injection`.
- 47/47 host unit tests. NPC movement travel identical baseline vs fix (dt16=3596 / dt64=3586 with a controlled cfg), confirming the change is inert for anything but held hero input.

Closes #456.
