### PR TITLE
test(walkthrough): assert what the opening actually does (#447)

### DIFF
--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -587,6 +587,27 @@ The keystone is `test_tick.sh`: it loads, advances 1 vs 60 ticks, and asserts th
 clock and the hero's idle-animation frame both advanced — proving the loop steps the
 simulation, not just a counter.
 
+### Driving the opening (`test_walkthrough_opening.sh`)
+
+The walkthrough e2e: cold boot into Twinsen's house, out through the front door, then a
+walk under injected input, all of it from a new game with no save in play. Four properties
+of the opening shape it, and each one is a way for a test written in there to look like it
+proves something it does not (all four measured, not assumed; see issue #447).
+
+| | |
+|---|---|
+| The new game is stamped on frame one | The hero's own Life script sets game vars 94 (`FLAG_DINO_VOYAGE`) and 253 (`FLAG_CHAPTER`) during the first simulated tick, before any state a test can dump. No cold-boot test can watch those go 0 to 1, so they serve as a boot assertion and never as a probe. The first flags that do flip during the run are 164 and 165, set by cube 49's script on arrival |
+| A tick-0 `teleport` is undone | `--exec` fires on the first tick, ahead of the opening script placing the hero, which then puts him back. The console reports the move and the run behaves as though nothing happened. Use `--exec-at 1` for anything positional |
+| The house opening owns the hero | He walks his opening track with no input at all, so a displacement test in the house passes on the script alone, and injected input moves him not at all. The first place input actually walks him is outside, in cube 49 |
+| The house talks after ~200 ticks | The opening dialogue opens a modal and the loop stops ticking. A house run either stays short of it or passes `skipmodals on` |
+
+Nothing inside the house advances quest state on its own, which is why the walkthrough's
+first quest event is the door: a teleport into any of the cube's scenaric boxes latches the
+hero's `ZoneSce` and stops there, and the giver boxes still want the grounded action edge no
+headless run has driven (see `zonelist` above). Every number the fixture asserts is identical
+on each retail master (Activision and EA, disc rips and the re-releases alike), so a failure
+is the engine rather than the install.
+
 ## Roadmap
 
 The harness is built so these are additive, not rewrites. Ordered by dependency — each step

--- a/tests/automation/test_cli_contract.sh
+++ b/tests/automation/test_cli_contract.sh
@@ -2,7 +2,8 @@
 # The CLI contract that automation depends on (#433). Every case here guards against a
 # run that silently does the wrong thing and still exits 0:
 #
-#   --help          prints usage and exits 0 WITHOUT booting the game
+#   --help          prints usage and exits 0 WITHOUT booting the game, and points at
+#                   --help-all, which is where the automation flags are listed
 #   unknown flag    exits non-zero instead of booting with the flag silently ignored
 #   missing value   exits non-zero instead of dropping the flag ("--tick" with no count)
 #   flag-as-value   exits non-zero instead of swallowing it ("--exec-at 5 --tick 30" must
@@ -18,10 +19,18 @@ TESTNAME=cli_contract
 precheck
 
 # --- --help: exits 0, prints usage, does not open a window ---------------------
+# Help is two tiers: --help is the player's page and names --help-all, which is
+# where the automation flags this suite runs on are listed. Both are asserted, or
+# a tier that stopped printing its half would read as a passing contract.
 out="$(timeout 10 "$LBA2_BIN" --help 2>/dev/null)" || fail "--help exited non-zero"
 case "$out" in
-*Usage:*--headless*) ;;
+*Usage:*--help-all*) ;;
 *) fail "--help did not print usage (got: $(echo "$out" | head -1))" ;;
+esac
+all="$(timeout 10 "$LBA2_BIN" --help-all 2>/dev/null)" || fail "--help-all exited non-zero"
+case "$all" in
+*Usage:*--headless*) ;;
+*) fail "--help-all did not list the automation flags (got: $(echo "$all" | head -1))" ;;
 esac
 
 # --- unknown flag: refuses to run ----------------------------------------------

--- a/tests/automation/test_walkthrough_opening.sh
+++ b/tests/automation/test_walkthrough_opening.sh
@@ -4,23 +4,54 @@
 # the real thing and asserts the engine's own reaction at each beat.
 #
 # The four beats mirror the start of any Twinsen's Odyssey walkthrough:
-#   1. New game starts you in Twinsen's house (island 0, cube 0).
-#   2. You can walk.
-#   3. Stepping into a scenaric trigger fires the hero's Life script and
-#      advances quest state (game vars flip).
-#   4. Walking into the doorway leaves the house for the next scene (cube 49).
+#   1. A new game starts you in Twinsen's house (island 0, cube 0), fresh.
+#   2. The house opening is the scene's own choreography: the hero walks it out
+#      himself, and the player has no control yet.
+#   3. Walking into the doorway leaves the house for the next scene (cube 49).
+#   4. Outside, that scene's script advances quest state and the hero answers input.
 #
 # Everything is driven with stock console verbs (input / teleport) under
 # --fixed-dt for determinism. Zone coordinates were read off the `zonelist`
-# console command (cube 0): scenaric zone Num=1 and the cube-change zone to 49.
+# console command (cube 0): the cube-change zone to 49 at [4].
+#
+# Four things about the opening that the beats are built around, each measured
+# rather than assumed. The first three are each a way for a test written in here
+# to prove nothing at all, which is what the earlier version of this file did:
+#
+#   * The opening Life script stamps the new game on the FIRST simulated frame:
+#     game vars 94 (FLAG_DINO_VOYAGE) and 253 (FLAG_CHAPTER) go to 1 before any
+#     tick a test can observe. No cold-boot test can ever watch those flip, so
+#     they are asserted here as the new-game stamp, never used as a probe.
+#   * --exec runs on tick 0, ahead of the opening script placing the hero, so a
+#     tick-0 `teleport` is silently undone. Every teleport below is --exec-at 1.
+#   * The house opening owns the hero: he walks it out on his own and injected
+#     input moves him not at all, so the walk assertion lives outside, in beat 4.
+#   * A house run past ~200 ticks walks into the opening dialogue and blocks on
+#     the modal. All house runs here stay well short of it.
+#
+# Nothing in the house advances quest state on its own: a teleport into any of
+# the cube's scenaric boxes latches the hero's ZoneSce and stops there, and the
+# giver boxes need a grounded action edge no headless run has managed. The door
+# is the opening's first real quest event, which is why beat 4 waits for it.
 #
 # Local-only: needs retail data (LBA2_GAME_DIR) and a build. No save required.
 TESTNAME=walkthrough_opening
 . "$(dirname "$0")/lib.sh"
 precheck
 
-d0="$(mktemp)"; d1="$(mktemp)"; d2="$(mktemp)"; d3="$(mktemp)"
-trap 'rm -f "$d0" "$d1" "$d2" "$d3"' EXIT
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+d0="$tmp/0.json"; d1="$tmp/1.json"; d2="$tmp/2.json"
+d3="$tmp/3.json"; d4="$tmp/4.json"
+
+# A user directory of this run's own. The beats below are distances the hero
+# covers per simulated tick, and lba2.cfg's FixedTimestep decides how many of
+# those a tick budget buys, so a shared config carrying another run's throttle
+# setting shortens the walk and reads as a broken engine. Isolating also keeps
+# the run off the developer's own saves and settings entirely.
+export LBA2_USER_DIR="$tmp/user"
+
+DOOR="teleport 12288 1664 10496"
 
 # ── Beat 1: a cold boot lands in Twinsen's house, in a fresh new-game state ──
 ctl_headless --fixed-dt 16 --tick 5 --dump-state "$d0" --exit >/dev/null 2>&1 \
@@ -31,34 +62,55 @@ isl=$(jget "$d0" "d['scene']['island']"); cube=$(jget "$d0" "d['scene']['cube']"
 ml=$(jget "$d0" "d['inventory']['magic_level']"); keys=$(jget "$d0" "d['inventory']['keys']")
 [ "$ml" = "0" ] && [ "$keys" = "0" ] \
     || fail "not a fresh new game: magic_level=$ml keys=$keys (want 0/0)"
-# The two quest flags beat 3 will flip must start clear, or that test proves nothing.
+# The new-game stamp the opening script writes on frame one. Asserted so a boot
+# that skipped it is caught here rather than mistaken for quest progress later.
 b94=$(jget "$d0" "d['vars']['nonzero'].get('94',0)"); b253=$(jget "$d0" "d['vars']['nonzero'].get('253',0)")
-[ "$b94" = "0" ] && [ "$b253" = "0" ] \
-    || fail "quest vars 94/253 not clear at boot: 94=$b94 253=$b253"
+[ "$b94" = "1" ] && [ "$b253" = "1" ] \
+    || fail "new game not stamped by the opening script: var94=$b94 var253(chapter)=$b253 (want 1/1)"
+# The flags beat 4 watches must start clear, or that test proves nothing.
+b164=$(jget "$d0" "d['vars']['nonzero'].get('164',0)"); b165=$(jget "$d0" "d['vars']['nonzero'].get('165',0)")
+[ "$b164" = "0" ] && [ "$b165" = "0" ] \
+    || fail "quest vars 164/165 not clear at boot: 164=$b164 165=$b165"
 
-# ── Beat 2: the hero walks under injected input (hold 'up' for 60 frames) ──
-ctl_headless --fixed-dt 16 --exec "input up 60" --tick 70 --dump-state "$d1" --exit >/dev/null 2>&1 \
-    || fail "walk run: non-zero exit ($?)"
+# ── Beat 2: the house opening runs itself, and the player has no control yet ──
+# The hero walks his opening track with no input at all, so a displacement test
+# in here would pass on the script alone. Both halves are asserted: he moves,
+# and the same run with 'up' held is identical, which is what sends the real
+# walk assertion outside to beat 4.
+ctl_headless --fixed-dt 16 --tick 70 --dump-state "$d1" --exit >/dev/null 2>&1 \
+    || fail "house idle run: non-zero exit ($?)"
+ctl_headless --fixed-dt 16 --exec-at 1 "input up 60" --tick 70 --dump-state "$d2" --exit >/dev/null 2>&1 \
+    || fail "house input run: non-zero exit ($?)"
 x0=$(jget "$d0" "d['hero']['x']"); z0=$(jget "$d0" "d['hero']['z']")
 x1=$(jget "$d1" "d['hero']['x']"); z1=$(jget "$d1" "d['hero']['z']")
-moved=$(python3 -c "print(abs($x1-$x0)+abs($z1-$z0))")
-[ "$moved" -gt 100 ] \
-    || fail "hero did not walk under 'input up': moved=$moved units (from $x0,$z0 to $x1,$z1)"
+x2=$(jget "$d2" "d['hero']['x']"); z2=$(jget "$d2" "d['hero']['z']")
+scripted=$(python3 -c "print(abs($x1-$x0)+abs($z1-$z0))")
+[ "$scripted" -gt 300 ] \
+    || fail "the opening did not walk the hero: moved=$scripted units (from $x0,$z0 to $x1,$z1)"
+[ "$x1" = "$x2" ] && [ "$z1" = "$z2" ] \
+    || fail "'input up' now moves the hero during the house opening ($x1,$z1 vs $x2,$z2): the walk beat can move back in here"
 
-# ── Beat 3: a scenaric trigger fires the hero's Life script and sets quest flags ──
-# zonelist cube 0: [0] scenaric Num=1 box=(12288,2048,2560)-(13823,3327,4095).
-ctl_headless --fixed-dt 16 --exec "teleport 13055 2687 3327" --tick 12 --dump-state "$d2" --exit >/dev/null 2>&1 \
-    || fail "scenaric run: non-zero exit ($?)"
-v94=$(jget "$d2" "d['vars']['nonzero'].get('94',0)"); v253=$(jget "$d2" "d['vars']['nonzero'].get('253',0)")
-[ "$v94" = "1" ] && [ "$v253" = "1" ] \
-    || fail "scenaric zone did not advance quest state: var94=$v94 var253=$v253 (want 1/1)"
-
-# ── Beat 4: walking into the doorway zone changes scene (leave the house) ──
+# ── Beat 3: walking into the doorway zone changes scene (leave the house) ──
 # zonelist cube 0: [4] cube Num=49 box=(11776,768,10240)-(12800,2560,10752).
-ctl_headless --fixed-dt 16 --exec "teleport 12288 1664 10496" --tick 20 --dump-state "$d3" --exit >/dev/null 2>&1 \
+ctl_headless --fixed-dt 16 --exec-at 1 "$DOOR" --tick 120 --dump-state "$d3" --exit >/dev/null 2>&1 \
     || fail "door run: non-zero exit ($?)"
 nc=$(jget "$d3" "d['scene']['cube']")
 [ "$nc" = "49" ] \
     || fail "did not transition through the door: cube=$nc (want 49)"
 
-pass "house 0/0 fresh, walked $moved units, scenaric set vars 94/253, door -> cube 49"
+# ── Beat 4: the new scene advances quest state, and the hero answers input ──
+# Cube 49's own Life script sets game vars 164 and 165 on arrival, the first
+# quest flags of the run that a cold boot did not already hold.
+v164=$(jget "$d3" "d['vars']['nonzero'].get('164',0)"); v165=$(jget "$d3" "d['vars']['nonzero'].get('165',0)")
+[ "$v164" = "1" ] && [ "$v165" = "1" ] \
+    || fail "leaving the house did not advance quest state: var164=$v164 var165=$v165 (want 1/1)"
+ctl_headless --fixed-dt 16 --exec-at 1 "$DOOR" --exec-at 10 "input up 100" --tick 120 \
+    --dump-state "$d4" --exit >/dev/null 2>&1 \
+    || fail "outside walk run: non-zero exit ($?)"
+x3=$(jget "$d3" "d['hero']['x']"); z3=$(jget "$d3" "d['hero']['z']")
+x4=$(jget "$d4" "d['hero']['x']"); z4=$(jget "$d4" "d['hero']['z']")
+walked=$(python3 -c "print(abs($x4-$x3)+abs($z4-$z3))")
+[ "$walked" -gt 500 ] \
+    || fail "hero did not walk under 'input up' outside: moved=$walked units (from $x3,$z3 to $x4,$z4)"
+
+pass "house 0/0 fresh, opening walked $scripted units on its own, door -> cube 49 set vars 164/165, then 'up' walked $walked units"


### PR DESCRIPTION
Closes #447.

The issue found the opening e2e red and beat 3 vacuous. Measuring the rest of it found three more wrong premises, so every beat behind the red one was also proving nothing.

## What was wrong

| Premise | What the engine does |
|---|---|
| Beat 1: game vars 94 and 253 are clear at boot | The hero's own Life script sets both on the **first simulated frame**. `lifetrace 0` at tick 0 shows `DoLife off=0`, `checks LF=15`, then `SET game_var[94]=1`, `SET game_var[253]=1`. No cold-boot run can watch these flip |
| Beat 3: the cube-0 scenaric zone advances quest state | It does not. Teleporting into each of the cube's 16 zones in turn moves nothing but position: the hero's script parks at off=344 checking `LF_VAR_GAME` and never reads `LF_ZONE`. The scenaric box latches his `ZoneSce` and stops there |
| Beats 3 and 4: `--exec "teleport ..."` puts the hero somewhere | `--exec` fires on tick 0, ahead of the opening script placing the hero, which then puts him back. Both teleports were silently undone: the console logged the move and the runs behaved as though nothing had happened |
| Beat 2: `input up` walks the hero | Inert in the house, at every tick tried. The idle and input runs are byte-identical. He walks ~928 units on his own, which is what the 100-unit threshold was passing on |

## What the fixture asserts now

1. Cold boot lands in the house (0/0), fresh (no magic, no keys), the opening script's new-game stamp is present, and the flags beat 4 watches are clear.
2. The opening walks the hero on its own, and holding `up` changes nothing. That second half is what sends the walk assertion outside.
3. The doorway zone leaves the house for cube 49, teleporting at `--exec-at 1` so it survives.
4. Arrival sets game vars 164 and 165, clear until then, and out there the hero does answer injected input.

Each assertion has a control run behind it. All four beats were mutation-tested: break the premise and the matching beat fails.

The run also takes a user directory of its own. The beats assert distances covered per simulated tick, and `lba2.cfg`'s `FixedTimestep` decides how many of those a tick budget buys, so another run's throttle setting left in a shared config shortens the walk into a failure. That is not hypothetical: it is what happens inside a full suite run today (see below).

`docs/CONTROL.md` grows a section for the fixture and the four opening properties, so the next person writing a beat in there does not have to measure them again.

## Distributions

Every number holds identically on all eight installs on hand: the hand-assembled tree, Steam Classic, GOG Galaxy Classic, the GOG DOS EU CD, and four disc rips spanning both the Activision (`Version: 1`) and EA (`Version: 3`) masters. Boot position, scripted drift, transition, quest vars and walk distance agree exactly, so a failure here is the engine rather than the install.

## Second commit

`test_cli_contract` was red on main for an unrelated reason: it asserted the pre-two-tier `--help` layout, and `--headless` now lives in `--help-all`. Each tier is asserted where it belongs. Separate commit, drop it if you would rather it went on its own.

## Found, not fixed

Running the whole suite turned up two more reds. Both predate this branch and neither is touched here:

- **`--fixed-timestep` persists into `lba2.cfg`.** `PERSO.CPP`'s `DefFileBufferWriteValue("FixedTimestep", ...)` writes the in-memory value at config save, so a run with the flag leaves `FixedTimestep: 100` behind for every later run. `CONTROL.CPP`'s own comment says the flag applies "for this run only, without persisting", which holds for the read path and not the write path. In the suite, `test_demo_behaviour_menu` poisons every alphabetically later test this way, which is why `test_projection_corpus` fails in a suite run and passes against a pristine user dir.
- **`test_ui_menu_main` is not hermetic.** Its golden has a "Load Game" row, which the main menu only offers when a named save exists. Its fixture pins `current.lba` but not the save list, so on a clean machine the capture is a four-row menu against a five-row golden. Drop any `.LBA` into the save directory and it passes.

Suite before: 34 passed, 2 skipped, 4 failed. After: 36 passed, 2 skipped, 2 failed.
