### PR TITLE
fix(verify-release): keep the version check alive without a container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `scripts/dev/verify-release.sh` keeps checking `--version` against the
+  filename on a host with no container runtime, by running same-arch
+  artifacts directly instead of skipping them. Only the clean-system claim
+  needs a container, so only that is lost, and the run still exits 2 to say
+  so. Previously both metadata checks were advertised as surviving while one
+  of them silently did not.
+
 - Booting a different install than the one you launched from now says so.
   When the folder you run from holds no usable data, discovery scans the
   parent directory and takes whatever install turns up next door. That is

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -254,6 +254,15 @@ Windows ZIPs, macOS DMGs and Android APKs aren't checked. Running them
 on a Linux host needs `wine`, `qemu-system-x86`, a Mac, or an Android
 emulator, which is more machinery than the marginal signal justifies.
 
+**Without a container runtime** the script still runs both metadata checks
+and exits 2 rather than 0. The channel is read straight out of the file, and
+`--version` is taken by running same-arch artifacts on the host, marked
+`(host run; clean-system NOT verified)` in the row. Cross-arch artifacts are
+not run at all. What a host run cannot show is the part only a container
+can: that the artifact executes on a machine with none of the build deps
+installed. So exit 2 means "a mislabelled artifact would have been caught,
+but this was not a release gate".
+
 **Docker Desktop under WSL.** If the script dies at `registering
 qemu-user-static binfmt` with `docker-credential-desktop.exe: Invalid
 argument` and exit 125, the culprit is `"credsStore": "desktop.exe"` in

--- a/scripts/dev/verify-release.sh
+++ b/scripts/dev/verify-release.sh
@@ -32,13 +32,17 @@
 # Exit codes:
 #   0  everything checked passed
 #   1  a check failed
-#   2  metadata passed but the run checks never executed (no container
-#      runtime), so the result is not a release gate
+#   2  the metadata checks passed but nothing was run in a clean container
+#      (no container runtime), so the result is not a release gate
 #
 # Requirements:
 #   - gh (authenticated), tar
-#   - docker, for the run checks only. Without a reachable daemon the
-#     metadata checks still run and the exit code is 2.
+#   - docker, for the clean-system claim only. Without a reachable daemon
+#     both metadata checks still run: the update channel is read from the
+#     file, and `--version` is taken by running same-arch artifacts on this
+#     host instead. Cross-arch artifacts are then not run at all. Exit 2
+#     either way, because "runs with none of its build deps installed" is
+#     what only a container can show.
 #   - aarch64 leg auto-registers qemu-user-static binfmt via
 #     tonistiigi/binfmt if not already set up
 set -euo pipefail
@@ -74,6 +78,7 @@ done
 #
 # Without a daemon the metadata checks still carry their full weight, so the
 # run proceeds; the run checks become SKIP rows and the exit code says so.
+HOST_ARCH="$(uname -m)"
 DOCKER_OK=1
 SKIPPED_NO_DOCKER=0
 if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
@@ -181,21 +186,41 @@ check_update_channel() {
 
 run_check() {
     local label="$1" platform="$2" mount_mode="$3" cmd="$4" expected="$5"
-    local out rc version
-    if (( ! DOCKER_OK )); then
-        RESULTS+=( "SKIP  $label  no container runtime — clean-system run not verified" )
+    local out rc version note=""
+    local want_arch="x86_64"
+    [[ "$platform" == "linux/arm64" ]] && want_arch="aarch64"
+
+    if (( ! DOCKER_OK )) && [[ "$want_arch" != "$HOST_ARCH" ]]; then
+        RESULTS+=( "SKIP  $label  no container runtime and cross-arch: not run at all" )
         SKIPPED_NO_DOCKER=$(( SKIPPED_NO_DOCKER + 1 ))
         return
     fi
-    # Guard against set -e propagating from $() when docker exits
-    # non-zero — we want to record the failure as a FAIL row, not abort
-    # the whole script and leave the rest of the artifacts unchecked.
-    if out=$( docker run --rm --platform "$platform" \
-        -v "$WORK_DIR:/test:$mount_mode" debian:stable-slim \
-        sh -c "$cmd" 2>&1 ); then
-        rc=0
+
+    if (( DOCKER_OK )); then
+        # Guard against set -e propagating from $() when docker exits
+        # non-zero — we want to record the failure as a FAIL row, not abort
+        # the whole script and leave the rest of the artifacts unchecked.
+        if out=$( docker run --rm --platform "$platform" \
+            -v "$WORK_DIR:/test:$mount_mode" debian:stable-slim \
+            sh -c "$cmd" 2>&1 ); then
+            rc=0
+        else
+            rc=$?
+        fi
     else
-        rc=$?
+        # No daemon, but the artifact is this host's architecture, so the
+        # version-vs-filename half of the check is still reachable: run it
+        # here instead. What is lost is the clean-system claim, since this
+        # box has the build deps installed, so the row says so and the run
+        # still exits 2. A mislabelled artifact is caught either way, which
+        # is the failure that otherwise reaches the Releases page unseen.
+        SKIPPED_NO_DOCKER=$(( SKIPPED_NO_DOCKER + 1 ))
+        note="  (host run; clean-system NOT verified)"
+        if out=$( sh -c "${cmd//\/test\//$WORK_DIR/}" 2>&1 ); then
+            rc=0
+        else
+            rc=$?
+        fi
     fi
     # --version may be preceded by stderr warnings (e.g. AppRun's
     # "Cannot find CA Certificates" notice) folded in via 2>&1. The
@@ -208,7 +233,7 @@ run_check() {
         RESULTS+=( "FAIL  $label  --version=$version but the filename says $expected" )
         FAIL=$(( FAIL + 1 ))
     else
-        RESULTS+=( "PASS  $label  --version=$version" )
+        RESULTS+=( "PASS  $label  --version=$version$note" )
         PASS=$(( PASS + 1 ))
     fi
 }
@@ -239,7 +264,6 @@ done
 # code works in the same container, which is what isolates the cause
 # to the AppImage runtime stub specifically). Skip cross-arch AppImages
 # and verify only AppImages whose arch matches the host.
-HOST_ARCH="$(uname -m)"
 for aimg in "${APPIMAGES[@]}"; do
     stem="${aimg%.AppImage}"
     case "$aimg" in
@@ -291,8 +315,9 @@ fi
 # worse than the FAIL rows this replaced. Distinct code so a caller that only
 # wants the metadata checks can choose to ignore it.
 if (( SKIPPED_NO_DOCKER > 0 )); then
-    echo "[verify-release] $SKIPPED_NO_DOCKER run check(s) never executed: no container runtime."
-    echo "[verify-release] metadata passed, but this run did NOT verify the artifacts"
+    echo "[verify-release] $SKIPPED_NO_DOCKER artifact(s) not run in a clean container: no container runtime."
+    echo "[verify-release] update channel and version-vs-filename were checked;"
+    echo "[verify-release] this run did NOT verify the artifacts"
     echo "[verify-release] execute on a clean system. Not a release gate as it stands."
     exit 2
 fi


### PR DESCRIPTION
Follow-up to #480, which made the script survive a host with no reachable
container runtime. It advertises two metadata checks as surviving that. Only
one did.

The channel check reads the file directly, so it lives. The version-vs-filename
check lives *inside* `run_check`, because it needs `--version` out of the
binary, so it went out with the container runs. A docker-less host printed
`metadata passed` having compared no versions at all:

```
  SKIP  tarball lba2cc-0.13.0-dev-linux-x86_64  no container runtime
  PASS  appimage lba2cc-0.13.0-dev-anylinux-x86_64  update-channel=latest-pre
  SKIP  appimage lba2cc-0.13.0-dev-anylinux-x86_64  no container runtime

[verify-release] metadata passed, but this run did NOT verify ...
```

Zero `--version=` rows. A mislabelled artifact would have walked straight
through, which is the failure that otherwise reaches the Releases page unseen
and is exactly what that check exists to stop.

## What changed

Only the *clean-system* claim needs a container. Reading `--version` does
not, provided the artifact matches the host architecture. So with no daemon,
same-arch artifacts run here and the comparison still happens:

```
  SKIP  tarball ...-linux-aarch64      no container runtime and cross-arch: not run at all
  PASS  tarball ...-linux-x86_64       --version=0.13.0-dev  (host run; clean-system NOT verified)
  PASS  appimage ...-anylinux-aarch64  update-channel=latest-pre
  SKIP  appimage ...-anylinux-aarch64  cross-arch AppImage (host=x86_64, image=aarch64)
  PASS  appimage ...-anylinux-x86_64   update-channel=latest-pre
  PASS  appimage ...-anylinux-x86_64   --version=0.13.0-dev  (host run; clean-system NOT verified)

4 passed, 0 failed, 2 skipped
```

Two passes became four, and the two that stay skipped now say *why* they are
different: cross-arch cannot run at all here, rather than sharing a message
with same-arch artifacts that could have.

Rows from a host run are marked, so no reader mistakes one for the container
result. **Exit stays 2**, because catching a mislabelled artifact is not the
same as proving one executes with none of its build deps installed, and only
the container shows the latter.

The closing message now names what was actually checked instead of claiming
"metadata passed" wholesale.

## Testing

Both paths exercised against the live `latest` release.

Without a runtime, on this host: the table above, exit 2.

With one, via a `docker`→podman shim so the script runs unmodified:

```
  PASS  tarball ...-linux-x86_64       --version=0.13.0-dev
  PASS  appimage ...-anylinux-x86_64   update-channel=latest-pre
  PASS  appimage ...-anylinux-x86_64   --version=0.13.0-dev
```

Same four passes, no `host run` marker, container path unchanged by the
refactor. (The aarch64 tarball fails there for want of a qemu binfmt handler
on this box, which predates this change.)

`shellcheck` clean.

One structural note: `HOST_ARCH` moved up beside the `DOCKER_OK` probe. It
was defined between the tarball loop and the AppImage loop, and `run_check`
now needs it during the tarball loop, where it would otherwise trip `set -u`.
