### PR TITLE
feat(cli): bind a profile to one install, and move it only when asked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `--profile <name>` (or `LBA2_PROFILE`) keeps a run's saves and settings under
   a name of their own, in `profiles/<name>/` inside the user folder. A profile
   remembers the install it was given, so naming it is enough after the first
-  time. Running without one writes where the game always did, so nothing
-  existing moves.
+  time. It binds once: naming another folder later runs against it and leaves the
+  binding alone, and `--bind-game-dir` is what moves it, so trying a second
+  install for one run cannot replace the setup the profile holds. Running without
+  a profile writes where the game always did, so nothing existing moves.
 - An empty file called `portable.txt` beside the binary makes the whole tree
   self-contained: the user folder becomes `User/<build>/` next to the binary, so
   a copy on a USB stick carries its saves with it. A `profile:` line in that file

--- a/SOURCES/CLI_ARGS.CPP
+++ b/SOURCES/CLI_ARGS.CPP
@@ -81,6 +81,10 @@ static const T_CLI_FLAG CliFlags[] = {
     /* Picking a folder is the act of choosing the one to remember. */
     {"--pick-game-dir", 0, 1, 0, 1, NULL, "", "choose the game-data folder, ignoring any\n"
                                               "remembered one"},
+    /* Moving a profile to a different install is its own act, because --game-dir alone is
+       for the run that names it. Recording the move is the point, so: writes. */
+    {"--bind-game-dir", 0, 1, 0, 1, NULL, "", "point this profile at the folder named on this\n"
+                                              "command line, replacing the one it remembers"},
     {"--version", 0, 0, 1, 0, NULL, "", "print the engine version and exit"},
     {"--help-all", 0, 0, 1, 0, NULL, "", "list every option, including automation and\n"
                                          "engine self-tests"},

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -3171,9 +3171,12 @@ int main(int argc, char *argv[]) {
            no extracted data, and both should be looking at the same disc. */
         char discImagePath[ADELINE_MAX_PATH] = "";
         bool explicitGameDir = (getenv("LBA2_GAME_DIR") != NULL);
+        bool bindGameDir = false;
         for (int i = 1; i < argc; i++) {
             if (!strcasecmp(argv[i], "--game-dir") || !strcasecmp(argv[i], "--data-dir"))
                 explicitGameDir = true;
+            if (!strcasecmp(argv[i], "--bind-game-dir"))
+                bindGameDir = true;
             if (strcasecmp(argv[i], "--disc") != 0 || i + 1 >= argc)
                 continue;
             /* Accept the cue as readily as the image: pointing tools at the cue
@@ -3248,18 +3251,49 @@ int main(int argc, char *argv[]) {
            without this rule, `--profile gog` on its own would happily settle on
            whatever install happened to sit beside the binary and remember it.
 
+           It binds once. A later --game-dir runs against that folder and leaves
+           the binding alone, because the two readings of a second folder are
+           opposites and only one of them is recoverable: "just this run" read as
+           "from now on" silently discards the setup the profile existed to hold,
+           while "from now on" read as "just this run" costs one more flag. So
+           moving a profile says so, with --bind-game-dir.
+
            The default profile keeps its old behaviour, where an explicit
            --game-dir is for this run only. Naming a profile is what says "this
-           is my setup"; running without one is not. */
-        if (Directories_GetProfile()[0] != '\0' && Res_ResolvedFromUserInput()) {
+           is my setup"; running without one is not.
+
+           Asks the resolved profile rather than the --profile seen while
+           scanning argv above, so LBA2_PROFILE binds exactly as the flag does. */
+        const bool haveProfile = Directories_GetProfile()[0] != '\0';
+        if (haveProfile && Res_ResolvedFromUserInput()) {
             char boundPath[ADELINE_MAX_PATH] = "";
-            const bool alreadyBound =
-                ReadPersistedGameDir(boundPath, ADELINE_MAX_PATH) &&
-                strcmp(boundPath, resFolderPath) == 0;
-            if (!alreadyBound && WritePersistedGameDir(resFolderPath)) {
-                Log_Info("Profile    '%s' now points at %s",
-                         Directories_GetProfile(), resFolderPath);
+            const bool bound = ReadPersistedGameDir(boundPath, ADELINE_MAX_PATH);
+            if (!bound || strcmp(boundPath, resFolderPath) != 0) {
+                if (!bound || bindGameDir) {
+                    if (WritePersistedGameDir(resFolderPath)) {
+                        Log_Info("Profile    '%s' now points at %s",
+                                 Directories_GetProfile(), resFolderPath);
+                    } else if (bound) {
+                        /* The write says why it failed; this says what it means,
+                           which is that the next run boots the old install. */
+                        Log_Warn("Profile    '%s' still points at %s: the move could "
+                                 "not be written",
+                                 Directories_GetProfile(), boundPath);
+                    }
+                } else {
+                    /* Said out loud, because the folder this run uses and the one
+                       the profile keeps now differ, and nothing else would show
+                       it until a later run booted the other install. */
+                    Log_Info("Profile    '%s' stays bound to %s; this run uses %s "
+                             "(--bind-game-dir moves it)",
+                             Directories_GetProfile(), boundPath, resFolderPath);
+                }
             }
+        } else if (bindGameDir) {
+            /* Nothing to bind, and a flag that quietly does nothing is how the
+               setting it was meant to move goes unnoticed. */
+            Log_Warn("--bind-game-dir needs a named profile (--profile) and a folder "
+                     "you named (--game-dir or LBA2_GAME_DIR); nothing was bound");
         }
 
         InitDirectories(userFolderPath, resFolderPath, userFolderPath, "",

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -32,10 +32,11 @@ lba2.cfg stores user preferences and last-save info. Read at startup, written at
 - Which flags may write is declared in `CLI_ARGS.CPP`'s `writes` column, printed under `--help-all` as
   "[keeps this in your settings]", and held to by
   [`tests/automation/test_cli_flag_contract.sh`](../tests/automation/test_cli_flag_contract.sh). Only
-  five may: `--profile` and `--pick-game-dir`, whose job is to record a choice; `--load`, because
-  restoring a save makes its player the current one and the config records that in `LastSave` exactly
-  as loading from the menu does; and `--exec` / `--exec-at`, which carry console commands and so carry
-  whatever those commands persist. Everything else must leave the settings byte-identical.
+  six may: `--profile`, `--pick-game-dir` and `--bind-game-dir`, whose job is to record a choice;
+  `--load`, because restoring a save makes its player the current one and the config records that in
+  `LastSave` exactly as loading from the menu does; and `--exec` / `--exec-at`, which carry console
+  commands and so carry whatever those commands persist. Everything else must leave the settings
+  byte-identical.
 
 ## Keys: what each does
 

--- a/docs/GAME_DATA.md
+++ b/docs/GAME_DATA.md
@@ -95,6 +95,19 @@ guessed at is not, because the probes are a fallback and writing one down would 
 install that profile's for good. Running without a profile keeps its old behaviour, where
 `--game-dir` applies to that run only.
 
+It binds once. Naming a different folder later runs against that folder and leaves the binding
+where it is, so trying another install for one run cannot quietly replace the setup the profile
+exists to hold. Moving a profile says so:
+
+```
+lba2cc --profile gog --game-dir /new/path                    # this run only
+lba2cc --profile gog --game-dir /new/path --bind-game-dir    # from now on
+```
+
+The run that does not move it logs the difference, naming both the folder it used and the one the
+profile keeps. `--bind-game-dir` with no profile, or with no folder you named, warns and binds
+nothing rather than passing silently.
+
 It's a single-line text file (the absolute path to the chosen game-data folder). Safe to delete by hand to force the picker to re-appear on next launch — the engine treats a missing file as "never picked," same as a fresh install.
 
 ### Forcing the picker without deleting the file

--- a/tests/automation/test_cli_flag_contract.sh
+++ b/tests/automation/test_cli_flag_contract.sh
@@ -63,8 +63,12 @@ MODES="
 --res-switch-test|--res-switch-test 2:1280x720
 --save-load-test|--save-load-test \"$tmp/slt.lba\"
 "
+# --bind-game-dir is checked here only for what this test asks of every writer,
+# that it writes. Its own behaviour, moving a binding rather than setting a fresh
+# one, needs a second run to be visible at all and lives in test_profile_bind.sh.
 WRITERS="
 --profile|--profile contract
+--bind-game-dir|--profile bindcontract --game-dir \"$LBA2_GAME_DIR\" --bind-game-dir
 --load|--load \"$SAVE\"
 --exec|--exec \"vsync off\"
 --exec-at|--exec-at 1 \"vsync off\"

--- a/tests/automation/test_profile_bind.sh
+++ b/tests/automation/test_profile_bind.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# A named profile binds to one install, and moving it has to say so.
+#
+# `--profile gog --game-dir <path>` once, then `--profile gog`: the binding is what
+# makes the second line work. A later `--game-dir` is then ambiguous, and the two
+# readings are not equally recoverable. Read as "from now on", a one-run override
+# silently discards the setup the profile existed to hold, and nothing shows it
+# until a later run boots the wrong install. Read as "just this run", a real move
+# costs one more flag. So --game-dir runs, and --bind-game-dir moves.
+#
+# Both directions, because either alone passes on a broken engine: an engine that
+# ignored --game-dir once bound would satisfy "the binding did not move", and one
+# that never bound anything would satisfy "--bind-game-dir changed it".
+#
+# Local-only (needs the binary and retail data); skips cleanly otherwise.
+TESTNAME=profile_bind
+. "$(dirname "$0")/lib.sh"
+precheck
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# The second install is a tree of symlinks to the real data, so two folders that
+# both boot cost nothing and neither depends on the developer having a spare copy.
+alt="$tmp/alt-install"
+mkdir -p "$alt"
+for f in "$LBA2_GAME_DIR"/*; do
+    ln -s "$f" "$alt/" 2>/dev/null
+done
+A="${LBA2_GAME_DIR%/}"
+B="$alt"
+u="$tmp/user"
+
+# stdin comes from /dev/null so a child cannot eat the rest of this script.
+run() { # run <extra args...>
+    ctl --user-dir "$u" --no-audio --language English --fixed-dt 16 --tick 2 --exit \
+        "$@" >/dev/null 2>&1 </dev/null
+}
+# The engine stores the path with a trailing separator; the comparison is about
+# which folder, not how it was spelled.
+bound() { sed -e 's:/*$::' "$u/profiles/p/last_game_dir.txt" 2>/dev/null; }
+# Which folder the run actually read its assets from, from the boot banner.
+assets() { awk '/^Assets:/ { print $2; exit }' "$u/profiles/p/adeline.log" | sed -e 's:/*$::'; }
+
+# --- 1. first use binds ------------------------------------------------------
+run --profile p --game-dir "$A"
+[ -f "$u/profiles/p/last_game_dir.txt" ] || fail "naming a folder on first use bound nothing"
+[ "$(bound)" = "$A" ] || fail "first use bound '$(bound)', expected '$A'"
+
+# --- 2. a second folder runs, and leaves the binding alone -------------------
+run --profile p --game-dir "$B"
+[ "$(assets)" = "$B" ] || fail "--game-dir did not run against '$B' (ran against '$(assets)')"
+[ "$(bound)" = "$A" ] || fail "--game-dir moved the binding to '$(bound)'; it is for the run only"
+
+# --- 3. asking to move it moves it -------------------------------------------
+run --profile p --game-dir "$B" --bind-game-dir
+[ "$(bound)" = "$B" ] || fail "--bind-game-dir left the binding at '$(bound)', expected '$B'"
+
+# --- 4. with nothing to bind, it says so -------------------------------------
+# A flag that quietly does nothing is how the setting it was meant to move goes
+# unnoticed, which is the failure this whole contract is about.
+run --game-dir "$A" --bind-game-dir
+grep -q "nothing was bound" "$u/adeline.log" \
+    || fail "--bind-game-dir without a profile bound nothing and said nothing"
+
+pass "binds once, runs anywhere, moves when asked"


### PR DESCRIPTION
A named profile remembers the install it was given, which is the whole reason `--profile gog` alone works on the second run. A later `--game-dir` was ambiguous, and it took the reading that cannot be undone.

## What it did

```
lba2cc --profile gog --game-dir /gog     # binds gog
lba2cc --profile gog --game-dir /steam   # ran on steam, and rebound gog to it
lba2cc --profile gog                     # boots steam
```

Trying a second install once replaced the setup the profile existed to hold. There was a log line, but nothing else showed it until a later run booted the wrong folder, by which point the folder that had been bound is not written down anywhere.

## What it does now

It binds once. `--game-dir` runs against the folder it names and leaves the binding where it is; `--bind-game-dir` moves it.

```
lba2cc --profile gog --game-dir /gog                     # binds gog
lba2cc --profile gog --game-dir /steam                   # runs on steam, gog stays gog
lba2cc --profile gog --game-dir /steam --bind-game-dir   # now gog is steam
```

The choice is not symmetric, which is the argument for the asymmetric default. "Just this run" taken as "from now on" silently discards a setting nobody asked to change. "From now on" taken as "just this run" costs one more flag.

First use is unchanged: an unbound profile still binds to the folder you name, so `--profile gog --game-dir <path>` once, then `--profile gog`, still reads the same. Only a folder you named binds, as before, never one a probe guessed at. Running without a profile is untouched.

## What it says

The run that does not move the binding names both folders, because otherwise the difference between the folder in use and the folder remembered is invisible until the next launch:

```
Profile    'gog' stays bound to /gog; this run uses /steam (--bind-game-dir moves it)
```

`--bind-game-dir` with no profile, or with no folder you named, warns and binds nothing rather than passing silently. A move that cannot be written warns too, saying the next run still boots the old install: the write reports why it failed, this reports what it means.

## The flag

Declared as writing in the `CLI_ARGS.CPP` table, since recording the move is the point rather than a side effect, and printed under `--help-all` as `[keeps this in your settings]`. `--pick-game-dir` was already the interactive form of the same act; this is the one a script can use.

## Tests

`tests/automation/test_profile_bind.sh`, both directions. Either alone passes on a broken engine: one that ignored `--game-dir` once bound would satisfy "the binding did not move", and one that never bound anything would satisfy "`--bind-game-dir` changed it". So it checks that the second run reads its assets from the folder it named, from the boot banner, and that the binding did not follow.

Against a build of `main` it fails on exactly that step:

```
FAIL: profile_bind: --game-dir moved the binding to '/tmp/tmp.Lgdvr1Oyk7/alt-install'; it is for the run only
```

The second install is a tree of symlinks to the real data, so two folders that both boot cost nothing and neither depends on having a spare copy.

`test_cli_flag_contract.sh` gets a case, as the contract requires of every declared writer. It only asks that the flag writes; the flag's own behaviour needs a second run to be visible at all, which is what the test above is for. That is noted next to the case rather than left to look like coverage it is not.

Suite 43 passed, 2 skipped, 0 failed, on a fresh user directory. Host tests 53/53. The two skips are polyrec and projection_demo, both opt-in builds.
