### PR TITLE
ci: cache what CI rebuilds, retry what it fetches

### DIFF
--- a/.github/workflows/docs-gate.yml
+++ b/.github/workflows/docs-gate.yml
@@ -37,10 +37,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - run: echo "Docs-only change — no build required."
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - run: echo "Docs-only change — no tests required."

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,6 +8,7 @@ concurrency:
 jobs:
   check-format:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Code Checkout
@@ -16,7 +17,10 @@ jobs:
       - name: Install clang-format
         # Keep this major version in sync with CLANG_FORMAT_MAJOR in
         # scripts/ci/clang-format-select.sh (the single source of truth).
-        run: sudo apt-get update && sudo apt-get install -y clang-format-18
+        # Acquire::Retries so a mirror hiccup costs a retry, not the run.
+        run: |
+          sudo apt-get -o Acquire::Retries=5 update
+          sudo apt-get -o Acquire::Retries=5 install -y clang-format-18
 
       - name: Check formatting
         run: bash ./scripts/ci/check-format.sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,6 +31,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Code Checkout
@@ -45,9 +46,13 @@ jobs:
           build-type: ${{ env.BUILD_TYPE }}
 
       # UASM is not required for this job (game + host tests: discovery + console state). ASM equivalence uses test.yml + Docker.
-      - name: Install latest CMake and ninja
-        uses: lukka/get-cmake@latest
-
+      #
+      # No CMake/ninja install step: the ubuntu-latest runner image ships
+      # CMake 3.31 and Ninja 1.13, both well past the 3.23 floor in
+      # CMakePresets.json. Fetching a newer pair on every run bought nothing
+      # and put a third-party action plus a release download on the critical
+      # path. The linux-tarball release job builds the same presets against
+      # apt's older CMake, so this floor has cover.
       - name: Configure
         run: |
           cmake -S . -B build \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -86,6 +86,7 @@ jobs:
   # a file no demo install has.
   build-demo:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Code Checkout
@@ -99,9 +100,7 @@ jobs:
           version: 3-latest
           build-type: ${{ env.BUILD_TYPE }}
 
-      - name: Install latest CMake and ninja
-        uses: lukka/get-cmake@latest
-
+      # No CMake/ninja install step, for the reason given on the build job.
       - name: Configure
         run: |
           cmake -S . -B build-demo \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,6 +27,7 @@ env:
 jobs:
   build:
     runs-on: macos-latest
+    timeout-minutes: 30
 
     steps:
       - name: Code Checkout
@@ -39,9 +40,8 @@ jobs:
           version: 3-latest
           build-type: ${{ env.BUILD_TYPE }}
 
-      - name: Install latest CMake and ninja
-        uses: lukka/get-cmake@latest
-
+      # See linux.yml: the macos-latest runner image already ships CMake and
+      # Ninja well past the 3.23 floor, so there is no toolchain fetch here.
       - name: Configure
         run: |
           cmake -S . -B build \

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -15,6 +15,7 @@ jobs:
   lint:
     name: Conventional Commit format
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v7

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -80,6 +80,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Download all platform artifacts
         uses: actions/download-artifact@v7

--- a/.github/workflows/release-linux-appimage.yml
+++ b/.github/workflows/release-linux-appimage.yml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v7

--- a/.github/workflows/release-linux-tarball.yml
+++ b/.github/workflows/release-linux-tarball.yml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v7

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v7

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v7

--- a/.github/workflows/reusable-build-android.yml
+++ b/.github/workflows/reusable-build-android.yml
@@ -27,6 +27,7 @@ jobs:
   build:
     name: "Build ${{ matrix.arch }}"
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -60,7 +61,8 @@ jobs:
           mkdir -p "${ANDROID_HOME}/cmdline-tools"
           if [ ! -f "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" ]; then
             CLI_ZIP="${RUNNER_TEMP}/cmdline-tools.zip"
-            curl -fsSLo "$CLI_ZIP" \
+            curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
+              -o "$CLI_ZIP" \
               "https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip"
             unzip -qo "$CLI_ZIP" -d "${RUNNER_TEMP}/cmdline-tools-unzip"
             mkdir -p "${ANDROID_HOME}/cmdline-tools/latest"
@@ -91,6 +93,20 @@ jobs:
           echo "${ANDROID_HOME}/build-tools/35.0.0" >> "$GITHUB_PATH"
           echo "${ANDROID_HOME}/platform-tools" >> "$GITHUB_PATH"
 
+      # SDL3 is built from source per ABI, and the result only moves when the
+      # pinned tag or the NDK does. Cache the checkout (the APK bundler reads
+      # SDL's Java sources out of it) alongside the install prefix, so a run
+      # that changes neither pays a cache restore instead of a clone plus a
+      # full SDL build. RUNNER_TEMP is a fixed path on hosted runners, so the
+      # absolute paths baked into SDL3Config.cmake stay valid across runs.
+      - name: Cache SDL3 for Android
+        uses: actions/cache@v6
+        with:
+          path: |
+            ${{ runner.temp }}/SDL3
+            ${{ runner.temp }}/sdl3-install
+          key: sdl3-android-${{ matrix.abi }}-release-3.2.16-ndk-28.2.13676358
+
       - name: Build SDL3 for Android
         run: |
           SDL3_DIR="${RUNNER_TEMP}/SDL3"
@@ -107,19 +123,23 @@ jobs:
             done
           fi
 
-          cmake -S "$SDL3_DIR" -B "$SDL3_BUILD" -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK}/build/cmake/android.toolchain.cmake" \
-            -DANDROID_ABI=${{ matrix.abi }} \
-            -DANDROID_PLATFORM=24 \
-            -DANDROID_STL=c++_shared \
-            -DSDL_SHARED=ON \
-            -DSDL_STATIC=OFF \
-            -DSDL_TEST=OFF \
-            -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384"
+          if [ ! -f "${SDL3_INSTALL}/lib/libSDL3.so" ]; then
+            cmake -S "$SDL3_DIR" -B "$SDL3_BUILD" -G Ninja \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK}/build/cmake/android.toolchain.cmake" \
+              -DANDROID_ABI=${{ matrix.abi }} \
+              -DANDROID_PLATFORM=24 \
+              -DANDROID_STL=c++_shared \
+              -DSDL_SHARED=ON \
+              -DSDL_STATIC=OFF \
+              -DSDL_TEST=OFF \
+              -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384"
 
-          cmake --build "$SDL3_BUILD" -- -j$(nproc)
-          cmake --install "$SDL3_BUILD" --prefix "$SDL3_INSTALL"
+            cmake --build "$SDL3_BUILD" -- -j$(nproc)
+            cmake --install "$SDL3_BUILD" --prefix "$SDL3_INSTALL"
+          else
+            echo "SDL3 restored from cache: ${SDL3_INSTALL}"
+          fi
 
           echo "SDL3_ANDROID_DIR=${SDL3_INSTALL}/lib/cmake/SDL3" >> "$GITHUB_ENV"
           echo "SDL3_DIR=${SDL3_INSTALL}/lib/cmake/SDL3" >> "$GITHUB_ENV"

--- a/.github/workflows/reusable-build-linux-appimage.yml
+++ b/.github/workflows/reusable-build-linux-appimage.yml
@@ -43,15 +43,34 @@ jobs:
           - runs-on: ubuntu-24.04-arm
             arch: aarch64
     container: ghcr.io/pkgforge-dev/archlinux:latest
+    timeout-minutes: 45
     steps:
       - name: Code Checkout
         uses: actions/checkout@v6
       - name: Preparing Container
         uses: pkgforge-dev/anylinux-setup-action@v2
+      # The script pulls from Arch mirrors and downloads appimagetool from a
+      # GitHub release; both have failed a leg outright when upstream returned
+      # 5xx. Retry the whole script rather than any one fetch: pacman and the
+      # CMake build are both incremental, so a second attempt costs seconds,
+      # and appimagetool's own internal retries are already exhausted by then.
       - name: Make AppImage
         env:
           LBA2_UPDATE_CHANNEL: ${{ inputs.update-channel }}
-        run: /bin/sh ./scripts/packaging/make-appimage.sh
+        run: |
+          for attempt in 1 2 3; do
+            # Start each attempt from a clean AppDir: a run that died inside
+            # quick-sharun leaves a half-populated tree behind, and the next
+            # attempt would then fail on that rather than on the real cause.
+            rm -rf ./AppDir ./dist
+            if /bin/sh ./scripts/packaging/make-appimage.sh; then
+              exit 0
+            fi
+            echo "AppImage build attempt ${attempt} failed; retrying in 15s"
+            sleep 15
+          done
+          echo "AppImage build failed after 3 attempts" >&2
+          exit 1
       - name: Upload temporary artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/reusable-build-linux-tarball.yml
+++ b/.github/workflows/reusable-build-linux-tarball.yml
@@ -25,6 +25,7 @@ jobs:
   build:
     name: "Build ${{ matrix.arch }}"
     runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -43,12 +44,13 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          sudo apt-get update
+          # Acquire::Retries so a mirror hiccup costs a retry, not the leg.
+          sudo apt-get -o Acquire::Retries=5 update
           # Build deps only — SDL3 comes from setup-sdl below (as a static
           # library), so we don't install libsdl3-dev. The transitive deps
           # SDL3 itself needs at build time (X11, Wayland, ALSA, etc.) are
           # pulled in here so SDL3's CMake build can configure all backends.
-          sudo apt-get install -y --no-install-recommends \
+          sudo apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
             cmake ninja-build build-essential \
             libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxi-dev \
             libxinerama-dev libxxf86vm-dev libxss-dev libxtst-dev \

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -24,6 +24,7 @@ jobs:
   build:
     name: "Build ${{ matrix.arch }}"
     runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reusable-build-windows.yml
+++ b/.github/workflows/reusable-build-windows.yml
@@ -24,6 +24,7 @@ jobs:
   build:
     name: "Build ${{ matrix.arch }}"
     runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,10 +61,39 @@ jobs:
   # Job id must stay `test` — branch protection on main requires this check name.
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Code Checkout
         uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # run_tests_docker.sh builds the image itself when it isn't already in
+      # the local daemon, which on a fresh runner means apt, two SDL3 source
+      # builds and the UASM download every single run (~2m10s, three upstream
+      # services on the critical path). Building it here instead puts those
+      # layers in the Actions cache, keyed by the Dockerfile's content: the
+      # image is only really rebuilt when docker/Dockerfile.test changes.
+      #
+      # The tag is what run_tests_docker.sh looks for, so it finds the loaded
+      # image and skips its own build. Keep the two names in sync.
+      #
+      # continue-on-error so this step can only ever make the job faster: if
+      # buildx or the Actions cache service is down, nothing is loaded and
+      # the script builds the image itself, costing time rather than the run.
+      - name: Build the ASM test image (Actions-cached layers)
+        continue-on-error: true
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile.test
+          platforms: linux/amd64
+          tags: lba2-test:latest
+          load: true
+          cache-from: type=gha,scope=asm-test-image
+          cache-to: type=gha,scope=asm-test-image
 
       - name: Run ASM vs C++ equivalence tests in Docker
         run: ./run_tests_docker.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,13 @@ jobs:
           tags: lba2-test:latest
           load: true
           cache-from: type=gha,scope=asm-test-image
-          cache-to: type=gha,scope=asm-test-image
+          # Export from main only. Actions cache scopes are per-ref: a
+          # pull_request run reads its own scope and the base branch, never a
+          # sibling topic branch, so exporting anywhere else writes a copy
+          # nothing will ever restore. Worse, the export costs ~80s on top of
+          # the build, which lands entirely on the miss path. Read-only
+          # everywhere else keeps a hit at ~25s and a miss at plain build cost.
+          cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,scope=asm-test-image' || '' }}
 
       - name: Run ASM vs C++ equivalence tests in Docker
         run: ./run_tests_docker.sh

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,6 +27,7 @@ env:
 jobs:
   build:
     runs-on: windows-latest
+    timeout-minutes: 30
 
     defaults:
       run:
@@ -38,8 +39,14 @@ jobs:
         with:
           msystem: UCRT64
           update: true
+          # Name the compiler package rather than the `-toolchain` group.
+          # The group also drags in gdb, gdb-multiarch, python, tcl and tk,
+          # about 320 MiB that nothing in this job uses, paid for on every run
+          # in unpack time and in the size of the pacman cache the action
+          # stores in the Actions cache. Same package set as
+          # reusable-build-windows.yml, minus the packaging-only `zip`.
           install: >-
-            mingw-w64-ucrt-x86_64-toolchain
+            mingw-w64-ucrt-x86_64-gcc
             mingw-w64-ucrt-x86_64-cmake
             mingw-w64-ucrt-x86_64-ninja
             mingw-w64-ucrt-x86_64-sdl3

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -53,10 +53,24 @@ RUN git clone --depth 1 --branch release-3.2.16 https://github.com/libsdl-org/SD
     && cmake --install /tmp/SDL/build32 \
     && rm -rf /tmp/SDL
 
-# NOTE: UASM is installed at container runtime (not during build) because UASM
-# is an x86_64 Linux binary that cannot execute under Rosetta during
-# `docker build --platform linux/amd64` on macOS ARM64.  QEMU emulation at
-# `docker run` time handles it correctly.
+# ── UASM assembler ────────────────────────────────────────────────────────────
+# Fetched here rather than at container runtime so a test run never depends on
+# GitHub's release CDN being reachable. A 503 from that download has failed the
+# whole suite before a single test compiled.
+#
+# Unpacking a binary does not execute it, so this still works during
+# `docker build --platform linux/amd64` on macOS ARM64. The earlier
+# runtime-install note was about *running* uasm, which the build never does;
+# the version check in run_tests_docker.sh runs under QEMU at `docker run`
+# time, where emulation handles it.
+ARG UASM_VERSION=2.57r
+ARG UASM_ARCHIVE=uasm257_linux64.zip
+RUN curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
+        -o /tmp/uasm.zip \
+        "https://github.com/Terraspace/UASM/releases/download/v${UASM_VERSION}/${UASM_ARCHIVE}" \
+    && unzip -oq /tmp/uasm.zip -d /usr/local/bin \
+    && chmod +x /usr/local/bin/uasm \
+    && rm -f /tmp/uasm.zip
 
 # ── Verify base tools ────────────────────────────────────────────────────────
 RUN cmake --version | head -1 && objcopy --version | head -1

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -152,7 +152,7 @@ Three rules follow from that, and the workflows apply them:
 |---|---|---|---|
 | SDL3 build | `libsdl-org/setup-sdl` (built in) | resolved SDL git hash + `runner.os`/`arch` | ~2 MB prefix, seconds |
 | MSYS2 install + pacman packages | `msys2/setup-msys2` (`cache: true` default) | package list + config hash | ~177 MB |
-| ASM test image layers | `docker/build-push-action`, `type=gha` | `docker/Dockerfile.test` content | the whole image |
+| ASM test image layers | `docker/build-push-action`, `type=gha` | `docker/Dockerfile.test` content | the whole image, ~300 MB; written by `main` only |
 | SDL3 for Android | `actions/cache` | ABI + SDL tag + NDK version | source tree + install prefix |
 
 The ASM test image is the one that matters most. `run_tests_docker.sh`
@@ -160,10 +160,20 @@ builds it whenever it is not already in the local daemon, which on a
 fresh runner is *every* run: apt, two SDL3 source builds, and the UASM
 download, about 2m10s of a 2m45s job. `test.yml` builds it through buildx
 with the Actions cache backend first, so `run_tests_docker.sh` finds the
-image already loaded and skips its own build. That step is
+image already loaded and skips its own build. Measured: 24s to restore
+against 131s to build, taking the job from 165s to 67s. That step is
 `continue-on-error`: if buildx or the cache service is unavailable,
 nothing is loaded and `run_tests_docker.sh` builds the image itself, so
 the job is slower but not red.
+
+Only `main` writes that cache. Actions cache scopes are per-ref, and a
+`pull_request` run reads its own scope plus the base branch, never a
+sibling topic branch. A topic branch exporting the image therefore writes
+a ~300 MB copy no other run can restore, and pays about 80s for the
+export on exactly the runs that missed. Read-only elsewhere keeps a hit at 24s
+and a miss at plain build cost. The practical consequence: a PR that
+edits `docker/Dockerfile.test` rebuilds the image on every run until it
+merges, because nothing on `main` matches its key yet.
 
 Note that the image's 64-bit SDL3 install is unused by CI: the
 `linux_test` preset is `-m32` throughout and points `SDL3_DIR` at

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -120,6 +120,89 @@ When you change the shared `paths-ignore` set, change `docs-gate.yml`'s
 `paths:` list to match. They are inverses of the same set and drift
 between them reopens the blocked-PR hole.
 
+## Caching and upstream dependencies
+
+Nothing in this repo is vendored: every run rebuilds its toolchain from
+somewhere else on the internet. That makes third-party availability the
+single largest source of red CI, ahead of actual test failures. Both
+failures in the recent run history were upstream 5xx responses, not code:
+
+- `curl` of the UASM release zip returned 503, failing the ASM suite
+  before a single test compiled.
+- `appimagetool`'s download exhausted its own five internal retries,
+  failing an AppImage release leg.
+
+Three rules follow from that, and the workflows apply them:
+
+1. **Bake, don't fetch.** Anything that can live in a cached image or a
+   cached prefix goes there. UASM is unpacked in `docker/Dockerfile.test`
+   rather than downloaded on each `docker run`; SDL3 for Android is built
+   once per `(ABI, tag, NDK)` and restored from the Actions cache after.
+2. **Retry what must be fetched.** `curl --retry 5 --retry-all-errors`,
+   `apt-get -o Acquire::Retries=5`, and a three-attempt loop around the
+   whole AppImage script (which fetches from Arch mirrors and a GitHub
+   release through tooling we do not control).
+3. **Bound every job.** All jobs carry `timeout-minutes`. Without it a
+   hung mirror connection burns the six-hour default before the job is
+   marked failed.
+
+### What is cached
+
+| Cache | Owner | Key | Restores |
+|---|---|---|---|
+| SDL3 build | `libsdl-org/setup-sdl` (built in) | resolved SDL git hash + `runner.os`/`arch` | ~2 MB prefix, seconds |
+| MSYS2 install + pacman packages | `msys2/setup-msys2` (`cache: true` default) | package list + config hash | ~177 MB |
+| ASM test image layers | `docker/build-push-action`, `type=gha` | `docker/Dockerfile.test` content | the whole image |
+| SDL3 for Android | `actions/cache` | ABI + SDL tag + NDK version | source tree + install prefix |
+
+The ASM test image is the one that matters most. `run_tests_docker.sh`
+builds it whenever it is not already in the local daemon, which on a
+fresh runner is *every* run: apt, two SDL3 source builds, and the UASM
+download, about 2m10s of a 2m45s job. `test.yml` builds it through buildx
+with the Actions cache backend first, so `run_tests_docker.sh` finds the
+image already loaded and skips its own build. That step is
+`continue-on-error`: if buildx or the cache service is unavailable,
+nothing is loaded and `run_tests_docker.sh` builds the image itself, so
+the job is slower but not red.
+
+Note that the image's 64-bit SDL3 install is unused by CI: the
+`linux_test` preset is `-m32` throughout and points `SDL3_DIR` at
+`/usr/local/sdl3-32`. It is kept for interactive use of the image. With
+the layers cached its build cost is only paid when the Dockerfile
+changes.
+
+**ccache is deliberately absent.** The compile steps are 14 s (macOS),
+18 s (Linux) and 70 s (Windows); only Windows is worth attacking, and a
+ccache directory that churns on every run would compete with the image
+layers for the repository's 10 GB Actions cache budget. Revisit if the
+Windows build grows or the cache budget frees up.
+
+### Where the toolchain still floats
+
+Two versions are resolved at run time rather than pinned:
+
+- `libsdl-org/setup-sdl` is called with `version: 3-latest` in
+  `linux.yml`, `macos.yml`, `reusable-build-linux-tarball.yml`, and
+  `reusable-build-macos.yml`, while `docker/Dockerfile.test`,
+  `reusable-build-android.yml`, and the `scripts/dev/` helpers pin
+  `release-3.2.16`. A new SDL3 release therefore invalidates the setup-sdl
+  cache and changes what CI links against with no commit in this repo.
+- `msys2/setup-msys2` runs with `update: true`, so the MinGW toolchain
+  advances whenever MSYS2 publishes.
+
+Both are deliberate, in that they surface upstream breakage early rather
+than letting it accumulate, but they are the reason a green run yesterday
+is not proof of a green run today.
+
+### Action pinning
+
+`libsdl-org/setup-sdl` is pinned to a commit SHA. Everything else uses a
+mutable major tag (`@v2`…`@v7`), and the container image for the AppImage
+build is `ghcr.io/pkgforge-dev/archlinux:latest`. That is the usual
+trade-off between supply-chain exposure and maintenance load; if it is
+ever tightened, do it with Dependabot's `github-actions` ecosystem so the
+pins have something keeping them current.
+
 ## Release tier
 
 The release workflows are documented in full in

--- a/run_tests_docker.sh
+++ b/run_tests_docker.sh
@@ -131,11 +131,18 @@ docker run --rm \
     bash -c '
         set -e
 
-        echo "--- Installing UASM ---"
-        curl -fsSL https://github.com/Terraspace/UASM/releases/download/v2.57r/uasm257_linux64.zip \
-            -o /tmp/uasm.zip
-        unzip -oq /tmp/uasm.zip -d /usr/local/bin
-        chmod +x /usr/local/bin/uasm
+        if [ -x /usr/local/bin/uasm ]; then
+            echo "--- UASM (baked into the image) ---"
+        else
+            # Only reached with an image built before UASM moved into the
+            # Dockerfile. Retries so a flaky CDN costs seconds, not the run.
+            echo "--- Installing UASM (stale image; rebuild with --rebuild) ---"
+            curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
+                https://github.com/Terraspace/UASM/releases/download/v2.57r/uasm257_linux64.zip \
+                -o /tmp/uasm.zip
+            unzip -oq /tmp/uasm.zip -d /usr/local/bin
+            chmod +x /usr/local/bin/uasm
+        fi
         uasm -? </dev/null 2>&1 | head -1 || true
 
         cp -a ${CONTAINER_SRC} /tmp/lba2


### PR DESCRIPTION
Both CI failures in the recent run history were upstream 5xx responses, not code:

- Run [31634309869](https://github.com/LBALab/lba2-classic-community/actions/runs/31634309869) — `curl` of the UASM release zip returned **503**, failing the ASM suite before a single test compiled. Unretried.
- Run [31639999869](https://github.com/LBALab/lba2-classic-community/actions/runs/31639999869) — `appimagetool`'s download exhausted its own five internal retries, so the rolling release shipped without an aarch64 AppImage.

Nothing here is vendored, so third-party availability is the largest source of red CI. These commits cut what each run has to fetch, cache what it must build, and stop a hung fetch from being able to fail a run silently.

## Where the time goes

Measured from step timings on recent runs. A PR is gated by its slowest leg.

| Job | Total | Dominant step |
|---|---|---|
| Windows | 2m54 | MSYS2 setup 91s, build 70s |
| Tests (Docker ASM) | 2m45 | image rebuild **2m11** |
| Linux | 56s | setup-sdl 30s (apt, not SDL) |
| macOS | 49s | build 14s |

`setup-sdl` and `setup-msys2` caches already hit (2 MB and 177 MB restores). The ASM image did not: `run_tests_docker.sh` builds it whenever it is not already in the local daemon, which on a hosted runner is every run — apt, **two** SDL3 source builds, and the UASM fetch.

## Commits

- `ci: bake UASM into the ASM test image` — the note claiming this had to happen at container runtime was about *executing* uasm; unzipping does not. Kills the 503 failure class.
- `ci: cache the ASM test image layers` — buildx with the Actions cache backend, keyed on the Dockerfile content. `continue-on-error`, so a cache-service outage costs time rather than the run.
- `ci: build against the runner's cmake and ninja` — both runner images ship CMake 3.31/4.4 and Ninja 1.13, past the 3.23 floor. Drops `lukka/get-cmake@latest`, an unpinned action plus a download, for two seconds of nothing.
- `ci: install only the MSYS2 packages the Windows build uses` — the `-toolchain` group is 68 packages / 1014 MiB including gdb, python, tcl and tk. Naming `gcc` gives the 694 MiB set the release build already uses.
- `ci: cache SDL3 for Android, retry the cmdline-tools download`
- `ci: retry the AppImage build past an upstream 5xx` — the fetch lives inside `quick-sharun`, so the whole script is the only retryable unit. Each attempt starts from a clean `AppDir`.
- `ci: retry apt, and bound every job with a timeout` — no job had `timeout-minutes`, so a connection that hangs rather than errors would sit on a runner for the six-hour default.
- `docs(ci): record what is cached and where the toolchain floats`
- `ci: give the demo build job the same toolchain treatment` — the demo SKU job landed in parallel with this branch, as a copy of the retail job including its `get-cmake` step and its missing timeout.

## Deliberately not in scope

**ccache.** Compiles are 14s / 18s / 70s; only Windows would pay, and a ccache directory churning every run would compete with the image layers for the repository's 10 GB Actions cache budget. The reasoning is written down in CI.md so it can be revisited if the Windows build grows.

**Pinning `version: 3-latest` or `update: true`.** Four workflows resolve SDL at run time while the Docker image, Android and the dev scripts pin `release-3.2.16`. Both floats surface upstream breakage early, which is a defensible trade; CI.md now names them as the reason a green run yesterday is not proof of a green run today.

## Also worth knowing

The test image's 64-bit SDL3 install is unused by CI — `linux_test` is `-m32` throughout and points `SDL3_DIR` at `/usr/local/sdl3-32`. It is kept for interactive use of the image, and with the layers cached its build cost is only paid when the Dockerfile changes.

## Validation

`actionlint` is clean apart from three pre-existing shellcheck warnings in `reusable-build-android.yml`. The image-cache speedup is an estimate until this branch runs; the Tests leg on this PR is the measurement.
