### PR TITLE
fix(test): give every automation test a settings folder of its own

### DIFF
--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -426,29 +426,44 @@ inventory, on an island whose dialogue bank has known text-ids).
 
 #### Environmental hygiene
 
-The `ui_*` captures are state-sensitive in three ways the `--load` argument doesn't cover:
+A fixture reads more than `--load` gives it. The engine takes its settings from the
+player's `lba2.cfg` with the install's stacked underneath, so every key a surface
+displays, and every key a camera or the sim consults, is an input the golden depends on
+without declaring. On someone else's machine those keys hold something else and the
+capture diverges, which is indistinguishable from a rendering regression by the time you
+see it as a hash.
 
-- **Language.** The engine reads `Language` from the developer's local `lba2.cfg`. A
-  golden captured under one language doesn't match captures on a machine with any other
-  language. `ctl_headless` (in `tests/automation/lib.sh`) pins `--language English`
-  for every UI capture — matches the in-repo `LBA2.CFG` default, makes goldens portable.
-- **Settings a surface prints.** A menu that shows a setting reads it from the same local
-  `lba2.cfg`, so the surface is only as reproducible as the keys it displays. The Display
-  submenu prints the vsync state, which made `ui_display` fail for anyone running with
-  `VSync: 0`, on a golden that was correct. That is the expensive way for this to surface:
-  a divergence that looks exactly like a regression. `ctl_headless` pins
-  `--vsync on` alongside `--language` and `--resolution`. A new surface that prints a
-  setting needs the same treatment, or a golden nobody else can reproduce.
-- **`current.lba` thumbnail.** `ui_menu_main` renders a small save-thumbnail at the top
-  of the main menu that the engine reads from
-  `~/.local/share/Twinsen/LBA2/save/current.lba`, *not* from `--load`. That file evolves
-  on every play session. `test_ui_menu_main.sh` wraps its run in `with_menu_main_fixture`
-  (also in `lib.sh`), which copies the corpus `Anon1.LBA` into `current.lba`, runs the
-  test, and restores the original on EXIT.
+**`lib.sh` gives each test a `LBA2_USER_DIR` of its own** unless the test named one
+first, so the profile a fixture reads is one it just created rather than the one the
+developer plays with. That is what makes the goldens mean anything off this machine: they
+were captured against a fresh profile, so a fresh profile is what reproduces them. It is
+done in `lib.sh` rather than per test because the rule only holds if it cannot be
+forgotten: a new fixture is isolated by existing.
 
-If you add a new `ui_*` surface that touches `~/.local/share/Twinsen/LBA2/` for any
-reason, wrap its `ui_compare` call in `with_menu_main_fixture` or write a sibling
-helper following the same backup/restore-on-trap pattern.
+Measured after the language and resolution pins were in place, four keys still moved a
+capture, and each is the developer's own preference rather than anything a test set:
+
+| key | what it moved |
+|-----|---------------|
+| `DisplayFullScreen` | the Display submenu's `Fullscreen` / `Windowed` row |
+| `VSync` | the Display submenu's `Vsync ON` / `Vsync OFF` row |
+| `FollowCamera` | the projection corpus, every save |
+| `DetailLevel` | the projection corpus, every save |
+
+Chasing that list with one flag per key does not converge, since it grows with every
+setting the game gains. A folder of its own covers the keys nobody has thought of yet.
+
+`ctl_headless` still pins `--language English`, `--resolution 640x480` and `--vsync on`
+on top. Isolation makes the rest of the profile irrelevant; the pins state the values the
+goldens actually assume, so a capture that needs a different one says so on the command
+line instead of in whoever's settings happened to be there. `--language` in particular
+still does real work: a fresh profile inherits the install's layer, and a French install
+ships `Language: Français`.
+
+A fresh profile is not an empty one. It is engine defaults plus the install's layered
+`lba2.cfg`, which is where `DisplayFullScreen: 1` comes from, since the engine's own
+default for that key is `FALSE`. That layer is a separate problem: values in it become the
+player's own settings on first exit, which is #495.
 
 ### Adding a new UI surface — the family pattern
 

--- a/tests/automation/lib.sh
+++ b/tests/automation/lib.sh
@@ -36,6 +36,35 @@ fi
 
 : "${LBA2_TEST_TIMEOUT:=90}"
 
+# A folder of this test's own, unless the test named one first.
+#
+# The engine reads its settings from the player's lba2.cfg with the install's stacked
+# underneath, so a fixture that doesn't isolate is comparing against whatever the
+# developer plays with. Every key a surface displays or a camera consults is then an
+# input the golden never declared: FollowCamera and DetailLevel move the projection
+# corpus, DisplayFullScreen and VSync move the Display submenu. The goldens are all
+# reproducible from a fresh folder, which is the state they were captured in, so
+# handing each test one is what makes them mean anything on someone else's machine.
+#
+# Isolating here rather than per test because the rule only holds if it cannot be
+# forgotten: a new fixture is isolated by existing, not by remembering to say so.
+if [ -z "${LBA2_USER_DIR:-}" ]; then
+    LBA2_USER_DIR="$(mktemp -d -t "lba2-${TESTNAME:-auto}-XXXXXX")"
+    _LIB_OWNS_USER_DIR="$LBA2_USER_DIR"
+fi
+export LBA2_USER_DIR
+
+# A test that installs its own EXIT trap replaces this one, in which case the folder
+# is left under TMPDIR rather than removed. That is the harmless direction: those
+# tests name their own folder anyway, so there is usually nothing here to remove, and
+# a leaked temp dir costs less than a cleanup that fought the test's own restore.
+_lib_cleanup() {
+    local rc=$?
+    [ -n "${_LIB_OWNS_USER_DIR:-}" ] && rm -rf "$_LIB_OWNS_USER_DIR"
+    return $rc
+}
+trap _lib_cleanup EXIT
+
 SKIP_RC=77 # autotools convention: a skipped test
 
 # user_dir -- the folder the engine writes to for this run: saves, lba2.cfg,


### PR DESCRIPTION
Follow-up to #501, and the test-side half of #495.

## What a fixture actually reads

The engine takes its settings from the player's `lba2.cfg` with the install's
stacked underneath. So every key a surface displays, and every key a camera or
the sim consults, is an input the golden depends on without declaring. On
another machine those keys hold something else and the capture diverges, which
by the time you see it is a hash that looks exactly like a rendering regression.

#501 pinned one such key, `VSync`, because #448 named that row. Pinning the row
rather than auditing the surface was the wrong instinct: the Display submenu
prints two settings, and the second one was still leaking.

## Measured

With `--language`, `--resolution` and `--vsync` already pinned, sweeping 22
key/value pairs against four probes, four keys still moved a capture. None is set
by any test; each is just the developer's own preference.

| key | what it moved |
|-----|---------------|
| `DisplayFullScreen` | the Display submenu's `Fullscreen` / `Windowed` row |
| `VSync` | the Display submenu's `Vsync ON` / `Vsync OFF` row |
| `FollowCamera` | the projection corpus, every save |
| `DetailLevel` | the projection corpus, every save |

`AllCameras`, `Shadow`, `DitherShading`, `TextureFilter`, `MenuMouse`,
`FlagDisplayText`, `MouseCamera*`, `ReverseStereo`, `ConsoleToggleKey`,
`CompressSave` and the `FollowCam*` tuning family were inert against these probes.

## Why not another flag

`--follow-camera`, `--detail-level`, `--fullscreen` next to `--vsync` chases a
list that grows with every setting the game gains, and only ever covers the keys
someone already thought of.

`lib.sh` hands each test an `LBA2_USER_DIR` of its own instead, unless the test
named one first. The goldens were captured against a fresh profile, so a fresh
profile is what reproduces them. 14 fixtures already did this by hand; 31 did
not. Doing it in `lib.sh` rather than per test is the point: a new fixture is
isolated by existing, not by remembering.

The existing pins stay. Isolation makes the rest of the profile irrelevant; the
pins state the values the goldens assume, so a capture needing a different one
says so on the command line. `--language` still does real work in particular,
since a fresh profile inherits the install's layer and a French install ships
`Language: Français`.

## Verification

Under a profile holding `VSync: 0`, `DisplayFullScreen: 0`, `FollowCamera: 1`,
`FixedTimestep: 100`:

| | `ui_display` | `projection_corpus` | full suite |
|---|---|---|---|
| current `main` | FAIL | FAIL | |
| this branch | PASS | PASS | 43 passed, 2 skipped, 0 failed |

Same 43/2/0 from an empty profile, and the directory the suite was pointed at is
untouched afterwards, which is what proves the isolation took rather than merely
being set.

## Relationship to #495

A fresh profile is not an empty one. It is engine defaults plus the install's
layered `lba2.cfg`, which is where the golden's `DisplayFullScreen: 1` comes
from: the engine's own default for that key is `FALSE`. The committed golden is
baked against a value laundered through exactly the mechanism #495 describes.

That makes #448 and #495 the read side and the write side of one missing thing.
A config value carries no provenance, so the engine cannot tell "the player chose
it" from "the install layer supplied it" from "built-in default" from "a harness
flag pinned it". #495 needs that on the write path. This PR does not attempt it;
it stops the developer's own settings reaching a fixture, which is a test-side
concern and separable.
