### PR TITLE
fix(menu): keypad Enter confirms a save name instead of typing an X

### DIFF
--- a/LIB386/H/SYSTEM/KEYBOARD_KEYS.H
+++ b/LIB386/H/SYSTEM/KEYBOARD_KEYS.H
@@ -146,6 +146,15 @@
 
 #define A_SPACE SDLK_SPACE
 #define A_RETURN SDLK_RETURN
+#define A_NUMPAD_ENTER SDLK_KP_ENTER
+
+/* True when a keycode stands for a character. Keys that do not produce one --
+   Enter, the arrows, Home/End, the function row, the whole keypad -- carry
+   SDLK_SCANCODE_MASK instead, and the low byte underneath is an unrelated
+   letter: keypad Enter's is 'X', Up's is 'R', keypad 1's is 'Y'. Text entry
+   must ask this before treating a keycode as a character, because truncating
+   one to its low byte types that letter rather than doing nothing. */
+#define A_IS_CHARACTER(akey) (((akey) & SDLK_SCANCODE_MASK) == 0)
 
 #define A_SUPPR SDLK_DELETE
 #define A_INS SDLK_INSERT

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -1241,7 +1241,10 @@ S32 InputPlayerName(S32 choice, char *name) {
         do {
             akey = GetAscii();
 
-            if (!IsValidChar(akey))
+            /* The illegal-filename set is a set of characters, so only ask it
+               about keycodes that are one. A keycode carrying the scancode mask
+               would be tested on the unrelated letter in its low byte. */
+            if (A_IS_CHARACTER(akey) AND !IsValidChar(akey))
                 akey = 0;
 
             switch (akey) {
@@ -1251,7 +1254,10 @@ S32 InputPlayerName(S32 choice, char *name) {
                 flag = -1;
                 break;
 
+            /* Retail treats keypad Enter as a universal confirm here: it commits
+               the name whether or not the player has it bound to anything. */
             case A_RETURN:
+            case A_NUMPAD_ENTER:
                 if (IsDatetimeReservedShape(PlayerName)) {
                     // Reserved shape: refuse and bounce back to the prior name.
                     PlayErrorSample();
@@ -1280,7 +1286,13 @@ S32 InputPlayerName(S32 choice, char *name) {
                 break;
 
             default:
-                akey &= 0xFF;
+                /* Only a character belongs in the name. A keycode standing for
+                   any other key carries the scancode mask, and the low byte
+                   under it is an unrelated letter (keypad Enter's is 'X', Up's
+                   is 'R'), so such a key is dropped rather than truncated into
+                   the field. */
+                if (!A_IS_CHARACTER(akey))
+                    break;
 
                 /* Max input cursor X = original 550 = centre(320) + 230 px. Keep the
                    same 230 px half-width at any resolution so the name-entry field


### PR DESCRIPTION
Closes #497. Reported by EPmager against the 14 Aug build (99c99ab), Windows, retail GOG data.

Keypad Enter neither confirmed a save name nor left it alone: it typed a capital `X` into the field. Both halves come from one line.

## The bug

`InputPlayerName` reads keys through `GetAscii`, which returns an SDL *keycode*. Keys with no character behind them carry `SDLK_SCANCODE_MASK`, so keypad Enter arrives as `0x40000058` and misses the `A_RETURN` case, which is `0x0d`. It then fell through to:

```c
default:
    akey &= 0xFF;
    if (x < ... AND akey >= 32 AND akey <= 122) {
        PlayerName[len++] = (char)akey;
```

`0x40000058 & 0xFF` is `0x58`, which is `'X'`.

The truncation was never specific to that key. Every masked keycode landed in the same branch with a low byte inside the printable window:

| key | keycode | typed |
|---|---|---|
| Keypad Enter | `0x40000058` | `X` |
| Right / Up / Down | `0x4000004f` / `52` / `51` | `O` / `R` / `Q` |
| Insert / Home / End | `0x40000049` / `4a` / `4d` | `I` / `J` / `M` |
| Page Up / Page Down | `0x4000004b` / `4e` | `K` / `N` |
| Keypad 1 / 0 / + / - | `0x40000059` / `62` / `57` / `56` | `Y` / `b` / `W` / `V` |
| F2 | `0x4000003b` | `;` |

Left escaped only because it shares the backspace case, and Delete only because `0x7f` falls just outside the window.

## The fix

Three parts, 23 lines:

- `A_NUMPAD_ENTER` joins `A_RETURN` on the confirm case, matching retail, which commits the name on keypad Enter whether or not the player has it bound to anything.
- A new `A_IS_CHARACTER` in the `A_` alias header. The default arm asks it whether a keycode is a character at all, and drops the key if not, rather than truncating it to a letter. That is what stops the next non-ASCII key typing a different stray character.
- `IsValidChar` is consulted only for keycodes that are characters. It is a set of illegal *characters*, so feeding it a masked keycode tested the same unrelated low byte, and a keycode whose low byte happened to be `:` or `|` would end the input drain loop early for that frame.

Everything stays behind the `A_` aliases; no SDL identifiers enter `SOURCES/`.

## Why the rest of the menus were unaffected

Every other confirm site already pairs the two Enters (`SOURCES/GAMEMENU.CPP:1812` and `:2938`, `SOURCES/CONSOLE/CONSOLE.CPP:853`). Those read scancodes, where keypad Enter is simply a different scancode. `InputPlayerName` is the only confirm that is keycode-based, which is exactly why EPmager saw keypad Enter work as menu select everywhere except while naming a save.

`LIB386/MENU/MENUFUNC.CPP:283` has the same `case A_RETURN` shape in its `InputString` helper and is deliberately left alone: `LIB386/MENU/` is not in any `add_subdirectory`, so it is unbuilt reference code from the original in-house editor. That closes the open question in the issue.

## Verification

The classification was checked against every key in the table above, confirming each masked keycode is rejected and every real character still accepted. It is not shipped as a test: the outcome is a property of the SDL keycode constants rather than of our logic, and `InputPlayerName` itself needs the full menu stack, so there is nothing a unit test could hold onto. In keeping with `lifetrace` / `objtrace`, no test accompanies it.

`make test` passes (53/53) and `scripts/ci/check-format.sh` is clean.

One note for anyone touching `SOURCES/GAMEMENU.CPP`: both `check-format.sh` and `apply-format.sh` skip files with uncommitted changes, so neither sees a violation you have just written. Only the pre-commit hook, which checks the staged blob, caught the one in this change.
