### PR TITLE
ci: move the latest tag and stamp the rolling release name

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -84,9 +84,16 @@ jobs:
           merge-multiple: true
 
       - name: Compose release body
+        id: meta
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
           TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
+          # A release's published_at doesn't advance when the release is
+          # updated in place, so the Releases page would keep showing the
+          # date this rolling release was first published. The commit and
+          # date go in the release name, which does update.
+          echo "sha_short=${SHA_SHORT}" >> "$GITHUB_OUTPUT"
+          echo "date=$(date -u +"%Y-%m-%d")" >> "$GITHUB_OUTPUT"
           cat > release-body.md <<EOF
           **Rolling pre-release.** Built from \`main\` on every push. For stable releases see [the Releases page](https://github.com/${{ github.repository }}/releases).
 
@@ -102,7 +109,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: latest
-          name: "Latest (rolling pre-release)"
+          name: "Latest (rolling pre-release) - ${{ steps.meta.outputs.sha_short }}, ${{ steps.meta.outputs.date }}"
           body_path: release-body.md
           files: |
             *.AppImage
@@ -116,7 +123,23 @@ jobs:
           # pre-release.
           prerelease: true
           make_latest: false
-          # softprops/action-gh-release@v2 moves the existing tag to the
-          # current commit and updates the release in place. No manual
-          # delete-then-create needed.
+          # This action creates the `latest` tag only when it's absent; an
+          # existing one is left pointing wherever it already pointed. The
+          # step below moves it. Body and assets do update in place.
           fail_on_unmatched_files: false
+
+      # Runs after the upload so the tag only ever advertises a commit whose
+      # artifacts finished uploading. Two pushes back-to-back cancel the older
+      # run mid-job, and a tag left behind the assets is recoverable where a
+      # tag ahead of them is not.
+      #
+      # Force-moves the tag, so a local `git fetch` needs --force to follow
+      # it. Nothing rebuilds in response: the tag-triggered release workflows
+      # filter `v*`, and ref updates authored by GITHUB_TOKEN don't trigger
+      # workflows at all.
+      - name: Point the latest tag at this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api -X PATCH "repos/${{ github.repository }}/git/refs/tags/latest" \
+            -f sha='${{ github.sha }}' -F force=true

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -517,6 +517,24 @@ Same packaging scripts (`make-appimage.sh`, `bundle-linux-tarball.sh`,
 naming. The rolling release is functionally a tag-release at HEAD-of-main
 with a moving tag instead of a fixed semver.
 
+**Read the name, not the timestamp.** A release's `published_at` is stamped
+once, when it is first published; updating a release in place never advances
+it. The rolling release's date on the Releases page therefore reads as the
+day this workflow first ran, however recent the build. The release *name*
+carries the short commit and build date instead:
+
+```
+Latest (rolling pre-release) - 9d91ab9, 2026-08-10
+```
+
+The body repeats both, with a link to the commit.
+
+**The tag moves, so plain `git fetch` won't follow it.** Once you hold an
+older `latest`, git rejects the update rather than clobbering your copy. Use
+`git fetch --force --tags origin`. Nothing rebuilds when the tag moves: the
+per-tag release workflows filter `v*`, and ref updates authored by
+`GITHUB_TOKEN` don't trigger workflows.
+
 **When to point users at it:** for community testers who want to
 verify a fix on `main` without building from source, or for "does this
 reproduce on the latest main?" bug-report triage. Otherwise prefer


### PR DESCRIPTION
The rolling pre-release has advertised `May 10` for four months, while the
artifacts on it were current. Two independent causes.

**The `latest` tag never moved.** `softprops/action-gh-release` creates the
tag only when it is absent; an existing one is left where it is. So `latest`
still pointed at `033a836`, the merge that introduced the workflow, across
200 runs. `git clone --branch latest` fetched May 10 source.

**`published_at` is stamped once.** It is set at first publish and never
advances on an in-place update, so the date shown on the Releases page cannot
be made to track the build.

## What this does

- Moves the tag explicitly via the refs API, **after** the artifact upload.
  Back-to-back pushes cancel the older run mid-job, and a tag left behind the
  assets is recoverable where a tag ahead of them advertises a commit whose
  artifacts never finished uploading.
- Puts the short commit and build date in the release name, which does update:
  `Latest (rolling pre-release) - 9d91ab9, 2026-08-10`. The body already
  carried both; now the page heading does too.
- Documents both in `docs/RELEASING.md`, plus the `git fetch --force --tags`
  needed to follow a moving tag. The table there already claimed the tag was
  force-moved on every push, which this finally makes true.
- Drops the comment asserting the action moves the tag.

Nothing rebuilds when the tag moves: the per-tag release workflows filter
`v*`, and ref updates authored by `GITHUB_TOKEN` do not trigger workflows.

## Why not delete-and-recreate

Deleting the release each run would refresh both timestamps and is the more
common pattern, but pre-releases notify watchers and subscribers cannot filter
them out. `main` takes 50-80 pushes a month, peaking at 24 in a day. Because
the current workflow only updates in place, it has sent exactly one release
notification since May; delete-and-recreate would take that to roughly 60 a
month and bury the stable `v0.x.y` notification that `make_latest: false`
exists to keep prominent.

## Verification

`actionlint` 1.7.12 with shellcheck 0.9.0 passes on the changed file and on
all 18 workflows. Confirmed it catches the new cross-step reference by
breaking `id: meta` in a scratch copy, which fails with `property "meta" is
not defined`. Note it cannot catch a misspelled output *key*, since
`$GITHUB_OUTPUT` contents are not statically knowable.

Whether `created_at` also refreshes once the tag moves is unverified; it may
be captured at release creation. The release *name* is what guarantees the
page reads correctly either way. The first run after merge answers it, since
this touches the workflow file, which is not in its own `paths-ignore`.

## Not in scope

The release currently holds 58 assets spanning six version prefixes
(`0.10.0-dev` through `0.13.0-dev`), because the action overwrites by
filename and the version is embedded in the name, so nothing ever collides.
Fixing that means renaming rolling artifacts to a stable `-latest-` form, plus
a one-time purge of the stale ones, and it needs a decision on whether the
`.AppImage.zsync` files can survive the rename. Separate change.
