### PR TITLE
fix(discovery): say so when the sibling scan boots a different install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Booting a different install than the one you launched from now says so.
+  When the folder you run from holds no usable data, discovery scans the
+  parent directory and takes whatever install turns up next door. That is
+  what makes a clone beside a retail copy work, and it also meant a demo
+  folder sitting beside a retail one silently loaded the retail data:
+  right-looking launch, wrong distribution, exit 0, and the only tell was
+  the `Assets:` line. It still falls back, and now warns and names the
+  install it settled on.
 - Running the game from inside an install whose data sits in `Common/` now
   finds it without `--game-dir`. Auto-discovery joined `Common/` only for
   paths you named explicitly, so an unflagged run depended on the sibling

--- a/SOURCES/RES_DISCOVERY.CPP
+++ b/SOURCES/RES_DISCOVERY.CPP
@@ -608,6 +608,20 @@ bool ResolveGameDataDir(char *outDir, U16 outMax, int *argc, char **argv) {
 
     Res_SetDiscoverySource("sibling scan");
     if (TryParentSiblingScan(outDir, outMax, tried, &triedCount)) {
+        /* Every other probe checks a place the caller implied: the folder they
+           ran from, one they named, a fixed relative path. This one enumerates
+           the parent and takes whatever install turns up, so a folder holding
+           no usable data boots the neighbour instead. Right-looking launch,
+           different distribution, exit 0, and the only tell is the Assets line.
+           A demo folder beside a retail one does exactly this.
+
+           The clone-beside-an-install layout it exists for is legitimate, so
+           this stays a fallback rather than becoming a refusal like the
+           --game-dir and LBA2_GAME_DIR mismatches. It just has to say so. */
+        Log_Warn("RES_DISCOVERY: no game data in the folder this was run from. "
+                 "Using a neighbouring install: %s",
+                 outDir);
+        Log_Warn("Name the one you want with --game-dir if that is not it.");
         return true;
     }
 

--- a/docs/GAME_DATA.md
+++ b/docs/GAME_DATA.md
@@ -12,6 +12,8 @@ Use the directory that contains `LBA2.HQR` (and the other `.hqr` files, `music/`
 
 **Sibling scan:** If the fixed paths above fail, the engine looks at siblings of the parent of the current working directory (for example the folder that contains both your clone and a retail install). For each immediate subdirectory, it tries that folder and `CommonClassic`, `common`, `Common`, and `Classic` under it. Only bounded scans (entry and directory-count limits); see `TryParentSiblingScan` in `SOURCES/RES_DISCOVERY.CPP`.
 
+This is the one probe that boots an install nobody named: it enumerates the parent and takes what it finds. That is wanted for a clone sitting beside a retail copy, and unwanted when the folder you launched from is itself an install this build cannot read, such as a demo next to a retail one. Discovery cannot tell those apart, so it stays a fallback and logs a warning naming the install it settled on. An unexpected `Assets:` line with that warning above it means the folder you ran from had nothing usable in it.
+
 ## Overrides (highest priority first)
 
 | Mechanism | Example |

--- a/tests/discovery/test_res_discovery.cpp
+++ b/tests/discovery/test_res_discovery.cpp
@@ -10,6 +10,7 @@
 #include <SYSTEM/DISCIMG.H>
 #include <SYSTEM/FILES.H>
 #include <SYSTEM/LIMITS.H>
+#include <SYSTEM/LOG.H>
 
 #include "DIRECTORIES.H"
 #include "RES_DISCOVERY.H"
@@ -113,6 +114,18 @@ static int chdir_portable(const char *p) {
 }
 
 #endif
+
+/** Reads a whole file into `buf`, NUL-terminated; empty string if unreadable. */
+static void slurp_file(const char *path, char *buf, size_t cap) {
+    buf[0] = '\0';
+    FILE *f = fopen(path, "rb");
+    if (f == NULL) {
+        return;
+    }
+    const size_t n = fread(buf, 1, cap - 1, f);
+    buf[n] = '\0';
+    fclose(f);
+}
 
 static void create_marker_hqr(const char *dir) {
     char marker[512];
@@ -335,6 +348,12 @@ static bool test_argv_game_dir() {
 /**
  * Simulates: clone at parent/repo_clone, retail at parent/RetailGame/lba2.hqr.
  * Discovery scans siblings of parent(repo_clone) and finds RetailGame.
+ *
+ * Also the substitution case: the run boots an install the caller never named,
+ * picked by enumerating the parent. That is wanted here and unwanted when the
+ * folder you are standing in is itself an install this build cannot read (a
+ * demo beside a retail copy), and discovery cannot tell those apart. So it
+ * stays a fallback and has to announce itself; this asserts it does.
  */
 static bool test_sibling_direct_next_to_cwd() {
     unsetenv_portable("LBA2_GAME_DIR");
@@ -369,6 +388,15 @@ static bool test_sibling_direct_next_to_cwd() {
         return false;
     }
 
+    /* File sinks flush per write, so the warning can be read back without
+       Log_Shutdown tearing logging down for every test that runs after.
+       Log_Init is what routes records to sinks at all; until it runs they go
+       to SDL's default stderr and no sink sees them. */
+    char logPath[600];
+    snprintf(logPath, sizeof(logPath), "%s/sibling.log", parent);
+    LogSink *fileSink = Log_MakeFileSink(logPath, LOG_WARN);
+    Log_AddSink(fileSink);
+
     char out[ADELINE_MAX_PATH];
     int argc = 1;
     char arg0[] = "lba2";
@@ -378,7 +406,22 @@ static bool test_sibling_direct_next_to_cwd() {
     if (!ok) {
         return false;
     }
-    return strstr(out, "RetailGame") != NULL;
+    if (strstr(out, "RetailGame") == NULL) {
+        fprintf(stderr, "test_sibling_direct_next_to_cwd: resolved '%s'\n", out);
+        return false;
+    }
+
+    char logBuf[4096];
+    slurp_file(logPath, logBuf, sizeof(logBuf));
+    Log_RemoveSink(fileSink);
+    if (strstr(logBuf, "neighbouring install") == NULL) {
+        fprintf(stderr,
+                "test_sibling_direct_next_to_cwd: booted an install the caller "
+                "never named without saying so; log was:\n%s\n",
+                logBuf);
+        return false;
+    }
+    return true;
 }
 
 /**
@@ -911,6 +954,12 @@ int main() {
     if (!SDL_Init(0)) {
         return 1;
     }
+
+    /* Route records through the sink layer rather than SDL's default stderr,
+       so a test can read back what the engine logged. The terminal sink keeps
+       the diagnostics these tests print on failure visible. */
+    Log_Init();
+    Log_AddSink(Log_MakeTerminalSink(LOG_INFO));
 
     /* Move the user's real persisted last_game_dir.txt aside (if any)
      * so it doesn't interfere with the sibling-scan tests, which


### PR DESCRIPTION
Follow-up to #476, found while sweeping the release collection for
regressions rather than from a report.

Discovery can boot an install you never asked for, silently. Standing in a
folder that holds nothing this build can read, the sibling scan enumerates
the parent directory and takes whatever install turns up next door:

```
cwd:     .../LBA2 Versions/Demo/          <- a 1997 demo, gates on RESS.HQR
Assets:  .../LBA2 Versions/LBA2-GOG/  (sibling scan)
```

Right-looking launch, wrong distribution, exit 0. The only tell is the
`Assets:` line, which reads as normal boot output.

This is the failure mode the codebase already calls out for the explicit
overrides. From `RES_DISCOVERY.CPP`, on why `--game-dir` refuses instead of
falling through: *"a launch against assets nobody asked for, reported only by
the `Assets:` line and still exiting 0."* Auto-discovery had the same hole
and no such guard.

## Why not just refuse

The sibling scan is the one probe that checks somewhere the caller never
implied. Every other one looks at the folder you ran from, a folder you
named, or a fixed relative path; this one enumerates and picks.

But it exists for a real layout, documented in `docs/GAME_DATA.md`: a repo
clone sitting beside a retail install. That is the same shape as the demo
case, and discovery has no way to tell "clone with no data" from "install
this build cannot read". So it stays a fallback and gains a warning naming
what it settled on:

```
[WARN] RES_DISCOVERY: no game data in the folder this was run from.
       Using a neighbouring install: /mnt/e/LBA2 Versions/LBA2-GOG/
[WARN] Name the one you want with --game-dir if that is not it.
```

## Measured across the release collection

Eight releases, launched from inside each folder with no flags, against a
locally built engine:

| Install | Resolved | Announced? |
|---|---|---|
| Demo | `LBA2-GOG/` (sibling scan) | **WARNS** |
| LBA2-GOG | `LBA2-GOG/` (working directory) | quiet |
| LBA2-Steam | `LBA2-Steam/Common/` (working directory, Common/) | quiet |
| LittleBigAdventure2 | `LittleBigAdventure2/` (working directory) | quiet |
| TWINSEN-BR | `TWINSEN-BR/` (working directory) | quiet |
| TWINSEN | `TWINSEN/` (working directory) | quiet |
| lba-2_202507 | `lba-2_202507/` (working directory) | quiet |
| little-big-adventure-2 | `LBA2-GOG/` (sibling scan) | **WARNS** |

The two that substitute announce it; the six that resolve to themselves stay
quiet. `little-big-adventure-2` is a folder of disc scans with no image in
it, so it has nothing of its own to find either.

Worth noting the resolution itself is unchanged. This does not fix those two
rows, because there is nothing correct to resolve to. It makes the
substitution legible.

## Testing

The assertion rides on `test_sibling_direct_next_to_cwd`, which already
builds exactly this shape (clone at `parent/repo_clone`, data at
`parent/RetailGame`), rather than adding a fixture for a one-line behaviour.

Reading a log line back needs `Log_Init` in the test's `main`: without it
records go to SDL's default stderr and never reach a sink at all, so a file
sink captures nothing. File sinks flush per write, so no `Log_Shutdown` is
needed and logging survives for every test that runs after.

Verified it fails without the change, by reverting `RES_DISCOVERY.CPP` to
`main`:

```
test_sibling_direct_next_to_cwd: booted an install the caller never named
without saying so; log was:
exit=1
```

Full host suite green: `100% tests passed, 0 tests failed out of 51`.

## Judgement call worth a second opinion

The warning fires for the clone-beside-an-install dev layout too, since it is
the same mechanism. That is one extra line at boot for anyone developing that
way. I think it is accurate rather than noisy, and it is the line a bug
report most wants pasted, but it is a taste call and it is two lines to scope
down if you disagree.
