### PR TITLE
fix(discovery): name the marker truthfully, stop a stale env var booting the wrong install, and say which probe matched

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ All releases: [Releases page](https://github.com/LBALab/lba2-classic-community/r
 
 You need a legitimate copy of LBA2 ([GOG](https://www.gog.com/game/little_big_adventure_2), [Steam](https://store.steampowered.com/app/398000/Little_Big_Adventure_2/), or your retail CD) — the engine doesn't ship assets.
 
-On first launch a folder picker opens; point it at the directory containing `lba2.hqr` (alongside `music/`, `video/`, `vox/`, …, or under a `Common/` / `CommonClassic/` subfolder for Steam/GOG re-releases). Your choice is remembered.
+On first launch a folder picker opens; point it at the directory containing `LBA2.HQR` (alongside `music/`, `video/`, `vox/`, …, or under a `Common/` / `CommonClassic/` subfolder for Steam/GOG re-releases). Your choice is remembered.
 
 To skip the picker, pass an explicit path:
 
@@ -90,8 +90,8 @@ On macOS, install with `brew install ninja sdl3`.
 
 1. `make` or `make help` — lists convenience targets (`build`, `run`, `clean`, `test`, …).
 2. `make build` — configures `build/` (Ninja, Debug) and compiles `lba2cc`. Or plain CMake: `cmake -B build && cmake --build build`.
-3. Point the engine at your game data — `export LBA2_GAME_DIR=/path`, `./data/` (gitignored), `--game-dir`, or bounded automatic discovery (the `lba2.hqr` marker is the only special-cased file). See [docs/GAME_DATA.md](docs/GAME_DATA.md).
-4. `make run` or `./scripts/dev/build-and-run.sh` — build if needed, then run. `make run` sets `LBA2_GAME_DIR` automatically if `./data` or `../LBA2` contains `lba2.hqr`; otherwise pass `--game-dir /path/to/classic/install` to the binary.
+3. Point the engine at your game data — `export LBA2_GAME_DIR=/path`, `./data/` (gitignored), `--game-dir`, or bounded automatic discovery (the `LBA2.HQR` marker is the only special-cased file). See [docs/GAME_DATA.md](docs/GAME_DATA.md).
+4. `make run` or `./scripts/dev/build-and-run.sh` — build if needed, then run. `make run` sets `LBA2_GAME_DIR` automatically if `./data` or `../LBA2` contains `LBA2.HQR`; otherwise pass `--game-dir /path/to/classic/install` to the binary.
 5. `make test` — host-only tests (path resolution, parsers, ABI bounds, version checks); no retail files or Docker required.
 
 **Windows:** Use MSYS2 (recommended; see [docs/WINDOWS.md](docs/WINDOWS.md)). Discovery and the game work the same (`LBA2_GAME_DIR`, `--game-dir`, paths with `\` or `/`). The root `Makefile` and `scripts/dev/*.sh` need a Unix-like shell (MSYS2 UCRT64, Git Bash, or WSL); alternatively run `cmake` and `build/SOURCES/lba2cc.exe` from cmd.exe / PowerShell and set the env var with `set LBA2_GAME_DIR=...`.

--- a/SOURCES/DIRECTORIES.CPP
+++ b/SOURCES/DIRECTORIES.CPP
@@ -35,7 +35,12 @@ extern "C" {
 #define DIR_NAME_VOICE_HD "vox" ADELINE_PATH_SEP
 #define DIR_NAME_VOICE_CD "lba2" ADELINE_PATH_SEP "vox" ADELINE_PATH_SEP
 #define DIR_NAME_VOICE_CD_US "twinsen" ADELINE_PATH_SEP "vox" ADELINE_PATH_SEP
-#define FILE_VALID_RES_DIR "lba2.hqr"
+/* Spelled the way every distribution ships it. Discover() probes as-is, upper,
+   lower and title case, so the set of names accepted is the same either way --
+   but the as-is probe is the one that hits on a real install, and the constant
+   is what the "we could not find your game data" messages quote back at the
+   player. Naming a spelling nobody has sends them off renaming files. */
+#define FILE_VALID_RES_DIR "LBA2.HQR"
 
 // --- Private state -----------------------------------------------------------
 bool directoriesInitialized = false;

--- a/SOURCES/INITADEL.C
+++ b/SOURCES/INITADEL.C
@@ -9,6 +9,7 @@
 #include "CONSOLE/CONSOLE.H" /* console buffer sink printer adapter */
 #include "CONTROL.H"
 #include "JOYSTICK.H"
+#include "RES_DISCOVERY.H" /* Res_GetDiscoverySource for the Assets banner line */
 #include <SYSTEM/LOG.H>
 #include "SVGA/INITMODE.H"
 #include "SVGA/SCREEN.H"
@@ -141,7 +142,18 @@ void InitAdeline(S32 argc, char *argv[]) {
                    LOG_ARCH_NAME, SDL_GetNumLogicalCPUCores(),
                    (SDL_GetSystemRAM() + 512) / 1024);
         Log_Raw("Built %s %s", __DATE__, __TIME__);
-        Log_Raw("Assets: %s", resFolderPath);
+        /* Which probe found the assets, in parentheses after the path. The probe
+           list runs silently, so "the engine booted the wrong install" and "the
+           engine ignored what I set" look identical in a bug report. Naming the
+           winner makes a pasted banner enough to tell them apart. */
+        {
+            const char *foundVia = Res_GetDiscoverySource();
+            if (foundVia != NULL && foundVia[0] != '\0') {
+                Log_Raw("Assets: %s  (%s)", resFolderPath, foundVia);
+            } else {
+                Log_Raw("Assets: %s", resFolderPath);
+            }
+        }
         /* When a disc image is mounted, one aligned line beside Assets: naming
            the image (basename only; it lives in the assets dir above). Silent
            (no line) otherwise, so the banner is byte-identical to a

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -3051,6 +3051,10 @@ int main(int argc, char *argv[]) {
                 exit(EXIT_FAILURE);
             }
             WritePersistedGameDir(resFolderPath);
+            /* The banner labels which probe resolved the assets, and this one
+               lives outside ResolveGameDataDir. Only for the run the picker
+               fires on; the next launch reports last_game_dir.txt. */
+            Res_SetDiscoverySource("first-launch picker");
         }
 
         /* --disc without an explicit game folder: the disc's own folder is the

--- a/SOURCES/RES_DISCOVERY.CPP
+++ b/SOURCES/RES_DISCOVERY.CPP
@@ -361,18 +361,38 @@ bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv) {
            persisted / auto-discovery probes below would boot a DIFFERENT install than the one
            asked for and say so only in the banner: a run against assets nobody asked for that
            still exits 0. */
-        Log_Error("RES_DISCOVERY: --game-dir '%s' does not hold the game data: no LBA2.HQR "
+        Log_Error("RES_DISCOVERY: --game-dir '%s' does not hold the game data: no %s "
                   "in it, nor in a Common/ inside it.",
-                  cliPath);
+                  cliPath, Directories_GetResMarker());
         Log_Error("Point it at the folder with the HQR files, or at the install that "
                   "contains it. Refusing to boot a different install instead.");
         return false;
     }
 
+    /* Same deal as --game-dir above, for the same reasons: the Common/ join,
+       because people point this at the install root too, and the refusal to
+       fall through, because an env var that names the wrong place should say so
+       rather than quietly boot whatever auto-discovery turns up.
+
+       That second half is the one that bites. LBA2_GAME_DIR gets exported in a
+       shell profile and forgotten, and without this the run continues down the
+       probe list and can land on a different install entirely: right-looking
+       boot, wrong assets, exit 0, and the only clue is the Assets path in the
+       banner. Returning false hands the caller its picker (or a clean error
+       when headless), which is loud and recoverable. */
     const char *env = getenv("LBA2_GAME_DIR");
-    if (env != NULL && env[0] != '\0' &&
-        NormalizeAndTry(env, outDir, outMax, tried, &triedCount, true)) {
-        return true;
+    if (env != NULL && env[0] != '\0') {
+        if (NormalizeAndTry(env, outDir, outMax, tried, &triedCount, true) ||
+            TryJoinBaseSub(env, "Common", outDir, outMax, tried, &triedCount, true)) {
+            return true;
+        }
+
+        Log_Error("RES_DISCOVERY: LBA2_GAME_DIR '%s' does not hold the game data: no "
+                  "%s in it, nor in a Common/ inside it.",
+                  env, Directories_GetResMarker());
+        Log_Error("Point it at the folder with the HQR files, or unset it. Refusing to "
+                  "boot a different install instead.");
+        return false;
     }
 
     /* --pick-game-dir bails out of the implicit-discovery chain and

--- a/SOURCES/RES_DISCOVERY.CPP
+++ b/SOURCES/RES_DISCOVERY.CPP
@@ -336,6 +336,23 @@ bool WritePersistedGameDir(const char *path) {
     return true;
 }
 
+/* The probe that won, for the boot banner. Set before each attempt rather than
+   on success: whatever was set last when a probe returns true is that probe's
+   label, and a failed attempt's label is overwritten by the next one before
+   anyone reads it. */
+static char s_discoverySource[64] = "";
+
+void Res_SetDiscoverySource(const char *label) {
+    if (label == NULL) {
+        s_discoverySource[0] = '\0';
+        return;
+    }
+    strncpy(s_discoverySource, label, sizeof(s_discoverySource) - 1);
+    s_discoverySource[sizeof(s_discoverySource) - 1] = '\0';
+}
+
+const char *Res_GetDiscoverySource(void) { return s_discoverySource; }
+
 bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv) {
     char tried[kMaxTried][ADELINE_MAX_PATH];
     int triedCount = 0;
@@ -352,8 +369,12 @@ bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv) {
         /* The path itself, then the subfolder a retail install keeps its data in: people
            point this at the install root (README says so, and the Makefile forwards
            GAME_DIR straight through), and the HQRs live one level down in Common/. */
-        if (NormalizeAndTry(cliPath, outDir, outMax, tried, &triedCount, true) ||
-            TryJoinBaseSub(cliPath, "Common", outDir, outMax, tried, &triedCount, true)) {
+        Res_SetDiscoverySource("--game-dir");
+        if (NormalizeAndTry(cliPath, outDir, outMax, tried, &triedCount, true)) {
+            return true;
+        }
+        Res_SetDiscoverySource("--game-dir, Common/");
+        if (TryJoinBaseSub(cliPath, "Common", outDir, outMax, tried, &triedCount, true)) {
             return true;
         }
 
@@ -382,8 +403,12 @@ bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv) {
        when headless), which is loud and recoverable. */
     const char *env = getenv("LBA2_GAME_DIR");
     if (env != NULL && env[0] != '\0') {
-        if (NormalizeAndTry(env, outDir, outMax, tried, &triedCount, true) ||
-            TryJoinBaseSub(env, "Common", outDir, outMax, tried, &triedCount, true)) {
+        Res_SetDiscoverySource("LBA2_GAME_DIR");
+        if (NormalizeAndTry(env, outDir, outMax, tried, &triedCount, true)) {
+            return true;
+        }
+        Res_SetDiscoverySource("LBA2_GAME_DIR, Common/");
+        if (TryJoinBaseSub(env, "Common", outDir, outMax, tried, &triedCount, true)) {
             return true;
         }
 
@@ -419,6 +444,7 @@ bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv) {
      * silently re-appearing on a previously-persisted launch is hard
      * to diagnose. */
     if (ReadPersistedGameDir(persisted, ADELINE_MAX_PATH)) {
+        Res_SetDiscoverySource("last_game_dir.txt");
         if (NormalizeAndTry(persisted, outDir, outMax, tried, &triedCount, true)) {
             return true;
         }
@@ -445,9 +471,16 @@ bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv) {
        and there are a lot of them. */
     basePath = SDL_GetBasePath();
     if (basePath != NULL) {
-        if (TryJoinBaseSub(basePath, "", outDir, outMax, tried, &triedCount, true) ||
-            TryJoinBaseSub(basePath, "data", outDir, outMax, tried, &triedCount) ||
-            TryJoinBaseSub(basePath, "game", outDir, outMax, tried, &triedCount)) {
+        Res_SetDiscoverySource("next to the binary");
+        if (TryJoinBaseSub(basePath, "", outDir, outMax, tried, &triedCount, true)) {
+            return true;
+        }
+        Res_SetDiscoverySource("next to the binary, data/");
+        if (TryJoinBaseSub(basePath, "data", outDir, outMax, tried, &triedCount)) {
+            return true;
+        }
+        Res_SetDiscoverySource("next to the binary, game/");
+        if (TryJoinBaseSub(basePath, "game", outDir, outMax, tried, &triedCount)) {
             return true;
         }
     }
@@ -455,6 +488,7 @@ bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv) {
     GetCurrentRunningDir(walk);
     walk[ADELINE_MAX_PATH - 1] = '\0';
     EnsureTrailingSeparator(walk, ADELINE_MAX_PATH);
+    Res_SetDiscoverySource("working directory");
     if (NormalizeAndTry(walk, outDir, outMax, tried, &triedCount, true)) {
         return true;
     }
@@ -465,6 +499,7 @@ bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv) {
      * adb push file.hqr /sdcard/Android/data/<pkg>/files/ */
     if (Android_GetExternalFilesDir(walk, ADELINE_MAX_PATH)) {
         EnsureTrailingSeparator(walk, ADELINE_MAX_PATH);
+        Res_SetDiscoverySource("Android app files dir");
         if (NormalizeAndTry(walk, outDir, outMax, tried, &triedCount))
             return true;
     }
@@ -473,10 +508,20 @@ bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv) {
      * may need MANAGE_EXTERNAL_STORAGE permission — see
      * docs/ANDROID.md). Try /sdcard/lba2cc/ first so users can keep data in a
      * subdirectory. Harmless no-op on non-Android. */
-    if (TryJoinBaseSub("/sdcard/", "lba2cc", outDir, outMax, tried, &triedCount) ||
-        TryJoinBaseSub("/storage/emulated/0/", "lba2cc", outDir, outMax, tried, &triedCount) ||
-        NormalizeAndTry("/sdcard/", outDir, outMax, tried, &triedCount) ||
-        NormalizeAndTry("/storage/emulated/0/", outDir, outMax, tried, &triedCount)) {
+    Res_SetDiscoverySource("/sdcard/lba2cc");
+    if (TryJoinBaseSub("/sdcard/", "lba2cc", outDir, outMax, tried, &triedCount)) {
+        return true;
+    }
+    Res_SetDiscoverySource("/storage/emulated/0/lba2cc");
+    if (TryJoinBaseSub("/storage/emulated/0/", "lba2cc", outDir, outMax, tried, &triedCount)) {
+        return true;
+    }
+    Res_SetDiscoverySource("/sdcard");
+    if (NormalizeAndTry("/sdcard/", outDir, outMax, tried, &triedCount)) {
+        return true;
+    }
+    Res_SetDiscoverySource("/storage/emulated/0");
+    if (NormalizeAndTry("/storage/emulated/0/", outDir, outMax, tried, &triedCount)) {
         return true;
     }
 
@@ -488,6 +533,7 @@ bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv) {
             break;
         }
         EnsureTrailingSeparator(walk, ADELINE_MAX_PATH);
+        Res_SetDiscoverySource("parent walk");
         if (NormalizeAndTry(walk, outDir, outMax, tried, &triedCount)) {
             return true;
         }
@@ -501,6 +547,7 @@ bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv) {
         int n = snprintf(rel, ADELINE_MAX_PATH, "%s%s%s", walk, "data",
                          ADELINE_PATH_SEP);
         if (n > 0 && (size_t)n < ADELINE_MAX_PATH) {
+            Res_SetDiscoverySource("working directory, data/");
             if (NormalizeAndTry(rel, outDir, outMax, tried, &triedCount)) {
                 return true;
             }
@@ -515,6 +562,7 @@ bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv) {
         int n = snprintf(rel, ADELINE_MAX_PATH, "%s..%s%s%s", walk,
                          ADELINE_PATH_SEP, "LBA2", ADELINE_PATH_SEP);
         if (n > 0 && (size_t)n < ADELINE_MAX_PATH) {
+            Res_SetDiscoverySource("../LBA2/ beside the working directory");
             if (NormalizeAndTry(rel, outDir, outMax, tried, &triedCount)) {
                 return true;
             }
@@ -529,12 +577,14 @@ bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv) {
         int n = snprintf(rel, ADELINE_MAX_PATH, "%s..%s%s%s", walk,
                          ADELINE_PATH_SEP, "game", ADELINE_PATH_SEP);
         if (n > 0 && (size_t)n < ADELINE_MAX_PATH) {
+            Res_SetDiscoverySource("../game/ beside the working directory");
             if (NormalizeAndTry(rel, outDir, outMax, tried, &triedCount)) {
                 return true;
             }
         }
     }
 
+    Res_SetDiscoverySource("sibling scan");
     if (TryParentSiblingScan(outDir, outMax, tried, &triedCount)) {
         return true;
     }

--- a/SOURCES/RES_DISCOVERY.CPP
+++ b/SOURCES/RES_DISCOVERY.CPP
@@ -107,7 +107,7 @@ bool NormalizeAndTry(const char *pathIn, char *outDir, U16 outMax,
 }
 
 void LogFailure(const char tried[][ADELINE_MAX_PATH], int triedCount) {
-    Log_Error("No valid game data directory (need lba2.hqr). Tried %d path(s).",
+    Log_Error("No valid game data directory (need LBA2.HQR). Tried %d path(s).",
               triedCount);
     for (int i = 0; i < triedCount; i++) {
         Log_Error("  - %s", tried[i]);

--- a/SOURCES/RES_DISCOVERY.H
+++ b/SOURCES/RES_DISCOVERY.H
@@ -33,6 +33,28 @@ bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv);
  */
 bool WritePersistedGameDir(const char *path);
 
+/**
+ * Which probe produced the directory ResolveGameDataDir returned, as a short
+ * label for the boot banner ("LBA2_GAME_DIR", "sibling scan", ...).
+ *
+ * The probe list runs silently, so a run that resolves the "wrong" folder for a
+ * good reason is indistinguishable from one that is simply broken: a forgotten
+ * LBA2_GAME_DIR outranking the picker looks identical to the picker not working.
+ * Naming the winning probe next to the path turns that into a one-line
+ * diagnosis.
+ *
+ * Never NULL. Reads "" before discovery has run, and stays valid for the
+ * process lifetime (points at static storage).
+ */
+const char *Res_GetDiscoverySource(void);
+
+/**
+ * Record the probe that resolved the directory. Called by ResolveGameDataDir
+ * for its own probes; exposed so the caller can label what it resolved outside
+ * them, which today is the first-launch picker.
+ */
+void Res_SetDiscoverySource(const char *label);
+
 #ifdef __cplusplus
 }
 #endif

--- a/SOURCES/RES_PICKER.CPP
+++ b/SOURCES/RES_PICKER.CPP
@@ -22,12 +22,12 @@
 
 extern "C" const char kPickerMsgDataNotFound[] =
     "Little Big Adventure 2 game data wasn't found.\n\n"
-    "Pick the folder that contains lba2.hqr (your retail LBA2 install).\n\n"
+    "Pick the folder that contains LBA2.HQR (your retail LBA2 install).\n\n"
     "Your choice is saved for next time.";
 
 extern "C" const char kPickerMsgInvalidPick[] =
-    "That folder doesn't contain lba2.hqr.\n\n"
-    "Pick your retail LBA2 install folder (the one with lba2.hqr).";
+    "That folder doesn't contain LBA2.HQR.\n\n"
+    "Pick your retail LBA2 install folder (the one with LBA2.HQR).";
 
 extern "C" const char kPickerMsgNoPicker[] =
     "The system folder picker isn't available here.\n\n"
@@ -38,7 +38,7 @@ extern "C" const char kPickerMsgNoPicker[] =
 
 extern "C" const char kPickerMsgAndroidData[] =
     "Little Big Adventure 2 game data wasn't found.\n\n"
-    "Copy your retail LBA2 data (lba2.hqr, music/, video/, vox/) to:\n"
+    "Copy your retail LBA2 data (LBA2.HQR, music/, video/, vox/) to:\n"
     "    /sdcard/lba2cc/\n\n"
     "then relaunch the app.";
 
@@ -59,7 +59,7 @@ struct PickerState {
 /* Strip trailing whitespace/newlines from a path. Some dialog backends
  * (notably zenity in some configurations) return the path with a
  * trailing newline; without trimming, IsValidResourceDir would look for
- * `lba2.hqr` at the wrong-named directory and silently fail. */
+ * `LBA2.HQR` at the wrong-named directory and silently fail. */
 void TrimTrailingWhitespace(char *s) {
     size_t len = strlen(s);
     while (len > 0 &&
@@ -237,7 +237,7 @@ extern "C" bool PromptForResDir(char *outPath, U16 outMax) {
         /* Apply trailing-separator normalization BEFORE validation.
          * Discover() in DIRECTORIES.CPP does `snprintf("%s%s", baseDir,
          * checkPath)` without injecting a separator, so a baseDir
-         * without a trailing slash gives "Commonlba2.hqr"-style joined
+         * without a trailing slash gives "CommonLBA2.HQR"-style joined
          * paths that always miss. The auto-discovery probe chain calls
          * EnsureTrailingSeparator pre-validation in NormalizeAndTry;
          * the picker has to do the same. Without this, picking a
@@ -247,13 +247,13 @@ extern "C" bool PromptForResDir(char *outPath, U16 outMax) {
         EnsureTrailingSeparator(state.chosen, ADELINE_MAX_PATH);
 
         /* Validation goes through the same gate the CLI and env overrides
-         * use, case-folding for `lba2.hqr` (per Discover() in
+         * use, case-folding for `LBA2.HQR` (per Discover() in
          * DIRECTORIES.CPP) included. The picker is not a special validation
          * path; it's the same probe with a different input source.
          *
          * The image-aware variant, because a folder somebody browsed to is as
          * explicit as a path they typed, and a retail CD rip is one .bin and a
-         * .cue with no extracted lba2.hqr to find. The cheap check is for the
+         * .cue with no extracted LBA2.HQR to find. The cheap check is for the
          * speculative candidate sweep, which this is not. */
         if (IsValidResourceDirOrImage(state.chosen)) {
             Log_Info("RES_PICKER: picked %s", state.chosen);

--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -48,7 +48,7 @@ These types contain pointer-sized fields and are larger on 64-bit than on 32-bit
 
 | Struct | File | File-backed? | Status |
 |--------|------|--------------|--------|
-| `S_CRED_OBJ_2` | [`SOURCES/CREDITS.H`](../SOURCES/CREDITS.H) | Yes — `lba2.hqr` index 0 | Fixed (#65). On-disk variant `S_CRED_OBJ_2_DISK` exists; runtime parser uses it. |
+| `S_CRED_OBJ_2` | [`SOURCES/CREDITS.H`](../SOURCES/CREDITS.H) | Yes — `LBA2.HQR` index 0 | Fixed (#65). On-disk variant `S_CRED_OBJ_2_DISK` exists; runtime parser uses it. |
 | `T_OBJET` | [`SOURCES/DEFINES.H:387`](../SOURCES/DEFINES.H) | No — runtime only; save uses field-by-field | Safe. |
 | `T_OBJET` (3DEXT MOUNFRAC) | [`SOURCES/3DEXT/DEFINES.H:26`](../SOURCES/3DEXT/DEFINES.H) | No — gated `#ifdef MOUNFRAC` | Safe. |
 

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -95,7 +95,7 @@ Place your retail LBA2 `.HQR` files on the device with ADB. **Recommended:
 it survives an uninstall/reinstall:
 
 ```bash
-adb push lba2.hqr /sdcard/lba2cc/
+adb push LBA2.HQR /sdcard/lba2cc/
 adb push ress.hqr /sdcard/lba2cc/
 # ...and the rest of your retail HQR set
 ```

--- a/docs/AUTOMATION_PLAN.md
+++ b/docs/AUTOMATION_PLAN.md
@@ -264,7 +264,7 @@ time.
    The only platform-sensitive surface is the file writes (`SavePNG`, JSON `fopen`); when
    an Xbox build appears, guard those two — not the whole feature.
 6. **Tests can't run in host-only CI.** The harness must boot the real engine (needs retail
-   `lba2.hqr`, and a save for `--load`), absent from the repo and from `make test`. The
+   `LBA2.HQR`, and a save for `--load`), absent from the repo and from `make test`. The
    `tests/automation/*.sh` scripts gate on data presence and skip cleanly when absent (like
    the Docker ASM tests need Docker). They're runnable usage docs locally, not CI gates.
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -6,7 +6,7 @@ lba2.cfg stores user preferences and last-save info. Read at startup, written at
 
 - Filename: `lba2.cfg` ([SOURCES/COMMON.H](../SOURCES/COMMON.H) line 83: `CFG_NAME`)
 - User config path: `GetCfgPath(PathConfigFile, ..., CFG_NAME)` → `directoriesCfgDir` + filename ([SOURCES/DIRECTORIES.CPP](../SOURCES/DIRECTORIES.CPP))
-- Default (assets): `GetDefaultCfgPath()` → `directoriesResDir` + filename (same folder as `lba2.hqr`, i.e. the game assets directory)
+- Default (assets): `GetDefaultCfgPath()` → `directoriesResDir` + filename (same folder as `LBA2.HQR`, i.e. the game assets directory)
 - If user config missing: copy from assets to config dir ([SOURCES/INITADEL.C](../SOURCES/INITADEL.C)). If the assets folder has no `lba2.cfg`, the engine writes an embedded copy (generated at build time from [SOURCES/LBA2.CFG](../SOURCES/LBA2.CFG) via [cmake/embed_lba2_cfg.cmake](../cmake/embed_lba2_cfg.cmake)) into the user config path instead of exiting.
 - **Default config source**: Prefer the file in the asset directory (`directoriesResDir`). The repo has `SOURCES/LBA2.CFG` and `SOURCES/CONFIG/LBA2.CFG` as reference/templates. See [GAME_DATA.md](GAME_DATA.md) for where assets live.
 

--- a/docs/DISC_IMAGE_SOURCE.md
+++ b/docs/DISC_IMAGE_SOURCE.md
@@ -66,7 +66,7 @@ separate source's job, not an external file.
    a multi-sector fixture covering cross-sector reads and EOF clamping.
 4. **mount + `OpenRead` intercept (data) + preflight + boot-log `Disc:` line.** A `DiscImage` manager
    (`LIB386/SYSTEM/DISCIMG.CPP`) content-probes the install dir for an ISO9660 image, locates the
-   asset-root subtree by finding the resource marker (`lba2.hqr`) inside it (CD masters nest under a
+   asset-root subtree by finding the resource marker (`LBA2.HQR`) inside it (CD masters nest under a
    volume dir, e.g. `/LBA2`), and resolves any path under the mount base by stripping the base and
    resolving the remainder beneath that root, so it serves *all* assets (the marker HQR included),
    not just media. `OpenRead` falls back to it (filesystem first); tagged virtual handles stream via
@@ -94,7 +94,7 @@ separate source's job, not an external file.
    PCM-passthrough source. Orthogonal to the `GameProfile`.
 
 A remaining increment for a pure rip (only the disc image present, nothing extracted): discovery
-validates the install dir by finding `lba2.hqr` *before* the mount, so a dir with only the image
+validates the install dir by finding `LBA2.HQR` *before* the mount, so a dir with only the image
 does not yet pass `IsValidResourceDir`. Making discovery probe a candidate dir's image closes that
 gap; today's target (`../LBA2-GOG`) ships the HQRs extracted, so discovery succeeds and only the
 media comes from the image.
@@ -202,7 +202,7 @@ because the root is found by marker rather than by name.
 
 All five are now closed. Listed in the order they bite a user, with the commit that fixes each.
 
-1. **Discovery rejected a pure dump.** `IsValidResourceDir` required `lba2.hqr` on the filesystem
+1. **Discovery rejected a pure dump.** `IsValidResourceDir` required `LBA2.HQR` on the filesystem
    and ran before `DiscImage_Mount`, so a directory holding only the image was refused with
    "does not hold the game data". It now falls through to `DiscImage_DirHoldsMarker`, which probes
    the folder for an image and looks for the marker inside it: the same question the mount answers

--- a/docs/GAME_DATA.md
+++ b/docs/GAME_DATA.md
@@ -21,7 +21,22 @@ Use the directory that contains `LBA2.HQR` (and the other `.hqr` files, `music/`
 | Persisted choice | `last_game_dir.txt` in the user-prefs folder, written automatically the first time you pick a folder via the launch dialog (see [First-launch folder picker](#first-launch-folder-picker) below) |
 | Discovery | See [SOURCES/RES_DISCOVERY.CPP](../SOURCES/RES_DISCOVERY.CPP): SDL binary directory, current working directory, parents of cwd, `./data`, `../LBA2`, `../game`, sibling scan of parent-of-cwd |
 
+Both `--game-dir` and `LBA2_GAME_DIR` also try a `Common/` inside the path you give, so pointing either at an install root works as well as pointing it at the data folder.
+
+**Naming a path that holds no game data stops the run.** Neither override falls through to the probes below it: an override that names the wrong place is a mistake, and continuing would boot whatever discovery turns up next. That is a launch against assets nobody asked for, reported only by the `Assets:` line and still exiting 0. You get the picker instead (or a clean error when headless).
+
 If none of the above resolves a valid directory, the engine falls back to the [First-launch folder picker](#first-launch-folder-picker). On a headless system (no display, CI runner, etc.), the picker can't open and the process exits with a log listing candidates tried and hints.
+
+## Which probe matched
+
+The boot banner names the probe that resolved the assets, after the path:
+
+```
+Assets: /home/user/GOG/tlba2-classic/Common/  (--game-dir, Common/)
+Assets: /home/user/LBA2-GOG/                  (sibling scan)
+```
+
+The probes run silently and in priority order, so without this a run that picks an unexpected folder for a good reason (a forgotten `LBA2_GAME_DIR`, a stale `last_game_dir.txt`) looks the same as one that is simply broken. The label is the difference between reading a bug report and guessing at one. Labels name the mechanism, not the code: `--game-dir`, `LBA2_GAME_DIR`, `last_game_dir.txt`, `next to the binary`, `working directory`, `parent walk`, `sibling scan`, `first-launch picker`, and the Android storage roots.
 
 ## First-launch folder picker
 

--- a/docs/GAME_DATA.md
+++ b/docs/GAME_DATA.md
@@ -4,11 +4,11 @@ The engine needs the original Little Big Adventure 2 data files. They are not in
 
 ## What to point the engine at
 
-Use the directory that contains `lba2.hqr` (and the other `.hqr` files, `music/`, `video/`, `vox/`, etc.). On Steam, classic data may live under a Classic-related install path; remastered or other editions may use a different layout — this fork targets classic data only.
+Use the directory that contains `LBA2.HQR` (and the other `.hqr` files, `music/`, `video/`, `vox/`, etc.). On Steam, classic data may live under a Classic-related install path; remastered or other editions may use a different layout — this fork targets classic data only.
 
-**Validation:** discovery and overrides only succeed when the chosen path is a directory that contains `lba2.hqr` (that is the required marker; see `IsValidResourceDir` / `FILE_VALID_RES_DIR` in `SOURCES/DIRECTORIES.CPP`). The filename is matched with the same case-folding logic as other asset files.
+**Validation:** discovery and overrides only succeed when the chosen path is a directory that contains `LBA2.HQR` (that is the required marker; see `IsValidResourceDir` / `FILE_VALID_RES_DIR` in `SOURCES/DIRECTORIES.CPP`). The filename is matched with the same case-folding logic as other asset files.
 
-**Single asset root:** Once that directory is chosen, `GetResPath`, `GetJinglePath`, `GetMoviePath`, and related APIs resolve files relative to that same `directoriesResDir` (see `InitDirectories` / `GetResPath` in `SOURCES/DIRECTORIES.CPP`). The engine does not look for `music/`, `video/`, `vox/`, or other `.hqr` files on separate paths; finding `lba2.hqr` establishes the one root for classic data.
+**Single asset root:** Once that directory is chosen, `GetResPath`, `GetJinglePath`, `GetMoviePath`, and related APIs resolve files relative to that same `directoriesResDir` (see `InitDirectories` / `GetResPath` in `SOURCES/DIRECTORIES.CPP`). The engine does not look for `music/`, `video/`, `vox/`, or other `.hqr` files on separate paths; finding `LBA2.HQR` establishes the one root for classic data.
 
 **Sibling scan:** If the fixed paths above fail, the engine looks at siblings of the parent of the current working directory (for example the folder that contains both your clone and a retail install). For each immediate subdirectory, it tries that folder and `CommonClassic`, `common`, `Common`, and `Classic` under it. Only bounded scans (entry and directory-count limits); see `TryParentSiblingScan` in `SOURCES/RES_DISCOVERY.CPP`.
 
@@ -25,13 +25,13 @@ If none of the above resolves a valid directory, the engine falls back to the [F
 
 ## First-launch folder picker
 
-When all four override mechanisms above fail and the engine is running in a windowed environment, it shows the platform-native folder dialog (NSOpenPanel on macOS, IFileDialog on Windows, GTK / xdg-desktop-portal on Linux). The user picks the folder containing `lba2.hqr`; the engine validates it via `IsValidResourceDir`, persists the choice to `last_game_dir.txt`, and continues startup.
+When all four override mechanisms above fail and the engine is running in a windowed environment, it shows the platform-native folder dialog (NSOpenPanel on macOS, IFileDialog on Windows, GTK / xdg-desktop-portal on Linux). The user picks the folder containing `LBA2.HQR`; the engine validates it via `IsValidResourceDir`, persists the choice to `last_game_dir.txt`, and continues startup.
 
 Android is the exception: there is no folder picker (SDL's file dialog returns `content://` document URIs, not filesystem paths the engine can probe). When discovery fails there, the engine shows a message telling the user to copy their data to `/sdcard/lba2cc/` and relaunch, instead of opening a dialog. See [docs/ANDROID.md](ANDROID.md) for the full Android data layout.
 
 | Scenario | Behavior |
 |---|---|
-| User picks a valid folder (contains `lba2.hqr`) | Engine launches; `last_game_dir.txt` updated; subsequent launches skip the dialog. |
+| User picks a valid folder (contains `LBA2.HQR`) | Engine launches; `last_game_dir.txt` updated; subsequent launches skip the dialog. |
 | User picks an invalid folder | Engine shows a "Game data not found" message and re-opens the dialog. |
 | User cancels the dialog | Engine exits cleanly (same exit code as the headless no-data case). |
 | Persisted path no longer valid (game install moved/deleted) | Engine silently falls through to auto-discovery, then the picker. The next valid pick rewrites `last_game_dir.txt`. |
@@ -79,14 +79,14 @@ If you want to force a specific backend even when both are installed, set `SDL_F
 
 **What “adjacent” means in discovery:** Heuristics only look at predictable relative locations (cwd, parents of cwd, `../LBA2`, `./data`, SDL binary dir, then siblings of the parent of cwd with a small set of subfolder names). There is no full-disk or deep recursive search. “Adjacent” here means *often the same parent folder as your clone* when you run from the repo root — not “any path on the machine.”
 
-**Safety:** Every candidate is accepted only if `IsValidResourceDir` succeeds (`lba2.hqr` present). There is no execution of paths from untrusted config beyond what you pass on the command line or in the environment.
+**Safety:** Every candidate is accepted only if `IsValidResourceDir` succeeds (`LBA2.HQR` present). There is no execution of paths from untrusted config beyond what you pass on the command line or in the environment.
 
 ## Developer layout
 
 Common choices:
 
 - Symlink or copy retail files into `data/` at the repo root (that directory is gitignored in this repo so retail files are not committed by mistake).
-- One directory up: `../LBA2/` (or `../game/`) with `lba2.hqr` inside.
+- One directory up: `../LBA2/` (or `../game/`) with `LBA2.HQR` inside.
 
 From any directory in the clone you can use:
 
@@ -102,9 +102,9 @@ Windows without Bash: configure CMake as in [WINDOWS.md](WINDOWS.md), then run `
 
 The GOG DRM-free standalone product (and the equivalent content inside the GOG Galaxy "Original Edition" DLC under `Speedrun/Windows/`) ships the 1997 retail CD-ROM as a raw BIN image (`LBA2.GOG`) rather than extracted files. HQRs are duplicated at the install root so gameplay loads, but `VIDEO.HQR`, music WAVs, and `.VOX` voices live only inside the BIN.
 
-**The engine reads the image directly (no extraction needed).** Point it at the install root, the folder holding both `lba2.hqr` and `LBA2.GOG`, and the disc-image source mounts the BIN and resolves the in-image assets (FMV, voices, music) through the normal file path. The image is detected by content (the ISO9660 "CD001" volume descriptor), not by name, so the `.gog` extension, a raw `.bin`/`.iso`, or a `.cue`/`.dat` pair all work. When a mount happens the boot log adds a `Disc:` line beside `Assets:`; with no image present the engine stays filesystem-only as before. See [DISC_IMAGE_SOURCE.md](DISC_IMAGE_SOURCE.md) for the mechanism.
+**The engine reads the image directly (no extraction needed).** Point it at the install root, the folder holding both `LBA2.HQR` and `LBA2.GOG`, and the disc-image source mounts the BIN and resolves the in-image assets (FMV, voices, music) through the normal file path. The image is detected by content (the ISO9660 "CD001" volume descriptor), not by name, so the `.gog` extension, a raw `.bin`/`.iso`, or a `.cue`/`.dat` pair all work. When a mount happens the boot log adds a `Disc:` line beside `Assets:`; with no image present the engine stays filesystem-only as before. See [DISC_IMAGE_SOURCE.md](DISC_IMAGE_SOURCE.md) for the mechanism.
 
-Discovery accepts a folder whose game data exists only inside the image: the `lba2.hqr` check falls through to a probe of any image sitting there. Today's GOG packages ship the HQRs extracted alongside the BIN anyway, so for them discovery succeeds on the filesystem and only the media comes from the image.
+Discovery accepts a folder whose game data exists only inside the image: the `LBA2.HQR` check falls through to a probe of any image sitting there. Today's GOG packages ship the HQRs extracted alongside the BIN anyway, so for them discovery succeeds on the filesystem and only the media comes from the image.
 
 **Extracting the media instead (optional).** If you would rather have loose files on disk (for modding, inspection, or to run without the image), extract them once:
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -24,7 +24,7 @@ LBA File Info omits `video.hqr`; the list below is complete per the source code.
 
 | File | Purpose |
 |------|---------|
-| `lba2.hqr` | Ending credits data |
+| `LBA2.HQR` | Ending credits data |
 | `scene.hqr` | Scripts defining active scene content |
 | `body.hqr` | 3D models of characters |
 | `anim.hqr` | Animations for 3D models |

--- a/docs/LBA1_PORT_PLAN.md
+++ b/docs/LBA1_PORT_PLAN.md
@@ -230,7 +230,7 @@ behaviour selector (LBA1 CTRL+arrows overlay vs **none in LBA2's menu UI**), hol
 single `HOLOMAP.C` vs LBA2's four `HOLO*` modules).
 
 **The keystone is a game-id, which does not exist yet** `[verified-from-code]`:
-`RES_DISCOVERY` only knows `lba2.hqr`; `DistribVersion` is publisher-logo only; `Version` is a
+`RES_DISCOVERY` only knows `LBA2.HQR`; `DistribVersion` is publisher-logo only; `Version` is a
 build string. A `GameId`/`GameProfile` is foundational: it is the **one dispatch point** that
 selects the per-game **native-format asset loaders/resolvers** (the in-engine adaptation of §7
 decision 9: body loader, background grid/block/brick resolver, sprite/palette reader, script VM
@@ -238,7 +238,7 @@ mode), plus the opcode-remap table, asset-name map, menu descriptor, and save sc
 "reading LBA1 assets unmodified" is not a separate mechanism: it *is* the `GameProfile` choosing
 LBA1 loaders. The retail files stay native on disk; only the in-memory structures are shared. **The game-select menu is its natural first
 consumer and belongs to the boot shell, not either game:** boot → `RES_DISCOVERY` finds data →
-if both an LBA1 marker (`lba.hqr`/`ress.hqr`) and `lba2.hqr` are present, show a 2-entry
+if both an LBA1 marker (`lba.hqr`/`ress.hqr`) and `LBA2.HQR` are present, show a 2-entry
 chooser on the existing `DoGameMenu`; single-game installs auto-select (today's LBA2 UX
 preserved); `--game lba1` forces it. This reframes the work as **"an Adeline engine shell that
 discovers data, picks a GameProfile, and runs"**: the north-star at the boot/UX layer.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -73,7 +73,7 @@ directory contains targeted ASM-vs-CPP tests for those low-level cases.
 
 ### 5. Host tests — console (`tests/console`)
 
-`tests/console/test_console_state.cpp` links the `console` library and exercises `SOURCES/CONSOLE/CONSOLE_STATE.CPP`: availability strings (same contract as `console_avail_in_game_scene` in `CONSOLE_CMD.CPP`), legacy video/menu/game labels from `Console_ModeString_FromState` (for tests), and `Console_FormatStatusIslandLine_FromState` (first line of the `status` command: island, cube, chapter; raw values like `cmd_status`, not give-style scene masking). No retail `lba2.hqr` or full engine init.
+`tests/console/test_console_state.cpp` links the `console` library and exercises `SOURCES/CONSOLE/CONSOLE_STATE.CPP`: availability strings (same contract as `console_avail_in_game_scene` in `CONSOLE_CMD.CPP`), legacy video/menu/game labels from `Console_ModeString_FromState` (for tests), and `Console_FormatStatusIslandLine_FromState` (first line of the `status` command: island, cube, chapter; raw values like `cmd_status`, not give-style scene masking). No retail `LBA2.HQR` or full engine init.
 
 `tests/console/test_console_commands.cpp` covers parser/output integration in `SOURCES/CONSOLE/CONSOLE.CPP` using host-only hooks: built-in `help` and `cmdlist`, unknown-command diagnostics, cvar set/get (`fps`), and a registered `status` command path that prints the same status headline format.
 

--- a/tests/discovery/test_res_discovery.cpp
+++ b/tests/discovery/test_res_discovery.cpp
@@ -248,6 +248,16 @@ static bool test_env_lba2_game_dir_common_join() {
                 out, root);
         return false;
     }
+    /* The banner has to name the probe that won, and this is the case that
+     * catches a mislabel: the env branch makes two attempts, so a label set
+     * once for the pair would report the wrong one for whichever hit second. */
+    const char *via = Res_GetDiscoverySource();
+    if (strcmp(via, "LBA2_GAME_DIR, Common/") != 0) {
+        fprintf(stderr,
+                "test_env_lba2_game_dir_common_join: labelled '%s', wanted 'LBA2_GAME_DIR, Common/'\n",
+                via);
+        return false;
+    }
     return true;
 }
 
@@ -308,7 +318,15 @@ static bool test_argv_game_dir() {
     if (!ok || argc != 1) {
         return false;
     }
-    return strstr(out, tmpl_ptr) != NULL;
+    if (strstr(out, tmpl_ptr) == NULL) {
+        return false;
+    }
+    const char *via = Res_GetDiscoverySource();
+    if (strcmp(via, "--game-dir") != 0) {
+        fprintf(stderr, "test_argv_game_dir: labelled '%s', wanted '--game-dir'\n", via);
+        return false;
+    }
+    return true;
 }
 
 /**

--- a/tests/discovery/test_res_discovery.cpp
+++ b/tests/discovery/test_res_discovery.cpp
@@ -205,6 +205,79 @@ static bool test_env_lba2_game_dir() {
     return strstr(out, tmpl_ptr) != NULL;
 }
 
+/* People point LBA2_GAME_DIR at the install root, same as --game-dir, so it
+ * gets the same Common/ join. */
+static bool test_env_lba2_game_dir_common_join() {
+    unsetenv_portable("LBA2_GAME_DIR");
+#ifndef _WIN32
+    char root[] = "/tmp/lba2disc_envc_XXXXXX";
+    if (mkdtemp(root) == NULL) {
+        return false;
+    }
+#else
+    char root[512];
+    if (!make_temp_dir(root, sizeof(root), "envc")) {
+        return false;
+    }
+#endif
+    char common[ADELINE_MAX_PATH + 16];
+    snprintf(common, sizeof(common), "%s/Common", root);
+    if (mkdir_portable(common) != 0) {
+        return false;
+    }
+    create_marker_hqr(common);
+
+    if (setenv_portable("LBA2_GAME_DIR", root) != 0) {
+        return false;
+    }
+
+    char out[ADELINE_MAX_PATH];
+    int argc = 1;
+    char arg0[] = "lba2";
+    char *argv[] = {arg0, NULL};
+    const bool ok = ResolveGameDataDir(out, ADELINE_MAX_PATH, &argc, argv);
+    unsetenv_portable("LBA2_GAME_DIR");
+
+    if (!ok) {
+        fprintf(stderr, "test_env_lba2_game_dir_common_join: did not resolve\n");
+        return false;
+    }
+    if (strstr(out, "Common") == NULL) {
+        fprintf(stderr,
+                "test_env_lba2_game_dir_common_join: got %s, wanted the Common/ inside %s\n",
+                out, root);
+        return false;
+    }
+    return true;
+}
+
+/* A stale LBA2_GAME_DIR must stop the run, not fall through to auto-discovery.
+ * Falling through boots whatever else is lying around: right-looking launch,
+ * assets nobody asked for, exit 0. The caller turns this false into its picker,
+ * or a clean error when headless. */
+static bool test_env_lba2_game_dir_no_fallthrough() {
+    unsetenv_portable("LBA2_GAME_DIR");
+    if (setenv_portable("LBA2_GAME_DIR", "/nonexistent/lba2disc_stale") != 0) {
+        return false;
+    }
+
+    char out[ADELINE_MAX_PATH];
+    int argc = 1;
+    char arg0[] = "lba2";
+    char *argv[] = {arg0, NULL};
+    out[0] = '\0';
+    const bool ok = ResolveGameDataDir(out, ADELINE_MAX_PATH, &argc, argv);
+    unsetenv_portable("LBA2_GAME_DIR");
+
+    if (ok) {
+        fprintf(stderr,
+                "test_env_lba2_game_dir_no_fallthrough: resolved %s from a bad env var\n",
+                out);
+        return false;
+    }
+    return true;
+}
+
 static bool test_argv_game_dir() {
     unsetenv_portable("LBA2_GAME_DIR");
 #ifndef _WIN32
@@ -671,6 +744,12 @@ int main() {
         failed++;
     }
     if (!test_env_lba2_game_dir()) {
+        failed++;
+    }
+    if (!test_env_lba2_game_dir_common_join()) {
+        failed++;
+    }
+    if (!test_env_lba2_game_dir_no_fallthrough()) {
         failed++;
     }
     if (!test_argv_game_dir()) {

--- a/tests/picker/test_res_picker.cpp
+++ b/tests/picker/test_res_picker.cpp
@@ -18,6 +18,8 @@
 
 #include "RES_PICKER.H"
 
+#include "DIRECTORIES.H" /* Directories_GetResMarker: the spelling to quote */
+
 #include <SYSTEM/ANDROID.H>
 #include <SYSTEM/LIMITS.H>
 
@@ -67,11 +69,18 @@ int main(void) {
     check_message("NoPicker", kPickerMsgNoPicker);
     check_message("AndroidData", kPickerMsgAndroidData);
 
-    /* Each message must carry the action it promises. */
-    check(strstr(kPickerMsgDataNotFound, "lba2.hqr") != NULL,
-          "DataNotFound: names lba2.hqr");
-    check(strstr(kPickerMsgInvalidPick, "lba2.hqr") != NULL,
-          "InvalidPick: names lba2.hqr");
+    /* Each message must carry the action it promises.
+     *
+     * Checked against the engine's own marker constant rather than a literal,
+     * and case-sensitively. A player reading "pick the folder with X" goes
+     * looking for exactly X, so the message has to quote the spelling the
+     * engine considers canonical, which is the spelling every distribution
+     * ships. Hard-coding it here let the two drift apart once already. */
+    const char *marker = Directories_GetResMarker();
+    check(strstr(kPickerMsgDataNotFound, marker) != NULL,
+          "DataNotFound: names the resource marker");
+    check(strstr(kPickerMsgInvalidPick, marker) != NULL,
+          "InvalidPick: names the resource marker");
     check(strstr(kPickerMsgNoPicker, "--game-dir") != NULL,
           "NoPicker: offers --game-dir");
     check(strstr(kPickerMsgNoPicker, "LBA2_GAME_DIR") != NULL,


### PR DESCRIPTION
Three things that all came out of asking why the boot messages disagreed with reality. Independent commits, reviewable one at a time.

Part 1 of #113.

## 1. The marker file is named `LBA2.HQR`, not `lba2.hqr`

`No valid game data directory (need lba2.hqr)` quotes a filename nobody has. Steam, both GOG builds and the Twinsen's Odyssey disc all ship `LBA2.HQR`.

It matters because that message is what a player reads when the engine cannot find their game, and it answers a question they did not ask. Discovery fails for real reasons: wrong folder, no `Common/` inside it, a stale env var. On a case-sensitive filesystem the reader sees `LBA2.HQR` on disk, believes the case is the problem, and renames it. That *works*, because the lower-case probe still matches, which is the worst available outcome: it confirms a wrong diagnosis and leaves the real cause untouched.

The engine also contradicted itself. Two errors reachable in one session said `no LBA2.HQR in it` and `need lba2.hqr`; the picker said lower-case three times while `PERSO`'s hint said upper.

`Discover` probes as-is, upper, lower and title case, so feeding it the upper-case name accepts exactly the same set. Verified: of six spellings on disk, the same three are found and the same three rejected, and all four installs still resolve. What changes is that the as-is probe is the one that hits on a real install, and the name the code calls canonical is a name that exists.

`tests/picker` asserted the literal, so it failed on the message change, correctly. It now checks against `Directories_GetResMarker()`, since a hard-coded copy is what let the two drift apart.

## 2. A stale `LBA2_GAME_DIR` could boot somebody else's install

```
--game-dir      ../LBA2  ->  ../LBA2/Common/
LBA2_GAME_DIR   ../LBA2  ->  /home/user/code/lba-hacking/LBA2-GOG/
```

The env var did not get the `Common/` join, and when it missed it fell through to the rest of the probe list. It named a Steam install; the engine booted a GOG one found by the sibling scan, reported only in the `Assets:` line, exit 0.

`--game-dir` already refuses this, and its comment gives the reason: falling through "would boot a DIFFERENT install than the one asked for and say so only in the banner". All of that applies to the env var and more so, because an env var gets exported in a shell profile and forgotten while a flag is retyped each run.

The env branch now mirrors the CLI one: path, then `path/Common`, then stop. Stopping hands the caller its picker on a desktop, or a clean error when headless.

Both new tests fail without the fix, and they fail by resolving to `LBA2-GOG` — the bug stated as an assertion.

## 3. The banner says which probe matched

```
Assets: ../LBA2/Common/                     (--game-dir, Common/)
Assets: ../TWINSEN/                         (LBA2_GAME_DIR)
Assets: /home/user/lba-hacking/LBA2-GOG/    (sibling scan)
```

Thirteen probes run in priority order and none of them says anything, so "picked the wrong install" and "ignored what I set" produce identical output. #113 exists because a forgotten `LBA2_GAME_DIR` outranked `--pick-game-dir` and the picker looked broken; item 2 above is the same variable losing silently in the other direction.

One parenthetical on a line that already exists. No new lines, nothing printed when the label is empty, no-data exit path untouched (verified: same three errors, no banner, exit 1).

The label is set before each attempt rather than on success, so no helper signature changes and nothing has to be threaded through `NormalizeAndTry`. The two-attempt probes are split into two labelled attempts rather than one `||` chain, which is the case a single label per branch would report wrongly, and the test pins exactly that.

## Verification

- 50/50 host tests, no new warnings.
- `dist_check` byte-identical across all three retail installs.
- All four installs resolve from their root: Steam, GOG DRM-free, GOG installed (Windows), Twinsen's Odyssey rip.
- Case matrix unchanged: three spellings accepted, three rejected, same three as before.

## Not included

Case-folding directory lookup. I proposed it, then went looking for evidence and found none: no discovery-failure reports across 97 issues, and every supported install already resolves. It would serve users who have hand-renamed files into a spelling no distribution ships, at the cost of new code in the boot path and a tiebreak rule for `lba2.hqr` and `LBA2.HQR` sitting side by side. Not worth it.

`CommonClassic` in the sibling probe holds `Images Texts Voices` and no marker in every install I have, so it can never match. Left alone here; it is a data point for #113's Part 2 audit rather than a change to make mid-stream.
