### PR TITLE
docs(camera): correct the camera control docs and document the shipped render options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ This repository is the community fork of the classic source release — a source
 
 ## Features
 
-- **Plays the whole game** — the original 1997 engine, ported to 64-bit and modern compilers; bring your own copy of LBA2
+- **The complete game** — the original 1997 engine, ported to 64-bit and modern compilers; bring your own copy of LBA2
 - **Native builds** — Linux, macOS, Windows, and Android / Android TV (7.0+, API 24)
 - **Widescreen and HD** — render resolutions up to 1080p, offered per monitor from the Display menu; the classic 640×480 4:3 mode is still there ([docs/RUNTIME_RESOLUTION.md](docs/RUNTIME_RESOLUTION.md))
-- **Reads disc images directly** — retail assets straight out of a raw ISO/BIN or `.cue` pair, so a GOG Original Edition install needs no extraction step
+- **Reads disc images directly** — retail assets straight out of a raw ISO/BIN or `.cue` pair, so a GOG Original Edition install or a CD rip needs no extraction step
 - **Retail-compatible saves** — 1997 saves load directly, and every build of this port writes the same 32-bit save bytes
 - **Frame-rate-independent movement** — a fixed 60 Hz simulation step, so walk and jump distances no longer change with your frame rate
 - **Gamepad support** — full controller mapping, radial deadzones, and a rebindable D-pad ([docs/CONTROLLER.md](docs/CONTROLLER.md))
-- **Third-person camera** — optional follow camera in exterior scenes, orbited and zoomed with the mouse or the right stick ([docs/CAMERA.md](docs/CAMERA.md))
+- **Third-person camera** — optional follow camera in exterior scenes, orbited with the mouse or the right stick, and zoomed with the mouse wheel or the numpad ([docs/CAMERA.md](docs/CAMERA.md))
+- **Render smoothing** — optional texture filtering and dithered shading for the software rasterizer, off by default ([docs/GFX_OPTIONS.md](docs/GFX_OPTIONS.md))
 - **Modern audio backend** — SDL3 in place of the original Miles Sound System
 - **FMV playback** — via the bundled open-source libsmacker
 - **Debug console** — always-on Quake-style console ([docs/CONSOLE.md](docs/CONSOLE.md))

--- a/docs/CAMERA.md
+++ b/docs/CAMERA.md
@@ -103,9 +103,11 @@ Branch history tried heavier correction (terrain penetration along the boom, LOS
 
 - Uses `CameraCenter(3)` (apply current globals only; skips the classic `SearchCameraPos` snap). Terrain occlusion is instead handled by the eased ground-clearance below; decor/scenery is not yet cleared for. This keeps the orbit from being fought every frame and matches “cinematic follow” rather than a hard “collision camera.”
 
-**Camera elevation:** Numpad `+` / `-` adjust `AlphaCam` freely (range 150–600) instead of switching between the two fixed `VueCamera` presets. Fires every frame while held (no debounce) for smooth real-time tilt.
+**Camera elevation:** the Camera-level inputs (`I_CAMERA_LEVEL_PLUS` / `I_CAMERA_LEVEL_MOINS`, bound by default to numpad `+` / `-` with Page Up / Page Down as the second binding) adjust `AlphaCam` freely (range 150–600) instead of switching between the two fixed `VueCamera` presets. Fires every frame while held (no debounce) for smooth real-time tilt. Being an input action rather than a raw key, it follows any rebinding done in Options → Keyboard.
 
-**Zoom input:** Numpad `/` and `*` update `FollowCamBaseDist` every frame while held; idle zoom/tilt still apply (dirty check includes base distance and `AlphaCam`).
+**Zoom input:** numpad `/` and `*`, or the mouse wheel, update `FollowCamBaseDist` every frame while held; idle zoom/tilt still apply (dirty check includes base distance and `AlphaCam`). Unlike elevation, zoom and pan read raw scancodes through `CheckKey` in `GereExtKeys`, so they are not rebindable and the numpad is the only keyboard route to zoom.
+
+**Zoom is per-session.** `FollowCamBaseDist` is neither persisted to `lba2.cfg` nor exposed as a console cvar. Only two things write the resting value: the first-frame init, and Center camera (Enter / gamepad B), which snaps it back to `FOLLOW_CAM_INITIAL_DIST`, the midpoint of the two `DefVueDistance` presets. Walking between scenes does not reset it. Changing the resting zoom therefore means editing that constant in `PERSO.CPP`; at tall render heights the HD recompose below also pulls the boom in, and that gain *is* live and persisted (`cam_hd_dist`).
 
 ### HD recompose (tall render heights)
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -49,6 +49,8 @@ lba2.cfg stores user preferences and last-save info. Read at startup, written at
 | LanguageCD | string | Same as Language | English | Voice CD language; only used with CDROM build |
 | FlagKeepVoice | string | ON, OFF | ON | Keep voice files on HD |
 | MenuMouse | int | 0, 1 | 1 | 1 = menu cursor, hover/left-click confirm, wheel for sliders and save list; 0 = keyboard/joystick only (classic) |
+| TextureFilter | int | 0–2 | 0 | Filtered texture sampling in the software fillers. 0=off (unchanged output), 1=horizontal 2-tap, 2=bilinear 4-tap. `LBA2_TEXFILTER` overrides for one run without persisting. See [GFX_OPTIONS.md](GFX_OPTIONS.md) |
+| DitherShading | int | 0, 1 | 0 | Ordered dither on Gouraud shade rows, softening the 16-step ramp banding. See [GFX_OPTIONS.md](GFX_OPTIONS.md) |
 
 ### Original keys (Adeline)
 
@@ -77,6 +79,7 @@ lba2.cfg stores user preferences and last-save info. Read at startup, written at
 |-----|---------|--------|------|
 | MenuMouse | Optional mouse UX in game menus (`FlagMenuMouse` in code). Default 1 (on). Set 0 to match classic keyboard/joystick-only menus. See [MENU.md](MENU.md) | ReadConfigFile / WriteConfigFile | Options → Advanced options |
 | FollowCamera | Auto camera for exterior scenes (0=classic, 1=auto). Community addition, not in original game; menu label is "Auto camera" / "Classic camera" | ReadConfigFile / WriteConfigFile | Options → Advanced options |
+| TextureFilter, DitherShading | Software-rasterizer smoothing, both off by default. Console cvars `gfx_texfilter` / `gfx_dither` | ReadConfigFile / WriteConfigFile | console only |
 
 ## Code reference
 

--- a/docs/CONTROLLER.md
+++ b/docs/CONTROLLER.md
@@ -28,8 +28,15 @@ fixed cameras have no orbit to drive.
 
 ### Keyboard
 
-`[` / `]` orbit, numpad `+` / `-` tilt elevation, numpad `*` / `/` zoom. Handled
-directly in `GereExtKeys`.
+`[` / `]` orbit, numpad `+` / `-` (or Page Up / Page Down) tilt elevation, numpad
+`*` / `/` zoom. All are handled in `GereExtKeys`, but by two different routes:
+
+- **Elevation** arrives as the Camera-level input action, so it honours whatever
+  the player set in Options → Keyboard. Numpad `+` / `-` and Page Up / Page Down
+  are just its two default bindings.
+- **Orbit and zoom** read their scancodes directly through `CheckKey`, so they
+  are fixed. On a keyboard without a numpad there is no way to zoom from the
+  keys at all, which is what the mouse wheel is for.
 
 ### Mouse
 

--- a/docs/GFX_OPTIONS.md
+++ b/docs/GFX_OPTIONS.md
@@ -2,6 +2,30 @@
 
 Variables and locations that can be changed or exposed as options to improve graphical quality, increase details and effects, etc.
 
+## Shipped options
+
+All three are off by default, so a stock run renders exactly as before. None of them has a menu entry yet; set them from the console or the config file.
+
+| Option | Console | lba2.cfg | Environment | Values |
+|--------|---------|----------|-------------|--------|
+| Texture filtering | `gfx_texfilter` | `TextureFilter` | `LBA2_TEXFILTER` | 0 off, 1 horizontal 2-tap, 2 bilinear 4-tap |
+| Dithered shading | `gfx_dither` | `DitherShading` | (none) | 0 off, 1 on |
+| Interior render scaling | (none) | (none) | `LBA2_ISO_DIV` | 1 off, 2 to 4 |
+
+**Texture filtering** smooths magnified texels on terrain, sea, and sky. The rasterizer works in palette indices, where averaging two entries is meaningless, so the blend is a precomputed table of the nearest palette index to each 25/50/75% RGB mix. Costs roughly 7% of frame time on terrain and 4% on a sea-heavy view at 1728x1080 with the 4-tap setting.
+
+**Dithered shading** applies an ordered dither to Gouraud shade rows, which softens the 16-step banding of the original palette ramps.
+
+**Interior render scaling** renders isometric interiors at 1/N of the chosen resolution and lets the present stretch them back, so the room is drawn larger. Nothing in an interior scales with the framebuffer (bricks are pre-rendered sprites and the iso projectors take no focal argument), so a bigger framebuffer otherwise just reveals more empty space around the room: it covers 29% of the frame at 1728x1080 against 82% at 640x480. Exteriors, whose projection does carry a focal, always render at full resolution.
+
+`LBA2_ISO_DIV` is read once at startup and cannot be changed mid-run. It is also ignored when the divided size would fall below the engine's 320x200 minimum, which is silent: at 640x480 a divisor of 2 works and 3 does nothing.
+
+```
+LBA2_ISO_DIV=2 ./lba2cc
+```
+
+## Ideas not yet wired up
+
 - DetailLevel and Shadow are stored in lba2.cfg and exposed via the Options menu; see [CONFIG.md](CONFIG.md) for the full key list.
 - `RAIN_RANGE` in `SOURCES/3DEXT/LINERAIN.ASM` controls how far the rain effect is drawn in the original ASM implementation.
 - In the community build, the rain line routine is compiled from `SOURCES/3DEXT/LINERAIN.CPP` by default; the ASM file is kept for historical reference. If you want a user-facing option for rain draw distance in modern builds, consider wiring it through the C++ implementation rather than only tweaking the ASM constant.


### PR DESCRIPTION
## What & why

Three graphics options shipped recently with no documentation anywhere, and the
README told players the right stick zooms the camera, which it never has. This
fixes the wrong claim and writes down what exists.

**Camera controls.** `docs/CONTROLLER.md` listed orbit, tilt and zoom together as
"handled directly in `GereExtKeys`", which hides the distinction a player runs
into: tilt arrives as the Camera-level input action and honours any rebinding in
Options, while orbit and zoom read raw scancodes through `CheckKey` and cannot be
remapped. So a keyboard with no numpad cannot zoom at all. Page Up / Page Down
turn out to be a second default binding for tilt and were undocumented.

The README bullet claimed the follow camera is "orbited and zoomed with the mouse
or the right stick". The stick orbits and tilts only, `ApplyManualCameraNudge` is
called with a `dZoom` of 0, and `CONTROLLER.md` already stated there is no stick
zoom.

`docs/CAMERA.md` also gains the fact that the resting zoom is per-session:
`FollowCamBaseDist` is neither persisted nor a cvar, only two sites write the
resting value, and Center camera is the one that resets it. Walking between
scenes does not, which the old wording implied.

**Render options.** `gfx_texfilter` (#452) and `gfx_dither` (#455) landed without
a mention in `docs/` or the README, and `LBA2_ISO_DIV` had never been documented,
so the only way to find any of them was the source or the pull request.
`GFX_OPTIONS.md` now collects the three with their console, cfg and environment
names, and `CONFIG.md` gains the two cfg keys.

## Notes for reviewers

Docs only, no code touched.

The keyboard claims are verified rather than read off the source. The harness
cannot drive these keys (`input seq` only sets the `Input` word, and zoom and pan
are on `CheckKey`, a gap `INPUT_SIM_PLAN.md` already notes), so I temporarily
overrode the `ApplyVirtualKeys` hook to hold arbitrary scancodes, ran a headless
exterior save with Auto camera on, and compared frames against a no-key baseline.
Each key held 60 ticks at `--fixed-dt 16`:

| Key | Scancode | Result |
|-----|----------|--------|
| `[` / `]` | 47 / 48 | both differ from baseline and from each other |
| numpad `/` / `*` | 84 / 85 | both differ |
| numpad `+` / `-` | 87 / 86 | both differ |
| Page Up / Page Down | 75 / 78 | byte-identical to numpad `+` / `-` |

The baseline frame was identical with and without the instrumented build, so the
probe had no side effect, and it is not part of this branch. The one link this
does not cover is SDL reporting the scancode on a physical press, which is shared
with every other key in the game.

Two things worth a second opinion:

- The frame-time and screen-coverage percentages in `GFX_OPTIONS.md` are quoted
  from #452's description, not re-measured here.
- `LBA2_ISO_DIV` is environment-only with no console or cfg route, unlike its two
  neighbours in that table. Documenting it that way is accurate today, but if it
  is meant to be a player-facing option it wants a cvar.

## Checklist

- [x] Build passes on my platform (Linux)
- [ ] If LIB386 / 3DEXT touched: ASM equivalence tests pass (`./run_tests_docker.sh`)
- [ ] If behavior changes: opt-in via flag/cvar/config (preserves default game feel)
- [x] Docs updated in the same PR if behavior or workflow changed
- [x] French comments and ASCII art preserved in any modified files
