### PR TITLE
fix(discovery): join Common/ under the binary and working directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Running the game from inside an install whose data sits in `Common/` now
+  finds it without `--game-dir`. Auto-discovery joined `Common/` only for
+  paths you named explicitly, so an unflagged run depended on the sibling
+  scan reaching that same folder from the parent directory. The scan stops
+  after 24 entries in filesystem order, so on a Steam library with more
+  games than that, the install the player was standing in could be dropped
+  and discovery gave up after 138 candidates. Reported from a Steam Deck.
 - Rolling `latest` AppImages no longer replace themselves with the newest
   stable release on first run. The `latest` keyword in the bundled
   self-updater's update information means "newest non-prerelease", not the

--- a/SOURCES/RES_DISCOVERY.CPP
+++ b/SOURCES/RES_DISCOVERY.CPP
@@ -480,6 +480,13 @@ bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv) {
         if (TryJoinBaseSub(basePath, "", outDir, outMax, tried, &triedCount, true)) {
             return true;
         }
+        /* Common/ before data/ and game/: it is where a retail install
+           actually keeps the HQRs, which is why --game-dir joins it too. The
+           other two are guesses kept for layouts people have built by hand. */
+        Res_SetDiscoverySource("next to the binary, Common/");
+        if (TryJoinBaseSub(basePath, "Common", outDir, outMax, tried, &triedCount)) {
+            return true;
+        }
         Res_SetDiscoverySource("next to the binary, data/");
         if (TryJoinBaseSub(basePath, "data", outDir, outMax, tried, &triedCount)) {
             return true;
@@ -495,6 +502,16 @@ bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv) {
     EnsureTrailingSeparator(walk, ADELINE_MAX_PATH);
     Res_SetDiscoverySource("working directory");
     if (NormalizeAndTry(walk, outDir, outMax, tried, &triedCount, true)) {
+        return true;
+    }
+
+    /* The retail layout, one level down from where you ran the game. Without
+       this, an install whose HQRs sit in Common/ was only ever found by the
+       sibling scan below reaching it from the parent, which is capped at
+       kMaxSiblingEntries in readdir order: a Steam library with more folders
+       than that cap dropped the very directory the user was standing in. */
+    Res_SetDiscoverySource("working directory, Common/");
+    if (TryJoinBaseSub(walk, "Common", outDir, outMax, tried, &triedCount)) {
         return true;
     }
 

--- a/docs/GAME_DATA.md
+++ b/docs/GAME_DATA.md
@@ -19,9 +19,9 @@ Use the directory that contains `LBA2.HQR` (and the other `.hqr` files, `music/`
 | Command line | `./lba2cc --game-dir /path/to/game` or `--data-dir` (alias) |
 | Environment | `export LBA2_GAME_DIR=/path/to/game` |
 | Persisted choice | `last_game_dir.txt` in the user-prefs folder, written automatically the first time you pick a folder via the launch dialog (see [First-launch folder picker](#first-launch-folder-picker) below) |
-| Discovery | See [SOURCES/RES_DISCOVERY.CPP](../SOURCES/RES_DISCOVERY.CPP): SDL binary directory, current working directory, parents of cwd, `./data`, `../LBA2`, `../game`, sibling scan of parent-of-cwd |
+| Discovery | See [SOURCES/RES_DISCOVERY.CPP](../SOURCES/RES_DISCOVERY.CPP): SDL binary directory and a `Common/` under it, current working directory and a `Common/` under it, parents of cwd, `./data`, `../LBA2`, `../game`, sibling scan of parent-of-cwd |
 
-Both `--game-dir` and `LBA2_GAME_DIR` also try a `Common/` inside the path you give, so pointing either at an install root works as well as pointing it at the data folder.
+Every root the engine probes also tries a `Common/` inside it, because that is where a retail install keeps the HQRs. So `--game-dir` and `LBA2_GAME_DIR` work pointed at either the install root or the data folder, and running the binary from inside an install root finds the data without any flag.
 
 **Naming a path that holds no game data stops the run.** Neither override falls through to the probes below it: an override that names the wrong place is a mistake, and continuing would boot whatever discovery turns up next. That is a launch against assets nobody asked for, reported only by the `Assets:` line and still exiting 0. You get the picker instead (or a clean error when headless).
 
@@ -92,7 +92,7 @@ If you want to force a specific backend even when both are installed, set `SDL_F
 
 **Explicit path (recommended for anything non-local):** Use `--game-dir` or `LBA2_GAME_DIR` when the install is not next to your working tree (another drive, `~/Games/…`, CI, etc.). That is the stable, portable option.
 
-**What “adjacent” means in discovery:** Heuristics only look at predictable relative locations (cwd, parents of cwd, `../LBA2`, `./data`, SDL binary dir, then siblings of the parent of cwd with a small set of subfolder names). There is no full-disk or deep recursive search. “Adjacent” here means *often the same parent folder as your clone* when you run from the repo root — not “any path on the machine.”
+**What “adjacent” means in discovery:** Heuristics only look at predictable relative locations (cwd and `./Common`, parents of cwd, `../LBA2`, `./data`, SDL binary dir and a `Common/` under it, then siblings of the parent of cwd with a small set of subfolder names). There is no full-disk or deep recursive search. “Adjacent” here means *often the same parent folder as your clone* when you run from the repo root, not “any path on the machine.”
 
 **Safety:** Every candidate is accepted only if `IsValidResourceDir` succeeds (`LBA2.HQR` present). There is no execution of paths from untrusted config beyond what you pass on the command line or in the environment.
 

--- a/tests/discovery/test_res_discovery.cpp
+++ b/tests/discovery/test_res_discovery.cpp
@@ -434,6 +434,94 @@ static bool test_sibling_commonclassic_nested() {
     return strstr(out, "CommonClassic") != NULL;
 }
 
+/**
+ * Steam-library regression: cwd is the install, HQRs are in its Common/, and
+ * the parent holds more folders than the sibling scan's kMaxSiblingEntries
+ * cap. Reported from a Deck with 25+ games in steamapps/common/, where the
+ * install the user was standing in fell off the end of the scan in readdir
+ * order and discovery gave up after 138 candidates.
+ *
+ * The cwd Common/ join has to be what answers this, so assert the discovery
+ * source and not just the result: the sibling scan can also reach
+ * <cwd>/Common/ from the parent, and whether it does depends on readdir
+ * order, which is exactly the non-determinism this test exists to rule out.
+ */
+static bool test_cwd_common_join_beats_sibling_cap() {
+    unsetenv_portable("LBA2_GAME_DIR");
+#ifndef _WIN32
+    char parent[] = "/tmp/lba2cwdcommon_XXXXXX";
+    if (mkdtemp(parent) == NULL) {
+        return false;
+    }
+#else
+    char parent[512];
+    if (!make_temp_dir(parent, sizeof(parent), "cwdc")) {
+        return false;
+    }
+#endif
+    char path[512];
+
+    /* Decoys: enough to exceed kMaxSiblingEntries (24). None of them hold
+       game data, so any of them matching would be a bug in its own right. */
+    for (int i = 0; i < 30; i++) {
+        snprintf(path, sizeof(path), "%s/Decoy Game %02d", parent, i);
+        if (mkdir_portable(path) != 0) {
+            return false;
+        }
+    }
+
+    snprintf(path, sizeof(path), "%s/Little Big Adventure 2", parent);
+    if (mkdir_portable(path) != 0) {
+        return false;
+    }
+    snprintf(path, sizeof(path), "%s/Little Big Adventure 2/Common", parent);
+    if (mkdir_portable(path) != 0) {
+        return false;
+    }
+    create_marker_hqr(path);
+
+    char oldcwd[4096];
+    if (getcwd_portable(oldcwd, sizeof(oldcwd)) == NULL) {
+        return false;
+    }
+    snprintf(path, sizeof(path), "%s/Little Big Adventure 2", parent);
+    if (chdir_portable(path) != 0) {
+        return false;
+    }
+
+    char out[ADELINE_MAX_PATH];
+    int argc = 1;
+    char arg0[] = "lba2";
+    char *argv[] = {arg0, NULL};
+    const bool ok = ResolveGameDataDir(out, ADELINE_MAX_PATH, &argc, argv);
+    const char *source = Res_GetDiscoverySource();
+    char sourceCopy[128];
+    snprintf(sourceCopy, sizeof(sourceCopy), "%s", source != NULL ? source : "");
+    chdir_portable(oldcwd);
+
+    if (!ok) {
+        fprintf(stderr,
+                "test_cwd_common_join_beats_sibling_cap: discovery failed to "
+                "find Common/ in the working directory\n");
+        return false;
+    }
+    if (strstr(out, "Common") == NULL) {
+        fprintf(stderr,
+                "test_cwd_common_join_beats_sibling_cap: resolved '%s', "
+                "expected the Common/ subdirectory\n",
+                out);
+        return false;
+    }
+    if (strcmp(sourceCopy, "working directory, Common/") != 0) {
+        fprintf(stderr,
+                "test_cwd_common_join_beats_sibling_cap: matched via '%s', "
+                "expected 'working directory, Common/'\n",
+                sourceCopy);
+        return false;
+    }
+    return true;
+}
+
 static bool test_embedded_cfg_write() {
 #ifndef _WIN32
     char dir[] = "/tmp/lba2emb_XXXXXX";
@@ -767,6 +855,9 @@ int main() {
         failed++;
     }
     if (!test_sibling_commonclassic_nested()) {
+        failed++;
+    }
+    if (!test_cwd_common_join_beats_sibling_cap()) {
         failed++;
     }
     if (!test_env_lba2_game_dir()) {

--- a/tests/discovery/test_res_discovery.cpp
+++ b/tests/discovery/test_res_discovery.cpp
@@ -522,6 +522,75 @@ static bool test_cwd_common_join_beats_sibling_cap() {
     return true;
 }
 
+/**
+ * Common/ outranks the data/ and game/ joins under the same root. A folder
+ * holding two valid installs is ambiguous either way, so this pins the answer
+ * rather than leaving it to the order the probes happen to be written in:
+ * Common/ is the layout a retail install actually ships, data/ and game/ are
+ * conventions people built by hand.
+ */
+static bool test_cwd_common_outranks_data() {
+    unsetenv_portable("LBA2_GAME_DIR");
+#ifndef _WIN32
+    char root[] = "/tmp/lba2prec_XXXXXX";
+    if (mkdtemp(root) == NULL) {
+        return false;
+    }
+#else
+    char root[512];
+    if (!make_temp_dir(root, sizeof(root), "prec")) {
+        return false;
+    }
+#endif
+    char path[512];
+    snprintf(path, sizeof(path), "%s/install", root);
+    if (mkdir_portable(path) != 0) {
+        return false;
+    }
+    snprintf(path, sizeof(path), "%s/install/Common", root);
+    if (mkdir_portable(path) != 0) {
+        return false;
+    }
+    create_marker_hqr(path);
+    snprintf(path, sizeof(path), "%s/install/data", root);
+    if (mkdir_portable(path) != 0) {
+        return false;
+    }
+    create_marker_hqr(path);
+
+    char oldcwd[4096];
+    if (getcwd_portable(oldcwd, sizeof(oldcwd)) == NULL) {
+        return false;
+    }
+    snprintf(path, sizeof(path), "%s/install", root);
+    if (chdir_portable(path) != 0) {
+        return false;
+    }
+
+    char out[ADELINE_MAX_PATH];
+    int argc = 1;
+    char arg0[] = "lba2";
+    char *argv[] = {arg0, NULL};
+    const bool ok = ResolveGameDataDir(out, ADELINE_MAX_PATH, &argc, argv);
+    const char *via = Res_GetDiscoverySource();
+    char viaCopy[128];
+    snprintf(viaCopy, sizeof(viaCopy), "%s", via != NULL ? via : "");
+    chdir_portable(oldcwd);
+
+    if (!ok) {
+        fprintf(stderr, "test_cwd_common_outranks_data: nothing resolved\n");
+        return false;
+    }
+    if (strcmp(viaCopy, "working directory, Common/") != 0) {
+        fprintf(stderr,
+                "test_cwd_common_outranks_data: resolved '%s' via '%s', "
+                "expected the Common/ join to win\n",
+                out, viaCopy);
+        return false;
+    }
+    return true;
+}
+
 static bool test_embedded_cfg_write() {
 #ifndef _WIN32
     char dir[] = "/tmp/lba2emb_XXXXXX";
@@ -858,6 +927,9 @@ int main() {
         failed++;
     }
     if (!test_cwd_common_join_beats_sibling_cap()) {
+        failed++;
+    }
+    if (!test_cwd_common_outranks_data()) {
         failed++;
     }
     if (!test_env_lba2_game_dir()) {


### PR DESCRIPTION
From a Steam Deck report. Running the AppImage from inside the install
failed to find the game data, while `--game-dir .` on that exact directory
worked:

```
No valid game data directory (need lba2.hqr). Tried 138 path(s).
  - /home/deck/.../Little Big Adventure 2/
  - ...
```

The data was in `Little Big Adventure 2/Common/`. That path is never a
candidate.

## Why

A retail install keeps its HQRs in `Common/`, which is why
[`--game-dir`](../blob/main/SOURCES/RES_DISCOVERY.CPP) and `LBA2_GAME_DIR`
both try that join. Auto-discovery did not. The working directory and the
binary directory were probed bare, plus `data/` and `game/` guesses. The
`Common/` join existed only inside `TryParentSiblingScan`, applied to *other*
directories: the folder you are standing in got less scrutiny than a random
neighbour.

So an unflagged run from inside an install could only be rescued by the
sibling scan reaching that same folder back down from the parent. That scan
stops after `kMaxSiblingEntries` (24) in `readdir` order. This Deck has more
than 24 folders in `steamapps/common/`, and "Little Big Adventure 2" fell off
the end.

The arithmetic in the report confirms it: 3 (AppImage mount) + 1 (cwd) + 4
(Android roots) + 7 (parent walk) + 3 (`data/`, `../LBA2/`, `../game/`) + **24
Steam folders × 5 variants** = **138**, matching "Tried 138 path(s)" exactly.
The last folder listed is the 24th.

That is also why this looked non-deterministic. A tester with a small Steam
library gets found by the sibling scan; one with 25+ games does not. Same
binary, same layout, different outcome.

## Confirmed against the reporter's follow-up

The reporter added two observations: running from inside `Common/` itself
works even in the Steam path, and *the same folder copied outside works
fine*. They wondered about permissions.

It is not permissions. Copying the folder elsewhere changes one thing that
matters: how many sibling folders share its parent. Holding the tree
identical and varying only the sibling count reproduces both halves of their
report:

| Sibling folders | Build | Result | Matched via |
|---|---|---|---|
| 5 | `main` | found | `sibling scan` |
| 30 | `main` | **not found** | nothing, gives up |
| 30 | this PR | found | `working directory, Common/` |

Five neighbours is the folder copied somewhere quiet. Thirty is
`steamapps/common`. Same layout, same permissions, same binary.

This is also why the test asserts the discovery source. At 5 siblings on
`main` the run *succeeds*, so a test checking only "was it found" would go
green against the unfixed code for the wrong reason.

## The fix

Two extra candidates, `<binary dir>/Common/` and `<cwd>/Common/`, ordered
ahead of the existing `data/` and `game/` joins because `Common/` is the real
retail layout and those two are folklore kept for hand-built setups.

Both take the cheap check rather than `allowImage`, matching their `data/`
and `game/` siblings. `allowImage` walks the directory and stays reserved for
paths somebody named, per the comment above `NormalizeAndTry`.

Deliberately **not** done, since discovery is already 138 candidates wide and
the aim was not to grow it further:

- The sibling scan's 24-entry cap is untouched. With the cwd join in place it
  is no longer what this scenario depends on. It remains order-dependent for
  genuinely-adjacent installs, which is a separate question.
- No new subfolder names. This mirrors the join `--game-dir` already does
  rather than applying the full `kSiblingSubdirs` matrix to every root.

## Testing

One test, matching the weight of the fix, building the reported shape: 30
decoy siblings to push past the cap, the data in `<cwd>/Common/`.

It asserts the **discovery source**, not just the result. The sibling scan
can also reach `<cwd>/Common/` from the parent, and whether it does depends
on `readdir` order, so asserting only "it was found" would pass for the wrong
reason on some filesystems. `Res_GetDiscoverySource()` pins which rule
answered.

Verified it fails without the fix, by reverting `RES_DISCOVERY.CPP` to `main`
and rebuilding:

```
test_cwd_common_join_beats_sibling_cap: discovery failed to find Common/ in
the working directory
exit=1
```

It fails at the first assertion, meaning the sibling scan did not save it
either, so the 30 decoys do reproduce the Deck faithfully. With the fix
restored, `exit=0`.

Full host suite green:

```
100% tests passed, 0 tests failed out of 51
```

`scripts/ci/check-format.sh` clean. The ASM test targets do not build on this
box for want of an assembler, which is pre-existing and unrelated.

## Regressions

The host suite and CI only prove existing tests still pass, and no existing
test covered precedence, so they would not have caught the one thing this
patch can change for someone already working. Probed it directly instead,
with `<cwd>/Common/` and `<cwd>/data/` both carrying the marker:

| Build | Resolves to | Via |
|---|---|---|
| `main` | `install/data/` | `working directory, data/` |
| this PR | `install/Common/` | `working directory, Common/` |

That reorder is intended, and is now pinned by
`test_cwd_common_outranks_data` so it cannot drift back unnoticed. A folder
holding two valid installs is ambiguous either way; `Common/` is what a
retail install ships and what `--game-dir` already joins, `data/` and `game/`
are hand-built conventions.

One further reorder, not separately tested: `<cwd>/Common/` now sits ahead of
the Android storage roots and the parent walk, because it is inserted
directly after the working-directory probe. Harmless in practice, since cwd
on Android is `/` or the app directory and `/Common/` will not exist, but it
is a change in order rather than only an addition.

Both new tests fail on `main` for their own distinct reasons and pass here:

```
test_cwd_common_join_beats_sibling_cap: discovery failed to find Common/ in
the working directory
test_cwd_common_outranks_data: resolved '/tmp/.../install/data/' via
'working directory, data/', expected the Common/ join to win
```

## Docs

`docs/GAME_DATA.md` said the `Common/` join was a property of `--game-dir`
and `LBA2_GAME_DIR` specifically. It is now a property of every root that
gets probed, so the discovery row and the "what adjacent means" paragraph are
updated to match.
