### PR TITLE
feat(demo): build and run the 1997 playable demo

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -72,8 +72,13 @@ jobs:
   # default build never touches. That is exactly how it silently stopped
   # compiling between 1997 and the LBA2_BUILD_DEMO option, so an edit to the
   # files it shares with retail (GAMEMENU, PERSO, SAVEGAME, OBJECT) can break it
-  # against a green matrix. Compile-and-link only: no demo game data on a runner,
-  # and this catches the whole class regardless.
+  # against a green matrix.
+  #
+  # The host tests run here too. They need no game data, and several of them
+  # assert against build-dependent values -- test_res_picker checks the picker
+  # modals quote Directories_GetResMarker(), which the demo build changes. A
+  # compile-only job stays green while those messages send a demo player after
+  # a file no demo install has.
   build-demo:
     runs-on: ubuntu-latest
 
@@ -98,11 +103,17 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
             -DCMAKE_PREFIX_PATH="${{ steps.sdl.outputs.prefix }}" \
             -DLBA2_BUILD_DEMO=ON \
+            -DLBA2_BUILD_TESTS=ON \
             -DLBA2_BUILD_ASM_EQUIV_TESTS=OFF \
             --preset linux
 
       - name: Build
-        run: cmake --build build-demo --target lba2cc
+        run: |
+          cmake --build build-demo --target lba2cc
+          cmake --build build-demo --target host_tests
+
+      - name: Host tests
+        run: cd build-demo && ctest -L host_quick --output-on-failure
 
       - name: Verify Binary
         run: test -f build-demo/SOURCES/lba2cc && echo "Demo build successful"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -67,3 +67,42 @@ jobs:
 
       - name: Verify Binary
         run: test -f build/SOURCES/lba2cc && echo "Build successful"
+
+  # The demo SKU compiles a different set of sources: ~60 #ifdef DEMO sites the
+  # default build never touches. That is exactly how it silently stopped
+  # compiling between 1997 and the LBA2_BUILD_DEMO option, so an edit to the
+  # files it shares with retail (GAMEMENU, PERSO, SAVEGAME, OBJECT) can break it
+  # against a green matrix. Compile-and-link only: no demo game data on a runner,
+  # and this catches the whole class regardless.
+  build-demo:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v5
+
+      - name: Install SDL3
+        uses: libsdl-org/setup-sdl@4ebea449684c989388fe6bcea0460e300d13a5ae # main @ 2025-12-20
+        id: sdl
+        with:
+          install-linux-dependencies: true
+          version: 3-latest
+          build-type: ${{ env.BUILD_TYPE }}
+
+      - name: Install latest CMake and ninja
+        uses: lukka/get-cmake@latest
+
+      - name: Configure
+        run: |
+          cmake -S . -B build-demo \
+            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+            -DCMAKE_PREFIX_PATH="${{ steps.sdl.outputs.prefix }}" \
+            -DLBA2_BUILD_DEMO=ON \
+            -DLBA2_BUILD_ASM_EQUIV_TESTS=OFF \
+            --preset linux
+
+      - name: Build
+        run: cmake --build build-demo --target lba2cc
+
+      - name: Verify Binary
+        run: test -f build-demo/SOURCES/lba2cc && echo "Demo build successful"

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 CMakeUserPresets.json
 out/
 build/
+# Demo SKU: a separate configure, so a second tree beside build/ (GAME_DATA.md)
+build-demo/
 dist/
 
 # Local retail drop (symlink or copy classic data here; never commit assets)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,16 @@ if(DEBUG_TOOLS)
     add_compile_definitions(DEBUG_TOOLS=1)
 endif()
 
+# The 1997 playable demo. A separate SKU, not a mode: the demo build has three
+# fixed save slots instead of free saves, chains them on cube exit, permanently
+# overlays the title logo, and ships neither voices nor cutscenes. Its data set
+# is a different install (one island), so a demo binary cannot run retail data
+# or the reverse. See docs/GAME_DATA.md.
+option(LBA2_BUILD_DEMO "Build the 1997 playable-demo SKU (needs demo game data)" OFF)
+if(LBA2_BUILD_DEMO)
+    add_compile_definitions(DEMO=1)
+endif()
+
 # Performance options
 option(LBA2_NATIVE_ARCH "Use -march=native for host-optimized build (not portable)" OFF)
 

--- a/SOURCES/ASSET_PREFLIGHT.CPP
+++ b/SOURCES/ASSET_PREFLIGHT.CPP
@@ -70,8 +70,14 @@ extern "C" int AssetPreflight(void) {
      * (When cutscene playback degrades gracefully it moves to the optional set.) */
     GetMoviePath(path, ADELINE_MAX_PATH, VIDEO_HQR_NAME);
     if (!fileExists(path)) {
+#ifdef DEMO
+        /* The demo has no cutscenes -- InitAcf() degrades instead of dying. */
+        Log_Warn("optional asset missing: %s (no cutscenes)", VIDEO_HQR_NAME);
+        ++missingOpt;
+#else
         Log_Error("missing required asset: %s", VIDEO_HQR_NAME);
         ++missingReq;
+#endif
     }
 
     const int nOpt = (int)(sizeof kOptionalHqr / sizeof kOptionalHqr[0]);

--- a/SOURCES/ASSET_PREFLIGHT.CPP
+++ b/SOURCES/ASSET_PREFLIGHT.CPP
@@ -65,13 +65,13 @@ extern "C" int AssetPreflight(void) {
         }
     }
 
-    /* video.hqr lives in video/ (GetMoviePath), not the root. It is loaded at
-     * boot by InitAcf(), which hard-fails without it — so it is required today.
-     * (When cutscene playback degrades gracefully it moves to the optional set.) */
+    /* video.hqr lives in video/ (GetMoviePath), not the root. Required in a
+     * retail build, where InitAcf() hard-fails without it. (When retail
+     * cutscene playback degrades gracefully it moves to the optional set.) */
     GetMoviePath(path, ADELINE_MAX_PATH, VIDEO_HQR_NAME);
     if (!fileExists(path)) {
 #ifdef DEMO
-        /* The demo has no cutscenes -- InitAcf() degrades instead of dying. */
+        /* No demo install has cutscenes, so InitAcf() degrades instead. */
         Log_Warn("optional asset missing: %s (no cutscenes)", VIDEO_HQR_NAME);
         ++missingOpt;
 #else

--- a/SOURCES/DEFINES.H
+++ b/SOURCES/DEFINES.H
@@ -165,10 +165,13 @@
 
 #include <FILEIO.H>
 
+/* The DEMO build pulled Adeline's CD-audio library by absolute path off the
+   1997 build machine. The demo ships its music as MUSIC/*.WAV, not CD tracks,
+   so nothing here needs it -- and the sibling CDROM include below was already
+   commented out for the same reason.
 #ifdef DEMO
 #include "/projet/lib386/lib_cd/lib_cd.h"
 #endif
-/*
 #ifdef	CDROM
 #include 	"/projet/lib386/lib_cd/lib_cd.h"
 #endif

--- a/SOURCES/DEFINES.H
+++ b/SOURCES/DEFINES.H
@@ -166,9 +166,9 @@
 #include <FILEIO.H>
 
 /* The DEMO build pulled Adeline's CD-audio library by absolute path off the
-   1997 build machine. The demo ships its music as MUSIC/*.WAV, not CD tracks,
-   so nothing here needs it -- and the sibling CDROM include below was already
-   commented out for the same reason.
+   1997 build machine. The demo ships its music as WAV files under MUSIC, not
+   as CD tracks, so nothing here needs it, and the sibling CDROM include below
+   was already commented out for the same reason.
 #ifdef DEMO
 #include "/projet/lib386/lib_cd/lib_cd.h"
 #endif

--- a/SOURCES/DIRECTORIES.CPP
+++ b/SOURCES/DIRECTORIES.CPP
@@ -300,7 +300,7 @@ void GetDefaultUserDir(char *outDir) {
     static bool initialized = false;
     static char userDir[ADELINE_MAX_PATH] = "";
     if (!initialized) {
-        char *sdlUserPath = SDL_GetPrefPath("Twinsen", "LBA2");
+        char *sdlUserPath = SDL_GetPrefPath(ADELINE_PREF_ORG, ADELINE_PREF_APP);
         if (sdlUserPath != NULL) {
             strncpy(userDir, sdlUserPath, ADELINE_MAX_PATH);
             userDir[ADELINE_MAX_PATH - 1] = '\0';

--- a/SOURCES/DIRECTORIES.CPP
+++ b/SOURCES/DIRECTORIES.CPP
@@ -35,15 +35,16 @@ extern "C" {
 #define DIR_NAME_VOICE_HD "vox" ADELINE_PATH_SEP
 #define DIR_NAME_VOICE_CD "lba2" ADELINE_PATH_SEP "vox" ADELINE_PATH_SEP
 #define DIR_NAME_VOICE_CD_US "twinsen" ADELINE_PATH_SEP "vox" ADELINE_PATH_SEP
-/* Spelled the way every distribution ships it. Discover() probes as-is, upper,
-   lower and title case, so the set of names accepted is the same either way --
-   but the as-is probe is the one that hits on a real install, and the constant
-   is what the "we could not find your game data" messages quote back at the
-   player. Naming a spelling nobody has sends them off renaming files. */
+/* Both spellings below are the way their distribution ships the file.
+   Discover() probes as-is, upper, lower and title case, so the set of names
+   accepted is the same either way -- but the as-is probe is the one that hits
+   on a real install, and the constant is what the "we could not find your game
+   data" messages quote back at the player. Naming a spelling nobody has sends
+   them off renaming files. */
 #ifdef DEMO
-/* The demo ships no LBA2.HQR -- that bank holds the credits reel, which the
-   demo does not have. RESS.HQR is the first thing the demo loads and is
-   present in every demo install, so it is the marker for this build. */
+/* No demo install ships LBA2.HQR: that bank holds the credits reel, which the
+   demo does not have. RESS.HQR is the first bank the demo loads and is present
+   in every demo install. */
 #define FILE_VALID_RES_DIR "RESS.HQR"
 #else
 #define FILE_VALID_RES_DIR "LBA2.HQR"

--- a/SOURCES/DIRECTORIES.CPP
+++ b/SOURCES/DIRECTORIES.CPP
@@ -40,7 +40,14 @@ extern "C" {
    but the as-is probe is the one that hits on a real install, and the constant
    is what the "we could not find your game data" messages quote back at the
    player. Naming a spelling nobody has sends them off renaming files. */
+#ifdef DEMO
+/* The demo ships no LBA2.HQR -- that bank holds the credits reel, which the
+   demo does not have. RESS.HQR is the first thing the demo loads and is
+   present in every demo install, so it is the marker for this build. */
+#define FILE_VALID_RES_DIR "RESS.HQR"
+#else
 #define FILE_VALID_RES_DIR "LBA2.HQR"
+#endif
 
 // --- Private state -----------------------------------------------------------
 bool directoriesInitialized = false;

--- a/SOURCES/DIRECTORIES.H
+++ b/SOURCES/DIRECTORIES.H
@@ -2,6 +2,21 @@
 
 #include <SYSTEM/ADELINE_TYPES.H>
 
+/// Org and app passed to SDL_GetPrefPath, so every user-writable path (saves,
+/// lba2.cfg, adeline.log, last_game_dir.txt) agrees on one folder.
+///
+/// The demo SKU takes its own. Its marker, RESS.HQR, is present in retail
+/// installs too, so a demo binary handed a retail path validates it; sharing
+/// last_game_dir.txt would hand it exactly that path the moment a retail build
+/// ran first. Separate folders keep the two SKUs from pointing each other at
+/// data neither can use, and keep demo saves out of a retail profile.
+#define ADELINE_PREF_ORG "Twinsen"
+#ifdef DEMO
+#define ADELINE_PREF_APP "LBA2-Demo"
+#else
+#define ADELINE_PREF_APP "LBA2"
+#endif
+
 // -----------------------------------------------------------------------------
 #ifdef __cplusplus
 extern "C" {

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -3839,7 +3839,7 @@ S32 MainGameMenu(S32 load) {
                 SlideShow();
                 //                                        DemoBumper() ;
                 GetSavePath(tmpFilePathSave, ADELINE_MAX_PATH, CURRENTSAVE_FILENAME);
-                unlink(tmpFilePathSave);
+                Delete(tmpFilePathSave); // was unlink(); Delete() is the portable wrapper
                 FlagShowEndDemo = TRUE;
 
                 Image_LoadStretched(tmpFilePathScreen, Log, PCR_MENU);
@@ -5014,6 +5014,11 @@ void DemoBumper(void) {
 		Load_HQR( tmpFilePath, Log, PCR_MENU ) ;
 	}
 */
+    /* ShowLogo leaves the bumper on screen, so the menu backdrop has to come
+       back from screen.hqr before the caller flips. */
+    char tmpFilePath[ADELINE_MAX_PATH];
+    GetResPath(tmpFilePath, ADELINE_MAX_PATH, SCREEN_HQR_NAME);
+
     ShowLogo(PCR_BUMPER, 5);
     Load_HQR(tmpFilePath, Log, PCR_MENU);
 }

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -3839,7 +3839,7 @@ S32 MainGameMenu(S32 load) {
                 SlideShow();
                 //                                        DemoBumper() ;
                 GetSavePath(tmpFilePathSave, ADELINE_MAX_PATH, CURRENTSAVE_FILENAME);
-                Delete(tmpFilePathSave); // was unlink(); Delete() is the portable wrapper
+                Delete(tmpFilePathSave);
                 FlagShowEndDemo = TRUE;
 
                 Image_LoadStretched(tmpFilePathScreen, Log, PCR_MENU);

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -3038,7 +3038,8 @@ int main(int argc, char *argv[]) {
              * in the message instead. */
             if (Control_IsActive() || Control_IsHeadless()) {
                 Log_Error("Game data not found. Pass --game-dir <folder containing "
-                          "LBA2.HQR> (often Common/), or set LBA2_GAME_DIR.");
+                          "%s> (often Common/), or set LBA2_GAME_DIR.",
+                          Directories_GetResMarker());
                 exit(EXIT_FAILURE);
             }
 

--- a/SOURCES/PLAYACF.CPP
+++ b/SOURCES/PLAYACF.CPP
@@ -15,6 +15,7 @@
 #include <AIL/VIDEO_AUDIO.H>
 #include <AIL/VIDEO_AUDIO_RESAMPLE.H>
 #include <FILEIO/SAVEPNG.H>
+#include <SYSTEM/LOG.H>
 #include <SYSTEM/WINDOW.H> // AppActive
 
 static int videoLogEnabled = 0;
@@ -80,7 +81,15 @@ void InitAcf(void) {
 
     GetMoviePath(PathAcf, ADELINE_MAX_PATH, VIDEO_HQR_NAME);
     if (!ExistsFileOrDir(PathAcf)) {
+#ifdef DEMO
+        /* The demo install ships no video/ -- retail's bank alone is bigger
+           than the whole demo. Run without cutscenes rather than refusing to
+           boot; PlayAcf() below no-ops while PathAcf is empty. */
+        Log_Warn("no %s: the demo runs without cutscenes", VIDEO_HQR_NAME);
+        PathAcf[0] = '\0';
+#else
         TheEndCheckFile(PathAcf);
+#endif
     }
 
     GetResPath(tmpFilePath, ADELINE_MAX_PATH, RESS_HQR_NAME);
@@ -361,6 +370,9 @@ static void PushCurrentFrameVideoAudio(smk smkObject, const int *tracksToPlay, i
 //---------------------------------------------------------------------------
 
 S32 PlayAcf(const char *name) {
+    if (!PathAcf[0])
+        return 0; /* no movie bank installed -- see InitAcf() */
+
     if (Control_IsVerbose())
         fprintf(stderr, "[control] modal: PlayAcf '%s' -- cutscene, blocks --exit\n", name);
 #ifdef USE_MVIDEO_SMACKER

--- a/SOURCES/PLAYACF.CPP
+++ b/SOURCES/PLAYACF.CPP
@@ -370,9 +370,6 @@ static void PushCurrentFrameVideoAudio(smk smkObject, const int *tracksToPlay, i
 //---------------------------------------------------------------------------
 
 S32 PlayAcf(const char *name) {
-    if (!PathAcf[0])
-        return 0; /* no movie bank installed -- see InitAcf() */
-
     if (Control_IsVerbose())
         fprintf(stderr, "[control] modal: PlayAcf '%s' -- cutscene, blocks --exit\n", name);
 #ifdef USE_MVIDEO_SMACKER
@@ -393,6 +390,16 @@ S32 PlayAcf(const char *name) {
         }
 
         ListVarGame[FLAG_ACF + (n / 16)] |= (S16)(1 << (n & 15));
+
+        if (!PathAcf[0]) {
+            /* No movie bank installed (InitAcf() leaves the path empty when
+               there is no video/). The flag above is already set, so scripts
+               see the cutscene the way they would one the player skipped. */
+            if (VideoLogIsEnabled())
+                SDL_Log("[VIDEO] PlayAcf: no movie bank, skipping '%s'", name);
+            s_playacf_playing = 0;
+            return 0;
+        }
 
         StopMusic();
         HQ_PauseSamples();

--- a/SOURCES/RES_DISCOVERY.CPP
+++ b/SOURCES/RES_DISCOVERY.CPP
@@ -107,8 +107,11 @@ bool NormalizeAndTry(const char *pathIn, char *outDir, U16 outMax,
 }
 
 void LogFailure(const char tried[][ADELINE_MAX_PATH], int triedCount) {
-    Log_Error("No valid game data directory (need LBA2.HQR). Tried %d path(s).",
-              triedCount);
+    /* Quote the marker this build actually looks for. A demo build wants
+       RESS.HQR, and naming a file the reader's install cannot have is what
+       sends them renaming things. */
+    Log_Error("No valid game data directory (need %s). Tried %d path(s).",
+              Directories_GetResMarker(), triedCount);
     for (int i = 0; i < triedCount; i++) {
         Log_Error("  - %s", tried[i]);
     }
@@ -273,10 +276,12 @@ bool TryParentSiblingScan(char *outDir, U16 outMax, char tried[][ADELINE_MAX_PAT
  * at picker-success time, before InitDirectories / InitAdeline have set
  * up the lba2.cfg buffer machinery. Written via stdio; read via stdio.
  *
- * Org/app naming ("Twinsen", "LBA2") matches the existing convention in
- * SOURCES/DIRECTORIES.CPP for SDL_GetPrefPath. */
+ * Org/app naming comes from ADELINE_PREF_ORG / ADELINE_PREF_APP in
+ * SOURCES/DIRECTORIES.H, so this pointer lands in the same folder as the
+ * saves and cfg it belongs with, and a demo build never reads a retail
+ * build's pick. */
 bool BuildPersistedGameDirPath(char *outPath, size_t outMax) {
-    char *prefPath = SDL_GetPrefPath("Twinsen", "LBA2");
+    char *prefPath = SDL_GetPrefPath(ADELINE_PREF_ORG, ADELINE_PREF_APP);
     if (prefPath == NULL) {
         return false;
     }

--- a/SOURCES/RES_PICKER.CPP
+++ b/SOURCES/RES_PICKER.CPP
@@ -20,14 +20,32 @@
    File scope (not the anonymous namespace below): extern "C" external linkage
    so the host test can reference them by name. */
 
+/* The marker this build validates against, spelled for a message body. A demo
+   build looks for RESS.HQR (FILE_VALID_RES_DIR in DIRECTORIES.CPP), and a modal
+   naming a file the reader's install cannot have is what sends them renaming
+   things. test_res_picker checks both bodies against Directories_GetResMarker(),
+   so the two spellings cannot drift apart. */
+#ifdef DEMO
+#define PICKER_MARKER "RESS.HQR"
+#define PICKER_INSTALL "your LBA2 demo install"
+/* A demo install carries no video/ and no vox/, and spells its music folder
+   MUSIC. Listing folders it cannot have would be the same wrong-file trap in
+   another form. */
+#define PICKER_DATA_SET "your LBA2 demo data (RESS.HQR, MUSIC/)"
+#else
+#define PICKER_MARKER "LBA2.HQR"
+#define PICKER_INSTALL "your retail LBA2 install"
+#define PICKER_DATA_SET "your retail LBA2 data (LBA2.HQR, music/, video/, vox/)"
+#endif
+
 extern "C" const char kPickerMsgDataNotFound[] =
     "Little Big Adventure 2 game data wasn't found.\n\n"
-    "Pick the folder that contains LBA2.HQR (your retail LBA2 install).\n\n"
+    "Pick the folder that contains " PICKER_MARKER " (" PICKER_INSTALL ").\n\n"
     "Your choice is saved for next time.";
 
 extern "C" const char kPickerMsgInvalidPick[] =
-    "That folder doesn't contain LBA2.HQR.\n\n"
-    "Pick your retail LBA2 install folder (the one with LBA2.HQR).";
+    "That folder doesn't contain " PICKER_MARKER ".\n\n"
+    "Pick " PICKER_INSTALL " folder (the one with " PICKER_MARKER ").";
 
 extern "C" const char kPickerMsgNoPicker[] =
     "The system folder picker isn't available here.\n\n"
@@ -38,7 +56,7 @@ extern "C" const char kPickerMsgNoPicker[] =
 
 extern "C" const char kPickerMsgAndroidData[] =
     "Little Big Adventure 2 game data wasn't found.\n\n"
-    "Copy your retail LBA2 data (LBA2.HQR, music/, video/, vox/) to:\n"
+    "Copy " PICKER_DATA_SET " to:\n"
     "    /sdcard/lba2cc/\n\n"
     "then relaunch the app.";
 

--- a/docs/GAME_DATA.md
+++ b/docs/GAME_DATA.md
@@ -6,7 +6,7 @@ The engine needs the original Little Big Adventure 2 data files. They are not in
 
 Use the directory that contains `LBA2.HQR` (and the other `.hqr` files, `music/`, `video/`, `vox/`, etc.). On Steam, classic data may live under a Classic-related install path; remastered or other editions may use a different layout — this fork targets classic data only.
 
-**Validation:** discovery and overrides only succeed when the chosen path is a directory that contains `LBA2.HQR` (that is the required marker; see `IsValidResourceDir` / `FILE_VALID_RES_DIR` in `SOURCES/DIRECTORIES.CPP`). The filename is matched with the same case-folding logic as other asset files.
+**Validation:** discovery and overrides only succeed when the chosen path is a directory that contains `LBA2.HQR` (that is the required marker; see `IsValidResourceDir` / `FILE_VALID_RES_DIR` in `SOURCES/DIRECTORIES.CPP`). The filename is matched with the same case-folding logic as other asset files. A demo build marks on `RESS.HQR` instead, because no demo install ships `LBA2.HQR`; see [The 1997 playable demo](#the-1997-playable-demo).
 
 **Single asset root:** Once that directory is chosen, `GetResPath`, `GetJinglePath`, `GetMoviePath`, and related APIs resolve files relative to that same `directoriesResDir` (see `InitDirectories` / `GetResPath` in `SOURCES/DIRECTORIES.CPP`). The engine does not look for `music/`, `video/`, `vox/`, or other `.hqr` files on separate paths; finding `LBA2.HQR` establishes the one root for classic data.
 
@@ -272,7 +272,9 @@ external audio track whose number is not a CD track number, is reported rather t
 
 The demo that shipped on magazine cover discs is a separate SKU, not a mode. Its data set is a
 different install and its behaviour lives behind `#ifdef DEMO` in the original sources, so a demo
-binary cannot run retail data and a retail binary cannot run demo data. Build it with:
+binary cannot run retail data and a retail binary cannot run demo data. It is a compile-time release
+axis rather than a `Version` key, alongside the other build variants in
+[VERSIONS.md](VERSIONS.md#build-variants). Build it with:
 
 ```bash
 cmake -S . -B build-demo -G Ninja -DLBA2_BUILD_DEMO=ON

--- a/docs/GAME_DATA.md
+++ b/docs/GAME_DATA.md
@@ -268,6 +268,56 @@ The script is idempotent (`--force` to overwrite, `--dry-run` to see the plan) a
 declines to guess: a cue that describes a different file than the image, or one with a single
 external audio track whose number is not a CD track number, is reported rather than acted on.
 
+## The 1997 playable demo
+
+The demo that shipped on magazine cover discs is a separate SKU, not a mode. Its data set is a
+different install and its behaviour lives behind `#ifdef DEMO` in the original sources, so a demo
+binary cannot run retail data and a retail binary cannot run demo data. Build it with:
+
+```bash
+cmake -S . -B build-demo -G Ninja -DLBA2_BUILD_DEMO=ON
+cmake --build build-demo
+```
+
+then point it at a demo install (`--game-dir`) the same way as retail.
+
+What the data holds, against the retail CD:
+
+| | Demo | Retail |
+|---|---|---|
+| Islands | `CITADEL` only | 17 `.ILE`/`.OBL` pairs |
+| `LBA2.HQR` (credits) | absent | present |
+| `ANIM3DS.HQR` | absent | present |
+| `VIDEO/VIDEO.HQR` | absent | 231 MB |
+| `VOX/` | absent | 39 banks across 3 languages |
+| Music | `MUSIC/*.WAV`, 9 tracks | 24 tracks |
+| `SCRSHOT.HQR` | present | absent |
+
+The HQR container is the same format throughout, same LZSS and LZMIT codecs and the same header
+layout, so every bank the demo does ship loads unmodified. The banks are subsets: 743 animations
+against 2084, 129 bodies against 470, 1243 background chunks against 18101. Music filenames are a
+subset of `ListJingle`, so the normal music path plays them with no special case. `SCRSHOT.HQR` is
+the one bank the demo adds, holding the marketing stills its slideshow shows.
+
+Two of those gaps are load-bearing and the demo build accounts for them: `LBA2.HQR` is the marker
+that identifies a resource directory, so the demo build looks for `RESS.HQR` instead, and
+`VIDEO.HQR` is required at boot, so the demo build warns and runs without cutscenes. Retail's movie
+bank alone is larger than the whole 17 MB demo, which is why no demo install has one.
+
+Behaviour that differs from retail, all of it original:
+
+- Three fixed scenarios (`demo0.lba`, `demo1.lba`, `demo2.lba`) instead of free saves. New Game
+  loads the first, Load Game is unavailable, and an in-game save writes back to the current slot
+  without prompting for a name.
+- Leaving certain cubes advances to the next scenario, hardcoded in `GereZoneChangeCube` handling
+  in `OBJECT.CPP` and commented in the original as "Grosse Rustine pour la demo".
+- The title logo is drawn over gameplay every frame. Retail ships the same sprites but draws them
+  only during the attract reel and on Activision/Virgin builds.
+- The player starts with all darts, sewer covers are forced hidden, ambient sound is suppressed in
+  the phantom cube, and the `LF_DEMO` life-script function reports `1` so scripts can branch on it.
+- The end of the demo runs the `SCRSHOT.HQR` slideshow, which the console exposes as
+  `ui slideshow`.
+
 ## Config file
 
 See [CONFIG.md](CONFIG.md). If `lba2.cfg` is missing from the user config folder, the engine copies from the asset directory when present; if the asset directory has no `lba2.cfg`, an embedded template (from the build) is written instead.

--- a/docs/GAME_DATA.md
+++ b/docs/GAME_DATA.md
@@ -283,6 +283,15 @@ cmake --build build-demo
 
 then point it at a demo install (`--game-dir`) the same way as retail.
 
+A demo build keeps its user-writable data in its own folder, `Twinsen/LBA2-Demo` rather than
+`Twinsen/LBA2`, so demo saves, `lba2.cfg`, `adeline.log` and the remembered game-data path never mix
+with a retail profile's. That last one is the reason it matters rather than merely being tidy: the
+demo's marker `RESS.HQR` is present in retail installs too, so a demo binary handed a retail path
+accepts it. Sharing `last_game_dir.txt` would hand it exactly that path as soon as a retail build
+had run first, and the demo would boot retail data it cannot play. Separate folders, no such
+handoff. Both builds still honour `--game-dir`, so naming the wrong install explicitly is still
+possible and still yours to get right.
+
 What the data holds, against the retail CD:
 
 | | Demo | Retail |

--- a/docs/GAME_DATA.md
+++ b/docs/GAME_DATA.md
@@ -287,18 +287,19 @@ What the data holds, against the retail CD:
 
 | | Demo | Retail |
 |---|---|---|
-| Islands | `CITADEL` only | 17 `.ILE`/`.OBL` pairs |
+| Islands | `CITADEL` only | 14 `.ILE`/`.OBL` pairs |
 | `LBA2.HQR` (credits) | absent | present |
 | `ANIM3DS.HQR` | absent | present |
 | `VIDEO/VIDEO.HQR` | absent | 231 MB |
 | `VOX/` | absent | 39 banks across 3 languages |
-| Music | `MUSIC/*.WAV`, 9 tracks | 24 tracks |
+| Music | 9 tracks | 25 tracks (all of `ListJingle`) |
 | `SCRSHOT.HQR` | present | absent |
 
 The HQR container is the same format throughout, same LZSS and LZMIT codecs and the same header
 layout, so every bank the demo does ship loads unmodified. The banks are subsets: 743 animations
-against 2084, 129 bodies against 470, 1243 background chunks against 18101. Music filenames are a
-subset of `ListJingle`, so the normal music path plays them with no special case. `SCRSHOT.HQR` is
+against 2084, 129 bodies against 470, 1243 background chunks against 18101. The demo ships its music
+as `MUSIC/*.WAV` where a modern retail tree ships `.ogg`, but the filenames are a subset of
+`ListJingle` either way, so the normal music path plays them with no special case. `SCRSHOT.HQR` is
 the one bank the demo adds, holding the marketing stills its slideshow shows.
 
 Two of those gaps are load-bearing and the demo build accounts for them: `LBA2.HQR` is the marker

--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -273,7 +273,7 @@ For completeness, the release axes that are compile-time rather than config-driv
 | Macro | Set by | Effect |
 |-------|--------|--------|
 | `CDROM` | [SOURCES/CMakeLists.txt:149](../SOURCES/CMakeLists.txt#L149) | Compiles the CD paths, so the volume-label and voice-folder branches are live |
-| `DEMO` | not set by this build | Three-cube demo: replaces `DistribLogo`'s switch, adds the demo bumper, forces the corner logo on |
+| `DEMO` | `LBA2_BUILD_DEMO` CMake option (default OFF) | The 1997 playable demo: replaces `DistribLogo`'s switch, adds the demo bumper, forces the corner logo on, and swaps free saves for three fixed slots. Needs demo game data; see [GAME_DATA.md](GAME_DATA.md#the-1997-playable-demo) |
 | `DEBUG_TOOLS` | CMake option | Skips the whole boot logo sequence, so no splash regardless of `DistribVersion` |
 | `DEBUG_TOOLS`, `TEST_TOOLS` | CMake options | Enable the stale-save fallback to `LoadGameOldVersion` at [OBJECT.CPP:1373](../SOURCES/OBJECT.CPP#L1373) |
 | `LBA_EDITOR`, `EDITLBA2` | editor build | Compiles the editor paths out of the game build |

--- a/tests/asset_preflight/test_asset_preflight.cpp
+++ b/tests/asset_preflight/test_asset_preflight.cpp
@@ -61,7 +61,7 @@ static int run_preflight(char *log, int max) {
 
 static void make_complete_tree(void) {
     SDL_CreateDirectory(ROOT);
-    touch("lba2.hqr"); /* IsValidResourceDir marker */
+    touch(Directories_GetResMarker()); /* IsValidResourceDir marker */
     touch(RESS_HQR_NAME);
     touch(SPRITES_HQR_NAME);
     touch(SPRIRAW_HQR_NAME);
@@ -101,9 +101,16 @@ static void test_required_missing(void) {
     del(SPRITES_HQR_NAME);
     del("video/" VIDEO_HQR_NAME);
     int r = run_preflight(g_log, sizeof g_log);
+#ifdef DEMO
+    /* No demo install ships cutscenes, so a missing video.hqr is a warning and
+       sprites.hqr is the only thing that blocks the boot. */
+    ASSERT_EQ_INT(1, r);
+    ASSERT_TRUE(strstr(g_log, "optional asset missing: video.hqr") != NULL);
+#else
     ASSERT_EQ_INT(2, r);
-    ASSERT_TRUE(strstr(g_log, "missing required asset: sprites.hqr") != NULL);
     ASSERT_TRUE(strstr(g_log, "missing required asset: video.hqr") != NULL);
+#endif
+    ASSERT_TRUE(strstr(g_log, "missing required asset: sprites.hqr") != NULL);
     touch(SPRITES_HQR_NAME); /* restore (video restored by next test) */
 }
 

--- a/tests/discovery/test_res_discovery.cpp
+++ b/tests/discovery/test_res_discovery.cpp
@@ -134,7 +134,7 @@ static bool had_persisted = false;
 static char persisted_path[ADELINE_MAX_PATH];
 
 static void compute_persisted_path() {
-    char *prefPath = SDL_GetPrefPath("Twinsen", "LBA2");
+    char *prefPath = SDL_GetPrefPath(ADELINE_PREF_ORG, ADELINE_PREF_APP);
     if (prefPath == NULL) {
         persisted_path[0] = '\0';
         return;
@@ -482,7 +482,7 @@ static bool test_persisted_last_game_dir() {
     unsetenv_portable("LBA2_GAME_DIR");
 
     /* Snapshot the un-overridden pref path. */
-    char *originalPrefPath = SDL_GetPrefPath("Twinsen", "LBA2");
+    char *originalPrefPath = SDL_GetPrefPath(ADELINE_PREF_ORG, ADELINE_PREF_APP);
     if (originalPrefPath == NULL) {
         return false;
     }
@@ -500,7 +500,7 @@ static bool test_persisted_last_game_dir() {
     /* Did the env override actually take? SDL3 may have cached the
      * pref path during an earlier call (e.g. from another test in
      * this same process), in which case our setenv is a no-op. */
-    char *overriddenPrefPath = SDL_GetPrefPath("Twinsen", "LBA2");
+    char *overriddenPrefPath = SDL_GetPrefPath(ADELINE_PREF_ORG, ADELINE_PREF_APP);
     if (overriddenPrefPath == NULL) {
         SDL_free(originalPrefPath);
         unsetenv_portable("XDG_DATA_HOME");

--- a/tests/discovery/test_res_discovery.cpp
+++ b/tests/discovery/test_res_discovery.cpp
@@ -116,7 +116,10 @@ static int chdir_portable(const char *p) {
 
 static void create_marker_hqr(const char *dir) {
     char marker[512];
-    snprintf(marker, sizeof(marker), "%s/lba2.hqr", dir);
+    /* The engine's own marker, not a literal: a demo build gates on RESS.HQR,
+       and a fixture spelling the retail name would build a tree that build
+       cannot discover. */
+    snprintf(marker, sizeof(marker), "%s/%s", dir, Directories_GetResMarker());
     FILE *f = fopen(marker, "wb");
     if (f) {
         fclose(f);
@@ -637,7 +640,12 @@ static bool write_case_fixture_iso(const char *path) {
     o = 0;
     iso_add_rec(root, &o, ISO_L_ROOT, 2048, true, &dot, 1);
     iso_add_rec(root, &o, ISO_L_ROOT, 2048, true, &dotdot, 1);
-    iso_add_rec(root, &o, ISO_L_HQR, 8, false, (const unsigned char *)"LBA2.HQR;1", 10);
+    /* Same reason as create_marker_hqr: the in-image marker has to be the one
+       this build looks for. ISO9660 identifiers carry the ";1" version suffix. */
+    char isoMarker[32];
+    snprintf(isoMarker, sizeof isoMarker, "%s;1", Directories_GetResMarker());
+    iso_add_rec(root, &o, ISO_L_HQR, 8, false, (const unsigned char *)isoMarker,
+                (unsigned char)strlen(isoMarker));
     iso_add_rec(root, &o, ISO_L_CFG, (U32)strlen(kImageCfgBody), false,
                 (const unsigned char *)"LBA2.CFG;1", 10);
 


### PR DESCRIPTION
The 1997 playable demo is a separate SKU that lives behind `#ifdef DEMO` in the original sources: three fixed save slots instead of free saves, scenario chaining on cube exit, a permanent title logo, no voices and no cutscenes. That code has never been through a compiler in this fork. This makes it build and run.

Configure with `-DLBA2_BUILD_DEMO=ON` and point the result at a demo install. Retail builds are untouched.

Rebased on `main` after #472 and #473. `VERSIONS.md` listed `DEMO` as "not set by this build", which this changes, so the build-variants table now names the option and the two docs cross-reference each other.

## What was in the way

**Bit rot.** Three things the demo path had drifted out of: an `#include` of Adeline's CD-audio library by absolute path off their 1997 build machine (`/projet/lib386/...`), `DemoBumper()` referencing a variable whose only declaration sits inside a commented-out block, and a raw `unlink()` where LIB386 provides `Delete()`.

**Two absent files that are load-bearing at boot.** `LBA2.HQR` is the marker that identifies a resource directory, and the demo has none: that bank holds the credits reel, which the demo does not have. The demo build looks for `RESS.HQR` instead. `VIDEO.HQR` is loaded by `InitAcf()`, which hard-fails without it; retail's movie bank is 231 MB, larger than the whole 17 MB demo, so no demo install ships one. The demo build warns and runs without cutscenes.

Both are `#ifdef DEMO`. The `PlayAcf()` guard added alongside them cannot fire in a retail build, because `InitAcf()` either sets the path or stops the program.

**No way in from the build system.** `LBA2_PRODUCT_NAME_DEMO` already existed and described itself as the name used "when the binary is built with `-DDEMO`", with nothing to set it. `LBA2_BUILD_DEMO` is that switch, default OFF. A demo binary needs demo data and cannot run retail data, so it is a separate configure rather than a runtime toggle.

## What the demo turns out to be

Documented in `docs/GAME_DATA.md`. The HQR container is the same format throughout, same LZSS and LZMIT codecs and the same header layout, so every bank the demo ships loads unmodified. The banks are subsets: one island, 743 animations against 2084, 129 bodies against 470, 1243 background chunks against 18101. Music filenames are a subset of `ListJingle`, so the existing music path plays them with no special case. `SCRSHOT.HQR` is the one bank the demo adds, holding the stills its closing slideshow shows, which the console already exposes as `ui slideshow`.

## Verification

`scripts/dev/dist_check.sh` run against `origin/main` (e79e8a75) and against this branch, on steam, gog and twinsen-rip installs. `summary.txt` is byte-identical between the two runs: same distributor resolution, same music sourcing, same render hashes for interior, exterior, menu, options, inventory and demo reel.

Host tests 51/51. `make format-check` clean. Demo build verified from a clean configure, booting demo data and rendering all three demo save slots.