### PR TITLE
feat(cli): declare which flags may change your settings, and hold them to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `--resolution` wrote the size it was given into `lba2.cfg`, so asking for one
+  launch at a different resolution replaced the one you had picked, and any
+  script that pinned a size for a screenshot rewrote your setting. It now renders
+  the run at the size asked for and leaves the stored one alone. Choosing a
+  resolution in the Display submenu or with the `resolution` console command
+  still keeps it, and a resolution auto-detected from your display still
+  re-derives each launch rather than freezing into the config.
 - `--fixed-timestep` and `--language` wrote themselves into `lba2.cfg`, so a flag
   documented as applying to one run changed the setting for every later launch:
   one `--fixed-timestep 100` throttled the game from then on, and one

--- a/SOURCES/CLI_ARGS.CPP
+++ b/SOURCES/CLI_ARGS.CPP
@@ -21,12 +21,28 @@
 
    common = shown in plain `--help`, the handful a player setting up a run actually reaches
    for. Everything else is automation or a self-test and appears only under `--help-all`, so
-   the player-facing help isn't a wall of flags they'll never type. */
+   the player-facing help isn't a wall of flags they'll never type.
+
+   writes = the flag may change the settings and saves in the user directory, and is allowed
+   to. Almost nothing may: a flag names a mode for one run, and a run told to do something
+   differently must not leave that behind for the next one. The exceptions are the flags
+   whose whole job is to act on stored state, where persisting is the point rather than a
+   side effect.
+
+   The distinction is not decoration. --fixed-timestep and --language each overrode a setting
+   the config write serialises out of a global, so one run with either changed it for good;
+   --resolution wrote the size a harness pinned for a screenshot over the one the player
+   picked. Each contradicted its own help text, and nothing noticed, because a leaked setting
+   only shows up as the next run behaving differently for no visible reason.
+   tests/automation/test_cli_flag_contract.sh holds every flag to the column: the ones marked
+   0 must leave the settings byte-identical, and the ones marked 1 must actually write, or a
+   flag that quietly stopped working would read as a passing contract. */
 typedef struct {
     const char *name;
     int nvalues;
     int nocase;
     int common;
+    int writes;
     const char *section; /* NULL to continue the previous one */
     const char *args;
     const char *help;
@@ -37,62 +53,72 @@ typedef struct {
 #define CLI_HELP_COL 29
 
 static const T_CLI_FLAG CliFlags[] = {
-    {"--help", 0, 0, 0, "Playing", "", "print this help and exit"},
-    {"-h", 0, 0, 0, NULL, "", "same as --help"},
-    {"--resolution", 1, 0, 1, NULL, "<WxH>", "render resolution, e.g. 1280x720. If the picture\n"
-                                             "ever comes up wrong, 640x480 always works"},
-    {"--language", 1, 0, 1, NULL, "<name>", "language for this run (English, Francais, ...)"},
-    {"--no-audio", 0, 0, 1, NULL, "", "start with sound and music off"},
-    {"--game-dir", 1, 1, 1, NULL, "<dir>", "folder holding the game data, the one with the\n"
-                                           "HQR files in it (often Common/)"},
-    {"--data-dir", 1, 1, 0, NULL, "<dir>", "same as --game-dir"},
-    {"--user-dir", 1, 0, 1, NULL, "<dir>", "folder for this run's saves, settings and log,\n"
-                                           "created if missing. LBA2_USER_DIR does the same.\n"
-                                           "Use it to keep two installs apart, or to run\n"
-                                           "against a fresh folder"},
-    {"--profile", 1, 0, 1, NULL, "<name>", "keep this run's saves and settings under a name of\n"
-                                           "their own, so several installs don't share them.\n"
-                                           "LBA2_PROFILE does the same. No name means the\n"
-                                           "usual folder"},
-    {"--disc", 1, 1, 0, NULL, "<file>", "mount this disc image instead of picking one\n"
-                                        "from the game folder. Takes an image or a cue\n"
-                                        "(the cue names its image). Use it when a folder\n"
-                                        "holds more than one, or the image lives\n"
-                                        "elsewhere"},
-    {"--pick-game-dir", 0, 1, 0, NULL, "", "choose the game-data folder, ignoring any\n"
-                                           "remembered one"},
-    {"--version", 0, 0, 1, NULL, "", "print the engine version and exit"},
-    {"--help-all", 0, 0, 1, NULL, "", "list every option, including automation and\n"
-                                      "engine self-tests"},
+    {"--help", 0, 0, 0, 0, "Playing", "", "print this help and exit"},
+    {"-h", 0, 0, 0, 0, NULL, "", "same as --help"},
+    {"--resolution", 1, 0, 1, 0, NULL, "<WxH>", "render resolution, e.g. 1280x720. If the picture\n"
+                                                "ever comes up wrong, 640x480 always works"},
+    {"--language", 1, 0, 1, 0, NULL, "<name>", "language for this run (English, Francais, ...)"},
+    {"--no-audio", 0, 0, 1, 0, NULL, "", "start with sound and music off"},
+    {"--game-dir", 1, 1, 1, 0, NULL, "<dir>", "folder holding the game data, the one with the\n"
+                                              "HQR files in it (often Common/)"},
+    {"--data-dir", 1, 1, 0, 0, NULL, "<dir>", "same as --game-dir"},
+    /* Selects which directory the run writes to; it does not add writes of its own. */
+    {"--user-dir", 1, 0, 1, 0, NULL, "<dir>", "folder for this run's saves, settings and log,\n"
+                                              "created if missing. LBA2_USER_DIR does the same.\n"
+                                              "Use it to keep two installs apart, or to run\n"
+                                              "against a fresh folder"},
+    /* Creates the profile on first use and records the install it was given, which is what
+       lets a later run name the profile alone. Recording is the feature, so: writes. */
+    {"--profile", 1, 0, 1, 1, NULL, "<name>", "keep this run's saves and settings under a name of\n"
+                                              "their own, so several installs don't share them.\n"
+                                              "LBA2_PROFILE does the same. No name means the\n"
+                                              "usual folder"},
+    {"--disc", 1, 1, 0, 0, NULL, "<file>", "mount this disc image instead of picking one\n"
+                                           "from the game folder. Takes an image or a cue\n"
+                                           "(the cue names its image). Use it when a folder\n"
+                                           "holds more than one, or the image lives\n"
+                                           "elsewhere"},
+    /* Picking a folder is the act of choosing the one to remember. */
+    {"--pick-game-dir", 0, 1, 0, 1, NULL, "", "choose the game-data folder, ignoring any\n"
+                                              "remembered one"},
+    {"--version", 0, 0, 1, 0, NULL, "", "print the engine version and exit"},
+    {"--help-all", 0, 0, 1, 0, NULL, "", "list every option, including automation and\n"
+                                         "engine self-tests"},
 
-    {"--headless", 0, 0, 0, "Automation", "", "no window, no audio device. Use this to drive the\n"
-                                              "game from a script: a visible window pauses the\n"
-                                              "game whenever it loses focus, which makes a run\n"
-                                              "unreproducible. Implies --no-audio."},
-    {"--no-autosave", 0, 0, 0, NULL, "", "don't write autosaves. Without this, walking the\n"
-                                         "hero into a new scene rewrites your autosave.\n"
-                                         "Saving from the menu still works."},
-    {"--load", 1, 0, 0, NULL, "<slot>", "restore a save before the run starts"},
-    {"--exec", 1, 0, 0, NULL, "<cmds>", "run ';'-separated console commands on the first tick"},
-    {"--exec-at", 2, 0, 0, NULL, "<tick> <cmds>", "run console commands at tick <tick>; repeatable.\n"
-                                                  "Use this when a command depends on a scene change\n"
-                                                  "having settled, which --exec cannot wait for."},
-    {"--tick", 1, 0, 0, NULL, "<n>", "advance n simulation ticks"},
-    {"--exit", 0, 0, 0, NULL, "", "quit once the tick budget is spent"},
-    {"--fixed-dt", 1, 0, 0, NULL, "<ms>", "advance the clock by a constant <ms> per tick, so a\n"
-                                          "run reproduces exactly (needs --headless)"},
-    {"--fixed-timestep", 1, 0, 0, NULL, "<ms>", "set the sim throttle for this run only (0 = off)"},
-    {"--screenshot", 1, 0, 0, NULL, "<path>", "write a PNG of the rendered frame"},
-    {"--dump-state", 1, 0, 0, NULL, "<path>", "write the engine state as JSON"},
-    {"--demo", 0, 0, 0, NULL, "", "attract/demo mode (only does anything on a demo scene)"},
-    {"--log-level", 1, 0, 0, NULL, "<level>", "debug | info | warn | error (default info)"},
-    {"--verbose", 0, 0, 0, NULL, "", "log scene and hero state as the run proceeds"},
+    {"--headless", 0, 0, 0, 0, "Automation", "", "no window, no audio device. Use this to drive the\n"
+                                                 "game from a script: a visible window pauses the\n"
+                                                 "game whenever it loses focus, which makes a run\n"
+                                                 "unreproducible. Implies --no-audio."},
+    {"--no-autosave", 0, 0, 0, 0, NULL, "", "don't write autosaves. Without this, walking the\n"
+                                            "hero into a new scene rewrites your autosave.\n"
+                                            "Saving from the menu still works."},
+    /* Restoring a save makes its player the current one, which the config records in
+       LastSave exactly as loading from the menu does. */
+    {"--load", 1, 0, 0, 1, NULL, "<slot>", "restore a save before the run starts"},
+    /* The console is the engine's imperative channel: `vsync off` and `fixedtimestep 40`
+       are the player choosing, and they persist whether typed in-game or sent from here.
+       That is the whole distinction this column draws, so these two are the flags that
+       carry commands rather than name a mode. */
+    {"--exec", 1, 0, 0, 1, NULL, "<cmds>", "run ';'-separated console commands on the first tick"},
+    {"--exec-at", 2, 0, 0, 1, NULL, "<tick> <cmds>", "run console commands at tick <tick>; repeatable.\n"
+                                                     "Use this when a command depends on a scene change\n"
+                                                     "having settled, which --exec cannot wait for."},
+    {"--tick", 1, 0, 0, 0, NULL, "<n>", "advance n simulation ticks"},
+    {"--exit", 0, 0, 0, 0, NULL, "", "quit once the tick budget is spent"},
+    {"--fixed-dt", 1, 0, 0, 0, NULL, "<ms>", "advance the clock by a constant <ms> per tick, so a\n"
+                                             "run reproduces exactly (needs --headless)"},
+    {"--fixed-timestep", 1, 0, 0, 0, NULL, "<ms>", "set the sim throttle for this run only (0 = off)"},
+    {"--screenshot", 1, 0, 0, 0, NULL, "<path>", "write a PNG of the rendered frame"},
+    {"--dump-state", 1, 0, 0, 0, NULL, "<path>", "write the engine state as JSON"},
+    {"--demo", 0, 0, 0, 0, NULL, "", "attract/demo mode (only does anything on a demo scene)"},
+    {"--log-level", 1, 0, 0, 0, NULL, "<level>", "debug | info | warn | error (default info)"},
+    {"--verbose", 0, 0, 0, 0, NULL, "", "log scene and hero state as the run proceeds"},
 
-    {"--polyrec", 1, 0, 0, "Engine self-tests", "<path>", "record polygon draw calls (ENABLE_POLY_RECORDING builds)"},
-    {"--capture-projection", 1, 0, 0, NULL, "<path>", "capture projection records"},
-    {"--projection-hash", 1, 0, 0, NULL, "<path>", "write the projection hash"},
-    {"--res-switch-test", 1, 0, 0, NULL, "<spec>", "runtime resolution-switch self-test"},
-    {"--save-load-test", 1, 0, 0, NULL, "<path>", "save/load round-trip self-test"},
+    {"--polyrec", 1, 0, 0, 0, "Engine self-tests", "<path>", "record polygon draw calls (ENABLE_POLY_RECORDING builds)"},
+    {"--capture-projection", 1, 0, 0, 0, NULL, "<path>", "capture projection records"},
+    {"--projection-hash", 1, 0, 0, 0, NULL, "<path>", "write the projection hash"},
+    {"--res-switch-test", 1, 0, 0, 0, NULL, "<spec>", "runtime resolution-switch self-test"},
+    {"--save-load-test", 1, 0, 0, 0, NULL, "<path>", "save/load round-trip self-test"},
 };
 
 static const int CliFlagCount = (int)(sizeof(CliFlags) / sizeof(CliFlags[0]));
@@ -150,6 +176,13 @@ static void PrintFlagLine(FILE *out, const T_CLI_FLAG *flag) {
         fprintf(out, "\n%*s", CLI_HELP_COL, "");
     }
     PrintHelpText(out, flag->help);
+    /* Said out loud, because the alternative is a player discovering it by finding a setting
+       changed. Everything unmarked applies to the one run and leaves the settings alone,
+       which is worth being able to rely on rather than assume. Also the one machine-readable
+       copy of the `writes` column, which is what test_cli_flag_contract.sh checks itself
+       against, so a new flag cannot be added to the table without the test seeing it. */
+    if (flag->writes)
+        fprintf(out, "%*s[keeps this in your settings]\n", CLI_HELP_COL, "");
 }
 
 void Cli_PrintUsage(const char *exeName, int full) {

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2664,11 +2664,12 @@ void WriteConfigFile(void) {
         ValueToPersist(FixedTimestep, StoredFixedTimestep, ForcedFixedTimestep()));
     DefFileBufferWriteValue("ConsoleToggleKey", Console_GetToggleScancode());
     /* Render resolution. Read at boot by Res_LoadBootDimensions (CLI > cfg >
-       auto-detect > compile-time default). Persist it only when the player
-       chose it explicitly (CLI/cfg at boot, or a runtime Res_Switch); an
-       auto-detected or defaulted resolution is left out so it re-derives from
-       the display each launch instead of freezing into the cfg on first exit. */
-    if (!Res_ResolutionIsAutoDerived()) {
+       auto-detect > compile-time default), but only two of those four are a
+       preference to keep: the cfg's own value, and a resolution the player
+       picked during the run. The other two are left out, so an auto-detected
+       size re-derives from the display each launch instead of freezing into the
+       cfg, and a --resolution run leaves whatever the config already held. */
+    if (Res_ResolutionShouldPersist()) {
         U32 baseW = 0, baseH = 0;
         Res_BaseDimensions(&baseW, &baseH);
         DefFileBufferWriteValue("ResolutionX", (S32)baseW);

--- a/SOURCES/RES_SWITCH.CPP
+++ b/SOURCES/RES_SWITCH.CPP
@@ -44,15 +44,21 @@
    width rule live in RES_CATALOG.H: the same limits the --resolution CLI, the
    console verb, and the Display submenu all derive from. */
 
-/* True when the live resolution came from auto-detect or the compile-time
-   default, i.e. the player never explicitly chose it. WriteConfigFile skips
-   persisting ResolutionX/Y in that case, so an auto resolution re-derives from
-   the display every launch instead of freezing into the cfg on first exit.
-   Cleared the moment the player picks a resolution explicitly: a successful
-   Res_Switch (menu / console verb), or a CLI / cfg value at boot. Defined here
-   so Res_Switch (below) and the boot resolver (further down) both see it. */
-static bool g_resIsAutoDerived = false;
-bool Res_ResolutionIsAutoDerived(void) { return g_resIsAutoDerived; }
+/* True when the live resolution is a preference to keep, which is what
+   WriteConfigFile writes ResolutionX/Y from. Set by the cfg's own value at boot
+   and by a player-chosen Res_Switch (Display submenu, `resolution` console
+   verb). Defined here so Res_Switch (below) and the boot resolver (further
+   down) both see it.
+
+   Two sizes are deliberately not preferences. An auto-detected or default one
+   re-derives from the display every launch instead of freezing into the cfg on
+   first exit. A --resolution on the command line is that run's size: the flag
+   is how you check one mode without adopting it, and a harness pinning 640x480
+   for a capture must not rewrite the player's own choice. Starting false is the
+   safe end of that: the keys are then left as the config already had them,
+   because WriteConfigFile rewrites the file it read. */
+static bool g_resShouldPersist = false;
+bool Res_ResolutionShouldPersist(void) { return g_resShouldPersist; }
 
 /* The resolution the player chose. Tracked apart from ModeDesiredX/Y because
    those hold whatever the current scene renders at, and an interior downshift
@@ -219,7 +225,7 @@ static bool Res_SwitchEx(U32 newW, U32 newH, bool playerChoice) {
     if (ModeDesiredX == newW && ModeDesiredY == newH) {
         /* Confirming the current mode is still an explicit choice. */
         if (playerChoice)
-            g_resIsAutoDerived = false;
+            g_resShouldPersist = true;
         return true;
     }
 
@@ -335,7 +341,7 @@ static bool Res_SwitchEx(U32 newW, U32 newH, bool playerChoice) {
        WriteConfigFile persist it across launches. A scene-driven switch is not
        a preference and must never freeze an interior size into the cfg. */
     if (playerChoice)
-        g_resIsAutoDerived = false;
+        g_resShouldPersist = true;
     return true;
 }
 
@@ -389,7 +395,10 @@ void Res_LoadBootDimensions(U32 *outW, U32 *outH) {
         *outW = (U32)Control_GetResolutionX();
         *outH = (U32)Control_GetResolutionY();
         g_bootDimSource = "CLI";
-        g_resIsAutoDerived = false;
+        /* Deliberately not a stored preference: g_resShouldPersist stays false,
+           so this run renders at the requested size and leaves ResolutionX/Y in
+           the config exactly as it found them. Adopting the size is what the
+           Display submenu and the `resolution` console verb are for. */
         return;
     }
 
@@ -421,7 +430,7 @@ void Res_LoadBootDimensions(U32 *outW, U32 *outH) {
                 *outW = (U32)w;
                 *outH = (U32)h;
                 g_bootDimSource = "cfg";
-                g_resIsAutoDerived = false;
+                g_resShouldPersist = true;
                 DefFileBufferRestoreState(&savedDef);
                 return;
             } else {
@@ -446,7 +455,7 @@ void Res_LoadBootDimensions(U32 *outW, U32 *outH) {
        docs/WIDESCREEN.md Phase 4. */
     if (Res_AutoDetectDimensions(outW, outH)) {
         g_bootDimSource = "auto";
-        g_resIsAutoDerived = true;
+        g_resShouldPersist = false;
         return;
     }
 
@@ -454,7 +463,7 @@ void Res_LoadBootDimensions(U32 *outW, U32 *outH) {
     *outW = RESOLUTION_X;
     *outH = RESOLUTION_Y;
     g_bootDimSource = "default";
-    g_resIsAutoDerived = true;
+    g_resShouldPersist = false;
 }
 
 /*══════════════════════════════════════════════════════════════════════════*/

--- a/SOURCES/RES_SWITCH.H
+++ b/SOURCES/RES_SWITCH.H
@@ -100,12 +100,18 @@ bool Res_AutoDetectDimensions(U32 *outW, U32 *outH);
    log: "CLI", "cfg", "auto", or "default". Static literal; never NULL. */
 const char *Res_BootDimensionsSource(void);
 
-/* True when the live resolution was auto-detected (or fell back to the
-   compile-time default) rather than chosen by the player. WriteConfigFile uses
-   this to skip persisting ResolutionX/Y, so an auto resolution re-derives from
-   the display each launch instead of freezing into the cfg. Cleared by a
-   successful Res_Switch and by a CLI/cfg value at boot. */
-bool Res_ResolutionIsAutoDerived(void);
+/* True when the live resolution is a stored preference that WriteConfigFile
+   should write to ResolutionX/Y. Set by the cfg's own value at boot and by a
+   successful player-chosen Res_Switch (the Display submenu, the `resolution`
+   console verb).
+
+   False for the two sizes nobody chose to keep: an auto-detected or
+   compile-time-default resolution, which re-derives from the display each
+   launch rather than freezing into the cfg, and a --resolution asked for on the
+   command line, which is that run's size only. False also means "leave the keys
+   alone", not "erase them": WriteConfigFile rewrites the config it read, so a
+   stored preference survives a run that overrode it. */
+bool Res_ResolutionShouldPersist(void);
 
 /* Read the boot fullscreen choice (lba2.cfg DisplayFullScreen) the same
    transient, heap-free way as Res_LoadBootDimensions, so the window can be

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -22,10 +22,13 @@ lba2.cfg stores user preferences and last-save info. Read at startup, written at
 - Options menu changes globals only; config is written once at exit. No intermediate saves when changing options.
 - **A setting forced for one run is not written back.** The write serialises globals, so without this a
   flag whose own help says "this run only" would leave its value in the player's config for every later
-  launch. `--fixed-timestep`, `--language` and `LBA2_TEXFILTER` are the three; `WriteConfigFile` puts the
-  stored preference back for each while the live value is still the one that was forced (`ValueToPersist`
-  in PERSO.CPP). `--resolution` is deliberately not one of them: it is a player-facing choice that
-  persists on purpose, which is also why an auto-detected resolution is left out of the file entirely.
+  launch. `--fixed-timestep`, `--language` and `LBA2_TEXFILTER` go through `ValueToPersist` in PERSO.CPP,
+  which puts the stored preference back while the live value is still the one that was forced.
+  `--resolution` reaches the same end differently: `Res_ResolutionShouldPersist` is false for it, so
+  `WriteConfigFile` leaves `ResolutionX/Y` as it found them. Only two things make a resolution a
+  preference to keep, the config's own value and a resolution picked during the run (Display submenu,
+  `resolution` console verb); an auto-detected one is left out of the file entirely so it re-derives
+  from the display each launch.
 
 ## Keys: what each does
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -29,6 +29,13 @@ lba2.cfg stores user preferences and last-save info. Read at startup, written at
   preference to keep, the config's own value and a resolution picked during the run (Display submenu,
   `resolution` console verb); an auto-detected one is left out of the file entirely so it re-derives
   from the display each launch.
+- Which flags may write is declared in `CLI_ARGS.CPP`'s `writes` column, printed under `--help-all` as
+  "[keeps this in your settings]", and held to by
+  [`tests/automation/test_cli_flag_contract.sh`](../tests/automation/test_cli_flag_contract.sh). Only
+  five may: `--profile` and `--pick-game-dir`, whose job is to record a choice; `--load`, because
+  restoring a save makes its player the current one and the config records that in `LastSave` exactly
+  as loading from the menu does; and `--exec` / `--exec-at`, which carry console commands and so carry
+  whatever those commands persist. Everything else must leave the settings byte-identical.
 
 ## Keys: what each does
 

--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -597,6 +597,16 @@ The keystone is `test_tick.sh`: it loads, advances 1 vs 60 ticks, and asserts th
 clock and the hero's idle-animation frame both advanced — proving the loop steps the
 simulation, not just a counter.
 
+`test_cli_flag_contract.sh` is the one that keeps the harness honest about the machine it
+runs on. A flag names a mode for one run, so a run told to render at 640x480 or throttle the
+sim must leave the player's settings exactly as it found them; the exceptions are the flags
+whose job is to act on stored state, declared in `CLI_ARGS.CPP`'s `writes` column and printed
+under `--help-all`. The test holds every flag to that column in both directions, and checks
+its own case list against `--help-all` so a flag added to the table cannot go untested. It
+exists because three flags had already broken the rule while their help text claimed
+otherwise, and a leaked setting only ever shows up as the next run behaving differently for
+no visible reason.
+
 ### Driving the opening (`test_walkthrough_opening.sh`)
 
 The walkthrough e2e: cold boot into Twinsen's house, out through the front door, then a

--- a/tests/automation/test_cli_flag_contract.sh
+++ b/tests/automation/test_cli_flag_contract.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Every flag against the contract its own table declares.
+#
+# A flag names a mode for one run. A run told to render at 640x480, or to throttle
+# the sim, or to speak German, must not leave that behind for the next one: the
+# settings belong to the player, and the harness runs constantly on the same
+# machine. The exceptions are the flags whose job is to act on stored state, where
+# persisting is the point rather than a side effect. CLI_ARGS.CPP's `writes` column
+# is where that is declared, and `--help-all` prints it as "[keeps this in your
+# settings]", which is what this test reads.
+#
+# Both directions, because either alone passes on a broken engine: a flag that does
+# nothing satisfies "leaves the settings alone", and one that changes them for good
+# satisfies "takes effect". So the modes are checked for byte-identical settings,
+# and the writing flags are checked to actually write.
+#
+# The list below is checked against --help-all, so a flag added to the table
+# without a case here fails rather than going untested.
+#
+# adeline.log is excluded throughout: it is this run's own record and is meant to
+# differ. Settings and saves are the subject.
+#
+# Local-only (needs the binary and retail data); skips cleanly otherwise.
+TESTNAME=cli_flag_contract
+. "$(dirname "$0")/lib.sh"
+precheck
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+SAVE="$REPO/tests/savegame/corpus/saves/steam_classic_2023/Anon1.LBA"
+[ -f "$SAVE" ] || skip "fixture save missing: $SAVE"
+
+# flag|sample arguments, re-parsed by eval so a value stays one argument: an
+# --exec split into words becomes a different command, and the case would then
+# pass or fail for a reason that has nothing to do with the flag. One case per
+# flag that takes part; the coverage check below proves the list is complete.
+# Flags that exit before the engine boots (--help, -h, --version, --help-all) and
+# the ones needing a display or an image nobody can assume (--pick-game-dir,
+# --disc) are listed as skipped, on purpose and by name, so "not covered" is
+# never silent.
+MODES="
+--resolution|--resolution 1280x720
+--language|--language Deutsch
+--no-audio|--no-audio
+--game-dir|--game-dir \"$LBA2_GAME_DIR\"
+--data-dir|--data-dir \"$LBA2_GAME_DIR\"
+--user-dir|
+--headless|--headless
+--no-autosave|--no-autosave
+--tick|--tick 3
+--exit|--exit
+--fixed-dt|--fixed-dt 16
+--fixed-timestep|--fixed-timestep 100
+--screenshot|--screenshot \"$tmp/shot.png\"
+--dump-state|--dump-state \"$tmp/dump.json\"
+--demo|--demo
+--log-level|--log-level debug
+--verbose|--verbose
+--polyrec|--polyrec \"$tmp/poly.rec\"
+--capture-projection|--capture-projection \"$tmp/proj.txt\"
+--projection-hash|--projection-hash \"$tmp/proj.hash\"
+--res-switch-test|--res-switch-test 2:1280x720
+--save-load-test|--save-load-test \"$tmp/slt.lba\"
+"
+WRITERS="
+--profile|--profile contract
+--load|--load \"$SAVE\"
+--exec|--exec \"vsync off\"
+--exec-at|--exec-at 1 \"vsync off\"
+"
+NOT_RUN="--help -h --version --help-all --pick-game-dir --disc"
+
+settings_snapshot() { # settings_snapshot <user-dir> <out-file>
+    ( cd "$1" 2>/dev/null && find . -type f ! -name 'adeline.log' | sort | while read -r f; do
+        printf '%s %s\n' "$(md5sum < "$f" | cut -c1-16)" "$f"
+      done ) > "$2"
+}
+
+# stdin comes from /dev/null: the loops below feed their case list on stdin, and a
+# child that inherits it eats the rest of the list. That failure is silent, and
+# looks like the flags it swallowed passing.
+run_into() { # run_into <user-dir> <extra args...>
+    ctl --user-dir "$1" --language English --no-audio --fixed-dt 16 --tick 3 --exit \
+        "${@:2}" >/dev/null 2>&1 </dev/null
+}
+
+# --- the baseline every case is compared against ------------------------------
+base_dir="$tmp/base"; base="$tmp/base.snap"
+run_into "$base_dir"
+[ -f "$base_dir/lba2.cfg" ] || fail "the baseline run wrote no config at all"
+settings_snapshot "$base_dir" "$base"
+[ -s "$base" ] || fail "the baseline snapshot is empty; nothing would be compared"
+
+# --- a mode leaves the settings exactly as it found them ----------------------
+n_modes=0
+while IFS='|' read -r flag args; do
+    [ -n "$flag" ] || continue
+    d="$tmp/m$n_modes"
+    eval run_into "\"\$d\"" "$args"
+    snap="$tmp/m$n_modes.snap"
+    settings_snapshot "$d" "$snap"
+    if ! diff -q "$base" "$snap" >/dev/null 2>&1; then
+        fail "$flag changed the settings: $(diff "$base" "$snap" | grep -E '^[<>]' | tr '\n' ' ')"
+    fi
+    n_modes=$((n_modes + 1))
+done <<EOF
+$MODES
+EOF
+
+# --- a flag that is meant to write does write ---------------------------------
+# Without this the block above would also pass on an engine that had stopped
+# writing the config at all, which is the failure it is least able to see.
+n_writers=0
+while IFS='|' read -r flag args; do
+    [ -n "$flag" ] || continue
+    d="$tmp/w$n_writers"
+    eval run_into "\"\$d\"" "$args"
+    snap="$tmp/w$n_writers.snap"
+    settings_snapshot "$d" "$snap"
+    if diff -q "$base" "$snap" >/dev/null 2>&1; then
+        fail "$flag is declared as keeping a setting but changed nothing"
+    fi
+    n_writers=$((n_writers + 1))
+done <<EOF
+$WRITERS
+EOF
+
+# --- the list above covers the table ------------------------------------------
+# --help-all prints every flag, and marks the ones the table says may write. A
+# flag missing from this test, or one whose declaration disagrees with the column
+# it is tested against, fails here rather than passing unnoticed.
+help_all="$tmp/help-all.txt"
+"$LBA2_BIN" --help-all > "$help_all" 2>/dev/null || fail "--help-all exited non-zero"
+
+not_run=$(printf '%s\n' "$NOT_RUN" | tr ' ' '\n' | grep -v '^$' | sort -u)
+declared_writers=$(awk '
+    /^  -/ { name = $1 }
+    /\[keeps this in your settings\]/ { if (name != "") { print name; name = "" } }
+' "$help_all" | sort -u)
+# --pick-game-dir is declared as writing and cannot be exercised here: it opens a
+# folder picker, which a headless run has no way to answer. Subtracting the
+# not-run list rather than relaxing the comparison keeps the coupling: a new
+# writing flag that can be run still has to have a case.
+declared_runnable=$(comm -23 <(printf '%s\n' "$declared_writers") <(printf '%s\n' "$not_run"))
+tested_writers=$(printf '%s\n' "$WRITERS" | cut -d'|' -f1 | grep -v '^$' | sort -u)
+[ "$declared_runnable" = "$tested_writers" ] || fail "the flags declared as writing and the flags tested as writing differ:
+  declared: $(printf '%s' "$declared_runnable" | tr '\n' ' ')
+  tested:   $(printf '%s' "$tested_writers" | tr '\n' ' ')"
+
+all_flags=$(awk '/^  -/ { print $1 }' "$help_all" | sort -u)
+covered=$(printf '%s\n%s\n%s\n' \
+    "$(printf '%s' "$MODES" | cut -d'|' -f1)" \
+    "$tested_writers" \
+    "$not_run" | grep -v '^$' | sort -u)
+missing=$(comm -23 <(printf '%s\n' "$all_flags") <(printf '%s\n' "$covered"))
+[ -z "$missing" ] || fail "no contract case for: $(printf '%s' "$missing" | tr '\n' ' ')"
+
+# Counts, because a loop that read a short list would otherwise report a pass for
+# the cases it never ran. This is the same silent-truncation failure the /dev/null
+# on run_into's stdin exists to prevent, asserted rather than assumed.
+want_modes=$(printf '%s' "$MODES" | grep -c '|')
+want_writers=$(printf '%s' "$WRITERS" | grep -c '|')
+[ "$n_modes" = "$want_modes" ] && [ "$n_writers" = "$want_writers" ] \
+    || fail "ran $n_modes/$want_modes mode cases and $n_writers/$want_writers writer cases"
+
+pass "$n_modes flags left the settings untouched, $n_writers kept what they were asked to"


### PR DESCRIPTION
Two commits: the `--resolution` decision, and the contract that stops the next flag doing the same thing quietly.

## Why a column

Three flags had already written themselves into `lba2.cfg` while their own help text said they applied to one run. Each was found by accident, one at a time, because a leaked setting shows up only as the next run behaving differently for no visible reason. The rule they broke was written down nowhere, so there was nothing for a fourth to violate.

## `--resolution` (first commit)

Asking for one launch at a different size replaced the size you had picked. `--resolution` set the same "explicit choice" flag the Display submenu sets, so `WriteConfigFile` wrote it at exit, and every harness run pinning 640x480 for a capture rewrote the player's resolution on the way out. Measured against the previous build:

```
seeded config:                  [ResolutionX: 1280 ResolutionY: 720]
  --resolution: [INFO] Display    640x480 (CLI)
  cfg after --resolution:       [ResolutionX: 640 ResolutionY: 480]   <- before
  cfg after --resolution:       [ResolutionX: 1280 ResolutionY: 720]  <- after
```

The flag was named for the question it used to answer, so it now states the decision: `Res_ResolutionShouldPersist`, true for the two sizes that are preferences (the config's own value, and one chosen during the run through `Res_Switch`) and false for the two that are not (auto-detect or the compile-time default, and the command line). False means leave the keys alone rather than erase them, because `WriteConfigFile` rewrites the config it read.

Nothing else moves: an auto-detected resolution still stays out of the file so it re-derives each launch, the Display submenu and the `resolution` console verb still persist what they pick, and a resolution switched mid-run still wins over the `--resolution` the run started with.

## The contract (second commit)

`CLI_ARGS.CPP` is already the one flag table, so `writes` sits beside `nvalues`, `nocase` and `common`. Five flags may write, each because it acts on stored state rather than naming a mode:

| Flag | Why |
|---|---|
| `--profile` | creates the profile and records the install it was given, which is what lets a later run name the profile alone |
| `--pick-game-dir` | choosing the folder to remember is the act |
| `--load` | restoring a save makes its player the current one, recorded in `LastSave` exactly as loading from the menu does |
| `--exec`, `--exec-at` | carry console commands, and the console is the imperative channel: `vsync off` typed in-game and sent from the command line are the same act |

Two of those five I would have got wrong by reasoning: `--load` and the `--exec` pair only turned up by running every flag against a baseline and diffing the user directory. That is the argument for the test existing rather than a comment.

`--help-all` prints the column as `[keeps this in your settings]`. Worth saying to a player, since the alternative is finding out by noticing a setting changed, and it gives the test one machine-readable copy to check itself against rather than a second list to keep in sync.

## The test

`tests/automation/test_cli_flag_contract.sh` runs every flag: 22 modes must leave the settings byte-identical, and the 4 writers it can drive must actually write (`--pick-game-dir` is declared but wants a folder dialog, so it is listed as not run). Both halves, because the first alone passes on an engine that stopped writing the config at all, and the second alone passes on a flag that changed the setting for good.

It then checks its own case list against `--help-all`, so a flag added to the table without a case here fails rather than going untested. The flags it cannot exercise are listed by name (`--help` and friends exit before the engine boots; `--pick-game-dir` wants a folder dialog; `--disc` wants an image nobody can assume), so "not covered" is never silent.

Against the build from before the first commit it fails, naming the flag:

```
FAIL: cli_flag_contract: --resolution changed the settings: < 4c6bb9b5 ./lba2.cfg > 0dd69217 ./lba2.cfg
```

`adeline.log` is excluded throughout: it is the run's own record and is meant to differ.

Two bugs in the test itself, both now asserted rather than assumed: a child process inherits the case list on stdin and eats it, which looks exactly like the swallowed flags passing; and a loop that read a short list reports a pass for cases it never ran.

## Found while building it, not fixed here

**Any install that ships its own `lba2.cfg` has its settings folded into the player's profile.** Not a flag issue, and not caused by anything in this PR:

| install | profile ends up with |
|---|---|
| a bare data folder | `WaveVolume: 127  DisplayFullScreen: 1  Gamepad22: 0` |
| GOG DOS (ships `LBA2.CFG`) | `WaveVolume: 97  DisplayFullScreen: 0  Gamepad22: 1045` |
| the TWINSEN disc | `WaveVolume: 97  DisplayFullScreen: 0  Gamepad22: 1045` |

The install's values are read into globals at boot and written to the player's file at exit, where they outlive the install they came from. Same shape as #489, and `test_config_upgrade.sh` asserts it only for `Version` / `ShowDistribLogo`. Worth its own issue.

`--profile` re-binding its install silently on every run is still an open question; it is declared as a writer here, which documents today's behaviour, so changing it later is a table flip plus a fix.
