### PR TITLE
ci: give the asset prune a repo to work against

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -139,9 +139,17 @@ jobs:
       # A build leg that failed therefore drops its platform's download
       # instead of leaving an older version in its place, which is what the
       # release body already tells readers to expect.
+      #
+      # Janitorial only: the release is correct without it, just cluttered.
+      # Never let a prune failure stop the tag from moving.
       - name: Prune assets from earlier builds
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
+          # This job never checks out the repo, so `gh release` subcommands
+          # have no remote to infer the repository from and fail before they
+          # reach the API. The `gh api` calls below name it in the path.
+          GH_REPO: ${{ github.repository }}
         run: |
           keep="$RUNNER_TEMP/keep.txt"
           find . -maxdepth 1 -type f ! -name 'release-body.md' \


### PR DESCRIPTION
The prune step added in #466 failed on every push to `main`:

```
pruning lba2cc-0.10.0-dev-anylinux-aarch64.AppImage
failed to run git: fatal: not a git repository (or any of the parent directories): .git
Error: Process completed with exit code 1.
```

The release job never checks out the repository, so `gh release delete-asset`
has no git remote to infer it from and fails before reaching the API. The
neighbouring `gh api` calls were unaffected because they name the repo in the
request path, which is exactly why the tag-move step worked and this did not.

## Impact

None to the release contents. The first `delete-asset` aborted the step under
`bash -e`, so **all 58 assets survived** and no pruning occurred. The tag move
is sequenced after the prune and was skipped, so `latest` sat one commit behind
`main` until the next green run.

## Fix

- `GH_REPO: ${{ github.repository }}` on the step, which covers every `gh`
  subcommand there rather than one flag on one call.
- `continue-on-error: true`. Pruning is janitorial: the release is correct
  without it and merely cluttered, so a prune failure must not stop the tag
  from moving. That is what turned a cosmetic bug into a red run and a stale
  tag.

## Verification

Reproduced from a non-git directory, which gives the identical
`failed to run git` error, then confirmed `GH_REPO` resolves it. Checked
`delete-asset` specifically against a non-existent asset name so nothing was
removed: it reaches the API and reports `asset not found`, and the asset count
stayed at 58. `actionlint` with shellcheck clean.

The gap in #466 was that my dry-run exercised the keep/prune *logic* with plain
shell and never invoked `gh`, so repo resolution went untested.