### PR TITLE
ci: close two cache staleness traps from #477

### DIFF
--- a/.github/workflows/reusable-build-android.yml
+++ b/.github/workflows/reusable-build-android.yml
@@ -93,19 +93,27 @@ jobs:
           echo "${ANDROID_HOME}/build-tools/35.0.0" >> "$GITHUB_PATH"
           echo "${ANDROID_HOME}/platform-tools" >> "$GITHUB_PATH"
 
-      # SDL3 is built from source per ABI, and the result only moves when the
-      # pinned tag or the NDK does. Cache the checkout (the APK bundler reads
-      # SDL's Java sources out of it) alongside the install prefix, so a run
-      # that changes neither pays a cache restore instead of a clone plus a
-      # full SDL build. RUNNER_TEMP is a fixed path on hosted runners, so the
+      # SDL3 is built from source per ABI. Cache the checkout (the APK bundler
+      # reads SDL's Java sources out of it) alongside the install prefix, so a
+      # run that changes neither pays a restore instead of a clone plus a full
+      # SDL build. RUNNER_TEMP is a fixed path on hosted runners, so the
       # absolute paths baked into SDL3Config.cmake stay valid across runs.
+      #
+      # The key hashes this whole file rather than naming the inputs, because
+      # everything that changes the output lives here: the SDL tag, the NDK
+      # version, ANDROID_PLATFORM, ANDROID_STL, the SHARED/STATIC split and the
+      # 16 KB page-size linker flags. A hand-written list would be a second
+      # thing to keep in sync, and forgetting to extend it links a stale SDL3
+      # into a shipped APK rather than merely wasting time. An unrelated edit
+      # to this file costs one 45s rebuild per ABI, which is the right way
+      # round to be wrong.
       - name: Cache SDL3 for Android
         uses: actions/cache@v6
         with:
           path: |
             ${{ runner.temp }}/SDL3
             ${{ runner.temp }}/sdl3-install
-          key: sdl3-android-${{ matrix.abi }}-release-3.2.16-ndk-28.2.13676358
+          key: sdl3-android-${{ matrix.abi }}-${{ hashFiles('.github/workflows/reusable-build-android.yml') }}
 
       - name: Build SDL3 for Android
         run: |

--- a/run_tests_docker.sh
+++ b/run_tests_docker.sh
@@ -105,6 +105,17 @@ if [ ${#TEST_NAMES[@]} -gt 0 ]; then
 fi
 
 # ── Run tests ─────────────────────────────────────────────────────────────────
+# The runtime fallback below needs the UASM release to fetch, but the version
+# belongs to the image. Read it out of the Dockerfile rather than repeating it:
+# two copies drift, and the failure is a stale image quietly assembling with a
+# different UASM than the one the Dockerfile declares.
+UASM_VERSION=$(sed -n 's/^ARG UASM_VERSION=//p' "${SCRIPT_DIR}/docker/Dockerfile.test")
+UASM_ARCHIVE=$(sed -n 's/^ARG UASM_ARCHIVE=//p' "${SCRIPT_DIR}/docker/Dockerfile.test")
+if [ -z "${UASM_VERSION}" ] || [ -z "${UASM_ARCHIVE}" ]; then
+    echo "ERROR: could not read ARG UASM_VERSION/UASM_ARCHIVE from docker/Dockerfile.test" >&2
+    exit 1
+fi
+
 TEST_LOG="${LOG_DIR}/test_run_$(date +%Y%m%d_%H%M%S).log"
 echo "==> Running tests (preset: ${PRESET}) …"
 # For render mode, we need read-write access to copy output files back
@@ -127,6 +138,8 @@ docker run --rm \
     -e "POLYREC_NAME=${POLYREC_NAME}" \
     -e "REPLAY_ARGS_STR=${REPLAY_ARGS[*]+"${REPLAY_ARGS[*]}"}" \
     -e "POLYREC_DEBUG_SLOPES=${POLYREC_DEBUG_SLOPES:-}" \
+    -e "UASM_VERSION=${UASM_VERSION}" \
+    -e "UASM_ARCHIVE=${UASM_ARCHIVE}" \
     "${IMAGE_NAME}" \
     bash -c '
         set -e
@@ -136,9 +149,9 @@ docker run --rm \
         else
             # Only reached with an image built before UASM moved into the
             # Dockerfile. Retries so a flaky CDN costs seconds, not the run.
-            echo "--- Installing UASM (stale image; rebuild with --rebuild) ---"
+            echo "--- Installing UASM ${UASM_VERSION} (stale image; rebuild with --rebuild) ---"
             curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
-                https://github.com/Terraspace/UASM/releases/download/v2.57r/uasm257_linux64.zip \
+                "https://github.com/Terraspace/UASM/releases/download/v${UASM_VERSION}/${UASM_ARCHIVE}" \
                 -o /tmp/uasm.zip
             unzip -oq /tmp/uasm.zip -d /usr/local/bin
             chmod +x /usr/local/bin/uasm


### PR DESCRIPTION
Two staleness traps introduced by #477, one of which can produce a wrong artifact rather than a slow one.

## The Android cache could serve a stale SDL3

The key named the SDL tag and the NDK version:

```yaml
key: sdl3-android-${{ matrix.abi }}-release-3.2.16-ndk-28.2.13676358
```

But the build it caches also depends on `ANDROID_PLATFORM=24`, `ANDROID_STL=c++_shared`, the `SDL_SHARED`/`SDL_STATIC` split, and the 16 KB page-size linker flags. None of those are in the key, so changing one leaves the old prefix in place and it gets linked into a shipped APK.

`check-16k-align.sh` covers exactly one of those flags, on one ABI. Nothing covers the rest.

The key now hashes the workflow file. Every input lives in that file, so there is no second list to forget to extend. The cost is that an unrelated edit to the file busts the cache and pays one 45s rebuild per ABI, which is the right way round to be wrong.

## The UASM version had two definitions

Baking UASM into the image left `ARG UASM_VERSION=2.57r` in `docker/Dockerfile.test` and a hardcoded `v2.57r` URL in the runtime fallback in `run_tests_docker.sh`. Bump one and an image built before the bump keeps assembling with the old UASM while the Dockerfile claims the new one — which surfaces as ASM equivalence tests disagreeing with no visible cause.

The script now reads the ARG out of the Dockerfile and passes it into the container, and fails loudly if it cannot read it rather than falling back to a stale default.

## Not addressed here

The remaining failure modes from the same review are either not worth machinery or cannot be fixed in the workflow:

- **Cache eviction is undetectable.** If main's image entry is evicted (10 GB cap, or 7 days idle), every PR silently rebuilds at 131s with CI green. Worth a periodic check rather than a code change.
- **`continue-on-error` on the image build is also a blindfold** — if buildx breaks while `run_tests_docker.sh`'s own build still works, caching is dead permanently and nothing goes red. Deliberate: the alternative is letting a cache-service outage fail the suite.
- **`cache-to` matches the literal `refs/heads/main`** and would silently stop writing if the default branch were renamed.
- **The AppImage retry hides genuine flakiness** — a leg failing 2 of 3 attempts every run looks green.

## Validation

`actionlint` clean apart from three pre-existing shellcheck warnings in `reusable-build-android.yml`; `shellcheck -S warning` clean on `run_tests_docker.sh`; the `sed` extraction verified against the real Dockerfile.

The Android key change cannot be proven by this PR's CI — `reusable-build-android.yml` only runs on release paths. Dispatching `release-android.yml` after merge should show a miss and a rebuild (the key changed), then a hit on the run after that.
