### PR TITLE
feat(tools): extract a playable game-data folder from a disc, drive included

### DIFF
--- a/docs/DISC_IMAGE_SOURCE.md
+++ b/docs/DISC_IMAGE_SOURCE.md
@@ -425,8 +425,30 @@ deliberately does not serve, not as an alternative to mounting. A `bin`+`cue` al
 and extracting it costs 535 MB to gain nothing.
 
 What it is for is a physical disc, whose themes the engine will not read (below), and a container
-that mounts data-only. Rip the audio with any tool and the script names the files; it takes the
-track number from the filename, so `track02.cdda.wav` and `Track 2.wav` both land right.
+that mounts data-only. Either rip the audio with any tool and let the script name the files, taking
+the track number from the filename so `track02.cdda.wav` and `Track 2.wav` both land right, or hand
+it the drive with `--from-drive` and let it read the disc itself.
+
+`--from-drive` reads the table of contents and the audio sectors directly: `IOCTL_CDROM_READ_TOC`
+and `IOCTL_CDROM_RAW_READ` on Windows, `CDROMREADTOCENTRY` and `CDROMREADAUDIO` on Linux. Reads are
+chunked at 27 sectors, which is the ATAPI ceiling of 63504 bytes; 64 comes back as "the parameter is
+incorrect". The Windows path is verified end to end against a real mixed-mode disc, the Linux one is
+written from the kernel headers with the struct layouts checked against the compiler but never run
+against a device, and macOS has no backend and says so.
+
+The one thing a table of contents cannot express that a cue can is where the music actually starts.
+The data track's run-out bleeds into the front of the first audio track, five sectors of it on the
+US disc, and a drive hands that back as audio. So the script finds the join by distribution rather
+than level: data read as audio is uniform noise averaging half of full scale, where the music after
+it averages 0.005. The trim only engages when the first sector is at or above a quarter of full
+scale, which no music reaches, so a track that merely starts loud is left alone. Run against the
+retail disc it independently lands on the same sector the corrected cue names by hand, and touches
+none of the other five tracks.
+
+Where this leaves quality: audio sectors carry no error correction, so a damaged disc gives clicks
+that `cdparanoia` would re-read and interpolate away and this will not. That is the price of no
+dependency, it is bounded, and the retry count is printed so it is visible rather than silent. A
+disc that reports retries is a disc to rip properly and bring back through `--tracks-from`.
 
 The naming is the whole contribution. A ripper knows track numbers and nothing else; that track 6
 holds `JADPCM01` rather than `TADPCM6` is this repo's finding, from the disc's own table of
@@ -460,8 +482,14 @@ place.
   backends (`IOCTL_CDROM_RAW_READ`, `CDROMREADAUDIO`, and something for macOS). Both are a lot of
   surface for the one player who has a physical disc and will not rip it, when a single pass through
   any imaging tool puts them on a path that already works end to end. That player now has a second
-  route as well: keep playing off the mounted disc and rip only the audio, which
-  `disc_extract.py --tracks-from` names into place (above).
+  route as well: keep playing off the mounted disc and take the themes off it once with
+  `disc_extract.py --from-drive` (above).
+
+  Note what that does *not* change. The extraction happening in a script is exactly why it is
+  allowed to be a dependency-free best effort: it runs once, its output is checked by ear, and a bad
+  read is visible as a retry count. The same code inside the engine would sit in the audio path,
+  where it would have to be right every time, on every drive, with no chance to inspect the result.
+  The shape carved out below is still the shape.
 
   If it is ever wanted, the shape is carved out: a fourth source at the tail of
   `PlayStreamInternal`, using the same `CDTRACKS` mapping, with the table of contents read from the

--- a/docs/DISC_IMAGE_SOURCE.md
+++ b/docs/DISC_IMAGE_SOURCE.md
@@ -417,6 +417,29 @@ not good enough when the failure mode is full-scale noise), and editing a cue to
 much work as converting the image properly. If a second sample ever turns up, this is a small
 change with the arithmetic already checked.
 
+## Extraction
+
+`scripts/dev/disc_extract.py` writes a rip out to loose files: the asset root's subtree, plus the
+Red Book tracks cut into `music/TADPCM2.WAV` and friends. It exists for the shapes the engine
+deliberately does not serve, not as an alternative to mounting. A `bin`+`cue` already plays whole,
+and extracting it costs 535 MB to gain nothing.
+
+What it is for is a physical disc, whose themes the engine will not read (below), and a container
+that mounts data-only. Rip the audio with any tool and the script names the files; it takes the
+track number from the filename, so `track02.cdda.wav` and `Track 2.wav` both land right.
+
+The naming is the whole contribution. A ripper knows track numbers and nothing else; that track 6
+holds `JADPCM01` rather than `TADPCM6` is this repo's finding, from the disc's own table of
+contents. So the script carries a copy of the `CDTRACKS.CPP` table, and `tests/cdtracks` reads both
+and fails if they disagree. A drift there would be silent in a way the engine's cannot be: nothing
+errors, the themes simply come out under each other's names.
+
+It refuses the same guesses the engine refuses. A cue whose `FILE` names something other than the
+image being read is reported, not applied, for the reason given above. A cue with a single external
+audio track is reported too: GOG's lists its one theme as `TRACK 02` when the music is `TADPCM6`, so
+the number there is not a CD track number, and the engine's own rule 4 draws the line in the same
+place.
+
 ## What is not done
 
 - **Drive-backed CD audio, a deliberate non-goal.** A player can point the engine at a mounted disc
@@ -436,7 +459,9 @@ change with the arithmetic already checked.
   same stream the image path uses. That means either a `libcdio` dependency or three platform
   backends (`IOCTL_CDROM_RAW_READ`, `CDROMREADAUDIO`, and something for macOS). Both are a lot of
   surface for the one player who has a physical disc and will not rip it, when a single pass through
-  any imaging tool puts them on a path that already works end to end.
+  any imaging tool puts them on a path that already works end to end. That player now has a second
+  route as well: keep playing off the mounted disc and rip only the audio, which
+  `disc_extract.py --tracks-from` names into place (above).
 
   If it is ever wanted, the shape is carved out: a fourth source at the tail of
   `PlayStreamInternal`, using the same `CDTRACKS` mapping, with the table of contents read from the
@@ -444,9 +469,6 @@ change with the arithmetic already checked.
 - **CD-DA out of an MDX.** Its audio region uses a different stride from its data region and its
   track table is encrypted, so there is nothing to address it with. MDX support is data only, and
   the conversion to `bin`+`cue` is the answer for anyone who wants the soundtrack.
-- **An extraction helper.** A script that writes `music/Track<NN>.wav` out of a `bin`+`cue` would
-  make any container playable with no engine risk. Worth having as the documented answer for NRG,
-  CCD and friends, but nothing needs it now that the common shapes resolve directly.
 
 ## Coverage
 
@@ -458,8 +480,9 @@ change with the arithmetic already checked.
 - `tests/cue`: the TOC parser over a retail in-image shape (with a hole in the track numbering, and
   an `INDEX 00` pregap that must not be mistaken for the start), a multi-file external rip, GOG's
   two-track shape, and a malformed `INDEX`. The original external-audio cases are unchanged.
-- `tests/cdtracks`: the mapping both ways, its bounds, path and case handling, and the check that
-  reads `MUSIC.CPP` to confirm the order still agrees.
+- `tests/cdtracks`: the mapping both ways, its bounds, path and case handling, the check that
+  reads `MUSIC.CPP` to confirm the order still agrees, and the one that reads `disc_extract.py` so
+  the extractor cannot name a theme differently from the engine.
 - `tests/disc_image`: the marker probe discovery uses, and that a raw image beats a cooked one
   regardless of name or directory order.
 

--- a/docs/GAME_DATA.md
+++ b/docs/GAME_DATA.md
@@ -200,6 +200,39 @@ root. Assets and jingles come straight off the medium; the themes need a rip, be
 from a drive is not something the engine does (see
 [DISC_IMAGE_SOURCE.md](DISC_IMAGE_SOURCE.md#what-is-not-done)).
 
+### Extracting to loose files
+
+You do not need this for a bin/cue rip, which plays as it is. It is for the cases the engine cannot
+serve from the medium: a physical disc whose themes you want, a container that mounts data-only
+(MDX, NRG, CCD), or simply wanting the files on disk to mod or inspect.
+
+```
+python3 scripts/dev/disc_extract.py /path/to/rip ~/lba2-data
+```
+
+That writes the game data out of the image and cuts the six Red Book tracks into
+`music/TADPCM2.WAV` and friends, about 535 MB from the US disc. Then
+`lba2cc --game-dir ~/lba2-data` as usual.
+
+If the audio has to come from somewhere else, rip it with whatever your platform has (`cdparanoia`,
+EAC, ImgBurn) and point the script at the result. It reads the track number out of each filename,
+so `track02.cdda.wav` and `Track 2.wav` both work:
+
+```
+python3 scripts/dev/disc_extract.py ~/ripped ~/lba2-data                    # audio only
+python3 scripts/dev/disc_extract.py disc.mdx ~/lba2-data --tracks-from ~/ripped
+```
+
+**The naming is the point.** A ripper gives you `track02.wav`; what it cannot tell you is that CD
+track 6 is `JADPCM01` rather than `TADPCM6`, or that the `TADPCM1` theme is not pressed on the US
+disc at all. That mapping lives in [CDTRACKS.CPP](../LIB386/SYSTEM/CDTRACKS.CPP), and
+`tests/cdtracks` fails if the script's copy of it drifts. Renaming the files by hand is where this
+goes wrong: every scene gets a plausible theme, just not its own.
+
+The script is idempotent (`--force` to overwrite, `--dry-run` to see the plan) and stdlib-only. It
+declines to guess: a cue that describes a different file than the image, or one with a single
+external audio track whose number is not a CD track number, is reported rather than acted on.
+
 ## Config file
 
 See [CONFIG.md](CONFIG.md). If `lba2.cfg` is missing from the user config folder, the engine copies from the asset directory when present; if the asset directory has no `lba2.cfg`, an embedded template (from the build) is written instead.

--- a/docs/GAME_DATA.md
+++ b/docs/GAME_DATA.md
@@ -214,9 +214,37 @@ That writes the game data out of the image and cuts the six Red Book tracks into
 `music/TADPCM2.WAV` and friends, about 535 MB from the US disc. Then
 `lba2cc --game-dir ~/lba2-data` as usual.
 
-If the audio has to come from somewhere else, rip it with whatever your platform has (`cdparanoia`,
-EAC, ImgBurn) and point the script at the result. It reads the track number out of each filename,
-so `track02.cdda.wav` and `Track 2.wav` both work:
+### Straight from the drive
+
+With the disc in a drive, `--from-drive` reads the soundtrack off it. Point the source at the game
+data on the disc (`<drive>:\TWINSEN` on the 1997 US disc) and name the drive:
+
+```
+python3 scripts/dev/disc_extract.py /media/cdrom/TWINSEN ~/lba2-data --from-drive /dev/sr0
+py -3 scripts\dev\disc_extract.py G:\TWINSEN C:\lba2-data --from-drive G
+```
+
+It reads the disc's own table of contents, so the track numbering is the disc's rather than a guess,
+and every audio track it finds has to be one the naming table knows or it says so. Omit the device
+and it uses the first drive it finds.
+
+**Trimming the join.** On a mixed-mode disc the data track's run-out bleeds into the front of the
+first audio track, and a drive hands that back as audio: five sectors of full-scale noise ahead of
+"The Empire" on the US disc. A cue can say "start later" and ours does; a table of contents cannot,
+so the script finds the join itself. What identifies it is not loudness but distribution, since data
+read as audio is uniform noise averaging half of full scale where the music that follows averages
+0.005. The test only opens on a first sector at or above a quarter of full scale, so a track that
+simply starts loud is never trimmed.
+
+Audio sectors carry no error correction, so a scratched disc gives clicks that `cdparanoia` would
+re-read and interpolate away and this will not. The script reports its retry count; if it is
+non-zero, or a theme sounds wrong, rip with `cdparanoia` and come back through `--tracks-from`.
+macOS has no drive backend here, so rip and use `--tracks-from` there.
+
+### From a rip you already made
+
+Rip with whatever your platform has (`cdparanoia`, EAC, ImgBurn) and point the script at the result.
+It reads the track number out of each filename, so `track02.cdda.wav` and `Track 2.wav` both work:
 
 ```
 python3 scripts/dev/disc_extract.py ~/ripped ~/lba2-data                    # audio only

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -76,7 +76,8 @@ for reproducibility; cited from the format and effects docs.
 | [dev/impact_disasm.py](dev/impact_disasm.py) | Disassemble and round-trip IMPACT effect bytecode (`RESS_IMPACT=47`). | [IMPACT_SCRIPTS.md](../docs/IMPACT_SCRIPTS.md) |
 | [dev/flow_dump.py](dev/flow_dump.py) | Decode FLOW particle-emitter definitions (`RESS_FLOW=45`). | [IMPACT_SCRIPTS.md](../docs/IMPACT_SCRIPTS.md) |
 | [dev/pof_dump.py](dev/pof_dump.py) | Decode POF 2D wireframe shapes (`RESS_POF=46`). | [IMPACT_SCRIPTS.md](../docs/IMPACT_SCRIPTS.md) |
-| [dev/iso_bin.py](dev/iso_bin.py) | Read the ISO9660 filesystem out of a raw Mode1/2352 CD image on the fly. | [DISC_IMAGE_SOURCE.md](../docs/DISC_IMAGE_SOURCE.md) |
+| [dev/iso_bin.py](dev/iso_bin.py) | Read the ISO9660 filesystem out of a raw Mode1/2352 (or cooked 2048) CD image on the fly. | [DISC_IMAGE_SOURCE.md](../docs/DISC_IMAGE_SOURCE.md) |
+| [dev/disc_extract.py](dev/disc_extract.py) | Extract a playable game-data folder from a rip or a ripped soundtrack, naming the CD tracks the way the engine asks for them (`--selftest` for the cue rules). | [GAME_DATA.md](../docs/GAME_DATA.md) |
 | [dev/acf_decode.py](dev/acf_decode.py) | Decode Adeline ACF/XCF cinematic frames (Time Commando tile codec). | spike |
 | [dev/acf_inspect.py](dev/acf_inspect.py) | Parse the ACF/XCF cinematic container chunk layout. | spike |
 | [dev/extract_lba2_gog_media.py](dev/extract_lba2_gog_media.py) | Extract FMV / VOX / music from a GOG `LBA2.GOG` BIN image into the install dir. | [GAME_DATA.md](../docs/GAME_DATA.md) |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -77,7 +77,7 @@ for reproducibility; cited from the format and effects docs.
 | [dev/flow_dump.py](dev/flow_dump.py) | Decode FLOW particle-emitter definitions (`RESS_FLOW=45`). | [IMPACT_SCRIPTS.md](../docs/IMPACT_SCRIPTS.md) |
 | [dev/pof_dump.py](dev/pof_dump.py) | Decode POF 2D wireframe shapes (`RESS_POF=46`). | [IMPACT_SCRIPTS.md](../docs/IMPACT_SCRIPTS.md) |
 | [dev/iso_bin.py](dev/iso_bin.py) | Read the ISO9660 filesystem out of a raw Mode1/2352 (or cooked 2048) CD image on the fly. | [DISC_IMAGE_SOURCE.md](../docs/DISC_IMAGE_SOURCE.md) |
-| [dev/disc_extract.py](dev/disc_extract.py) | Extract a playable game-data folder from a rip or a ripped soundtrack, naming the CD tracks the way the engine asks for them (`--selftest` for the cue rules). | [GAME_DATA.md](../docs/GAME_DATA.md) |
+| [dev/disc_extract.py](dev/disc_extract.py) | Extract a playable game-data folder from a rip, a CD drive (`--from-drive`) or a ripped soundtrack, naming the CD tracks the way the engine asks for them (`--selftest` for the cue and TOC rules). | [GAME_DATA.md](../docs/GAME_DATA.md) |
 | [dev/acf_decode.py](dev/acf_decode.py) | Decode Adeline ACF/XCF cinematic frames (Time Commando tile codec). | spike |
 | [dev/acf_inspect.py](dev/acf_inspect.py) | Parse the ACF/XCF cinematic container chunk layout. | spike |
 | [dev/extract_lba2_gog_media.py](dev/extract_lba2_gog_media.py) | Extract FMV / VOX / music from a GOG `LBA2.GOG` BIN image into the install dir. | [GAME_DATA.md](../docs/GAME_DATA.md) |

--- a/scripts/dev/disc_extract.py
+++ b/scripts/dev/disc_extract.py
@@ -6,8 +6,8 @@ shape this script is optional. It exists for the cases the engine cannot serve:
 
   * A physical disc. Data and jingles play straight off a mounted CD, but the six
     themes are Red Book audio and reading audio from a drive is a deliberate
-    non-goal (see docs/DISC_IMAGE_SOURCE.md). Rip the audio with any tool, point
-    this at the result, and the themes become files the engine loads normally.
+    non-goal for the engine (see docs/DISC_IMAGE_SOURCE.md). `--from-drive` reads
+    them here instead, where a dependency-free best effort is allowed to be one.
   * A container the engine mounts data-only: an MDX (encrypted track table), NRG,
     CCD. Convert or rip the audio separately, then use `--tracks-from`.
   * Wanting loose files on disk for modding or inspection.
@@ -19,13 +19,16 @@ That mapping is CD_TRACK_NAMES below, kept in step with LIB386/SYSTEM/CDTRACKS.C
 by tests/cdtracks.
 
 Usage:
-  disc_extract.py SOURCE OUTDIR [--tracks-from DIR] [--force] [--dry-run]
+  disc_extract.py SOURCE OUTDIR [--from-drive [DEV]] [--tracks-from DIR]
+                                [--force] [--dry-run]
 
-  SOURCE  a .cue, a disc image, a directory holding either, or a directory of
-          already-ripped track WAVs (audio only, for the mounted-disc flow).
+  SOURCE  a .cue, a disc image, a directory holding either, a mounted disc, or a
+          directory of already-ripped track WAVs.
 
 Examples:
   disc_extract.py TWINSEN.cue ~/lba2-data
+  disc_extract.py /media/cdrom/TWINSEN ~/lba2-data --from-drive /dev/sr0
+  disc_extract.py G:\\TWINSEN C:\\lba2-data --from-drive G
   disc_extract.py /media/cdrom ~/lba2-data --tracks-from ~/ripped
   disc_extract.py ~/ripped ~/lba2-data           # audio only, into an existing tree
 
@@ -39,6 +42,7 @@ import argparse
 import os
 import re
 import shutil
+import struct
 import sys
 import wave
 
@@ -305,6 +309,43 @@ class Plan(object):
         print("  %-40s %10s  %s" % (os.path.basename(dest), size or "?", what))
 
 
+def open_wav(dest):
+    wf = wave.open(dest, "wb")
+    wf.setnchannels(CDDA_CHANNELS)
+    wf.setsampwidth(CDDA_WIDTH)
+    wf.setframerate(CDDA_RATE)
+    return wf
+
+
+def write_wav_from_drive(drive, dest, first_sector, sectors, plan):
+    """Rip a track off the disc in the chunks the transport allows.
+
+    A failed chunk is retried before giving up, and the count comes back so a
+    disc that is struggling says so rather than producing quiet damage."""
+    payload = sectors * RAW_SECTOR
+    if plan.keep_existing(dest, payload + 44):
+        return 0
+    plan.note(dest, payload + 44,
+              "CD track from LBA %d (%d sectors)" % (first_sector, sectors))
+    if plan.dry_run:
+        return 0
+    retries = 0
+    with open_wav(dest) as wf:
+        done = 0
+        while done < sectors:
+            count = min(MAX_SECTORS_PER_READ, sectors - done)
+            for attempt in range(3):
+                try:
+                    wf.writeframes(drive.read_audio(first_sector + done, count))
+                    break
+                except DriveError:
+                    retries += 1
+                    if attempt == 2:
+                        raise
+            done += count
+    return retries
+
+
 def write_wav_from_sectors(src, dest, first_sector, sectors, plan):
     """Cut a CD-DA track out of a raw image. Sector bytes are already the PCM the
     WAV wants, so this is a header plus a copy."""
@@ -315,10 +356,7 @@ def write_wav_from_sectors(src, dest, first_sector, sectors, plan):
               "CD track from sector %d (%d sectors)" % (first_sector, sectors))
     if plan.dry_run:
         return
-    with open(src, "rb") as fh, wave.open(dest, "wb") as wf:
-        wf.setnchannels(CDDA_CHANNELS)
-        wf.setsampwidth(CDDA_WIDTH)
-        wf.setframerate(CDDA_RATE)
+    with open(src, "rb") as fh, open_wav(dest) as wf:
         fh.seek(first_sector * RAW_SECTOR)
         left = payload
         while left > 0:
@@ -352,6 +390,36 @@ def extract_tree(img, iso_root, lba, size, outdir, plan):
                 data = img.read_lba(clba + done, batch)
                 fh.write(data[:csize - done * iso_bin.USER])
                 done += batch
+
+
+def holds_marker(directory):
+    """Whether a directory is game data, by the marker discovery uses."""
+    try:
+        return any(n.upper() == MARKER for n in os.listdir(directory))
+    except OSError:
+        return False
+
+
+def copy_data_tree(srcdir, outdir, plan):
+    """Copy an already-readable game-data tree, which is what a mounted disc is."""
+    for root, dirs, files in os.walk(srcdir):
+        dirs.sort()
+        rel = os.path.relpath(root, srcdir)
+        target = outdir if rel == "." else os.path.join(outdir, rel)
+        for name in sorted(files):
+            src = os.path.join(root, name)
+            dest = os.path.join(target, name)
+            try:
+                size = os.path.getsize(src)
+            except OSError:
+                continue
+            if plan.keep_existing(dest, size):
+                continue
+            plan.note(dest, size, os.path.join(rel, name) if rel != "." else name)
+            if plan.dry_run:
+                continue
+            os.makedirs(target, exist_ok=True)
+            shutil.copyfile(src, dest)
 
 
 def copy_ripped(sources, outdir, plan):
@@ -391,6 +459,302 @@ def ripped_wavs_in(directory):
     return out
 
 
+# --- reading a drive ---------------------------------------------------------
+# Audio sectors carry no error correction, so a scratched disc gives clicks that
+# cdparanoia would re-read and interpolate away and this will not. That is the
+# trade for having no dependency; --from-drive reports its retry count so a bad
+# read is visible, and a damaged disc is a reason to rip with cdparanoia and come
+# back through --tracks-from.
+MAX_SECTORS_PER_READ = 27  # 27 x 2352 = 63504, just under the 64 KB ATAPI ceiling
+LEADOUT_TRACK = 0xAA
+MSF_OFFSET = 150  # MSF counts from 00:02:00, so LBA 0 is at frame 150
+
+
+class DriveError(Exception):
+    pass
+
+
+class TocTrack(object):
+    def __init__(self, number, lba, is_data):
+        self.number = number
+        self.lba = lba
+        self.is_data = is_data
+
+    def __repr__(self):
+        return "TocTrack(%d, %d, %s)" % (self.number, self.lba, self.is_data)
+
+
+def parse_toc_buffer(buf):
+    """Parse a Windows CDROM_TOC into TocTracks, lead-out included.
+
+    Header is Length[2] big-endian, FirstTrack, LastTrack; then 8-byte entries of
+    Reserved, Adr/Ctrl, TrackNumber, Reserved, then a 4-byte address whose last
+    three bytes are M, S, F."""
+    if len(buf) < 4:
+        raise DriveError("table of contents too short (%d bytes)" % len(buf))
+    tracks = []
+    for o in range(4, len(buf) - 7, 8):
+        number = buf[o + 2]
+        if number == 0:
+            break
+        ctrl = buf[o + 1] & 0x0F
+        m, s, f = buf[o + 5], buf[o + 6], buf[o + 7]
+        lba = (m * 60 + s) * 75 + f - MSF_OFFSET
+        tracks.append(TocTrack(number, lba, bool(ctrl & 0x04)))
+        if number == LEADOUT_TRACK:
+            break
+    if not tracks:
+        raise DriveError("table of contents lists no tracks")
+    return tracks
+
+
+def audio_tracks_from_toc(toc):
+    """[(track number, first sector, sector count)] for the audio a disc carries.
+
+    Each track runs to the start of the next entry, and the lead-out is what
+    bounds the last one, which is why it has to be in the table."""
+    spans = []
+    for i, t in enumerate(toc):
+        if t.is_data or t.number == LEADOUT_TRACK or i + 1 >= len(toc):
+            continue
+        count = toc[i + 1].lba - t.lba
+        if count > 0:
+            spans.append((t.number, t.lba, count))
+    return spans
+
+
+class WindowsDrive(object):
+    """CD access through DeviceIoControl. Verified against a real mixed-mode disc."""
+
+    IOCTL_CDROM_READ_TOC = 0x24000
+    IOCTL_CDROM_RAW_READ = 0x2403E
+    TRACK_MODE_CDDA = 2
+
+    def __init__(self, device):
+        import ctypes
+        from ctypes import wintypes
+
+        self.ctypes = ctypes
+        self.wintypes = wintypes
+        letter = device.strip().rstrip(":").replace("\\", "").replace(".", "")
+        self.path = "\\\\.\\%s:" % letter[-1:].upper()
+        self.name = self.path
+
+    def _open(self):
+        ctypes, wintypes = self.ctypes, self.wintypes
+        create = ctypes.windll.kernel32.CreateFileW
+        create.restype = wintypes.HANDLE  # must not truncate the handle on win64
+        create.argtypes = [wintypes.LPCWSTR, wintypes.DWORD, wintypes.DWORD,
+                           ctypes.c_void_p, wintypes.DWORD, wintypes.DWORD,
+                           wintypes.HANDLE]
+        invalid = ctypes.c_void_p(-1).value
+        for access in (0x80000000, 0):  # GENERIC_READ, then none: many IOCTLs allow it
+            handle = create(self.path, access, 0x1 | 0x2, None, 3, 0, None)
+            if handle is not None and handle != invalid:
+                return handle
+        raise DriveError("cannot open %s (error %d)"
+                         % (self.path, self.ctypes.get_last_error()))
+
+    def _ioctl(self, code, in_buf, out_size):
+        ctypes, wintypes = self.ctypes, self.wintypes
+        handle = self._open()
+        try:
+            control = ctypes.windll.kernel32.DeviceIoControl
+            control.argtypes = [wintypes.HANDLE, wintypes.DWORD, ctypes.c_void_p,
+                                wintypes.DWORD, ctypes.c_void_p, wintypes.DWORD,
+                                ctypes.POINTER(wintypes.DWORD), ctypes.c_void_p]
+            out = ctypes.create_string_buffer(out_size)
+            returned = wintypes.DWORD(0)
+            ok = control(handle, code,
+                         in_buf, len(in_buf) if in_buf else 0,
+                         out, out_size, ctypes.byref(returned), None)
+            if not ok:
+                raise DriveError("ioctl 0x%X on %s failed (error %d)"
+                                 % (code, self.path, ctypes.GetLastError()))
+            return out.raw[:returned.value]
+        finally:
+            ctypes.windll.kernel32.CloseHandle(handle)
+
+    def read_toc(self):
+        return parse_toc_buffer(self._ioctl(self.IOCTL_CDROM_READ_TOC, None, 2048))
+
+    def read_audio(self, lba, sectors):
+        import struct as _struct
+        # RAW_READ_INFO. DiskOffset is a byte offset of lba * 2048 even though
+        # CDDA hands back 2352-byte sectors, which is this IOCTL's own quirk.
+        info = _struct.pack("<qII", lba * 2048, sectors, self.TRACK_MODE_CDDA)
+        data = self._ioctl(self.IOCTL_CDROM_RAW_READ, info, sectors * RAW_SECTOR)
+        if len(data) != sectors * RAW_SECTOR:
+            raise DriveError("short read at LBA %d: %d bytes for %d sectors"
+                             % (lba, len(data), sectors))
+        return data
+
+
+class LinuxDrive(object):
+    """CD access through the cdrom ioctls.
+
+    The struct layouts are taken from <linux/cdrom.h> and let ctypes do the
+    alignment, but nothing here has been run against a device: this box has no
+    optical drive. If it fails, rip with cdparanoia and use --tracks-from, which
+    is the tested path."""
+
+    CDROMREADTOCHDR = 0x5305
+    CDROMREADTOCENTRY = 0x5306
+    CDROMREADAUDIO = 0x530E
+    CDROM_LBA = 1
+
+    def __init__(self, device):
+        import ctypes
+        import fcntl
+
+        self.ctypes = ctypes
+        self.fcntl = fcntl
+        self.name = device
+        self.path = device
+
+        class Addr(ctypes.Union):
+            _fields_ = [("msf", ctypes.c_uint8 * 3), ("lba", ctypes.c_int)]
+
+        class TocHeader(ctypes.Structure):
+            _fields_ = [("trk0", ctypes.c_uint8), ("trk1", ctypes.c_uint8)]
+
+        class TocEntry(ctypes.Structure):
+            _fields_ = [("track", ctypes.c_uint8),
+                        ("adr", ctypes.c_uint8, 4),
+                        ("ctrl", ctypes.c_uint8, 4),
+                        ("format", ctypes.c_uint8),
+                        ("addr", Addr),
+                        ("datamode", ctypes.c_uint8)]
+
+        class ReadAudio(ctypes.Structure):
+            _fields_ = [("addr", Addr),
+                        ("addr_format", ctypes.c_uint8),
+                        ("nframes", ctypes.c_int),
+                        ("buf", ctypes.POINTER(ctypes.c_uint8))]
+
+        self.TocHeader, self.TocEntry, self.ReadAudio = TocHeader, TocEntry, ReadAudio
+
+    def _fd(self):
+        try:  # O_NONBLOCK so an empty or spinning-up drive fails rather than hangs
+            return os.open(self.path, os.O_RDONLY | os.O_NONBLOCK)
+        except OSError as exc:
+            raise DriveError("cannot open %s: %s" % (self.path, exc))
+
+    def read_toc(self):
+        fd = self._fd()
+        try:
+            header = self.TocHeader()
+            self.fcntl.ioctl(fd, self.CDROMREADTOCHDR, header)
+            tracks = []
+            numbers = list(range(header.trk0, header.trk1 + 1)) + [LEADOUT_TRACK]
+            for number in numbers:
+                entry = self.TocEntry()
+                entry.track = number
+                entry.format = self.CDROM_LBA
+                self.fcntl.ioctl(fd, self.CDROMREADTOCENTRY, entry)
+                tracks.append(TocTrack(number, entry.addr.lba, bool(entry.ctrl & 0x04)))
+            return tracks
+        except OSError as exc:
+            raise DriveError("reading the table of contents of %s: %s" % (self.path, exc))
+        finally:
+            os.close(fd)
+
+    def read_audio(self, lba, sectors):
+        ctypes = self.ctypes
+        fd = self._fd()
+        try:
+            buf = (ctypes.c_uint8 * (sectors * RAW_SECTOR))()
+            request = self.ReadAudio()
+            request.addr.lba = lba
+            request.addr_format = self.CDROM_LBA
+            request.nframes = sectors
+            request.buf = ctypes.cast(buf, ctypes.POINTER(ctypes.c_uint8))
+            self.fcntl.ioctl(fd, self.CDROMREADAUDIO, request)
+            return bytes(bytearray(buf))
+        except OSError as exc:
+            raise DriveError("reading audio at LBA %d from %s: %s" % (lba, self.path, exc))
+        finally:
+            os.close(fd)
+
+
+# On a mixed-mode disc the data track's run-out bleeds into the front of the first
+# audio track, and a drive hands it back as audio: five sectors of full-scale noise
+# before the music on the US disc. A cue can say "start later" and ours does; a TOC
+# cannot, so a drive rip has to find the join itself.
+#
+# What separates them is not loudness but distribution. Data read as audio is
+# uniform noise, so its mean sample magnitude sits near half of full scale, where the
+# music that follows measures 0.005 and even a brickwalled master stays under about
+# 0.35 because music has crest factor and noise does not. The gate is set at 0.40 to
+# sit clear of both, the skip is capped at one transport read, and a trim is printed
+# rather than done quietly, because the one signal this cannot tell from data is a
+# sustained full-scale tone (a sine averages 0.637) and that deserves to be visible.
+RUNOUT_GATE = 0.40  # a first sector this loud on average is data, not music
+RUNOUT_TAIL = 0.05  # keep skipping while the noise fades out
+RUNOUT_MAX_SECTORS = MAX_SECTORS_PER_READ  # one transport read, ~360 ms, is plenty
+
+
+def mean_magnitude(sector):
+    """Mean absolute sample value of one CD-DA sector, as a fraction of full scale."""
+    samples = struct.unpack("<%dh" % (len(sector) // 2), sector)
+    if not samples:
+        return 0.0
+    return sum(abs(v) for v in samples) / float(len(samples) * 32768)
+
+
+def runout_sectors(head):
+    """How many leading sectors of `head` are data run-out rather than music."""
+    if not head or mean_magnitude(head[0]) < RUNOUT_GATE:
+        return 0
+    skipped = 0
+    for sector in head[:RUNOUT_MAX_SECTORS]:
+        if mean_magnitude(sector) < RUNOUT_TAIL:
+            break
+        skipped += 1
+    return skipped
+
+
+def trim_leading_runout(drive, first_lba, sectors):
+    """(first sector, count) with any data run-out trimmed off the head."""
+    probe = min(RUNOUT_MAX_SECTORS, sectors)
+    if probe <= 0:
+        return first_lba, sectors
+    data = drive.read_audio(first_lba, probe)
+    head = [data[i * RAW_SECTOR:(i + 1) * RAW_SECTOR] for i in range(probe)]
+    skip = runout_sectors(head)
+    return first_lba + skip, sectors - skip
+
+
+def default_device():
+    """The drive to use when --from-drive names none."""
+    if sys.platform == "win32":
+        import ctypes
+        mask = ctypes.windll.kernel32.GetLogicalDrives()
+        for i in range(26):
+            if not mask & (1 << i):
+                continue
+            root = "%s:\\" % chr(ord("A") + i)
+            if ctypes.windll.kernel32.GetDriveTypeW(root) == 5:  # DRIVE_CDROM
+                return chr(ord("A") + i)
+        raise DriveError("no CD drive found")
+    for path in ("/dev/cdrom", "/dev/sr0", "/dev/sr1"):
+        if os.path.exists(path):
+            return path
+    raise DriveError("no CD drive found (looked for /dev/cdrom and /dev/sr0)")
+
+
+def open_drive(device):
+    if not device:
+        device = default_device()
+    if sys.platform == "win32":
+        return WindowsDrive(device)
+    if sys.platform.startswith("linux"):
+        return LinuxDrive(device)
+    raise DriveError(
+        "reading a drive is not implemented on %s. Rip the audio with a tool your "
+        "platform has, then pass --tracks-from." % sys.platform)
+
+
 # --- self-test ---------------------------------------------------------------
 # The cue rules are where this can be wrong without anything failing: get a span
 # or a track number off and every theme still plays, just not its own. `--selftest`
@@ -424,6 +788,21 @@ FILE "track03.wav" WAVE
   TRACK 03 AUDIO
     INDEX 01 00:00:00
 """
+
+# The US disc's own CDROM_TOC, read off the drive with IOCTL_CDROM_READ_TOC. One
+# data track and six audio, lead-out at 292864. Kept verbatim so the parse is
+# pinned against a real disc rather than a table written to match the parser.
+RETAIL_TOC_HEX = (
+    "00420107"
+    "0014010000000200"
+    "0010020000 2E083F"
+    "0010030000 31363F"
+    "0010040000 35061A"
+    "0010050000 38271A"
+    "0010060000 3C151A"
+    "0010070000 3D0F1A"
+    "0010AA0000 410640"
+).replace(" ", "")
 
 
 def selftest():
@@ -468,21 +847,153 @@ def selftest():
     check("track number from a space", track_number_of("Track 7.wav"), 7)
     check("track number from none", track_number_of("purple.wav"), None)
 
+    # The disc's own table of contents, against the addresses the corrected cue
+    # records. Every track sits 150 frames above its offset in a BIN that dropped
+    # the data-track run-out, which is what makes the two views agree.
+    toc = parse_toc_buffer(bytearray.fromhex(RETAIL_TOC_HEX))
+    check("toc track count", len(toc), 8)
+    check("toc data track", (toc[0].number, toc[0].lba, toc[0].is_data), (1, 0, True))
+    check("toc audio numbering", [t.number for t in toc[1:-1]], [2, 3, 4, 5, 6, 7])
+    check("toc all audio", [t.is_data for t in toc[1:]], [False] * 7)
+    check("toc leadout", (toc[-1].number, toc[-1].lba), (LEADOUT_TRACK, 292864))
+    check("toc track 2", toc[1].lba, 207368 + MSF_OFFSET - 5)  # the 5 run-out sectors
+    check("toc track 3", toc[2].lba, 224313 + MSF_OFFSET)
+    check("toc spans", audio_tracks_from_toc(toc),
+          [(2, 207513, 16950), (3, 224463, 14363), (4, 238826, 15975),
+           (5, 254801, 16650), (6, 271451, 4050), (7, 275501, 17363)])
+    # Every audio track on this disc must be one the naming table knows, or a
+    # theme would come off the disc with nowhere to go.
+    check("toc tracks are all named",
+          [n for n, _, _ in audio_tracks_from_toc(toc) if n not in CD_TRACK_NAMES], [])
+
+    # The run-out trim, on sectors built to look like what it has to tell apart.
+    # A plain LCG so the "noise" is the same on every run and every machine.
+    def noise_sector():
+        out = bytearray()
+        seed = 12345
+        for _ in range(RAW_SECTOR // 2):
+            seed = (1103515245 * seed + 12345) & 0x7FFFFFFF
+            out += struct.pack("<h", (seed >> 8) % 65536 - 32768)
+        return bytes(out)
+
+    def level_sector(amplitude):
+        return struct.pack("<h", amplitude) * (RAW_SECTOR // 2)
+
+    silence = level_sector(0)
+    quiet = level_sector(160)  # about what the music measures
+    noise = noise_sector()
+
+    check("noise looks like data", round(mean_magnitude(noise), 1), 0.5)
+    check("silence measures zero", mean_magnitude(silence), 0.0)
+    check("trim skips the run-out", runout_sectors([noise, noise, silence, quiet]), 2)
+    check("trim leaves clean audio alone", runout_sectors([quiet] * 4), 0)
+    check("trim leaves silence alone", runout_sectors([silence] * 4), 0)
+    check("trim needs the gate to open", runout_sectors([quiet, noise, noise]), 0)
+    check("trim on nothing", runout_sectors([]), 0)
+    check("trim is capped", runout_sectors([noise] * 100), RUNOUT_MAX_SECTORS)
+
     for line in failures:
         print("FAIL %s" % line)
     print("%d check(s), %d failed" % (checks[0], len(failures)))
     return 1 if failures else 0
 
 
+# --- music sources -----------------------------------------------------------
+def music_from_cue(image, cue, raw, outdir, plan):
+    tracks = parse_cue(cue)
+    print("Cue:        %s (%d tracks)" % (cue, len(tracks)))
+    loose = external_audio(tracks)
+    if loose:
+        base = os.path.dirname(os.path.abspath(cue))
+        print("Music:      one file per track, named by the cue")
+        copy_ripped([(n, os.path.join(base, f)) for n, f in loose
+                     if os.path.isfile(os.path.join(base, f))], outdir, plan)
+    elif not cue_names(cue, tracks, image):
+        # A cue's INDEX addresses belong to the file it names. Applying them to a
+        # different one lands mid-sector and plays as full-scale noise, so
+        # "probably the same disc" is not enough.
+        print("Music:      %s describes %r, not this image"
+              % (os.path.basename(cue), tracks[0].source))
+    elif not raw:
+        print("Music:      image is cooked (2048), so it carries no CD audio")
+    else:
+        spans = audio_spans(tracks, os.path.getsize(image) // RAW_SECTOR)
+        if spans:
+            print("Music:      matched by CD track number")
+            target = music_dir_in(outdir)
+            if not plan.dry_run:
+                os.makedirs(target, exist_ok=True)
+            for number, first, count in spans:
+                name = CD_TRACK_NAMES.get(number)
+                if name is None:
+                    print("  track %02d carries no music on this disc" % number)
+                    continue
+                write_wav_from_sectors(image, os.path.join(target, name + ".WAV"),
+                                       first, count, plan)
+        elif single_external(tracks):
+            print("Music:      one external audio file (%s), whose cue number is not "
+                  "a CD track number" % single_external(tracks))
+            print("            The engine plays it as it stands; leave it where it "
+                  "is rather than renaming it here.")
+        else:
+            print("Music:      the cue lists no audio tracks in this image")
+
+
+def music_from_drive(drive, outdir, plan):
+    """Read the disc's own table of contents and rip each audio track it lists."""
+    try:
+        toc = drive.read_toc()
+    except DriveError as exc:
+        raise SystemExit("%s\nRip the audio with cdparanoia or ImgBurn and pass "
+                         "--tracks-from instead." % exc)
+
+    spans = audio_tracks_from_toc(toc)
+    data = [t for t in toc if t.is_data]
+    print("Drive:      %s" % drive.name)
+    print("TOC:        %d track(s), %d data, %d audio, lead-out %d"
+          % (len(toc) - 1, len(data), len(spans), toc[-1].lba))
+    if not spans:
+        print("Music:      this disc has no audio tracks")
+        return
+
+    print("Music:      from the disc's own table of contents")
+    target = music_dir_in(outdir)
+    if not plan.dry_run:
+        os.makedirs(target, exist_ok=True)
+
+    retries = 0
+    for number, first, count in spans:
+        name = CD_TRACK_NAMES.get(number)
+        if name is None:
+            print("  track %02d is audio, but no theme is mapped to it" % number)
+            continue
+        try:
+            start, count = trim_leading_runout(drive, first, count)
+            if start != first:
+                print("  track %02d starts with %d sector(s) of data run-out, trimmed"
+                      % (number, start - first))
+            first = start
+            retries += write_wav_from_drive(
+                drive, os.path.join(target, name + ".WAV"), first, count, plan)
+        except DriveError as exc:
+            print("  track %02d failed: %s" % (number, exc))
+    if retries:
+        print("            %d chunk(s) needed a retry, so check those themes by ear"
+              % retries)
+
+
 # --- driver ------------------------------------------------------------------
 def resolve_source(source):
-    """(image path or None, cue path or None, ripped WAVs or [])."""
+    """(image, cue, ripped WAVs, plain data directory), each None or empty if absent."""
     if os.path.isdir(source):
-        wavs = ripped_wavs_in(source)
         image = pick_image(source)
-        if image is None:
-            return None, None, wavs
-        return image, pick_cue(image), []
+        if image is not None:
+            return image, pick_cue(image), [], None
+        # A mounted disc, or any install: the files are already readable, so the
+        # data side is a copy and only the audio needs a source.
+        if holds_marker(source):
+            return None, None, [], source
+        return None, None, ripped_wavs_in(source), None
     ext = os.path.splitext(source)[1].lower()
     if ext in CUE_EXTS:
         tracks = parse_cue(source)
@@ -492,9 +1003,9 @@ def resolve_source(source):
         if not os.path.isfile(image):
             raise SystemExit("%s names %r, which is not beside it"
                              % (source, tracks[0].source))
-        return image, source, []
+        return image, source, [], None
     if ext in IMAGE_EXTS or looks_like_image(source):
-        return source, pick_cue(source), []
+        return source, pick_cue(source), [], None
     raise SystemExit("%s is not a cue, an image, or a directory holding either" % source)
 
 
@@ -502,12 +1013,15 @@ def main():
     ap = argparse.ArgumentParser(
         description="Extract a playable game-data folder from a CD, themes included.")
     ap.add_argument("source", nargs="?",
-                    help="a .cue, a disc image, or a directory holding "
-                         "either (or a directory of ripped track WAVs)")
+                    help="a .cue, a disc image, a directory holding either, a mounted "
+                         "disc, or a directory of ripped track WAVs")
     ap.add_argument("outdir", nargs="?", help="where to write the game data")
     ap.add_argument("--tracks-from", metavar="DIR",
                     help="take the CD audio from a folder of ripped WAVs instead of "
                          "from the image (for containers whose audio is unreachable)")
+    ap.add_argument("--from-drive", metavar="DEVICE", nargs="?", const="",
+                    help="read the CD audio off a drive (/dev/sr0, or a Windows drive "
+                         "letter); omit the value to use the first one found")
     ap.add_argument("--force", action="store_true",
                     help="overwrite files already at the destination")
     ap.add_argument("--dry-run", action="store_true", help="say what would be written")
@@ -520,19 +1034,28 @@ def main():
     if not a.source or not a.outdir:
         ap.error("SOURCE and OUTDIR are both required")
 
-    image, cue, ripped = resolve_source(a.source)
+    image, cue, ripped, datadir = resolve_source(a.source)
     if a.tracks_from:
         ripped = ripped_wavs_in(a.tracks_from)
         if not ripped:
             raise SystemExit("no track WAVs in %s" % a.tracks_from)
 
+    drive = None
+    if a.from_drive is not None:
+        try:
+            drive = open_drive(a.from_drive)
+        except DriveError as exc:
+            raise SystemExit("%s" % exc)
+
     plan = Plan(a.force, a.dry_run)
     if not a.dry_run:
         os.makedirs(a.outdir, exist_ok=True)
 
-    if image is None and not ripped:
-        raise SystemExit("%s holds no disc image and no ripped WAVs" % a.source)
+    if image is None and datadir is None and not ripped and drive is None:
+        raise SystemExit("%s holds no disc image, no game data and no ripped WAVs"
+                         % a.source)
 
+    raw = False
     if image is not None:
         print("Image:      %s" % image)
         img = iso_bin.open_image(image)
@@ -550,54 +1073,23 @@ def main():
         print("Data:")
         extract_tree(img, iso_root, lba, size, a.outdir, plan)
         img.f.close()
+    elif datadir is not None:
+        print("Data dir:   %s" % datadir)
+        print("Data:")
+        copy_data_tree(datadir, a.outdir, plan)
 
-        if cue and not ripped:
-            tracks = parse_cue(cue)
-            print("Cue:        %s (%d tracks)" % (cue, len(tracks)))
-            loose = external_audio(tracks)
-            if loose:
-                base = os.path.dirname(os.path.abspath(cue))
-                print("Music:      one file per track, named by the cue")
-                copy_ripped(
-                    [(n, os.path.join(base, f)) for n, f in loose
-                     if os.path.isfile(os.path.join(base, f))], a.outdir, plan)
-            elif not cue_names(cue, tracks, image):
-                # A cue's INDEX addresses belong to the file it names. Applying
-                # them to a different one lands mid-sector and plays as
-                # full-scale noise, so "probably the same disc" is not enough.
-                print("Music:      %s describes %r, not this image"
-                      % (os.path.basename(cue), tracks[0].source))
-            elif not raw:
-                print("Music:      image is cooked (2048), so it carries no CD audio")
-            else:
-                sectors = os.path.getsize(image) // RAW_SECTOR
-                spans = audio_spans(tracks, sectors)
-                if spans:
-                    print("Music:      matched by CD track number")
-                    target = music_dir_in(a.outdir)
-                    if not a.dry_run:
-                        os.makedirs(target, exist_ok=True)
-                    for number, first, count in spans:
-                        name = CD_TRACK_NAMES.get(number)
-                        if name is None:
-                            print("  track %02d carries no music on this disc" % number)
-                            continue
-                        write_wav_from_sectors(
-                            image, os.path.join(target, name + ".WAV"),
-                            first, count, plan)
-                elif single_external(tracks):
-                    print("Music:      one external audio file (%s), whose cue number "
-                          "is not a CD track number" % single_external(tracks))
-                    print("            The engine plays it as it stands; leave it "
-                          "where it is rather than renaming it here.")
-                else:
-                    print("Music:      the cue lists no audio tracks in this image")
-        elif not cue and not ripped:
-            print("Music:      no cue beside the image, so the themes stay silent")
-
-    if ripped:
+    # One audio source, in the order of how much it is trusted: a drive is the
+    # disc itself, a rip the user made is next, and a cue is an assertion about a
+    # file. Whichever wins, the naming is the same.
+    if drive is not None:
+        music_from_drive(drive, a.outdir, plan)
+    elif ripped:
         print("Music:      from %s" % (a.tracks_from or a.source))
         copy_ripped(ripped, a.outdir, plan)
+    elif image is not None and cue:
+        music_from_cue(image, cue, raw, a.outdir, plan)
+    elif image is not None:
+        print("Music:      no cue beside the image, so the themes stay silent")
 
     # What matters is whether each theme ended up with a file, not how it got
     # there: on GOG the same music sits inside the data track, so counting only
@@ -609,7 +1101,7 @@ def main():
             "%s (track %02d)" % (CD_TRACK_NAMES[n], n) for n in missing))
     print("%d file(s) written, %d already there, %.1f MB"
           % (plan.written, plan.skipped, plan.bytes / 1048576.0))
-    if not a.dry_run and image is not None:
+    if not a.dry_run and (image is not None or datadir is not None):
         print("Play it with: lba2cc --game-dir %s" % os.path.abspath(a.outdir))
 
 

--- a/scripts/dev/disc_extract.py
+++ b/scripts/dev/disc_extract.py
@@ -1,0 +1,617 @@
+#!/usr/bin/env python3
+"""Extract a playable game-data folder out of a CD, including the Red Book themes.
+
+The engine already mounts a bin+cue rip and plays everything off it, so for that
+shape this script is optional. It exists for the cases the engine cannot serve:
+
+  * A physical disc. Data and jingles play straight off a mounted CD, but the six
+    themes are Red Book audio and reading audio from a drive is a deliberate
+    non-goal (see docs/DISC_IMAGE_SOURCE.md). Rip the audio with any tool, point
+    this at the result, and the themes become files the engine loads normally.
+  * A container the engine mounts data-only: an MDX (encrypted track table), NRG,
+    CCD. Convert or rip the audio separately, then use `--tracks-from`.
+  * Wanting loose files on disk for modding or inspection.
+
+What only this repo can tell you is the naming. Every ripper hands back
+`track02.wav`; nothing else knows that CD track 6 is JADPCM01 rather than
+TADPCM6, or that the ListJingle[1] theme is not pressed on the US disc at all.
+That mapping is CD_TRACK_NAMES below, kept in step with LIB386/SYSTEM/CDTRACKS.CPP
+by tests/cdtracks.
+
+Usage:
+  disc_extract.py SOURCE OUTDIR [--tracks-from DIR] [--force] [--dry-run]
+
+  SOURCE  a .cue, a disc image, a directory holding either, or a directory of
+          already-ripped track WAVs (audio only, for the mounted-disc flow).
+
+Examples:
+  disc_extract.py TWINSEN.cue ~/lba2-data
+  disc_extract.py /media/cdrom ~/lba2-data --tracks-from ~/ripped
+  disc_extract.py ~/ripped ~/lba2-data           # audio only, into an existing tree
+
+Then: lba2cc --game-dir ~/lba2-data
+
+Python 3 stdlib only. Idempotent: a file already there at the expected size is
+left alone unless you pass --force. `--selftest` checks the cue rules against
+fixtures and needs no disc.
+"""
+import argparse
+import os
+import re
+import shutil
+import sys
+import wave
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import iso_bin
+
+# CD track N holds ListJingle[N]. Track 1 is the data track, so the ListJingle[1]
+# theme (TADPCM1) has no track and is not on the US disc. Mirrors CD_TRACK_NAMES
+# in LIB386/SYSTEM/CDTRACKS.CPP; tests/cdtracks reads both so they cannot drift.
+CD_TRACK_NAMES = {
+    2: "TADPCM2",
+    3: "TADPCM3",
+    4: "TADPCM4",
+    5: "TADPCM5",
+    6: "JADPCM01",
+    7: "TADPCM6",
+}
+
+# The marker that says a directory holds game data, same one discovery uses
+# (FILE_VALID_RES_DIR in SOURCES/DIRECTORIES.CPP).
+MARKER = "LBA2.HQR"
+
+# The music subdirectory, in the four spellings Discover sweeps. The engine finds
+# any of them; we reuse whichever the output tree already has.
+MUSIC_DIR = "music"
+MUSIC_SPELLINGS = ("music", "MUSIC", "Music")
+
+RAW_SECTOR = 2352  # a CD-DA sector: 588 stereo frames of 16-bit LE PCM
+CDDA_RATE = 44100
+CDDA_CHANNELS = 2
+CDDA_WIDTH = 2
+
+IMAGE_EXTS = (".bin", ".iso", ".img", ".gog", ".dot", ".mdf", ".raw")
+CUE_EXTS = (".cue", ".dat", ".toc")
+
+
+# --- cue sheet ---------------------------------------------------------------
+class CueTrack(object):
+    def __init__(self, number, mode, source):
+        self.number = number
+        self.mode = mode  # AUDIO, MODE1/2352, ...
+        self.source = source  # the FILE this track lives in
+        self.indexes = {}  # index number -> LBA within that file
+
+    @property
+    def start(self):
+        return self.indexes.get(1, self.indexes.get(0))
+
+    @property
+    def first_index(self):
+        """Where the track's area begins, pregap included."""
+        return self.indexes.get(0, self.indexes.get(1))
+
+
+def msf_to_lba(text):
+    m, s, f = (int(p) for p in text.split(":"))
+    return (m * 60 + s) * 75 + f
+
+
+def parse_cue(path):
+    """Return the cue's tracks in file order. Raises ValueError on a bad INDEX."""
+    tracks = []
+    source = None
+    current = None
+    with open(path, "r", errors="replace") as fh:
+        for lineno, line in enumerate(fh, 1):
+            line = line.strip()
+            if not line or line.upper().startswith("REM"):
+                continue
+            head = line.split(None, 1)[0].upper()
+            if head == "FILE":
+                m = re.match(r'FILE\s+"([^"]+)"|FILE\s+(\S+)', line, re.I)
+                if m:
+                    source = m.group(1) or m.group(2)
+            elif head == "TRACK":
+                parts = line.split()
+                if len(parts) >= 3:
+                    current = CueTrack(int(parts[1]), parts[2].upper(), source)
+                    tracks.append(current)
+            elif head == "INDEX" and current is not None:
+                parts = line.split()
+                if len(parts) >= 3:
+                    try:
+                        current.indexes[int(parts[1])] = msf_to_lba(parts[2])
+                    except ValueError:
+                        raise ValueError(
+                            "%s:%d: malformed INDEX %r" % (path, lineno, parts[2]))
+    return tracks
+
+
+def audio_spans(tracks, image_sectors):
+    """[(track number, first sector, sector count)] for audio inside one image.
+
+    A track runs from its INDEX 01 to the start of the next track's area, so a
+    pregap belongs to the track that follows it, as Red Book defines it. Only
+    tracks sharing the data track's FILE are in here; a cue that names a separate
+    file per track is handled as loose audio instead."""
+    inside = [t for t in tracks if t.mode == "AUDIO" and t.source == tracks[0].source]
+    spans = []
+    for i, t in enumerate(inside):
+        if t.start is None:
+            continue
+        nxt = inside[i + 1].first_index if i + 1 < len(inside) else None
+        end = nxt if nxt is not None else image_sectors
+        if end > t.start:
+            spans.append((t.number, t.start, end - t.start))
+    return spans
+
+
+def cue_names(cue, tracks, image):
+    """Whether the cue's first FILE really is the image we are reading."""
+    if not tracks or not tracks[0].source:
+        return False
+    named = os.path.join(os.path.dirname(os.path.abspath(cue)), tracks[0].source)
+    return os.path.abspath(named) == os.path.abspath(image)
+
+
+def external_audio(tracks):
+    """[(track number, filename)] for a cue that names one file per audio track.
+
+    Only when there are at least two of them. A cue with a single external audio
+    file is not describing a disc's track numbering: GOG's lists its one theme as
+    TRACK 02 when the music is TADPCM6, so reading the number there renames the
+    wrong theme. The engine draws the same line for the same reason."""
+    if not tracks:
+        return []
+    loose = _loose_audio(tracks)
+    return loose if len(loose) >= 2 else []
+
+
+def _loose_audio(tracks):
+    if not tracks:
+        return []
+    return [(t.number, t.source) for t in tracks
+            if t.mode == "AUDIO" and t.source and t.source != tracks[0].source]
+
+
+def single_external(tracks):
+    """The filename of a cue's lone external audio track, if that is its shape."""
+    loose = _loose_audio(tracks)
+    return loose[0][1] if len(loose) == 1 else None
+
+
+# --- locating things ---------------------------------------------------------
+def looks_like_image(path):
+    try:
+        img = iso_bin.open_image(path)
+    except OSError:
+        return None
+    if img is not None:
+        img.f.close()
+    return img is not None
+
+
+def pick_image(directory):
+    """The best image in a directory: raw beats cooked, then larger beats smaller.
+
+    Same ranking the engine uses, so both land on the same file when a rip ships
+    a .bin and a .iso of the same disc and only the .bin has the audio."""
+    best = None
+    for name in sorted(os.listdir(directory)):
+        path = os.path.join(directory, name)
+        if not os.path.isfile(path):
+            continue
+        if os.path.splitext(name)[1].lower() in CUE_EXTS:
+            continue
+        try:
+            img = iso_bin.open_image(path)
+        except OSError:
+            continue
+        if img is None:
+            continue
+        raw = img.is_raw
+        img.f.close()
+        rank = (1 if raw else 0, os.path.getsize(path))
+        if best is None or rank > best[0]:
+            best = (rank, path)
+    return best[1] if best else None
+
+
+def pick_cue(image_path):
+    """The cue beside an image: its own stem first, then any single one there."""
+    directory = os.path.dirname(os.path.abspath(image_path))
+    stem = os.path.splitext(os.path.basename(image_path))[0]
+    for ext in CUE_EXTS:
+        candidate = os.path.join(directory, stem + ext)
+        if os.path.isfile(candidate):
+            return candidate
+        candidate = os.path.join(directory, stem + ext.upper())
+        if os.path.isfile(candidate):
+            return candidate
+    found = [os.path.join(directory, n) for n in sorted(os.listdir(directory))
+             if os.path.splitext(n)[1].lower() in CUE_EXTS]
+    return found[0] if len(found) == 1 else None
+
+
+def find_asset_root(img, root_lba, root_size):
+    """(iso path, lba, size) of the directory holding LBA2.HQR.
+
+    CD masters nest the game under a volume directory (/TWINSEN on the US disc,
+    /LBA2 on GOG's), so the marker is what finds it, not a fixed name."""
+    for name, lba, size, is_dir in iso_bin.list_dir(img, root_lba, root_size):
+        if not is_dir and name.upper() == MARKER:
+            return "", root_lba, root_size
+    for path, lba, size, is_dir in iso_bin.walk(img, root_lba, root_size):
+        if is_dir:
+            for name, _, _, child_is_dir in iso_bin.list_dir(img, lba, size):
+                if not child_is_dir and name.upper() == MARKER:
+                    return path, lba, size
+    return None
+
+
+def music_dir_in(outdir):
+    """The music folder to write into: whichever spelling is already there."""
+    for spelling in MUSIC_SPELLINGS:
+        candidate = os.path.join(outdir, spelling)
+        if os.path.isdir(candidate):
+            return candidate
+    return os.path.join(outdir, MUSIC_DIR)
+
+
+def themes_without_a_file(outdir, stems):
+    """CD track numbers whose theme has no file in the output, in track order."""
+    have = set(stems)
+    target = music_dir_in(outdir)
+    if os.path.isdir(target):
+        for name in os.listdir(target):
+            have.add(os.path.splitext(name)[0].upper())
+    return [n for n in sorted(CD_TRACK_NAMES) if CD_TRACK_NAMES[n].upper() not in have]
+
+
+def track_number_of(filename):
+    """The CD track number a ripped file names, or None.
+
+    Rippers vary (track02.cdda.wav, Track 2.wav, 02.wav); the first run of digits
+    is the track number in all of them."""
+    m = re.search(r"\d+", os.path.basename(filename))
+    return int(m.group(0)) if m else None
+
+
+# --- writing -----------------------------------------------------------------
+class Plan(object):
+    def __init__(self, force, dry_run):
+        self.force = force
+        self.dry_run = dry_run
+        self.written = 0
+        self.skipped = 0
+        self.bytes = 0
+        self.stems = set()  # every basename the run put in place, minus extension
+
+    def keep_existing(self, dest, expected_size):
+        if self.force or not os.path.exists(dest):
+            return False
+        if expected_size is None or os.path.getsize(dest) == expected_size:
+            self.skipped += 1
+            self.stems.add(os.path.splitext(os.path.basename(dest))[0].upper())
+            return True
+        return False
+
+    def note(self, dest, size, what):
+        self.written += 1
+        self.stems.add(os.path.splitext(os.path.basename(dest))[0].upper())
+        self.bytes += size or 0
+        print("  %-40s %10s  %s" % (os.path.basename(dest), size or "?", what))
+
+
+def write_wav_from_sectors(src, dest, first_sector, sectors, plan):
+    """Cut a CD-DA track out of a raw image. Sector bytes are already the PCM the
+    WAV wants, so this is a header plus a copy."""
+    payload = sectors * RAW_SECTOR
+    if plan.keep_existing(dest, payload + 44):
+        return
+    plan.note(dest, payload + 44,
+              "CD track from sector %d (%d sectors)" % (first_sector, sectors))
+    if plan.dry_run:
+        return
+    with open(src, "rb") as fh, wave.open(dest, "wb") as wf:
+        wf.setnchannels(CDDA_CHANNELS)
+        wf.setsampwidth(CDDA_WIDTH)
+        wf.setframerate(CDDA_RATE)
+        fh.seek(first_sector * RAW_SECTOR)
+        left = payload
+        while left > 0:
+            chunk = fh.read(min(left, RAW_SECTOR * 512))
+            if not chunk:
+                break
+            wf.writeframes(chunk)
+            left -= len(chunk)
+
+
+def extract_tree(img, iso_root, lba, size, outdir, plan):
+    """Write the asset root's subtree out, keeping the on-disc names."""
+    for path, clba, csize, is_dir in iso_bin.walk(img, lba, size, iso_root):
+        rel = path[len(iso_root):].lstrip("/")
+        dest = os.path.join(outdir, *rel.split("/"))
+        if is_dir:
+            if not plan.dry_run:
+                os.makedirs(dest, exist_ok=True)
+            continue
+        if plan.keep_existing(dest, csize):
+            continue
+        plan.note(dest, csize, rel)
+        if plan.dry_run:
+            continue
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        nsec = (csize + iso_bin.USER - 1) // iso_bin.USER
+        with open(dest, "wb") as fh:
+            done = 0  # sectors
+            while done < nsec:
+                batch = min(512, nsec - done)
+                data = img.read_lba(clba + done, batch)
+                fh.write(data[:csize - done * iso_bin.USER])
+                done += batch
+
+
+def copy_ripped(sources, outdir, plan):
+    """Name a ripper's output the way the engine asks for it."""
+    target = music_dir_in(outdir)
+    for number, path in sorted(sources):
+        name = CD_TRACK_NAMES.get(number)
+        if name is None:
+            print("  skipping %s: track %s carries no music on this disc"
+                  % (os.path.basename(path), number))
+            continue
+        # Keep the source format in the name. The engine asks for NAME.WAV and
+        # falls back to NAME.ogg, so a renamed OGG only loads under its own
+        # extension.
+        ext = os.path.splitext(path)[1]
+        dest = os.path.join(target, name + (".WAV" if ext.lower() == ".wav" else ext))
+        size = os.path.getsize(path)
+        if plan.keep_existing(dest, size):
+            continue
+        plan.note(dest, size, "track %02d from %s" % (number, os.path.basename(path)))
+        if plan.dry_run:
+            continue
+        os.makedirs(target, exist_ok=True)
+        shutil.copyfile(path, dest)
+
+
+def ripped_wavs_in(directory):
+    """[(track number, path)] for the WAVs a ripper left in a folder."""
+    out = []
+    for name in sorted(os.listdir(directory)):
+        path = os.path.join(directory, name)
+        if not os.path.isfile(path) or not name.lower().endswith(".wav"):
+            continue
+        number = track_number_of(name)
+        if number is not None:
+            out.append((number, path))
+    return out
+
+
+# --- self-test ---------------------------------------------------------------
+# The cue rules are where this can be wrong without anything failing: get a span
+# or a track number off and every theme still plays, just not its own. `--selftest`
+# pins them against fixture cues, no disc needed. The naming table has its own
+# guard on the engine side, in tests/cdtracks.
+RETAIL_CUE = """FILE "TWINSEN.bin" BINARY
+  TRACK 01 MODE1/2352
+    INDEX 01 00:00:00
+  TRACK 02 AUDIO
+    INDEX 01 46:04:68
+  TRACK 03 AUDIO
+    INDEX 00 49:50:60
+    INDEX 01 49:50:63
+"""
+
+GOG_CUE = """FILE "LBA2.GOG" BINARY
+  TRACK 01 MODE1/2352
+    INDEX 01 00:00:00
+FILE "LBA2.OGG" MP3
+  TRACK 02 AUDIO
+      INDEX 01 00:00:00
+"""
+
+PER_TRACK_CUE = """FILE "data.bin" BINARY
+  TRACK 01 MODE1/2352
+    INDEX 01 00:00:00
+FILE "track02.wav" WAVE
+  TRACK 02 AUDIO
+    INDEX 01 00:00:00
+FILE "track03.wav" WAVE
+  TRACK 03 AUDIO
+    INDEX 01 00:00:00
+"""
+
+
+def selftest():
+    import tempfile
+
+    failures = []
+    checks = [0]
+
+    def check(name, got, want):
+        checks[0] += 1
+        if got != want:
+            failures.append("%s: got %r, want %r" % (name, got, want))
+
+    def cue_of(text):
+        fh = tempfile.NamedTemporaryFile("w", suffix=".cue", delete=False)
+        fh.write(text)
+        fh.close()
+        return fh.name
+
+    check("msf", msf_to_lba("46:04:68"), 207368)
+    check("msf zero", msf_to_lba("00:00:00"), 0)
+
+    retail = parse_cue(cue_of(RETAIL_CUE))
+    check("retail tracks", len(retail), 3)
+    # Track 2 ends where track 3's pregap starts, not where its INDEX 01 does:
+    # an INDEX 00 belongs to the track that follows it.
+    check("retail spans", audio_spans(retail, 300000),
+          [(2, 207368, 224310 - 207368), (3, 224313, 300000 - 224313)])
+    check("retail has no loose audio", external_audio(retail), [])
+
+    gog = parse_cue(cue_of(GOG_CUE))
+    # The trap: one external file whose cue number is not a CD track number.
+    check("gog is not mapped by number", external_audio(gog), [])
+    check("gog names its file", single_external(gog), "LBA2.OGG")
+    check("gog has nothing inside the image", audio_spans(gog, 300000), [])
+
+    per_track = parse_cue(cue_of(PER_TRACK_CUE))
+    check("per-track cue maps by number", external_audio(per_track),
+          [(2, "track02.wav"), (3, "track03.wav")])
+
+    check("track number from cdparanoia", track_number_of("track02.cdda.wav"), 2)
+    check("track number from a space", track_number_of("Track 7.wav"), 7)
+    check("track number from none", track_number_of("purple.wav"), None)
+
+    for line in failures:
+        print("FAIL %s" % line)
+    print("%d check(s), %d failed" % (checks[0], len(failures)))
+    return 1 if failures else 0
+
+
+# --- driver ------------------------------------------------------------------
+def resolve_source(source):
+    """(image path or None, cue path or None, ripped WAVs or [])."""
+    if os.path.isdir(source):
+        wavs = ripped_wavs_in(source)
+        image = pick_image(source)
+        if image is None:
+            return None, None, wavs
+        return image, pick_cue(image), []
+    ext = os.path.splitext(source)[1].lower()
+    if ext in CUE_EXTS:
+        tracks = parse_cue(source)
+        if not tracks or not tracks[0].source:
+            raise SystemExit("%s names no FILE" % source)
+        image = os.path.join(os.path.dirname(os.path.abspath(source)), tracks[0].source)
+        if not os.path.isfile(image):
+            raise SystemExit("%s names %r, which is not beside it"
+                             % (source, tracks[0].source))
+        return image, source, []
+    if ext in IMAGE_EXTS or looks_like_image(source):
+        return source, pick_cue(source), []
+    raise SystemExit("%s is not a cue, an image, or a directory holding either" % source)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Extract a playable game-data folder from a CD, themes included.")
+    ap.add_argument("source", nargs="?",
+                    help="a .cue, a disc image, or a directory holding "
+                         "either (or a directory of ripped track WAVs)")
+    ap.add_argument("outdir", nargs="?", help="where to write the game data")
+    ap.add_argument("--tracks-from", metavar="DIR",
+                    help="take the CD audio from a folder of ripped WAVs instead of "
+                         "from the image (for containers whose audio is unreachable)")
+    ap.add_argument("--force", action="store_true",
+                    help="overwrite files already at the destination")
+    ap.add_argument("--dry-run", action="store_true", help="say what would be written")
+    ap.add_argument("--selftest", action="store_true",
+                    help="check the cue rules against fixtures; needs no disc")
+    a = ap.parse_args()
+
+    if a.selftest:
+        return selftest()
+    if not a.source or not a.outdir:
+        ap.error("SOURCE and OUTDIR are both required")
+
+    image, cue, ripped = resolve_source(a.source)
+    if a.tracks_from:
+        ripped = ripped_wavs_in(a.tracks_from)
+        if not ripped:
+            raise SystemExit("no track WAVs in %s" % a.tracks_from)
+
+    plan = Plan(a.force, a.dry_run)
+    if not a.dry_run:
+        os.makedirs(a.outdir, exist_ok=True)
+
+    if image is None and not ripped:
+        raise SystemExit("%s holds no disc image and no ripped WAVs" % a.source)
+
+    if image is not None:
+        print("Image:      %s" % image)
+        img = iso_bin.open_image(image)
+        if img is None:
+            raise SystemExit("%s is not an ISO9660 image" % image)
+        pvd = iso_bin.get_pvd(img)
+        rlba, rsize = iso_bin.root_record(pvd)
+        found = find_asset_root(img, rlba, rsize)
+        if found is None:
+            raise SystemExit("no %s inside %s, so this is not LBA2 game data"
+                             % (MARKER, image))
+        iso_root, lba, size = found
+        raw = img.is_raw
+        print("Asset root: %s" % (iso_root or "/"))
+        print("Data:")
+        extract_tree(img, iso_root, lba, size, a.outdir, plan)
+        img.f.close()
+
+        if cue and not ripped:
+            tracks = parse_cue(cue)
+            print("Cue:        %s (%d tracks)" % (cue, len(tracks)))
+            loose = external_audio(tracks)
+            if loose:
+                base = os.path.dirname(os.path.abspath(cue))
+                print("Music:      one file per track, named by the cue")
+                copy_ripped(
+                    [(n, os.path.join(base, f)) for n, f in loose
+                     if os.path.isfile(os.path.join(base, f))], a.outdir, plan)
+            elif not cue_names(cue, tracks, image):
+                # A cue's INDEX addresses belong to the file it names. Applying
+                # them to a different one lands mid-sector and plays as
+                # full-scale noise, so "probably the same disc" is not enough.
+                print("Music:      %s describes %r, not this image"
+                      % (os.path.basename(cue), tracks[0].source))
+            elif not raw:
+                print("Music:      image is cooked (2048), so it carries no CD audio")
+            else:
+                sectors = os.path.getsize(image) // RAW_SECTOR
+                spans = audio_spans(tracks, sectors)
+                if spans:
+                    print("Music:      matched by CD track number")
+                    target = music_dir_in(a.outdir)
+                    if not a.dry_run:
+                        os.makedirs(target, exist_ok=True)
+                    for number, first, count in spans:
+                        name = CD_TRACK_NAMES.get(number)
+                        if name is None:
+                            print("  track %02d carries no music on this disc" % number)
+                            continue
+                        write_wav_from_sectors(
+                            image, os.path.join(target, name + ".WAV"),
+                            first, count, plan)
+                elif single_external(tracks):
+                    print("Music:      one external audio file (%s), whose cue number "
+                          "is not a CD track number" % single_external(tracks))
+                    print("            The engine plays it as it stands; leave it "
+                          "where it is rather than renaming it here.")
+                else:
+                    print("Music:      the cue lists no audio tracks in this image")
+        elif not cue and not ripped:
+            print("Music:      no cue beside the image, so the themes stay silent")
+
+    if ripped:
+        print("Music:      from %s" % (a.tracks_from or a.source))
+        copy_ripped(ripped, a.outdir, plan)
+
+    # What matters is whether each theme ended up with a file, not how it got
+    # there: on GOG the same music sits inside the data track, so counting only
+    # the CD tracks we cut would report every theme missing from a folder that
+    # has them all.
+    missing = themes_without_a_file(a.outdir, plan.stems)
+    if missing:
+        print("No file for: %s" % ", ".join(
+            "%s (track %02d)" % (CD_TRACK_NAMES[n], n) for n in missing))
+    print("%d file(s) written, %d already there, %.1f MB"
+          % (plan.written, plan.skipped, plan.bytes / 1048576.0))
+    if not a.dry_run and image is not None:
+        print("Play it with: lba2cc --game-dir %s" % os.path.abspath(a.outdir))
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/scripts/dev/iso_bin.py
+++ b/scripts/dev/iso_bin.py
@@ -14,6 +14,10 @@ bytes, so the ISO9660 filesystem is walked in place — no need to materialize a
 plain `.iso`. Verified against the Adeline CD dumps for LBA1 (`LBA.DOT`), Time
 Commando (`GAME.GOG`), and LBA2 (`LBA2.GOG`).
 
+A cooked image (2048 bytes/sector, data track only, what a `.iso` usually is) reads
+the same way with the stride and header offset changed, so `open_image` accepts
+either. Only a raw one carries the audio tracks.
+
 This also doubles as the working spec for an in-engine ISO9660-from-image reader that
 could let the engine load media directly from a GOG package without an extraction step
 (see issue #119). For bulk extraction of LBA2's missing media into an install dir, use
@@ -32,15 +36,40 @@ SECTOR = 2352
 USER = 2048
 HDR = 16  # 12 sync + 4 header before the 2048 user bytes (Mode1/2352)
 
+# Raw first: a cooked image has no sync pattern, so it can only be read one way,
+# while a raw one read as cooked lands mid-sector and matches nothing.
+LAYOUTS = ((SECTOR, HDR), (USER, 0))
+
 class Image:
-    def __init__(self, path):
+    def __init__(self, path, stride=SECTOR, hdr=HDR):
         self.f = open(path, "rb")
+        self.stride = stride
+        self.hdr = hdr
     def read_lba(self, lba, count=1):
         out = bytearray()
         for i in range(count):
-            self.f.seek((lba + i) * SECTOR + HDR)
+            self.f.seek((lba + i) * self.stride + self.hdr)
             out += self.f.read(USER)
         return bytes(out)
+    @property
+    def is_raw(self):
+        return self.stride == SECTOR
+
+def open_image(path):
+    """Open an image whichever layout it uses, or return None if it is not ISO9660.
+
+    Raw (2352) carries the CD-DA audio tracks alongside the filesystem; cooked
+    (2048) is the data track alone. Both are readable here, but only a raw image
+    has audio to extract."""
+    for stride, hdr in LAYOUTS:
+        img = Image(path, stride, hdr)
+        try:
+            if img.read_lba(16)[1:6] == b"CD001":
+                return img
+        except OSError:
+            pass
+        img.f.close()
+    return None
 
 def parse_dir_records(data):
     """Yield (name, lba, size, is_dir) from a directory extent's bytes."""
@@ -123,7 +152,9 @@ def main():
     ap.add_argument("--tree", action="store_true", help="recursive listing from root")
     ap.add_argument("--extract", nargs=2, metavar=("ISOPATH", "OUT"))
     a = ap.parse_args()
-    img = Image(a.image)
+    img = open_image(a.image)
+    if img is None:
+        raise SystemExit("not an ISO9660 image (no CD001 at LBA 16, either layout)")
     pvd = get_pvd(img)
     rlba, rsize = root_record(pvd)
     volid = pvd[40:72].decode("latin-1").strip()

--- a/tests/cdtracks/CMakeLists.txt
+++ b/tests/cdtracks/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Host regression test for the CD-track mapping (LIB386/SYSTEM/CDTRACKS.CPP).
 # Pins which CD track carries which music on a disc that keeps its soundtrack as
-# Red Book audio, and that the mapping stays in step with SOURCES/MUSIC.CPP.
+# Red Book audio, and that the mapping stays in step with SOURCES/MUSIC.CPP and
+# with the copy scripts/dev/disc_extract.py names its output by.
 # Pure table lookup: no SDL, no filesystem, no disc image.
 add_executable(test_cdtracks
     test_cdtracks.cpp

--- a/tests/cdtracks/test_cdtracks.cpp
+++ b/tests/cdtracks/test_cdtracks.cpp
@@ -5,13 +5,14 @@
  * decides which sectors a music request plays, so getting it wrong is silent:
  * every scene gets a plausible theme, just not its own.
  *
- * Three things are pinned. The lookup itself (names, bounds, path and case
+ * Four things are pinned. The lookup itself (names, bounds, path and case
  * handling); that the table still agrees with SOURCES/MUSIC.CPP's ListJingle,
- * which is where the order comes from; and that MUSIC.CPP's two track tables
+ * which is where the order comes from; that MUSIC.CPP's two track tables
  * still hold identical music numbers, which is what lets PlayMusic route both
- * releases through one path. The last two read that source file rather than
- * linking it, so the table can live beside the disc code without the two
- * drifting apart unnoticed.
+ * releases through one path; and that scripts/dev/disc_extract.py, which names
+ * a ripper's output by this same mapping, still spells it the same way. Those
+ * three read their source file rather than linking it, so the table can live
+ * beside the disc code without the copies drifting apart unnoticed.
  */
 #include "test_harness.h"
 
@@ -120,6 +121,56 @@ static void test_agrees_with_music_cpp(void) {
     }
 }
 
+/* The extractor cuts CD audio out of a rip and names the files, so it carries its
+   own copy of this table. A drift there is silent in a way the engine's is not:
+   nothing fails, the themes just come out under each other's names. Read its
+   `CD_TRACK_NAMES = { 2: "TADPCM2", ... }` and require an exact match. */
+static void test_agrees_with_extractor(void) {
+    std::string path = std::string(TEST_SOURCE_ROOT) + "scripts/dev/disc_extract.py";
+    FILE *f = fopen(path.c_str(), "rb");
+    ASSERT_TRUE(f != NULL);
+    if (!f)
+        return;
+    std::string text;
+    char buf[4096];
+    size_t n;
+    while ((n = fread(buf, 1, sizeof(buf), f)) > 0)
+        text.append(buf, n);
+    fclose(f);
+
+    size_t start = text.find("CD_TRACK_NAMES = {");
+    ASSERT_TRUE(start != std::string::npos);
+    if (start == std::string::npos)
+        return;
+    size_t end = text.find('}', start);
+    ASSERT_TRUE(end != std::string::npos);
+    if (end == std::string::npos)
+        return;
+
+    int seen = 0;
+    for (size_t i = text.find('{', start) + 1; i < end;) {
+        size_t digit = text.find_first_of("0123456789", i);
+        if (digit == std::string::npos || digit > end)
+            break;
+        size_t colon = text.find(':', digit);
+        if (colon == std::string::npos || colon > end)
+            break;
+        size_t q1 = text.find('"', colon);
+        size_t q2 = (q1 == std::string::npos) ? q1 : text.find('"', q1 + 1);
+        if (q1 == std::string::npos || q2 == std::string::npos || q2 > end)
+            break;
+        int track = atoi(text.c_str() + digit);
+        std::string name = text.substr(q1 + 1, q2 - q1 - 1);
+        const char *mine = CdTracks_NameForNumber(track);
+        ASSERT_TRUE(mine != NULL && name == mine);
+        seen++;
+        i = q2 + 1;
+    }
+    /* Every audio track the engine knows has to be in the script's table too, or
+       the extractor would quietly leave one theme unnamed. */
+    ASSERT_EQ_INT(CDTRACKS_LAST_AUDIO - CDTRACKS_FIRST_AUDIO + 1, seen);
+}
+
 /* Pull a `U8 <name>[] = { ... };` initialiser out of MUSIC.CPP as (value, hasJingleFlag)
    pairs. Entries look like "JINGLE | 9, // comment" or "3, // comment". */
 static bool read_track_table(const char *table, std::vector<std::pair<int, bool>> &out) {
@@ -193,6 +244,7 @@ int main(void) {
     RUN_TEST(test_number_by_name);
     RUN_TEST(test_round_trip);
     RUN_TEST(test_agrees_with_music_cpp);
+    RUN_TEST(test_agrees_with_extractor);
     RUN_TEST(test_track_tables_agree_on_music_numbers);
     TEST_SUMMARY();
     return test_failures != 0;


### PR DESCRIPTION
A `bin`+`cue` rip already plays whole, so this is not for that: extracting one costs 535 MB to gain nothing. It is for the shapes the engine deliberately does not serve.

The real case is a physical disc. Data and jingles play straight off a mounted CD, but the six themes are Red Book audio, and drive-backed CD audio is a documented non-goal for the engine: it would sit in the audio path, where it has to be right every time on every drive with no chance to inspect the result. Until now the answer was "go make a 700 MB image first". A script runs once, its output is checked by ear, and a bad read can be reported, so the same job is allowed to be a dependency-free best effort here.

The others are a container we mount data-only (MDX, NRG, CCD) and wanting loose files to mod or inspect. `DISC_IMAGE_SOURCE.md` has listed an extraction helper under *What is not done* since the disc work landed; this is it.

```
disc_extract.py /path/to/rip ~/lba2-data                      # image, CD tracks included
disc_extract.py /media/cdrom/TWINSEN ~/lba2-data --from-drive /dev/sr0
disc_extract.py G:\TWINSEN C:\lba2-data --from-drive G
disc_extract.py ~/ripped ~/lba2-data                          # a rip you already made
disc_extract.py disc.mdx ~/lba2-data --tracks-from ~/ripped
```

## The naming is the contribution

Every ripper hands back `track02.wav`. What none of them can know is that CD track 6 holds `JADPCM01` rather than `TADPCM6`, or that the `ListJingle[1]` theme is not pressed on the US disc at all. That came out of the disc's own table of contents and it is this repo's finding, so the script carries a copy of the `CDTRACKS.CPP` table and `tests/cdtracks` reads both and fails if they disagree.

Drift there is silent in a way the engine's cannot be: nothing errors, the themes come out under each other's names and every scene gets a plausible one. Checked by renaming an entry and by dropping one.

## What it refuses to guess

Both are lines the engine already draws:

- A cue whose `FILE` names something other than the image being read is reported, not applied. Those `INDEX` addresses land mid-sector in a different file and play as full-scale noise.
- A cue with a single external audio track is reported too. GOG's lists its one theme as `TRACK 02` when the music is `TADPCM6`, so the number there is not a CD track number.

## Reading a drive

`IOCTL_CDROM_READ_TOC` and `IOCTL_CDROM_RAW_READ` on Windows, `CDROMREADTOCENTRY` and `CDROMREADAUDIO` on Linux. It reads the disc's own table of contents rather than inferring numbering from filenames, which is worth more than the convenience: this repo has already been wrong once about which track holds which theme.

Reads chunk at 27 sectors, the ATAPI ceiling of 63504 bytes, found by trying 64 and getting *the parameter is incorrect*. Failed chunks retry three times and the count is printed, because audio sectors carry no error correction and a scratched disc gives clicks `cdparanoia` would have interpolated away. A disc that reports retries is one to rip properly and bring back through `--tracks-from`.

### Finding where the music starts

A cue can say "start track 2 late" and ours does. A table of contents cannot, and on a mixed-mode disc the data track's run-out bleeds into the front of the first audio track: five sectors of full-scale noise ahead of *The Empire*.

Reading a drive there is no cue, so the join is found by distribution rather than level. Data read as audio is uniform noise, and the measurements are not close:

| | mean sample magnitude |
| --- | --- |
| the run-out sectors | 0.503 |
| the music after them | 0.005 |
| a brickwalled master, worst case | ~0.35 |

The gate is 0.40, clear of both, because music has crest factor and noise does not. It tests only the first sector, caps the skip at one transport read, and prints when it fires, the last because the one signal it cannot tell from data is a sustained full-scale tone (a sine averages 0.637).

Run against the retail disc it lands on the same sector the corrected cue names by hand, and touches none of the other five tracks.

## Verification

Against the US retail rip, 1.6 s for 535 MB:

- Extracted data byte-identical to what the image serves, by md5, including the 231 MB `VIDEO.HQR`.
- Track audio byte-identical at the sectors the corrected cue documents.
- `dist_check.sh` gives the extracted folder the same release identity, the same assets and all six identical pixel hashes as the mounted rip, differing only in serving music from files (`fff`) instead of the image (`ccc`).

Against a real mixed-mode disc in a drive, run under Windows Python rather than a shim:

- TOC reports 7 tracks, 1 data, 6 audio, lead-out 292864, matching the disc read independently through PowerShell.
- **All six themes ripped off the drive are byte-identical to the same themes cut from the image**, and all 109 data files match.
- `dist_check.sh` again gives the same identity, assets and six pixel hashes as the mounted rip.

GOG and a cooked `.iso` report their limits instead of guessing.

## What ships untested, and is marked so

- **The Linux backend.** Written from `<linux/cdrom.h>` with the struct layouts checked against the compiler (`cdrom_tocentry` 12 bytes, `cdrom_read_audio` 24, field offsets 0/4/8/16), but the development box has no optical device, so it has never been run. If it fails, the error names `cdparanoia` and `--tracks-from`, which is the tested path.
- **macOS** has no drive backend and says so rather than guessing.

## Coverage

`--selftest`, 29 checks, no disc needed: the cue rules including the GOG trap and an `INDEX 00` pregap that belongs to the track after it, the retail disc's real TOC bytes as a fixture so the parse is pinned against a disc rather than a table written to match it, and the trim rule against synthetic sectors from a fixed LCG.

`tests/cdtracks` grows a fifth case reading the script's table. `host_quick` 50/50.

## Also here

`iso_bin.py` now reads cooked 2048 images as well as raw 2352, which `disc_extract` needs to answer "does this image carry audio at all" before offering to extract any. `Image(path)` still defaults to raw, so existing callers are unchanged.

Reviewable per commit; the five are separable.
