### PR TITLE
fix(test): let a UI capture name the vsync setting instead of reading yours

### DIFF
--- a/SOURCES/CLI_ARGS.CPP
+++ b/SOURCES/CLI_ARGS.CPP
@@ -112,6 +112,8 @@ static const T_CLI_FLAG CliFlags[] = {
     {"--fixed-dt", 1, 0, 0, 0, NULL, "<ms>", "advance the clock by a constant <ms> per tick, so a\n"
                                              "run reproduces exactly (needs --headless)"},
     {"--fixed-timestep", 1, 0, 0, 0, NULL, "<ms>", "set the sim throttle for this run only (0 = off)"},
+    {"--vsync", 1, 0, 0, 0, NULL, "<on|off>", "set the vsync setting for this run only, so a\n"
+                                              "capture reads it instead of the local one"},
     {"--screenshot", 1, 0, 0, 0, NULL, "<path>", "write a PNG of the rendered frame"},
     {"--dump-state", 1, 0, 0, 0, NULL, "<path>", "write the engine state as JSON"},
     {"--demo", 0, 0, 0, 0, NULL, "", "attract/demo mode (only does anything on a demo scene)"},

--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -65,6 +65,8 @@ static int s_have_fixed_dt = 0;
 static long s_fixed_dt = 0;
 static int s_have_fixed_timestep = 0;
 static long s_fixed_timestep = 0;
+static int s_have_vsync = 0;
+static int s_vsync = 0;
 static int s_have_dump = 0;
 static char s_dump_path[ADELINE_MAX_PATH];
 static int s_have_shot = 0;
@@ -235,6 +237,30 @@ void Control_ParseArgs(int *argc, char *argv[]) {
                 s_have_fixed_timestep = 1;
             }
             s_active = 1;
+            read += 2;
+            continue;
+        }
+        if (!strcmp(a, "--vsync") && has_val) {
+            /* Pin DisplayVSync for this run only, without persisting to lba2.cfg (unlike the
+               `vsync` console verb and the Display menu's own toggle). The Display submenu
+               prints the setting as a row, so a UI capture inherits whatever the local cfg
+               holds unless the run says which one it wants.
+
+               The setting, not the frame pacing: Control_Begin drops the presentation cap for
+               every --exit run regardless, so pinning this on doesn't put a harness run back
+               behind a ~60 fps wait. */
+            const char *val = argv[read + 1];
+            /* Same spellings the `vsync` console verb takes, so knowing one tells you the
+               other. */
+            if (!strcasecmp(val, "on") || !strcmp(val, "1")) {
+                s_vsync = 1;
+                s_have_vsync = 1;
+            } else if (!strcasecmp(val, "off") || !strcmp(val, "0")) {
+                s_vsync = 0;
+                s_have_vsync = 1;
+            } else {
+                fprintf(stderr, "[control] --vsync: invalid '%s' (use on|off)\n", val);
+            }
             read += 2;
             continue;
         }
@@ -524,6 +550,14 @@ int Control_HasFixedTimestep(void) {
 
 long Control_GetFixedTimestep(void) {
     return s_fixed_timestep;
+}
+
+int Control_HasVSync(void) {
+    return s_have_vsync;
+}
+
+int Control_GetVSync(void) {
+    return s_vsync;
 }
 
 int Control_NoAudio(void) {

--- a/SOURCES/CONTROL.H
+++ b/SOURCES/CONTROL.H
@@ -72,6 +72,18 @@ int Control_GetLanguage(void);
 int Control_HasFixedTimestep(void);
 long Control_GetFixedTimestep(void);
 
+/* Vsync override via --vsync <on|off>. Returns 1 if the flag was supplied (use
+   Control_GetVSync for the forced value, 0 or 1), 0 otherwise (the engine reads the
+   cfg's VSync key as normal). Applied in PERSO.CPP where ReadConfigFile takes that key;
+   WriteConfigFile reads these back so the forced value is not persisted, unlike the
+   `vsync` console verb and the Display menu's toggle.
+
+   This is the setting the Display submenu prints, which is why a UI capture needs to be
+   able to name it. Frame pacing is a separate matter: Control_Begin drops the
+   presentation cap for every --exit run whatever this says. */
+int Control_HasVSync(void);
+int Control_GetVSync(void);
+
 /* --no-audio: skip InitAIL() and InitSampleDriver() at boot. Returns 1 if the flag
    was supplied, 0 otherwise. With audio init skipped, the SDL audio subsystem
    never opens a stream and the dummy driver's nanosleep pacing (~74% of sys time

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2351,6 +2351,7 @@ static S32 StoredTexFilter = 0;
 static S32 EnvTexFilter = -1;
 static S32 StoredFixedTimestep = 16;
 static S32 StoredLanguage = 0;
+static S32 StoredVSync = TRUE;
 
 /* The value to write for such a setting: the stored preference while the live
    value is still the one the override forced, otherwise the live value, because
@@ -2372,6 +2373,10 @@ static S32 ForcedFixedTimestep(void) {
 
 static S32 ForcedLanguage(void) {
     return Control_HasLanguage() ? (S32)Control_GetLanguage() : -1;
+}
+
+static S32 ForcedVSync(void) {
+    return Control_HasVSync() ? (S32)Control_GetVSync() : -1;
 }
 
 void ReadConfigFile(void) {
@@ -2452,6 +2457,12 @@ void ReadConfigFile(void) {
 
     if (DisplayVSync < 0 OR DisplayVSync > 1)
         DisplayVSync = TRUE;
+
+    /* Same precedence the language uses: an explicit request for this run beats the stored
+       preference, and the preference is kept so WriteConfigFile can tell the two apart. */
+    StoredVSync = DisplayVSync;
+    if (Control_HasVSync())
+        DisplayVSync = (S32)Control_GetVSync();
 
     /* Renderer exists by now (SetWindowFullscreen above operates on the same
        window/renderer pair), so this applies the saved choice immediately.
@@ -2652,7 +2663,7 @@ void WriteConfigFile(void) {
     DefFileBufferWriteValue("DetailLevel", DetailLevel);
     DefFileBufferWriteValue("FullScreen", VideoFullScreen);
     DefFileBufferWriteValue("DisplayFullScreen", DisplayFullScreen);
-    DefFileBufferWriteValue("VSync", DisplayVSync);
+    DefFileBufferWriteValue("VSync", ValueToPersist(DisplayVSync, StoredVSync, ForcedVSync()));
     DefFileBufferWriteValue("DitherShading", GfxDitherShading);
     /* An environment override is for the run that asked for it: persisting the
        live value would turn `LBA2_TEXFILTER=2 ./lba2cc` into a permanent

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -22,7 +22,7 @@ lba2.cfg stores user preferences and last-save info. Read at startup, written at
 - Options menu changes globals only; config is written once at exit. No intermediate saves when changing options.
 - **A setting forced for one run is not written back.** The write serialises globals, so without this a
   flag whose own help says "this run only" would leave its value in the player's config for every later
-  launch. `--fixed-timestep`, `--language` and `LBA2_TEXFILTER` go through `ValueToPersist` in PERSO.CPP,
+  launch. `--fixed-timestep`, `--language`, `--vsync` and `LBA2_TEXFILTER` go through `ValueToPersist` in PERSO.CPP,
   which puts the stored preference back while the live value is still the one that was forced.
   `--resolution` reaches the same end differently: `Res_ResolutionShouldPersist` is false for it, so
   `WriteConfigFile` leaves `ResolutionX/Y` as it found them. Only two things make a resolution a
@@ -70,6 +70,7 @@ lba2.cfg stores user preferences and last-save info. Read at startup, written at
 | MenuMouse | int | 0, 1 | 1 | 1 = menu cursor, hover/left-click confirm, wheel for sliders and save list; 0 = keyboard/joystick only (classic) |
 | TextureFilter | int | 0–2 | 0 | Filtered texture sampling in the software fillers. 0=off (unchanged output), 1=horizontal 2-tap, 2=bilinear 4-tap. `LBA2_TEXFILTER` overrides for one run without persisting. See [GFX_OPTIONS.md](GFX_OPTIONS.md) |
 | FixedTimestep | int | 0–100 (ms) | 16 | Sim throttle, so movement is frame-rate independent above 60 fps; 0 restores the historical per-frame simulation. Set by the `fixedtimestep` console verb; `--fixed-timestep` overrides for one run without persisting. See [MOVEMENT_FRAMERATE.md](MOVEMENT_FRAMERATE.md) |
+| VSync | int | 0, 1 | 1 | Cap the frame rate to the display refresh. Invalid values → 1. Set by the Display submenu's toggle and the `vsync` console verb; `--vsync <on\|off>` overrides for one run without persisting. The Display submenu prints it, so a UI capture has to pin it; see [CONTROL.md](CONTROL.md#environmental-hygiene) |
 | DitherShading | int | 0, 1 | 0 | Ordered dither on Gouraud shade rows, softening the 16-step ramp banding. See [GFX_OPTIONS.md](GFX_OPTIONS.md) |
 
 ### Original keys (Adeline)

--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -55,6 +55,10 @@ lba2cc --help                 print the player-facing flag list and exit (an unk
                               but only in a --headless run)
        --fixed-timestep <ms>  set the sim throttle (FixedTimestep) for this run only, no cfg
                               persist (0 = off); combine with a small --fixed-dt to force skips
+       --vsync <on|off>       set the vsync setting (DisplayVSync) for this run only, no cfg
+                              persist. The setting, not the frame pacing: a --exit run drops
+                              the presentation cap either way. Pin it for any capture of a
+                              surface that prints the setting, such as the Display submenu
        --language <name>      override Language at boot (English | Français | Deutsch |
                               Español | Italiano | Portugues; or EN | FR | DE | SP | IT | PO)
        --no-audio             skip InitAIL() and InitSampleDriver() at boot — bypasses
@@ -88,8 +92,8 @@ All flags are optional and composable. With none, the game launches normally. Pa
 flag that *asks the engine to do something* (`--load`, `--exec`, `--exec-at`, `--tick`,
 `--dump-state`, `--screenshot`, `--exit`, …) takes the automated boot path and skips the
 distributor/Adeline logos. Flags that only describe the environment (`--headless`,
-`--no-autosave`, `--resolution`, `--language`, `--no-audio`) do not, so `lba2cc --headless`
-on its own is still just the game, with no window.
+`--no-autosave`, `--resolution`, `--language`, `--no-audio`, `--vsync`) do not, so
+`lba2cc --headless` on its own is still just the game, with no window.
 
 Order of operations: `--load` (or a fresh start) → first tick runs `--exec` →
 advance to N ticks → `--dump-state` + `--screenshot` → `--exit`.
@@ -158,7 +162,9 @@ Console output is mirrored to stdout, so any command's output is readable from a
 - **Vsync is off under the harness.** A `--exit` run disables the renderer's vsync cap so
   the loop runs flat-out instead of at ~60 fps — a long `--tick N` run is ~10-14x faster
   (e.g. 2000 ticks: ~34 s to ~2.5 s here). Presentation only: the dumped state and rendered
-  pixels are identical (verified 0 drift over the save corpus).
+  pixels are identical (verified 0 drift over the save corpus). The `DisplayVSync` *setting*
+  is a separate thing, still read from the cfg and still printed by the Display submenu;
+  `--vsync <on|off>` pins it for the run without touching the cfg.
 - **A tick is one main-loop iteration, normally one rendered frame.** In a settled scene
   the two are identical. The exception is a cube transition: when a script (or a `cube`
   command) changes the scene, the loop restarts its body to load the new cube, which counts
@@ -420,12 +426,19 @@ inventory, on an island whose dialogue bank has known text-ids).
 
 #### Environmental hygiene
 
-The `ui_*` captures are state-sensitive in two ways the `--load` argument doesn't cover:
+The `ui_*` captures are state-sensitive in three ways the `--load` argument doesn't cover:
 
 - **Language.** The engine reads `Language` from the developer's local `lba2.cfg`. A
   golden captured under one language doesn't match captures on a machine with any other
   language. `ctl_headless` (in `tests/automation/lib.sh`) pins `--language English`
   for every UI capture — matches the in-repo `LBA2.CFG` default, makes goldens portable.
+- **Settings a surface prints.** A menu that shows a setting reads it from the same local
+  `lba2.cfg`, so the surface is only as reproducible as the keys it displays. The Display
+  submenu prints the vsync state, which made `ui_display` fail for anyone running with
+  `VSync: 0`, on a golden that was correct. That is the expensive way for this to surface:
+  a divergence that looks exactly like a regression. `ctl_headless` pins
+  `--vsync on` alongside `--language` and `--resolution`. A new surface that prints a
+  setting needs the same treatment, or a golden nobody else can reproduce.
 - **`current.lba` thumbnail.** `ui_menu_main` renders a small save-thumbnail at the top
   of the main menu that the engine reads from
   `~/.local/share/Twinsen/LBA2/save/current.lba`, *not* from `--load`. That file evolves

--- a/tests/automation/lib.sh
+++ b/tests/automation/lib.sh
@@ -85,9 +85,10 @@ ctl() {
 }
 
 # ctl_headless <args...> — same as ctl but also pins SDL_VIDEODRIVER=dummy,
-# Language to English, and the render resolution to 640x480. Used by UI
-# capture tests where the committed goldens were rendered under the dummy
-# video driver, English UI, and the engine's default 640x480 framebuffer.
+# Language to English, the render resolution to 640x480, and vsync on. Used
+# by UI capture tests where the committed goldens were rendered under the
+# dummy video driver, English UI, the engine's default 640x480 framebuffer
+# and the engine's default vsync setting.
 #
 # --language English: without this, tests fail on machines whose local
 # lba2.cfg has any other Language: key (typically Français, which is also
@@ -106,9 +107,16 @@ ctl() {
 # Goldens are rendering-only (no audio sampling), so dropping audio init
 # doesn't affect them — verified by re-running the suite with this in
 # place and confirming all eight ui_* goldens stay byte-identical.
+#
+# --vsync on: the Display submenu prints the setting as one of its rows, so
+# without this the capture reads the developer's own cfg and a machine with
+# VSync: 0 fails ui_display on a golden that is correct. Pinning the setting
+# doesn't slow the run down, because a --exit run drops the presentation cap
+# either way (Control_Begin).
 ctl_headless() {
     timeout "$LBA2_TEST_TIMEOUT" \
-        "$LBA2_BIN" --headless --no-autosave --language English --resolution 640x480 "$@"
+        "$LBA2_BIN" --headless --no-autosave --language English --resolution 640x480 \
+        --vsync on "$@"
 }
 
 # ctl_headless_cfg_driven <args...> — same as ctl_headless but does NOT
@@ -126,7 +134,7 @@ ctl_headless_cfg_driven() {
 ctl_headless_at() {
     local res="$1"; shift
     SDL_AUDIODRIVER=dummy SDL_VIDEODRIVER=dummy timeout "$LBA2_TEST_TIMEOUT" \
-        "$LBA2_BIN" --language English --no-audio --resolution "$res" "$@"
+        "$LBA2_BIN" --language English --no-audio --resolution "$res" --vsync on "$@"
 }
 
 # seed_menu_save_dir <user-dir> <fresh|returning> [save-file]

--- a/tests/automation/test_cli_flag_contract.sh
+++ b/tests/automation/test_cli_flag_contract.sh
@@ -52,6 +52,7 @@ MODES="
 --exit|--exit
 --fixed-dt|--fixed-dt 16
 --fixed-timestep|--fixed-timestep 100
+--vsync|--vsync off
 --screenshot|--screenshot \"$tmp/shot.png\"
 --dump-state|--dump-state \"$tmp/dump.json\"
 --demo|--demo

--- a/tests/automation/test_cli_override_persistence.sh
+++ b/tests/automation/test_cli_override_persistence.sh
@@ -7,6 +7,10 @@
 # launch, and one --language Deutsch to check the German text made German the
 # setting. Their own help text and their comments said the opposite.
 #
+# --vsync joins them for the same reason it exists: the Display submenu prints
+# the setting, so a UI capture has to be able to name it, and a run that named
+# it must not leave the player's own choice replaced.
+#
 # Both halves are asserted, because either one alone passes on a broken engine.
 # "Does not persist" is satisfied by a flag that does nothing at all, and "takes
 # effect" is satisfied by one that changes the setting for good. The chosen-value
@@ -36,13 +40,16 @@ run >/dev/null
 [ -f "$user/lba2.cfg" ] || fail "no config was written at all"
 base_step=$(value_of FixedTimestep)
 base_lang=$(value_of Language)
-[ -n "$base_step" ] && [ -n "$base_lang" ] \
-    || fail "config is missing the keys under test (FixedTimestep='$base_step' Language='$base_lang')"
+base_vsync=$(value_of VSync)
+[ -n "$base_step" ] && [ -n "$base_lang" ] && [ -n "$base_vsync" ] \
+    || fail "config is missing the keys under test (FixedTimestep='$base_step' Language='$base_lang' VSync='$base_vsync')"
 
 # Probe values that differ from the baseline, or the run would override a setting
 # to what it already was and every assertion below would hold for free.
 probe_step=100; [ "$base_step" = "100" ] && probe_step=50
 probe_lang=Deutsch; [ "$base_lang" = "Deutsch" ] && probe_lang=Italiano
+probe_vsync=off; want_vsync=OFF
+[ "$base_vsync" = "0" ] && { probe_vsync=on; want_vsync=ON; }
 
 # --- --fixed-timestep: in force for the run, absent from the config -----------
 out=$(run --fixed-timestep "$probe_step" --exec-at 1 "fixedtimestep")
@@ -59,6 +66,17 @@ printf '%s' "$out" | grep -aqE "Language +$probe_lang" \
 got=$(value_of Language)
 [ "$got" = "$base_lang" ] \
     || fail "--language $probe_lang persisted: config says '$got', was '$base_lang'"
+
+# --- --vsync: same, and the console reports the state it forced ---------------
+# Asked for through the console rather than a banner line because the setting has
+# no other visible spelling, and `vsync` with no argument prints it without
+# writing anything (unlike `vsync on`, which is the player choosing).
+out=$(run --vsync "$probe_vsync" --exec-at 1 "vsync")
+printf '%s' "$out" | grep -aqE "Vsync: $want_vsync" \
+    || fail "--vsync $probe_vsync did not take effect: $(printf '%s' "$out" | grep -aoE 'Vsync: .*' | head -1)"
+got=$(value_of VSync)
+[ "$got" = "$base_vsync" ] \
+    || fail "--vsync $probe_vsync persisted: config says '$got', was '$base_vsync'"
 
 # --- a setting the player chose is a different thing, and does persist --------
 # Without this the two assertions above would also pass on an engine that had
@@ -81,4 +99,4 @@ out=$(run --exec-at 1 "fixedtimestep")
 printf '%s' "$out" | grep -aqE "FixedTimestep: ON \($chosen ms" \
     || fail "the chosen $chosen ms is not in force next launch: $(printf '%s' "$out" | grep -aoE 'FixedTimestep: .*' | head -1)"
 
-pass "--fixed-timestep and --language apply without persisting; a chosen $chosen ms survives both"
+pass "--fixed-timestep, --language and --vsync apply without persisting; a chosen $chosen ms survives them"

--- a/tests/automation/test_cli_override_persistence.sh
+++ b/tests/automation/test_cli_override_persistence.sh
@@ -87,6 +87,15 @@ got=$(value_of FixedTimestep)
 [ "$got" = "$chosen" ] \
     || fail "the console's own 'fixedtimestep $chosen' did not persist: config says '$got'"
 
+# Vsync is the case worth stating on its own: the Display menu's toggle flips the
+# global and writes nothing itself, so the exit write is the only thing that keeps
+# a player's choice. `vsync $probe_vsync` reaches that same write with the same
+# values the toggle would, so a per-run override swallowing it would show up here.
+run --exec "vsync $probe_vsync" >/dev/null
+chosen_vsync=$(value_of VSync)
+[ "$chosen_vsync" != "$base_vsync" ] \
+    || fail "the console's own 'vsync $probe_vsync' did not persist: config still says '$chosen_vsync'"
+
 # --- and a later overridden run leaves that choice alone ----------------------
 # The regression this test exists for: the harness runs constantly on developer
 # machines, and each run used to overwrite whatever the player had set.
@@ -95,8 +104,14 @@ got=$(value_of FixedTimestep)
 [ "$got" = "$chosen" ] \
     || fail "--fixed-timestep $probe_step overwrote the chosen $chosen: config says '$got'"
 
+# Same for the vsync the player chose, against the pin every UI capture now passes.
+run --vsync "$base_vsync" >/dev/null
+got=$(value_of VSync)
+[ "$got" = "$chosen_vsync" ] \
+    || fail "--vsync $base_vsync overwrote the chosen $chosen_vsync: config says '$got'"
+
 out=$(run --exec-at 1 "fixedtimestep")
 printf '%s' "$out" | grep -aqE "FixedTimestep: ON \($chosen ms" \
     || fail "the chosen $chosen ms is not in force next launch: $(printf '%s' "$out" | grep -aoE 'FixedTimestep: .*' | head -1)"
 
-pass "--fixed-timestep, --language and --vsync apply without persisting; a chosen $chosen ms survives them"
+pass "--fixed-timestep, --language and --vsync apply without persisting; a chosen $chosen ms and VSync $chosen_vsync survive them"


### PR DESCRIPTION
Closes #448.

## The golden was correct

`ui_display` failed against a golden that had not drifted. The Display submenu
prints the vsync state as one of its rows, the engine reads that from the local
`lba2.cfg`, and the golden was captured at the default (on). Every machine
playing with `VSync: 0` therefore failed the fixture.

The capture and the golden differ by 1610 pixels in a single bounding box,
`(238,252)-(401,281)`:

```
golden:  Vsync ON
capture: Vsync OFF
```

Flipping that one key in an otherwise identical config makes it pass. The issue
asked for the divergence to be attributed to a merged PR before re-blessing;
the answer is that no re-bless was warranted, because nothing had changed.

From the hash alone this is indistinguishable from a rendering regression,
which is the expensive way for an environment leak to present itself.

## The fix

`--vsync <on|off>` pins the setting for one run without writing it back, the
same shape `--language` and `--fixed-timestep` already use: parsed in
`CONTROL.CPP`, applied where `ReadConfigFile` takes the `VSync` key, routed
through the existing `ValueToPersist` so the player's own choice survives.
`ctl_headless` and `ctl_headless_at` pass `--vsync on` alongside
`--language English` and `--resolution 640x480`.

It is the setting, not the frame pacing. `Control_Begin` drops the presentation
cap for every `--exit` run regardless, so a pinned harness run is no slower.

The resolution axis of this bug is already closed: a cfg at 800x600 passes, and
the run no longer rewrites `ResolutionX/Y` (#492/#494). Vsync was what was left.

## The menu still owns the setting

The Display menu's toggle flips the global and writes nothing itself, so
`WriteConfigFile` at exit is the only thing keeping a player's choice, and that
is the line this PR touches. Without `--vsync` on the command line `ForcedVSync`
is -1 and `ValueToPersist` returns the live value unconditionally, so the write
is byte-identical to before.

Measured across launches on a fresh user dir:

| Run | Config after |
|-----|--------------|
| default | `VSync: 1` |
| setting flipped off | `VSync: 0` |
| next launch | reports `Vsync: OFF`, still 0 |
| harness run pinning `--vsync on` | reports `Vsync: ON`, still 0 |
| flipped back on | `VSync: 1` |

## Tests

- `test_cli_flag_contract.sh` gains the `--vsync` case. It reads the flag table
  back out of `--help-all`, so a new flag with no case fails rather than going
  untested.
- `test_cli_override_persistence.sh` covers both halves: the flag takes effect
  and leaves nothing behind, and a chosen vsync reaches the config and survives
  a later run pinning the opposite. The first alone would pass on a flag that
  does nothing.
- All twelve `ui_*` goldens pass against a config that previously failed one,
  with the developer's `VSync: 0` still 0 afterwards.
- `make test`: 53/53.

## Docs

`CONTROL.md` gains the flag entry, the environment-flags list, and a note
separating the `DisplayVSync` setting from the presentation cap. Its
Environmental hygiene section gains a "settings a surface prints" bullet written
so the next such surface gets the same treatment. `CONFIG.md` gains the `VSync`
row, which was missing from the key table, and lists `--vsync` among the
overrides that go through `ValueToPersist`.

## Noticed on the way, not fixed here

`test_projection_corpus` is sensitive to the same class of leak through two
different keys: `FollowCamera` and `FixedTimestep`. A default config passes,
mine fails, and normalising those two makes it pass. `--fixed-timestep` already
exists so half of it is a one-line pin; `FollowCamera` has no flag and would
need the same treatment given here. Separate change.
