### PR TITLE
docs: name the HQR files the way they ship, and write the casing rule down

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,8 @@ Apply these behavior rules on every non-trivial task:
 
 Style rules and rationale (language dialect, indentation, types, C++98, preservation) live in [CODESTYLE.md](CODESTYLE.md) — read it before writing engine code. The agent-critical invariant: **ported original code stays C-style to mirror the ASM; new infrastructure with no ASM original may use conservative C++98 features.** Never modernize game code (see the Never list). When unsure, match the file you are editing.
 
+**Resolving an asset path: never hand-roll filename spellings.** Retail files are uppercase while the engine asks in lower case, and the only thing bridging that is `Discover` in [SOURCES/DIRECTORIES.CPP](SOURCES/DIRECTORIES.CPP), which probes as-is, upper, lower and title case. Build every asset path through `GetResPath` / `GetJinglePath` / `GetMoviePath` / `GetVoicePath` so it inherits those probes. Writing your own `snprintf` of a candidate name works on the install you tested and silently misses on another: `STREAM.CPP`'s `track<N>.ogg` fallback hand-rolls two spellings and loses every theme track on an all-uppercase install while the jingles keep playing, which reads as "some music is missing" rather than a filename problem.
+
 Formatting mechanics (agent-operational):
 
 - Formatting: clang-format with checked-in `.clang-format`; exclusions live in `.clang-format-ignore` (ASM, `LIB386/libsmacker/`, vendored `stb_*`, and a handful of legacy lookup-table files). When adding vendored third-party code or generated/hand-tuned lookup tables, add the path to `.clang-format-ignore` in the same commit — single source of truth for local scripts, CI, and the pre-commit hook.
@@ -134,6 +136,9 @@ For tone and engineering principles, see [CONTRIBUTING.md "Doing good work here"
 
 **Accuracy (always pair with formatting):**
 
+- Retail asset files are **UPPERCASE**: `LBA2.HQR`, `RESS.HQR`, `TEXT.HQR`, and so on, in every distribution (Steam, both GOG builds, the retail disc). Name them that way in docs, in user-facing strings, and in shell commands a reader will paste. Lower case is easy to type and names a file nobody has, which sends a stuck player renaming files instead of fixing the real problem. Two deliberate exceptions, both kept lower case on purpose: the token list in [docs/RELEASING.md](docs/RELEASING.md) that exists to show grep false positives, and LBA1 markers in [docs/LBA1_PORT_PLAN.md](docs/LBA1_PORT_PLAN.md).
+- Quoting a C identifier or string literal is different from naming a file. `HQR_NAMES.H` spells its constants lower case (`RESS_HQR_NAME "ress.hqr"`), and a doc quoting that source should match the source. Upper case is for "this file is on your disk"; the literal's own case is for "this is what the code says".
+- Directory names have no single truth, so leave them alone: Steam ships `Music/` but `VIDEO/` and `VOX/`, and other installs differ. Case discovery handles it.
 - Verify file paths, line numbers, function names, and command flags against the working tree before believing them.
 - From `docs/`, links to `SOURCES/` or `LIB386/` need the `../` prefix (`[…](../SOURCES/X.CPP)`). Common breakage spot.
 - Cross-check claims about CMake options, presets, and CI workflows against `CMakeLists.txt`, `CMakePresets.json`, and `.github/workflows/`.

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -96,7 +96,7 @@ it survives an uninstall/reinstall:
 
 ```bash
 adb push LBA2.HQR /sdcard/lba2cc/
-adb push ress.hqr /sdcard/lba2cc/
+adb push RESS.HQR /sdcard/lba2cc/
 # ...and the rest of your retail HQR set
 ```
 

--- a/docs/BOOT_LOG_PLAN.md
+++ b/docs/BOOT_LOG_PLAN.md
@@ -433,14 +433,14 @@ Decisions:
 - **Asset preflight** — dedicated module `SOURCES/ASSET_PREFLIGHT.{H,CPP}`
   (`int AssetPreflight()`), called from `main` after `InitDirectories`/`Log_Init`,
   before any heavy load. Checks each expected asset with the **correct
-  per-category resolver**: root `.hqr` via `GetResPath`, `video.hqr` via
+  per-category resolver**: root `.hqr` via `GetResPath`, `VIDEO.HQR` via
   `GetMoviePath` (it lives in `video/`, not the root — `GetResPath` gave a false
   "missing"), and the `music/` and `vox/` subtrees via
   `GetJinglePath`/`GetVoicePath` (subtree presence — those are per-track /
   per-language collections the audio modules enumerate). Case-folding discovery
   handles `VIDEO/`/`Music/`/`VOX/`.
 - **Classification by actual boot-fatality.** Required = the root HQRs **and
-  `video.hqr`** (loaded at boot by `InitAcf`, which hard-fails without it today).
+  `VIDEO.HQR`** (loaded at boot by `InitAcf`, which hard-fails without it today).
   Optional = `holomap`/`scene`/`screen`/`lba_bkg`/`music`/`vox` (loaded on
   demand; missing only matters if that feature is used).
 - **Fail fast.** `AssetPreflight` returns the missing-*required* count; `main`
@@ -450,10 +450,10 @@ Decisions:
   load, and exits **non-zero** (unlike `TheEndCheckFile`, which exits 0).
   Optional missing → `Log_Warn`, boot continues, `Assets N missing (0 required)`.
   (Making the optional set degrade gracefully *at use time* — e.g. skip cutscenes
-  when `video.hqr` is absent, which would move it back to optional — is PR B.)
+  when `VIDEO.HQR` is absent, which would move it back to optional — is PR B.)
 - **Test:** `tests/asset_preflight/` (integration; builds a fake game tree,
   links DIRECTORIES + sys + SDL like `tests/discovery`) asserts the
-  required/optional verdicts, the fail-fast count, and the `video.hqr`-in-`video/`
+  required/optional verdicts, the fail-fast count, and the `VIDEO.HQR`-in-`video/`
   resolver (the regression that shipped once). The `*_HQR_NAME` defines were
   split into `SOURCES/HQR_NAMES.H` so the module + test skip the `C_EXTERN.H`
   prelude.
@@ -470,7 +470,7 @@ Decisions:
   budget (`MaxIndex = maxrsrc`), not the file's entry count; real counts need an
   HQR-header reader — deferred. The preflight presence check covers verification.
 - Graceful runtime degradation for missing optional assets (don't crash on
-  `video.hqr` at cutscene time) is **PR B**, separate from this shape work.
+  `VIDEO.HQR` at cutscene time) is **PR B**, separate from this shape work.
 
 ### Phase 6 — Exit screen module — done
 

--- a/docs/ENGINE_GAME_INTERFACE.md
+++ b/docs/ENGINE_GAME_INTERFACE.md
@@ -114,7 +114,7 @@ Each opcode body calls engine C functions directly. Categories:
 
 **Storage:** scripts are not a dedicated resource — they are embedded inline in the
 per-cube scene blob. `LoadScene(numscene)` (`SOURCES/DISKFUNC.CPP:50`) loads the scene from
-`scene.hqr` into `PtrScene`, then walks the blob with a byte cursor, reading for the hero
+`SCENE.HQR` into `PtrScene`, then walks the blob with a byte cursor, reading for the hero
 and each object a length-prefixed Track stream then a Life stream:
 
 ```c

--- a/docs/FEATURE_WORKFLOW.md
+++ b/docs/FEATURE_WORKFLOW.md
@@ -66,7 +66,7 @@ Truth hierarchy: code > this document > external sources.
    - `BuildGameMainMenu` — filters by runtime state
    - `GameOptionMenu` — Options submenu (text IDs 11–47)
    - `DoGameMenu` — generic driver; handles sliders (type 2–7)
-   - Text IDs from `text.hqr`; need to add new string if new label
+   - Text IDs from `TEXT.HQR`; need to add new string if new label
 
 4. **Docs to update:**
    - MENU.md — update menu tree, add new entry to Options if applicable

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -14,32 +14,32 @@ Truth hierarchy: code > this document > external sources.
 | BufCube | Collision grid | 64x64x25 cell grid loaded per interior scene. Each cell holds a collision value. | `SOURCES/GRILLE.CPP` | -- |
 | Zone | Trigger zone | Axis-aligned bounding box that triggers an action when the hero enters it. | `SOURCES/COMMON.H` (`T_ZONE`), `SOURCES/OBJECT.CPP` (`CheckZoneSce`) | -- |
 | Zone type | -- | Numeric 0-9 (`MAX_TYPES_ZONE=10`). Type 0 = cube change, type 1 = camera, type 6 = ladder. No named constants in source. | `SOURCES/COMMON.H`, `SOURCES/OBJECT.CPP` | -- |
-| HQR | -- | Archive file format used for all game resources. | `SOURCES/COMMON.H` (file name constants) | [LBA File Info](https://lbafileinfo.kaziq.net/index.php/LBA_2_files) (incomplete; missing video.hqr) |
+| HQR | -- | Archive file format used for all game resources. | `SOURCES/COMMON.H` (file name constants) | [LBA File Info](https://lbafileinfo.kaziq.net/index.php/LBA_2_files) (incomplete; missing VIDEO.HQR) |
 
 ## HQR resource files
 
 Purposes sourced from [LBA File Info](https://lbafileinfo.kaziq.net/index.php/LBA_2_files),
 verified against `#define` constants in `SOURCES/COMMON.H` (lines 66-80).
-LBA File Info omits `video.hqr`; the list below is complete per the source code.
+LBA File Info omits `VIDEO.HQR`; the list below is complete per the source code.
 
 | File | Purpose |
 |------|---------|
 | `LBA2.HQR` | Ending credits data |
-| `scene.hqr` | Scripts defining active scene content |
-| `body.hqr` | 3D models of characters |
-| `anim.hqr` | Animations for 3D models |
-| `anim3ds.hqr` | 3DS-format animations |
-| `objfix.hqr` | 3D models of fixed objects |
-| `samples.hqr` | Sound samples (excluding voices) |
-| `text.hqr` | In-game dialogue text |
-| `screen.hqr` | Full-screen images |
-| `sprites.hqr` | Compressed sprites; see [MENU.md](MENU.md) for **`SPRITE_CURSOR`** (173) and the menu pointer |
-| `spriraw.hqr` | Raw-format sprites |
-| `ress.hqr` | Miscellaneous resources |
-| `lba_bkg.hqr` | Isometric background maps, bricks, objects |
-| `holomap.hqr` | Holomap data and textures |
-| `video.hqr` | Video/cinematic data |
-| `scrshot.hqr` | Demo screenshot images |
+| `SCENE.HQR` | Scripts defining active scene content |
+| `BODY.HQR` | 3D models of characters |
+| `ANIM.HQR` | Animations for 3D models |
+| `ANIM3DS.HQR` | 3DS-format animations |
+| `OBJFIX.HQR` | 3D models of fixed objects |
+| `SAMPLES.HQR` | Sound samples (excluding voices) |
+| `TEXT.HQR` | In-game dialogue text |
+| `SCREEN.HQR` | Full-screen images |
+| `SPRITES.HQR` | Compressed sprites; see [MENU.md](MENU.md) for **`SPRITE_CURSOR`** (173) and the menu pointer |
+| `SPRIRAW.HQR` | Raw-format sprites |
+| `RESS.HQR` | Miscellaneous resources |
+| `LBA_BKG.HQR` | Isometric background maps, bricks, objects |
+| `HOLOMAP.HQR` | Holomap data and textures |
+| `VIDEO.HQR` | Video/cinematic data |
+| `SCRSHOT.HQR` | Demo screenshot images |
 
 ### ILE/OBL pairs (exterior island surfaces)
 

--- a/docs/IMPACT_SCRIPTS.md
+++ b/docs/IMPACT_SCRIPTS.md
@@ -9,13 +9,13 @@ Life (`LM_*`) and Track (`TM_*`) scripts. Reversed during the input-replay resea
 
 The reference graph is fully resolved: an IMPACT command points at a FLOW (`flow=N`), a POF
 (`pof=N`), or a sprite/sample/body — all by index. FLOW and POF are reversed below; sprite,
-sample, and body indices address `sprites.hqr`, `samples.hqr`, and `body.hqr` respectively.
+sample, and body indices address `SPRITES.HQR`, `SAMPLES.HQR`, and `BODY.HQR` respectively.
 
 ## Runtime
 
 `DoImpact(num, x, y, z, owner)` (`SOURCES/IMPACT.CPP`) executes impact `num` at world position
 `(x,y,z)`, walking a compiled command stream and spawning the effects. The compiled blob is
-loaded once from `ress.hqr` resource **`RESS_IMPACT` (47)** into `BufferImpact`
+loaded once from `RESS.HQR` resource **`RESS_IMPACT` (47)** into `BufferImpact`
 (`PERSO.CPP:2592`). The `THROW`/`FLOW` commands feed the extra/particle systems
 (`ThrowExtra*`, `CreateExtraParticleFlow`, `InitExtraPof`); `SAMPLE` plays a positional sound;
 `SPRITE` spawns an animated sprite. The editor-only `CompileImpact()` turns human-readable
@@ -51,7 +51,7 @@ Operand layouts (`h` = s16, `i` = s32, `B` = u8), taken from `DoImpact`'s runtim
 
 ## The shipped impacts (retail data)
 
-The retail `ress.hqr` blob is 2160 bytes, **42 impacts** (slot 42 empty). Command frequency:
+The retail `RESS.HQR` blob is 2160 bytes, **42 impacts** (slot 42 empty). Command frequency:
 `THROW_OBJ` 56, `SAMPLE` 34, `FLOW` 25, `FLOW_SPRITE` 20, `SPRITE` 13, `FLOW_OBJ`/`FLOW_POF` 8
 each, `THROW` 8, `THROW_POF` 3. They read as hit/explosion effects — e.g. impact 0 plays a
 sound, emits a sprite flow and two particle flows, hurls seven copies of body 62 (debris) at
@@ -60,7 +60,7 @@ varied angles/speeds, and finishes with an animated sprite.
 ## Tooling
 
 - `scripts/dev/hqr_inspect.py <hqr> --entry 47 --dump impact.bin` — extract + decompress the
-  blob from `ress.hqr`.
+  blob from `RESS.HQR`.
 - `scripts/dev/impact_disasm.py impact.bin` — disassemble all impacts.
 - `scripts/dev/impact_disasm.py impact.bin --check` — round-trip: reassemble and verify
   **byte-identical** to the original. This passes on the retail blob, which proves the codec is
@@ -70,7 +70,7 @@ varied angles/speeds, and finishes with an animated sprite.
 ## FLOW — particle-emitter definitions (`RESS_FLOW` = 45)
 
 The `FLOW`/`FLOW_SPRITE`/`FLOW_OBJ`/`FLOW_POF` commands above reference a particle emitter by
-index. Those emitters live in `ress.hqr` resource **`RESS_FLOW` (45)**, loaded raw by `Load_HQR`
+index. Those emitters live in `RESS.HQR` resource **`RESS_FLOW` (45)**, loaded raw by `Load_HQR`
 into `TabPartFlow` (`FLOW.CPP:112`) — a **flat array of `T_FLOW`**, no offset table, so flow `N`
 is simply the Nth record. `CreateParticleFlow`/`CreateExtraParticleFlow` instantiate it.
 
@@ -96,7 +96,7 @@ flow 81 (wide cone, 56 dots) and flow 55 (narrow, 4 dots).
 
 `THROW_POF`/`FLOW_POF` reference a POF by index. A POF is a small **2D point-and-line wireframe**
 (a spark/star/debris outline) drawn scaled and rotated in screen space by `PofDisplay3DExt`
-(`SOURCES/POF.CPP`); `InitExtraPof` spawns a flying extra that renders it. The blob (`ress.hqr`
+(`SOURCES/POF.CPP`); `InitExtraPof` spawns a flying extra that renders it. The blob (`RESS.HQR`
 resource **`RESS_POF` (46)**, loaded raw into `BufferPof`, `PERSO.CPP:2588`) uses the same
 container as IMPACT: a U32 offset table (count = first/4), each slot a byte offset to a POF.
 

--- a/docs/INPUT_REPLAY_RESEARCH.md
+++ b/docs/INPUT_REPLAY_RESEARCH.md
@@ -90,7 +90,7 @@ offset of entry 0, so `entries = first/4`); each slot is a byte offset to a
 LZSS, 2 LZMIT) followed by the data. `scripts/dev/hqr_inspect.py` enumerates and decompresses
 entries (LZSS ported from `LZ.CPP`, verified: decompressed sizes match headers).
 
-`scene.hqr` holds **224 cube slots, entry N = cube N**; cube 193 is 1022 bytes (LZSS).
+`SCENE.HQR` holds **224 cube slots, entry N = cube N**; cube 193 is 1022 bytes (LZSS).
 
 **Scene resource layout** (`DISKFUNC.CPP`): an ambiance/sample/jingle header, then `HERO_START`
 (`CubeStartX/Y/Z`, then the hero's **Track script** and **Life script**, each `s16`-size-prefixed),

--- a/docs/MENU.md
+++ b/docs/MENU.md
@@ -71,9 +71,9 @@ Flow: `RealGameMainMenu` (template) → `BuildGameMainMenu(firstloop)` → `Game
 
 ## Submenus
 
-- **Options** (`OptionsMenu`): top-level submenu for Sound volume, Choose language, Advanced options, and Keyboard Config. Reuses original `text.hqr` labels where they already exist and keeps custom localized labels only for the new submenu concepts. Calls `GereVolumeMenu()`, `GereLanguageMenu()`, `GereAdvancedOptionsMenu()`, and `MenuConfig()`. Calls `SetDetailLevel()` on exit.
+- **Options** (`OptionsMenu`): top-level submenu for Sound volume, Choose language, Advanced options, and Keyboard Config. Reuses original `TEXT.HQR` labels where they already exist and keeps custom localized labels only for the new submenu concepts. Calls `GereVolumeMenu()`, `GereLanguageMenu()`, `GereAdvancedOptionsMenu()`, and `MenuConfig()`. Calls `SetDetailLevel()` on exit.
 - **Volume** (`GereVolumeMenu`): `VolumeMenuVoice` / `VolumeMenuNoVoice` depending on `FlagSpeak`. Sliders for Sample, Voice, Music, and General volume. Persisted via [CONFIG.md](CONFIG.md).
-- **Language** (`GereLanguageMenu`): cycles text language and voice language independently. Text changes reload `text.hqr` immediately; voice changes update the active `LanguageCD` setting.
+- **Language** (`GereLanguageMenu`): cycles text language and voice language independently. Text changes reload `TEXT.HQR` immediately; voice changes update the active `LanguageCD` setting.
 - **Advanced options** (`GereAdvancedOptionsMenu`): toggles stereo handling, movie cameras, follow camera, video playback size, window fullscreen mode, and subtitle display; includes the existing Detail Level slider.
 - **Save/Load** (`SavedGameManagement`, `ChoosePlayerName`): Player name selection, save slots, `GameChoiceMenu[]`, `SavedConfirmMenu[]` for delete
 - **Keyboard config** (`MenuConfig`): standalone config tool in [SOURCES/CONFIG/](../SOURCES/CONFIG/) or in-game `ReadInputConfig`/`WriteInputConfig`
@@ -82,7 +82,7 @@ Flow: `RealGameMainMenu` (template) → `BuildGameMainMenu(firstloop)` → `Game
 
 - `U16 *ptrmenu`: `[selected, nb_entries, y_center, dia_num, (type, text_id)*]`
 - `DrawGameMenu()`, `DoGameMenu()` in GAMEMENU.CPP (lines 1760, 1823)
-- Text IDs from `text.hqr` / dialogue system (`GetMultiText`), plus synthetic IDs (e.g. `MENU_ID_*` in the 2100 range) resolved in `BuildCustomMenuText()`
+- Text IDs from `TEXT.HQR` / dialogue system (`GetMultiText`), plus synthetic IDs (e.g. `MENU_ID_*` in the 2100 range) resolved in `BuildCustomMenuText()`
 - Type in each entry: 0 = plain text/toggle, 2–6 = volume sliders, 7 = Detail Level slider, 8 = text language cycle, 9 = voice language cycle
 
 ## Menu layout
@@ -116,18 +116,18 @@ The main menu still uses only the six template actions (70–75). Options (74) a
 
 The reworked Options screen uses two sources of copy, by design:
 
-- **`text.hqr` via `GetMultiText`** — Original dialogue IDs for volume, stereo, movie camera, video size, subtitles, and other strings that already existed in the retail game.
+- **`TEXT.HQR` via `GetMultiText`** — Original dialogue IDs for volume, stereo, movie camera, video size, subtitles, and other strings that already existed in the retail game.
 - **In-code `LocalizedMenuLabels`** in [SOURCES/MENU_LABELS.CPP](../SOURCES/MENU_LABELS.CPP): UTF-8 strings, converted with `CopyUtf8ToCp850` / `FormatUtf8ToCp850` for the menu font. The table is **one row per label**, each row carrying its own enum id plus all six translations; the column follows `Language` (same index as the UI language). Used for new submenu titles (“Choose language”, “Advanced options”, …), the display fullscreen OFF/ON lines, and the key-config footer. Its contract (id equals index, no missing translation, matching printf specifiers across languages) is pinned by [tests/menu_labels](../tests/menu_labels).
 
-When the player changes UI language, `ReloadMultiTextFile` refreshes `text.hqr` strings and the `LocalizedMenuLabels` index updates together, so both layers stay aligned.
+When the player changes UI language, `ReloadMultiTextFile` refreshes `TEXT.HQR` strings and the `LocalizedMenuLabels` index updates together, so both layers stay aligned.
 
 The “Texts:” / “Voices:” lines format `GetLocalizedMenuLabel` with `GetLanguageName(Language)` / `GetLanguageName(LanguageCD)` — i.e. the canonical names from `TabLanguage[]` (English, Français, …), not per-locale translations of those names.
 
-Adding a new UI language requires both the usual `text.hqr` coverage and a new translation column in every row of `LocalizedMenuLabels`. See [TEXT.md](TEXT.md) for why the `text.hqr` half of that is the hard part.
+Adding a new UI language requires both the usual `TEXT.HQR` coverage and a new translation column in every row of `LocalizedMenuLabels`. See [TEXT.md](TEXT.md) for why the `TEXT.HQR` half of that is the hard part.
 
 For voice lines and packaged assets, see [GLOSSARY.md](GLOSSARY.md) and [CONFIG.md](CONFIG.md) (`Language`, `LanguageCD`).
 
-For the text engine underneath all of this (the `text.hqr` format, id resolution, fonts and codepages, the dialogue machine), see [TEXT.md](TEXT.md).
+For the text engine underneath all of this (the `TEXT.HQR` format, id resolution, fonts and codepages, the dialogue machine), see [TEXT.md](TEXT.md).
 
 ## Implementation notes
 
@@ -136,7 +136,7 @@ For the text engine underneath all of this (the `text.hqr` format, id resolution
 - **DEMO build**: Save/Load (72, 73) are disabled (greyed out, skipped by Up/Down). After ~50 min idle (or Shift+D), `SlideShow()` runs; returns `9999` to trigger credits.
 - **Volume sliders**: Type 2–6 map to globals; left/right adjust with `VOLUME_TIMER_KEY` (5 ticks) debounce. Sample and General volume sliders play random SFX preview when focused.
 - **DetailLevel → Shadow**: `SetDetailLevel()` (GAMEMENU.CPP line 458) derives Shadow, RainEnable, MaxPolySea, FlagDrawHorizon from DetailLevel. Shadow in config is read at startup but overwritten when leaving Options.
-- **Localized custom labels**: See "Mixed localization (new Options strings)" above — split between `text.hqr` and `LocalizedMenuLabels` / CP850.
+- **Localized custom labels**: See "Mixed localization (new Options strings)" above — split between `TEXT.HQR` and `LocalizedMenuLabels` / CP850.
 - **Options entry count**: Top-level `GameOptionMenu[1]` is 5 in `OptionsMenu()`. Nested volume/language/advanced menus set their own entry counts per `DEMO` / `FlagSpeak` / CDROM.
 
 ## Limitations
@@ -168,9 +168,9 @@ Set `MenuMouse: 0` in `lba2.cfg` for keyboard/joystick-only menus.
 
 ### Why the menu pointer matches the game (`SPRITE_CURSOR`)
 
-Retail LBA2 almost never needed a mouse in the main menus (keyboard/joystick first), so the shipped menus used a tiny embedded bitmap (`BinGphMouse` in the engine). Separately, the data tables in [SOURCES/COMMON.H](../SOURCES/COMMON.H) already name a `SPRITE_CURSOR` index (173) next to other UI chrome (`SPRITE_DISK`, ardoise corners, etc.). That entry lives in `sprites.hqr` and was meant for in-game UI pointer use, not for the classic menu loop—easy to miss if you never played with the mouse in contexts that draw it.
+Retail LBA2 almost never needed a mouse in the main menus (keyboard/joystick first), so the shipped menus used a tiny embedded bitmap (`BinGphMouse` in the engine). Separately, the data tables in [SOURCES/COMMON.H](../SOURCES/COMMON.H) already name a `SPRITE_CURSOR` index (173) next to other UI chrome (`SPRITE_DISK`, ardoise corners, etc.). That entry lives in `SPRITES.HQR` and was meant for in-game UI pointer use, not for the classic menu loop—easy to miss if you never played with the mouse in contexts that draw it.
 
-The community menu mouse path simply loads `HQR_Get(HQRPtrSprite, SPRITE_CURSOR)` ([SOURCES/DEFINES.H](../SOURCES/DEFINES.H) → `MENU_MOUSE_SPRITE_HQR_INDEX`). So the pointer is original art already on the disc; we are not inventing new pixels. If `sprites.hqr` is missing or the entry fails to load, [SOURCES/GAMEMENU_MOUSE.CPP](../SOURCES/GAMEMENU_MOUSE.CPP) falls back to `BinGphMouse` like the DOS build.
+The community menu mouse path simply loads `HQR_Get(HQRPtrSprite, SPRITE_CURSOR)` ([SOURCES/DEFINES.H](../SOURCES/DEFINES.H) → `MENU_MOUSE_SPRITE_HQR_INDEX`). So the pointer is original art already on the disc; we are not inventing new pixels. If `SPRITES.HQR` is missing or the entry fails to load, [SOURCES/GAMEMENU_MOUSE.CPP](../SOURCES/GAMEMENU_MOUSE.CPP) falls back to `BinGphMouse` like the DOS build.
 
 **Implementation:** [SOURCES/GAMEMENU_MOUSE.CPP](../SOURCES/GAMEMENU_MOUSE.CPP), [SOURCES/GAMEMENU.CPP](../SOURCES/GAMEMENU.CPP) (`DoGameMenu`, `ChoosePlayerName`).
 


### PR DESCRIPTION
Follow-up to #469, which fixed the marker filename in the engine's own messages and left the rest of the documentation half-converted.

Every retail asset ships uppercase. Measured across Steam, both GOG builds and the disc: `LBA2.HQR`, `RESS.HQR`, `TEXT.HQR`, `SCENE.HQR`, all of them. No distribution ships a lower-case one.

The docs were split roughly down the middle, often inside a single file:

| file | docs said lower | docs said upper |
| --- | --- | --- |
| `TEXT.HQR` | 11 | 14 |
| `RESS.HQR` | 8 | 2 |
| `VIDEO.HQR` | 8 | 5 |
| `SCENE.HQR` | 3 | 11 |

`GLOSSARY.md` was the sharpest case, and my own doing: its asset table lists files on disk, and #469 left exactly one uppercase row among fifteen lower-case ones.

## What changed

45 mentions across eight files. The one that can waste someone's time is `ANDROID.md`, where `adb push ress.hqr /sdcard/lba2cc/` is a command to paste and the file in their hand is `RESS.HQR`.

Two deliberately left alone:

- `RELEASING.md` — its mention is a list of lower-case tokens that produce grep false positives when renaming the binary. Upper-casing it destroys the point.
- `LBA1_PORT_PLAN.md` — LBA1 markers, whose shipped case I have not surveyed. Different game, not my claim to make.

## Reviewed, not swept

A blanket replace is the mistake this project already has a scar from, so every changed line was checked. Nothing on a line quoting a C identifier or literal moved: `HQR_NAMES.H` spells its constants lower case (`RESS_HQR_NAME "ress.hqr"`), and a doc quoting source should match the source.

The rule, now written down in AGENTS.md:

- **Upper case** when naming a file on the reader's disk.
- **The literal's own case** when quoting what the code says.
- **Leave directories alone** — they have no single truth. Steam alone ships `Music/` beside `VIDEO/` and `VOX/`.

## Also in AGENTS.md: the code-side rule

Case tolerance lives in exactly one place, `Discover`, which probes as-is / upper / lower / title. Any path built without it is a latent case bug. The live example is `STREAM.CPP`'s `track<N>.ogg` fallback, which hand-writes two spellings and therefore loses every theme track on an all-uppercase install while jingles keep playing. That reads as "some music is missing" rather than a filename problem. Not fixed here; it is a behaviour defect and wants its own change.

Docs and AGENTS.md only. No code, no tests, no build impact.
