### PR TITLE
fix(config): stop a one-run flag changing the setting for good

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `--fixed-timestep` and `--language` wrote themselves into `lba2.cfg`, so a flag
+  documented as applying to one run changed the setting for every later launch:
+  one `--fixed-timestep 100` throttled the game from then on, and one
+  `--language Deutsch` to check the German text made German the language. Both
+  now apply to the run that asked and leave the stored preference alone, while a
+  setting changed on purpose (the options menu, the `fixedtimestep` console verb)
+  persists as before.
 - The console verbs that persist one setting (`distrib`, `vsync`,
   `fixedtimestep`) stored nothing on any install that ships its own `lba2.cfg`,
   which is every retail disc and GOG. Writing a single key went straight to the

--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -518,6 +518,14 @@ int Control_GetLanguage(void) {
     return s_language;
 }
 
+int Control_HasFixedTimestep(void) {
+    return s_have_fixed_timestep;
+}
+
+long Control_GetFixedTimestep(void) {
+    return s_fixed_timestep;
+}
+
 int Control_NoAudio(void) {
     return s_no_audio;
 }

--- a/SOURCES/CONTROL.H
+++ b/SOURCES/CONTROL.H
@@ -64,6 +64,14 @@ long Control_GetResolutionY(void);
 int Control_HasLanguage(void);
 int Control_GetLanguage(void);
 
+/* Sim-throttle override via --fixed-timestep <ms>. Returns 1 if the flag was supplied
+   (use Control_GetFixedTimestep for the forced value, 0..100, 0 = off), 0 otherwise.
+   Applied on the first tick in Control_TickHook, after ReadConfigFile has taken the
+   cfg's value. WriteConfigFile reads these back so the forced value is not persisted:
+   the flag is documented as this run only, unlike the `fixedtimestep` console verb. */
+int Control_HasFixedTimestep(void);
+long Control_GetFixedTimestep(void);
+
 /* --no-audio: skip InitAIL() and InitSampleDriver() at boot. Returns 1 if the flag
    was supplied, 0 otherwise. With audio init skipped, the SDL audio subsystem
    never opens a stream and the dummy driver's nanosleep pacing (~74% of sys time

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2337,11 +2337,42 @@ restartloop:
  *══════════════════════════════════════════════════════════════════════════*/
 /*──────────────────────────────────────────────────────────────────────────*/
 
-/* What lba2.cfg held for the texture filter, and what an LBA2_TEXFILTER
-   override forced for this run (-1 when none). WriteConfigFile needs both to
-   tell a per-run override apart from a genuine change. */
+/* What lba2.cfg held for a setting some override may be forcing for this run,
+   and what the override forced (-1 when none). WriteConfigFile needs both to
+   tell a per-run override apart from a genuine change.
+
+   Every flag here says "this run only" in its own help text, and a run that
+   said so must not leave the value behind for the next one: `--fixed-timestep 100`
+   once would otherwise throttle every later launch, and `--language Deutsch` for
+   one look at the German text would make German the setting. --resolution is
+   deliberately not in this list; it is a player-facing preference that persists
+   on purpose (see WriteConfigFile). */
 static S32 StoredTexFilter = 0;
 static S32 EnvTexFilter = -1;
+static S32 StoredFixedTimestep = 16;
+static S32 StoredLanguage = 0;
+
+/* The value to write for such a setting: the stored preference while the live
+   value is still the one the override forced, otherwise the live value, because
+   then something during the run changed it on purpose.
+
+   The comparison is on the value, not on who last wrote it. Settings reached
+   through cvars are registered as bare pointers with no on-change hook, so
+   setting the same value from the console during an overridden run cannot be
+   told from not touching it: that does not persist, while setting a different
+   one does. Accepted trade for not growing the cvar API. */
+static S32 ValueToPersist(S32 live, S32 stored, S32 forced) {
+    return (forced >= 0 && live == forced) ? stored : live;
+}
+
+/* -1 when the run was not given the flag, which is what ValueToPersist wants. */
+static S32 ForcedFixedTimestep(void) {
+    return Control_HasFixedTimestep() ? (S32)Control_GetFixedTimestep() : -1;
+}
+
+static S32 ForcedLanguage(void) {
+    return Control_HasLanguage() ? (S32)Control_GetLanguage() : -1;
+}
 
 void ReadConfigFile(void) {
     const char *ptr;
@@ -2434,6 +2465,9 @@ void ReadConfigFile(void) {
     FixedTimestep = DefFileBufferReadValueDefault("FixedTimestep", 16);
     if (FixedTimestep < 0 OR FixedTimestep > 100)
         FixedTimestep = 16;
+    /* Before Control_TickHook applies any --fixed-timestep, so this is the
+       player's own setting rather than the throttle a harness run forced. */
+    StoredFixedTimestep = FixedTimestep;
 
     /* Console toggle scancode (SDL scancode integer); invalid values fall back to F12 in console module. */
     Console_SetToggleScancode(DefFileBufferReadValueDefault("ConsoleToggleKey", K_F12));
@@ -2603,7 +2637,8 @@ void WriteConfigFile(void) {
     WriteGamepadConfig();  // Sauve Config Gamepad dans LBA2.CFG
     WriteVolumeSettings(); // Sauve volumes dans LBA2.CFG
 
-    DefFileBufferWriteString("Language", GetLanguageName(Language));
+    DefFileBufferWriteString(
+        "Language", GetLanguageName(ValueToPersist(Language, StoredLanguage, ForcedLanguage())));
 #ifdef CDROM
     DefFileBufferWriteString("LanguageCD", GetLanguageName(LanguageCD));
 #endif
@@ -2621,19 +2656,12 @@ void WriteConfigFile(void) {
     DefFileBufferWriteValue("DitherShading", GfxDitherShading);
     /* An environment override is for the run that asked for it: persisting the
        live value would turn `LBA2_TEXFILTER=2 ./lba2cc` into a permanent
-       setting nobody chose, so the stored value wins while the live one still
-       matches what the environment forced.
-
-       The comparison is on the value, not on who last wrote it, because cvars
-       are registered as bare pointers with no on-change hook. Setting the same
-       value from the console during an overridden run is therefore
-       indistinguishable from not touching it, and does not persist; setting a
-       different one does. Accepted trade for not growing the cvar API. */
+       setting nobody chose. */
     DefFileBufferWriteValue("TextureFilter",
-                            (EnvTexFilter >= 0 && PolyTexFilter == EnvTexFilter)
-                                ? StoredTexFilter
-                                : PolyTexFilter);
-    DefFileBufferWriteValue("FixedTimestep", FixedTimestep);
+                            ValueToPersist(PolyTexFilter, StoredTexFilter, EnvTexFilter));
+    DefFileBufferWriteValue(
+        "FixedTimestep",
+        ValueToPersist(FixedTimestep, StoredFixedTimestep, ForcedFixedTimestep()));
     DefFileBufferWriteValue("ConsoleToggleKey", Console_GetToggleScancode());
     /* Render resolution. Read at boot by Res_LoadBootDimensions (CLI > cfg >
        auto-detect > compile-time default). Persist it only when the player
@@ -3356,6 +3384,9 @@ int main(int argc, char *argv[]) {
     //-------------------
 
     InitLanguage(); // multilangue
+    /* What the cfg resolved to, captured before the override below replaces it,
+       so WriteConfigFile can put the player's own language back. */
+    StoredLanguage = Language;
     /* --language <name> override: bypass the cfg's Language key for this run.
        Used by the test harness to pin a deterministic language regardless of
        whatever the local cfg says, and useful for any dev wanting to spot-

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -20,6 +20,12 @@ lba2.cfg stores user preferences and last-save info. Read at startup, written at
 - **Read**: `ReadConfigFile()` in [SOURCES/PERSO.CPP](../SOURCES/PERSO.CPP) (line 1701), invoked from `InitProgram()` at line 1825
 - **Write**: `WriteConfigFile()` in PERSO.CPP (line 1757), called from `TheEndInfo()` (line 1955)
 - Options menu changes globals only; config is written once at exit. No intermediate saves when changing options.
+- **A setting forced for one run is not written back.** The write serialises globals, so without this a
+  flag whose own help says "this run only" would leave its value in the player's config for every later
+  launch. `--fixed-timestep`, `--language` and `LBA2_TEXFILTER` are the three; `WriteConfigFile` puts the
+  stored preference back for each while the live value is still the one that was forced (`ValueToPersist`
+  in PERSO.CPP). `--resolution` is deliberately not one of them: it is a player-facing choice that
+  persists on purpose, which is also why an auto-detected resolution is left out of the file entirely.
 
 ## Keys: what each does
 
@@ -52,6 +58,7 @@ lba2.cfg stores user preferences and last-save info. Read at startup, written at
 | FlagKeepVoice | string | ON, OFF | ON | Keep voice files on HD |
 | MenuMouse | int | 0, 1 | 1 | 1 = menu cursor, hover/left-click confirm, wheel for sliders and save list; 0 = keyboard/joystick only (classic) |
 | TextureFilter | int | 0–2 | 0 | Filtered texture sampling in the software fillers. 0=off (unchanged output), 1=horizontal 2-tap, 2=bilinear 4-tap. `LBA2_TEXFILTER` overrides for one run without persisting. See [GFX_OPTIONS.md](GFX_OPTIONS.md) |
+| FixedTimestep | int | 0–100 (ms) | 16 | Sim throttle, so movement is frame-rate independent above 60 fps; 0 restores the historical per-frame simulation. Set by the `fixedtimestep` console verb; `--fixed-timestep` overrides for one run without persisting. See [MOVEMENT_FRAMERATE.md](MOVEMENT_FRAMERATE.md) |
 | DitherShading | int | 0, 1 | 0 | Ordered dither on Gouraud shade rows, softening the 16-step ramp banding. See [GFX_OPTIONS.md](GFX_OPTIONS.md) |
 
 ### Original keys (Adeline)

--- a/tests/automation/test_cli_override_persistence.sh
+++ b/tests/automation/test_cli_override_persistence.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# A flag that says "this run only" leaves nothing behind, and still takes effect.
+#
+# --fixed-timestep and --language both override a setting that WriteConfigFile
+# serialises out of a global at exit, so both used to write themselves into the
+# player's lba2.cfg: one run with --fixed-timestep 100 throttled every later
+# launch, and one --language Deutsch to check the German text made German the
+# setting. Their own help text and their comments said the opposite.
+#
+# Both halves are asserted, because either one alone passes on a broken engine.
+# "Does not persist" is satisfied by a flag that does nothing at all, and "takes
+# effect" is satisfied by one that changes the setting for good. The chosen-value
+# beats then prove the keys can move at all, or the first half would pass on an
+# engine that had simply stopped writing the config.
+#
+# Local-only (needs the binary and retail data); skips cleanly otherwise.
+TESTNAME=cli_override_persistence
+. "$(dirname "$0")/lib.sh"
+precheck
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+user="$tmp/user"
+
+run() { # run <extra args...> -> boot output on stdout
+    ctl --user-dir "$user" --fixed-dt 16 --tick 3 --exit "$@" 2>&1
+}
+
+value_of() { # value_of <key>
+    grep -aE "^[[:space:]]*${1}[[:space:]]*:" "$user/lba2.cfg" 2>/dev/null | head -1 |
+        sed -E 's/^[^:]*:[[:space:]]*//; s/[[:space:]]*$//' | tr -d '\r'
+}
+
+# --- what this machine's config says before anything overrides it -------------
+run >/dev/null
+[ -f "$user/lba2.cfg" ] || fail "no config was written at all"
+base_step=$(value_of FixedTimestep)
+base_lang=$(value_of Language)
+[ -n "$base_step" ] && [ -n "$base_lang" ] \
+    || fail "config is missing the keys under test (FixedTimestep='$base_step' Language='$base_lang')"
+
+# Probe values that differ from the baseline, or the run would override a setting
+# to what it already was and every assertion below would hold for free.
+probe_step=100; [ "$base_step" = "100" ] && probe_step=50
+probe_lang=Deutsch; [ "$base_lang" = "Deutsch" ] && probe_lang=Italiano
+
+# --- --fixed-timestep: in force for the run, absent from the config -----------
+out=$(run --fixed-timestep "$probe_step" --exec-at 1 "fixedtimestep")
+printf '%s' "$out" | grep -aqE "FixedTimestep: ON \($probe_step ms" \
+    || fail "--fixed-timestep $probe_step did not take effect: $(printf '%s' "$out" | grep -aoE 'FixedTimestep: .*' | head -1)"
+got=$(value_of FixedTimestep)
+[ "$got" = "$base_step" ] \
+    || fail "--fixed-timestep $probe_step persisted: config says '$got', was '$base_step'"
+
+# --- --language: same, and the banner names the language it ran in ------------
+out=$(run --language "$probe_lang")
+printf '%s' "$out" | grep -aqE "Language +$probe_lang" \
+    || fail "--language $probe_lang did not take effect: $(printf '%s' "$out" | grep -aoE 'Language +.*' | head -1)"
+got=$(value_of Language)
+[ "$got" = "$base_lang" ] \
+    || fail "--language $probe_lang persisted: config says '$got', was '$base_lang'"
+
+# --- a setting the player chose is a different thing, and does persist --------
+# Without this the two assertions above would also pass on an engine that had
+# stopped writing the config, or stopped honouring the key.
+chosen=40; [ "$base_step" = "40" ] && chosen=24
+run --exec "fixedtimestep $chosen" >/dev/null
+got=$(value_of FixedTimestep)
+[ "$got" = "$chosen" ] \
+    || fail "the console's own 'fixedtimestep $chosen' did not persist: config says '$got'"
+
+# --- and a later overridden run leaves that choice alone ----------------------
+# The regression this test exists for: the harness runs constantly on developer
+# machines, and each run used to overwrite whatever the player had set.
+run --fixed-timestep "$probe_step" >/dev/null
+got=$(value_of FixedTimestep)
+[ "$got" = "$chosen" ] \
+    || fail "--fixed-timestep $probe_step overwrote the chosen $chosen: config says '$got'"
+
+out=$(run --exec-at 1 "fixedtimestep")
+printf '%s' "$out" | grep -aqE "FixedTimestep: ON \($chosen ms" \
+    || fail "the chosen $chosen ms is not in force next launch: $(printf '%s' "$out" | grep -aoE 'FixedTimestep: .*' | head -1)"
+
+pass "--fixed-timestep and --language apply without persisting; a chosen $chosen ms survives both"


### PR DESCRIPTION
A flag whose help says "this run only" was changing the setting for good.

`WriteConfigFile` serialises globals at exit, and `--fixed-timestep` and `--language` each override a global, so both wrote themselves into the player's `lba2.cfg`. One `--fixed-timestep 100` throttled every later launch. One `--language Deutsch` to look at the German text made German the language. The code contradicted its own documentation in three places: each flag's help text, and the comments in `CONTROL.H` and `CONTROL.CPP` saying the cfg was not touched.

Measured across every run-scoped flag before touching anything:

| Flag | Before | After |
|---|---|---|
| `--fixed-timestep 100` | `FixedTimestep: 16` → `100` | clean |
| `--language Deutsch` | `Language: English` → `Deutsch` | clean |
| `--resolution 1280x720` | writes `ResolutionX/Y` | unchanged, deliberate |
| `--no-audio`, `--log-level`, `--demo`, `--verbose` | clean | clean |

## The rule

It already existed for `LBA2_TEXFILTER`, which keeps the stored preference while the live value is still what the environment forced. It is now a named helper rather than an open-coded comparison:

```c
static S32 ValueToPersist(S32 live, S32 stored, S32 forced) {
    return (forced >= 0 && live == forced) ? stored : live;
}
```

The two new cases go through it and the texture filter reuses it. `ReadConfigFile` records what the config held for the throttle; `InitProgram` records the language the config resolved to, before the override replaces it.

`--resolution` deliberately stays out: it is a player-facing choice that persists on purpose, which is also why an auto-detected resolution is left out of the file entirely. That distinction is now written down in `CONFIG.md`, along with a `FixedTimestep` row the key table never had.

## Nothing changes for a run that passes neither flag

With no override in force the helper returns the live value. The config a plain run writes is byte-identical to the previous build's, checked three ways: the ordinary path (194 keys), after a console `fixedtimestep`, and with `--resolution`.

## The test asserts both halves

`tests/automation/test_cli_override_persistence.sh`, because either half alone passes on a differently-broken engine. A flag that does nothing satisfies "does not persist"; one that changes the setting for good satisfies "takes effect". So it asserts the flag applies (the throttle reports the forced value, the banner names the language), that the config is unchanged, and then has the console choose a value and checks that one *does* persist, or the first half would also pass on an engine that had stopped writing the config at all. Probe values are picked to differ from whatever the local machine's baseline is, so it cannot pass by overriding a setting to what it already was.

Both assertions fail against a build of current `main`:

```
FAIL: cli_override_persistence: --fixed-timestep 100 persisted: config says '100', was '16'
FAIL: cli_override_persistence: --language Deutsch persisted: config says 'Deutsch', was 'English'
```

## It was also making the local suite order-dependent

`test_demo_behaviour_menu` runs `--fixed-timestep 100` without isolating its user directory, so every alphabetically later test inherited the throttle. `test_projection_corpus` failed on a golden hash for that reason alone. A/B on the same fresh user directory, poisoner then victim:

```
unfixed   FixedTimestep left behind: 100   ->  projection_corpus: FAIL
fixed     FixedTimestep left behind: 16    ->  projection_corpus: PASS
```

Clean-room suite (fresh user dir): **39 passed, 2 skipped, 1 failed**, against 36/2/2 before this branch. The remaining red is `test_ui_menu_main`, unrelated and untouched: its golden has a "Load Game" row, which the main menu only offers when a named save exists, so it fails on any clean machine.

## Follow-up, not in here

The general form is a `writes` column in the `T_CLI_FLAG` table plus a contract test asserting the user directory is byte-identical after every non-writing flag. That turns this from a convention into an invariant, and puts the two remaining judgment calls (`--resolution`, and `--profile` silently re-binding its install on every run) into data rather than argument. Separate branch.
