### PR TITLE
fix(disc): let an installed file beat the disc image's copy of it

### DIFF
--- a/LIB386/H/SYSTEM/FILES.H
+++ b/LIB386/H/SYSTEM/FILES.H
@@ -62,8 +62,17 @@ U32 Delete(const char *filename);
 S32 Touch(const char *filename);
 U32 FileSize(const char *filename);
 
-/// Check if file or directory \p path exists.
+/// Check if file or directory \p path exists, on the filesystem or in a
+/// mounted disc image.
 bool ExistsFileOrDir(const char *path);
+
+/// Check if file or directory \p path exists on the filesystem alone, ignoring
+/// any mounted disc image. Use when a caller must not let the image answer for
+/// something installed: OpenRead resolves the filesystem first, so a search
+/// that settles on a name only the image holds resolves to the image's copy
+/// even when the real file is sitting there under another spelling.
+bool ExistsOnFilesystem(const char *path);
+
 bool IsDirectory(const char *path);
 
 // =============================================================================

--- a/LIB386/SYSTEM/FILES.CPP
+++ b/LIB386/SYSTEM/FILES.CPP
@@ -131,11 +131,17 @@ U32 FileSize(const char *filename) {
     return (U32)((fsize == -1) ? 0 : fsize);
 }
 
-bool ExistsFileOrDir(const char *path) {
+bool ExistsOnFilesystem(const char *path) {
     assert(path != NULL);
 
     struct stat status = {};
-    if (stat(path, &status) == 0) {
+    return (stat(path, &status) == 0);
+}
+
+bool ExistsFileOrDir(const char *path) {
+    assert(path != NULL);
+
+    if (ExistsOnFilesystem(path)) {
         return true;
     }
     return DiscImage_Exists(path);

--- a/SOURCES/DIRECTORIES.CPP
+++ b/SOURCES/DIRECTORIES.CPP
@@ -60,44 +60,64 @@ S32 directoriesDistVersion;
  * @return TRUE if discovered. When FALSE \p outFound is unchanged.
  * @note If \p foundMaxSize is 0, \p outFound will be ignored.
  */
+/* One sweep of the case variations, asking `exists` about each in turn. Leaves
+   the winning spelling in `variation`. */
+static bool DiscoverPass(char *variation, U16 variationMaxSize,
+                         const char *baseDir, const char *checkPath,
+                         bool (*exists)(const char *)) {
+    char fullPath[ADELINE_MAX_PATH];
+
+    strncpy(variation, checkPath, variationMaxSize);
+    variation[variationMaxSize - 1] = '\0'; // Guarantee
+
+    // Try as is
+    snprintf(fullPath, ADELINE_MAX_PATH, "%s%s", baseDir, variation);
+    if (exists(fullPath))
+        return true;
+
+    // Try uppercase
+    SDL_strupr(variation);
+    snprintf(fullPath, ADELINE_MAX_PATH, "%s%s", baseDir, variation);
+    if (exists(fullPath))
+        return true;
+
+    // Try lowercase
+    SDL_strlwr(variation);
+    snprintf(fullPath, ADELINE_MAX_PATH, "%s%s", baseDir, variation);
+    if (exists(fullPath))
+        return true;
+
+    // Try title case (first letter uppercase, rest lowercase)
+    if (variation[0] >= 'a' && variation[0] <= 'z')
+        variation[0] -= 32;
+    snprintf(fullPath, ADELINE_MAX_PATH, "%s%s", baseDir, variation);
+    return exists(fullPath);
+}
+
 bool Discover(char *outFound, U16 foundMaxSize, const char *baseDir,
               const char *checkPath) {
     assert(((foundMaxSize > 0) && (outFound != NULL)) || (foundMaxSize == 0));
     assert(baseDir != NULL);
     assert(checkPath != NULL);
 
-    bool found;
-    char fullPath[ADELINE_MAX_PATH];
     char variation[ADELINE_MAX_PATH];
 
-    strncpy(variation, checkPath, ADELINE_MAX_PATH);
-    variation[ADELINE_MAX_PATH - 1] = '\0'; // Guarantee
+    /* Filesystem first, across every spelling, before the disc image gets a
+       say. One pass over ExistsFileOrDir would stop at whichever spelling the
+       image happens to hold, and a mounted image answers case-insensitively, so
+       the very first probe hits and the file actually installed -- under a
+       different case -- is never tried. OpenRead then finds nothing on disk at
+       that spelling and falls through to the image's copy.
 
-    // Try as is
-    snprintf(fullPath, ADELINE_MAX_PATH, "%s%s", baseDir, variation);
-    found = ExistsFileOrDir(fullPath);
-
+       That is how a GOG install came up in French: it is asked for lba2.cfg,
+       has LBA2.CFG on disk saying English, and ships LBA2.GOG, an ISO whose own
+       LBA2.CFG leaves Language empty. Installed data has to beat the image,
+       which is what OpenRead already promises one level down. */
+    bool found = DiscoverPass(variation, ADELINE_MAX_PATH, baseDir, checkPath,
+                              ExistsOnFilesystem);
     if (!found) {
-        // Try uppercase
-        SDL_strupr(variation);
-        snprintf(fullPath, ADELINE_MAX_PATH, "%s%s", baseDir, variation);
-        found = ExistsFileOrDir(fullPath);
-
-        if (!found) {
-            // Try lowercase
-            SDL_strlwr(variation);
-            snprintf(fullPath, ADELINE_MAX_PATH, "%s%s", baseDir, variation);
-            found = ExistsFileOrDir(fullPath);
-        }
-
-        if (!found) {
-            // Try title case (first letter uppercase, rest lowercase)
-            SDL_strlwr(variation);
-            if (variation[0] >= 'a' && variation[0] <= 'z')
-                variation[0] -= 32;
-            snprintf(fullPath, ADELINE_MAX_PATH, "%s%s", baseDir, variation);
-            found = ExistsFileOrDir(fullPath);
-        }
+        found = DiscoverPass(variation, ADELINE_MAX_PATH, baseDir, checkPath,
+                             ExistsFileOrDir);
     }
 
     // Copy to out if requested and variation was found

--- a/tests/discovery/test_res_discovery.cpp
+++ b/tests/discovery/test_res_discovery.cpp
@@ -7,9 +7,11 @@
  */
 
 #include <SYSTEM/ADELINE_TYPES.H>
+#include <SYSTEM/DISCIMG.H>
 #include <SYSTEM/FILES.H>
 #include <SYSTEM/LIMITS.H>
 
+#include "DIRECTORIES.H"
 #include "RES_DISCOVERY.H"
 
 #include <SDL3/SDL.h>
@@ -478,6 +480,177 @@ static bool test_persisted_last_game_dir() {
 #endif
 }
 
+/* ── An installed file beats a mounted image's copy of it (#461) ────────── */
+
+/* Minimal flat ISO9660: a root directory holding LBA2.HQR and LBA2.CFG. Same
+ * record encoding as tests/disc_image, without the nested volume directory,
+ * which this test does not need. */
+static void iso_both32(unsigned char *p, U32 v) {
+    p[0] = (unsigned char)(v & 0xFF);
+    p[1] = (unsigned char)((v >> 8) & 0xFF);
+    p[2] = (unsigned char)((v >> 16) & 0xFF);
+    p[3] = (unsigned char)((v >> 24) & 0xFF);
+    p[4] = (unsigned char)((v >> 24) & 0xFF);
+    p[5] = (unsigned char)((v >> 16) & 0xFF);
+    p[6] = (unsigned char)((v >> 8) & 0xFF);
+    p[7] = (unsigned char)(v & 0xFF);
+}
+
+static void iso_both16(unsigned char *p, unsigned v) {
+    p[0] = (unsigned char)(v & 0xFF);
+    p[1] = (unsigned char)((v >> 8) & 0xFF);
+    p[2] = (unsigned char)((v >> 8) & 0xFF);
+    p[3] = (unsigned char)(v & 0xFF);
+}
+
+static void iso_add_rec(unsigned char *sector, int *offset, U32 lba, U32 len,
+                        bool isDir, const unsigned char *name, int nameLen) {
+    int recLen = 33 + nameLen;
+    if (recLen & 1) {
+        recLen++;
+    }
+    unsigned char *r = sector + *offset;
+    memset(r, 0, (size_t)recLen);
+    r[0] = (unsigned char)recLen;
+    iso_both32(r + 2, lba);
+    iso_both32(r + 10, len);
+    r[25] = isDir ? 0x02 : 0x00;
+    iso_both16(r + 28, 1);
+    r[32] = (unsigned char)nameLen;
+    memcpy(r + 33, name, (size_t)nameLen);
+    *offset += recLen;
+}
+
+#define ISO_SECTORS 22
+#define ISO_L_PVD 16
+#define ISO_L_ROOT 18
+#define ISO_L_HQR 19
+#define ISO_L_CFG 20
+
+static const char kImageCfgBody[] = "FROM-IMAGE";
+static const char kDiskCfgBody[] = "FROM-DISK";
+
+static bool write_case_fixture_iso(const char *path) {
+    static unsigned char image[ISO_SECTORS * 2048];
+    memset(image, 0, sizeof(image));
+
+    unsigned char *pvd = image + ISO_L_PVD * 2048;
+    pvd[0] = 0x01;
+    memcpy(pvd + 1, "CD001", 5);
+    pvd[6] = 0x01;
+    const unsigned char dot = 0x00, dotdot = 0x01;
+    int o = 156; /* the root directory record lives at offset 156 of the PVD */
+    iso_add_rec(pvd, &o, ISO_L_ROOT, 2048, true, &dot, 1);
+
+    unsigned char *root = image + ISO_L_ROOT * 2048;
+    o = 0;
+    iso_add_rec(root, &o, ISO_L_ROOT, 2048, true, &dot, 1);
+    iso_add_rec(root, &o, ISO_L_ROOT, 2048, true, &dotdot, 1);
+    iso_add_rec(root, &o, ISO_L_HQR, 8, false, (const unsigned char *)"LBA2.HQR;1", 10);
+    iso_add_rec(root, &o, ISO_L_CFG, (U32)strlen(kImageCfgBody), false,
+                (const unsigned char *)"LBA2.CFG;1", 10);
+
+    memcpy(image + ISO_L_HQR * 2048, "HQRSTUB", 7);
+    memcpy(image + ISO_L_CFG * 2048, kImageCfgBody, strlen(kImageCfgBody));
+
+    FILE *f = fopen(path, "wb");
+    if (f == NULL) {
+        return false;
+    }
+    const bool ok = fwrite(image, 1, sizeof(image), f) == sizeof(image);
+    fclose(f);
+    return ok;
+}
+
+static bool read_whole_file(const char *path, char *out, int outMax) {
+    S32 h = OpenRead(path);
+    if (!h) {
+        return false;
+    }
+    S32 n = Read(h, out, (U32)(outMax - 1));
+    Close(h);
+    if (n < 0) {
+        return false;
+    }
+    out[n] = '\0';
+    return true;
+}
+
+/* A mounted image answers case-insensitively, so a case sweep that lets it
+ * speak too early settles on a spelling only the image holds -- and OpenRead,
+ * finding nothing on disk under that spelling, then serves the image's copy
+ * even though the real file is right there. That is how a GOG install (asked
+ * for lba2.cfg, LBA2.CFG on disk, LBA2.GOG mounted) read the image's config
+ * instead of its own and came up in French. */
+static bool test_installed_file_beats_image_copy() {
+    char dir[ADELINE_MAX_PATH];
+#ifdef _WIN32
+    if (!make_temp_dir(dir, sizeof(dir), "shadow")) {
+        return false;
+    }
+#else
+    snprintf(dir, sizeof(dir), "/tmp/lba2disc_shadow_XXXXXX");
+    if (mkdtemp(dir) == NULL) {
+        return false;
+    }
+#endif
+
+    char base[ADELINE_MAX_PATH + 8];
+    char isoPath[ADELINE_MAX_PATH + 32];
+    char diskCfg[ADELINE_MAX_PATH + 32];
+    snprintf(base, sizeof(base), "%s/", dir);
+    snprintf(isoPath, sizeof(isoPath), "%sdisc.iso", base);
+    snprintf(diskCfg, sizeof(diskCfg), "%sLBA2.CFG", base);
+
+    create_marker_hqr(dir);
+    if (!write_case_fixture_iso(isoPath)) {
+        fprintf(stderr, "test_installed_file_beats_image_copy: cannot write iso\n");
+        return false;
+    }
+    FILE *f = fopen(diskCfg, "wb");
+    if (f == NULL) {
+        return false;
+    }
+    fwrite(kDiskCfgBody, 1, strlen(kDiskCfgBody), f);
+    fclose(f);
+
+    InitDirectories(base, base, base, "", 0);
+    if (!DiscImage_Mount(base, Directories_GetResMarker())) {
+        fprintf(stderr, "test_installed_file_beats_image_copy: mount failed\n");
+        return false;
+    }
+
+    bool ok = true;
+    char resolved[ADELINE_MAX_PATH];
+    char body[64];
+
+    /* Installed on disk as LBA2.CFG, asked for as lba2.cfg: the installed file
+     * wins, both in the resolved spelling and in what comes back. */
+    GetDefaultCfgPath(resolved, ADELINE_MAX_PATH, "lba2.cfg");
+    if (!read_whole_file(resolved, body, (int)sizeof(body)) ||
+        strcmp(body, kDiskCfgBody) != 0) {
+        fprintf(stderr,
+                "test_installed_file_beats_image_copy: %s served '%s', wanted '%s'\n",
+                resolved, body, kDiskCfgBody);
+        ok = false;
+    }
+
+    /* Nothing installed under any spelling: the image is then the right answer,
+     * which is how a bare disc rip (no extracted files at all) still boots. */
+    unlink_portable(diskCfg);
+    GetDefaultCfgPath(resolved, ADELINE_MAX_PATH, "lba2.cfg");
+    if (!read_whole_file(resolved, body, (int)sizeof(body)) ||
+        strcmp(body, kImageCfgBody) != 0) {
+        fprintf(stderr,
+                "test_installed_file_beats_image_copy: image fallback served '%s', wanted '%s'\n",
+                body, kImageCfgBody);
+        ok = false;
+    }
+
+    DiscImage_Unmount();
+    return ok;
+}
+
 int main() {
     if (!SDL_Init(0)) {
         return 1;
@@ -507,6 +680,11 @@ int main() {
         failed++;
     }
     if (!test_persisted_last_game_dir()) {
+        failed++;
+    }
+    /* Last: InitDirectories asserts it runs once, and the cases above resolve
+     * paths without it. */
+    if (!test_installed_file_beats_image_copy()) {
         failed++;
     }
     SDL_Quit();


### PR DESCRIPTION
Closes #461. Regression from #460.

A GOG install comes up in French. Its `lba2.cfg` says English; the value the engine read said nothing at all, because it was reading a different file.

## What was happening

GOG ships `LBA2.GOG`, a real ISO9660 image (the CD image it hands DOSBox), so the content probe added in #460 mounts it. Inside is another `LBA2.CFG` whose `Language` and `LanguageCD` are empty. `InitLanguage` matches the value against `TabLanguage`, an empty string matches nothing, the loop falls through without assigning, and `Language` keeps its initialiser of `1`. That is `Français`, not English as the comment beside the initialiser claims. The wrong value is written into the new profile, so it sticks.

`Discover` asks `ExistsFileOrDir` about each case variation in turn and stops at the first hit. That helper answers for the filesystem *and* for a mounted image, and an image answers case-insensitively, so the very first probe succeeds: the engine asks for `lba2.cfg`, the image says yes, discovery settles there, and `OpenRead` finds no `lba2.cfg` on disk so it serves the image's copy. GOG's own file is sitting right there as `LBA2.CFG`, never tried.

Nothing about this was specific to the config. Any asset whose installed name differs in case from the name the engine asks for was resolving to the image's copy.

## The fix

Sweep every spelling against the filesystem first, and only fall back to an image-aware sweep when nothing is installed under any of them. That is the contract `OpenRead` already keeps one level down, restored across the whole lookup instead of only within a single probe. `ExistsOnFilesystem` is the disk-only half of `ExistsFileOrDir`, which is all the first pass needs.

Mounting `LBA2.GOG` stays. GOG's `VIDEO.HQR` exists only inside it, and withholding it fails the boot on a missing required asset. The fix is precedence, not suppression.

## Verification

`dist_check` diffs to exactly one row:

```
- gog  3 (ea)  Français  mounted  ok  iix (8)  ...  40e35dcc44af  20f5e1beb8df  ...
+ gog  3 (ea)  English   mounted  ok  iix (8)  ...  7bcb11f26e91  e62b3c6a8767  ...
```

The two hashes that move are the menu and options captures, which carry text, and they now equal what Steam and the TWINSEN rip render for the same English screens. Music resolution, the mount, the interior/exterior/inventory/demo captures and the other two installs are all unchanged.

Per install:

- **GOG**: reads its own config (English, and no UTF-8 mojibake written back into a latin-1 profile), still mounts the image for FMV.
- **TWINSEN rip**: config exists only inside the image, still found, still `Version: 1`.
- **Steam**: no image, untouched.

49/49 host tests, no new warnings. Discovery cost is unchanged where it matters: a failing discovery from a neutral cwd is 0.36 s and `test_res_discovery` is 31 ms, so the extra filesystem pass does not walk back toward the sweep cost that stalled CI during #460.

## Test

`tests/discovery` grows a case-precedence case: a fixture with `LBA2.CFG` on disk and `lba2.cfg` inside a mounted image, asserting the disk copy is served, and that the image copy is served once nothing is installed. Without the fix it fails with the exact symptom:

```
test_installed_file_beats_image_copy: .../lba2.cfg served 'FROM-IMAGE', wanted 'FROM-DISK'
```

## Not in scope

`Language` defaulting to `Français` on any no-match is its own latent bug: `TabLanguage[1]` is Français while both the initialiser comment and `InitLanguage`'s fallback claim English, and the same no-match path leaves `FlagSpeak` FALSE. This PR stops the wrong file being read; it does not touch that fallback.
