### PR TITLE
ci: add ASan, clang and script lint gates, and disable type-based aliasing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,98 @@
+name: Lint
+
+# The non-C++ surface: the shell scripts that build, package and verify every
+# release, the Python that decodes game formats, and the workflow YAML that runs
+# all of it. Nothing checked any of it before this workflow, which is backwards:
+# these are the tools the C++ gates stand on.
+#
+# paths set (not paths-ignore, unlike the build workflows): the jobs here read
+# nothing else, so a C++ or docs change has no reason to spend a runner on them.
+on:
+  push:
+    paths: &lint-paths
+      - '**.sh'
+      - '**.py'
+      - '.github/workflows/**'
+      - '.shellcheckrc'
+      - 'ruff.toml'
+  pull_request:
+    paths: *lint-paths
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+# Versions are pinned rather than taken from the runner image or a floating
+# latest. A linter that changes its mind on someone else's release schedule
+# turns a green branch red for reasons nobody in this repo touched, and the
+# first thing that teaches contributors is to stop reading it.
+env:
+  SHELLCHECK_VERSION: '0.9.0'
+  ACTIONLINT_VERSION: '1.7.12'
+  RUFF_VERSION: '0.16.3'
+
+jobs:
+  # Rule selection and the two suppressions live in .shellcheckrc so a local run
+  # matches. Severity is the exception: shellcheck only takes it from the
+  # command line.
+  shellcheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v5
+
+      - name: Install shellcheck
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+            | tar -xJ -C "$HOME/.local/bin" --strip-components=1 "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/shellcheck" --version
+
+      - name: Lint shell scripts
+        run: git ls-files -z -- '*.sh' | xargs -0 shellcheck -S warning -f gcc
+
+  # actionlint shells out to shellcheck for the body of every `run:` block, so
+  # it needs the same pinned binary the job above uses. Without it the workflow
+  # shell would be checked by whatever version the runner image happens to ship.
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v5
+
+      - name: Install shellcheck and actionlint
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+            | tar -xJ -C "$HOME/.local/bin" --strip-components=1 "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
+          curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            | tar -xz -C "$HOME/.local/bin" actionlint
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/actionlint" --version
+
+      - name: Lint workflows
+        run: actionlint -color
+
+  # Rule selection lives in ruff.toml, pinned there for the same reason the
+  # version is pinned here.
+  ruff:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v5
+
+      - name: Install ruff
+        run: |
+          pipx install "ruff==${RUFF_VERSION}"
+          ruff --version
+
+      - name: Lint Python scripts
+        run: git ls-files -z -- '*.py' | xargs -0 ruff check --no-cache --output-format=concise

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -87,6 +87,48 @@ jobs:
       - name: Verify Binary
         run: test -f build/SOURCES/lba2cc && echo "Build successful"
 
+  # The same sources through a second front end. gcc and clang disagree about
+  # enough C++98 corners that gcc accepting a change is not evidence clang will,
+  # and the only other clang in the matrix is AppleClang on the macOS leg, where
+  # a front-end break reads as a platform failure and gets diagnosed as one.
+  # The linux_clang preset already existed for local warning comparisons;
+  # nothing ran it.
+  build-clang:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v5
+
+      - name: Install SDL3
+        uses: libsdl-org/setup-sdl@4ebea449684c989388fe6bcea0460e300d13a5ae # main @ 2025-12-20
+        id: sdl
+        with:
+          install-linux-dependencies: true
+          version: 3-latest
+          build-type: ${{ env.BUILD_TYPE }}
+
+      - name: Configure
+        run: |
+          cmake -S . -B build-clang \
+            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+            -DCMAKE_PREFIX_PATH="${{ steps.sdl.outputs.prefix }}" \
+            -DLBA2_BUILD_TESTS=ON \
+            -DLBA2_BUILD_ASM_EQUIV_TESTS=OFF \
+            --preset linux_clang
+
+      - name: Build
+        run: |
+          cmake --build build-clang --target lba2cc
+          cmake --build build-clang --target host_tests
+
+      - name: Host tests
+        run: cd build-clang && ctest -L host_quick --output-on-failure
+
+      - name: Verify Binary
+        run: test -f build-clang/SOURCES/lba2cc && echo "Clang build successful"
+
   # AddressSanitizer over the same host tests the build job runs. The suite was
   # already clean when this job was added, so it can only ever fail on something
   # new: a heap overflow, a use-after-free, or a leak introduced by a change.

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -87,6 +87,47 @@ jobs:
       - name: Verify Binary
         run: test -f build/SOURCES/lba2cc && echo "Build successful"
 
+  # AddressSanitizer over the same host tests the build job runs. The suite was
+  # already clean when this job was added, so it can only ever fail on something
+  # new: a heap overflow, a use-after-free, or a leak introduced by a change.
+  # That also makes it a host stand-in for Android MTE, which is what the
+  # linux_sanitize preset was written for.
+  #
+  # host_tests only, not lba2cc. The build job already proves the game target
+  # compiles, and nothing here can run it without retail data, so a second full
+  # link buys no coverage. The tests themselves take about three seconds.
+  sanitize:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v5
+
+      - name: Install SDL3
+        uses: libsdl-org/setup-sdl@4ebea449684c989388fe6bcea0460e300d13a5ae # main @ 2025-12-20
+        id: sdl
+        with:
+          install-linux-dependencies: true
+          version: 3-latest
+          build-type: ${{ env.BUILD_TYPE }}
+
+      # No -DCMAKE_BUILD_TYPE here: the preset pins Debug, and passing Release
+      # would strip the frame pointers ASan needs for a readable stack.
+      - name: Configure
+        run: |
+          cmake -S . -B build-asan \
+            -DCMAKE_PREFIX_PATH="${{ steps.sdl.outputs.prefix }}" \
+            -DLBA2_BUILD_TESTS=ON \
+            -DLBA2_BUILD_ASM_EQUIV_TESTS=OFF \
+            --preset linux_sanitize
+
+      - name: Build
+        run: cmake --build build-asan --target host_tests
+
+      - name: Host tests under AddressSanitizer
+        run: cd build-asan && ctest -L host_quick --output-on-failure
+
   # The demo SKU compiles a different set of sources: ~60 #ifdef DEMO sites the
   # default build never touches. That is exactly how it silently stopped
   # compiling between 1997 and the LBA2_BUILD_DEMO option, so an edit to the

--- a/.github/workflows/reusable-build-android.yml
+++ b/.github/workflows/reusable-build-android.yml
@@ -143,7 +143,7 @@ jobs:
               -DSDL_TEST=OFF \
               -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384"
 
-            cmake --build "$SDL3_BUILD" -- -j$(nproc)
+            cmake --build "$SDL3_BUILD" -- -j"$(nproc)"
             cmake --install "$SDL3_BUILD" --prefix "$SDL3_INSTALL"
           else
             echo "SDL3 restored from cache: ${SDL3_INSTALL}"
@@ -162,7 +162,7 @@ jobs:
 
       - name: Build LBA2 native library
         run: |
-          cmake --build --preset ${{ matrix.preset }} -- -j$(nproc) 2>&1
+          cmake --build --preset ${{ matrix.preset }} -- -j"$(nproc)" 2>&1
 
       - name: Bundle APK
         run: |
@@ -189,7 +189,7 @@ jobs:
       - name: Verify 16 KB page alignment (arm64-v8a)
         if: matrix.arch == 'arm64-v8a'
         run: |
-          APK=$(ls dist/*-arm64-v8a.apk | head -1)
+          APK=$(find dist -maxdepth 1 -name '*-arm64-v8a.apk' | sort | head -1)
           bash scripts/dev/check-16k-align.sh "$APK"
 
       - name: Upload temporary artifact

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ out/
 build/
 # Demo SKU: a separate configure, so a second tree beside build/ (GAME_DATA.md)
 build-demo/
+# AddressSanitizer host tests: linux_sanitize is a different build type again
+build-asan/
 dist/
 
 # Local retail drop (symlink or copy classic data here; never commit assets)

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ build/
 build-demo/
 # AddressSanitizer host tests: linux_sanitize is a different build type again
 build-asan/
+# Second front end: linux_clang, kept beside build/ so both stay warm
+build-clang/
 dist/
 
 # Local retail drop (symlink or copy classic data here; never commit assets)

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,19 @@
+# shellcheck settings for this repo.
+#
+# Kept here rather than as flags on the CI invocation so that running
+# `shellcheck scripts/dev/whatever.sh` by hand reports what the Lint workflow
+# reports. The one exception is severity, which shellcheck only takes from the
+# command line: CI passes `-S warning`, so add that locally to match. See
+# docs/CI.md.
+#
+# Info and style findings stay out of the gate. Clearing them would be a
+# rewrite of 65 scripts rather than a lint; raise the bar once that backlog is
+# worth working through.
+
+# SC1091 (cannot follow sourced file): the sourced paths are computed at run
+# time, so a static check cannot resolve them.
+#
+# SC2034 (variable appears unused): the control-harness tests set TESTNAME and
+# friends for tests/automation/lib.sh to read after the source. Checked one file
+# at a time, every one of those reads as a dead assignment.
+disable=SC1091,SC2034

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,19 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
     endif()
 endif()
 
+# Type-based alias analysis has to stay off. The 1997 sources read a struct
+# field back through a pointer of another type to get at its packed halves --
+# `*(U32 *)&current->V_MapU` in the polygon clipper, the same shape in the
+# object renderer and the HQR loader. Watcom defined that; ISO C++ does not, so
+# gcc and clang are entitled to reorder or fold those loads once optimisation is
+# on, and Release builds here run at -O2 or above with LTO. Eleven sites do it,
+# spread across the code least tolerant of a silent codegen change, so the build
+# opts out rather than rewriting them one at a time. The flag costs almost
+# nothing on this workload.
+if(NOT MSVC)
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-fno-strict-aliasing>)
+endif()
+
 if(LBA2_NATIVE_ARCH)
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64|i[3-6]86")
         add_compile_options(-march=native)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -44,7 +44,7 @@
       "name": "linux_clang",
       "inherits": "linux",
       "displayName": "Linux (Clang)",
-      "description": "Same as linux but with clang/clang++ — use locally to compare warnings vs GCC (not CI default).",
+      "description": "Same as linux but with clang/clang++. Runs in CI as the build-clang job, and locally to compare warnings against GCC.",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++"

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -19,7 +19,7 @@ ties both tiers together — path filtering, the docs-only gate, and the
 
 | Workflow | Tier | Trigger | Job(s) | What it does |
 |---|---|---|---|---|
-| `linux.yml` | Validation | push, PR, dispatch | `build` | Configure (`linux` preset), build `lba2cc` + `host_tests`, run `ctest -L host_quick` |
+| `linux.yml` | Validation | push, PR, dispatch | `build`, `build-demo`, `sanitize` | Configure (`linux` preset), build `lba2cc` + `host_tests`, run `ctest -L host_quick`; the same for the demo SKU; and the host tests once more under AddressSanitizer |
 | `macos.yml` | Validation | push, PR, dispatch | `build` | Same, on `macos-latest` (`macos_arm64` preset) |
 | `windows.yml` | Validation | push, PR, dispatch | `build` | Same, on Windows MSYS2 UCRT64 (`windows_ucrt64` preset) |
 | `test.yml` | Validation | push, PR, dispatch | `test` | Docker: `./run_tests_docker.sh` — full ASM↔C++ equivalence suite (Linux only, slow) |
@@ -33,6 +33,13 @@ ties both tiers together — path filtering, the docs-only gate, and the
 Host build jobs (`linux`/`macos`/`windows`) need neither retail game
 files nor Docker. The Docker job (`test.yml`) builds a 32-bit UASM image
 and replays polyrec captures; it does not run the host discovery tests.
+
+`linux.yml`'s `sanitize` job re-runs the host tests against the
+`linux_sanitize` preset. The suite was clean under AddressSanitizer when
+the job landed, so a red result there means a change introduced a heap
+overflow, a use-after-free, or a leak. It builds `host_tests` only: the
+`build` job already covers the game target, and no CI job has the retail
+data needed to run it.
 
 ## Triggers: push and pull request
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -19,11 +19,12 @@ ties both tiers together — path filtering, the docs-only gate, and the
 
 | Workflow | Tier | Trigger | Job(s) | What it does |
 |---|---|---|---|---|
-| `linux.yml` | Validation | push, PR, dispatch | `build`, `build-demo`, `sanitize` | Configure (`linux` preset), build `lba2cc` + `host_tests`, run `ctest -L host_quick`; the same for the demo SKU; and the host tests once more under AddressSanitizer |
+| `linux.yml` | Validation | push, PR, dispatch | `build`, `build-clang`, `build-demo`, `sanitize` | Configure (`linux` preset), build `lba2cc` + `host_tests`, run `ctest -L host_quick`; the same through clang and for the demo SKU; and the host tests once more under AddressSanitizer |
 | `macos.yml` | Validation | push, PR, dispatch | `build` | Same, on `macos-latest` (`macos_arm64` preset) |
 | `windows.yml` | Validation | push, PR, dispatch | `build` | Same, on Windows MSYS2 UCRT64 (`windows_ucrt64` preset) |
 | `test.yml` | Validation | push, PR, dispatch | `test` | Docker: `./run_tests_docker.sh` — full ASM↔C++ equivalence suite (Linux only, slow) |
 | `format.yml` | Validation | push, PR, dispatch | `check-format` | `scripts/ci/check-format.sh` (clang-format) |
+| `lint.yml` | Validation | push, PR (shell/Python/workflow paths), dispatch | `shellcheck`, `actionlint`, `ruff` | Lints the non-C++ surface. Settings live in `.shellcheckrc` and `ruff.toml`; tool versions are pinned in the workflow |
 | `pr-title.yml` | Validation | PR | `lint` | Conventional-commit lint on the PR title |
 | `docs-gate.yml` | Validation | push, PR | `build`, `test` | No-op stand-ins for the required `build`/`test` checks on docs-only changes — see [below](#docs-only-gate) |
 | `release-*.yml` | Release | `v*` tags, dispatch | `build` → `release` | Per-platform tag releases |

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,16 @@
+# ruff settings for the scripts under scripts/ and tests/.
+#
+# The selection is pinned rather than left at ruff's default, because that
+# default has grown between releases: taking it as given means a ruff upgrade
+# can turn a branch red without anyone here changing a line.
+
+[lint]
+# F is pyflakes: undefined names, unused imports, unused locals, f-strings with
+# nothing to interpolate. E9 is the errors that stop a file being parsed at all.
+# Both find bugs.
+#
+# The style rules (E4/E7 spacing and statement layout, line length, import
+# order) stay out on purpose. This repo has never adopted a Python formatter,
+# and the dev scripts lean on dense one-liners while decoding a format; turning
+# those rules on would be a reformat, not a lint.
+select = ["F", "E9"]

--- a/scripts/dev/acf_decode.py
+++ b/scripts/dev/acf_decode.py
@@ -18,7 +18,7 @@ relative motion, 8x8 and 4x4) plus optional residual 'update' passes.
 Usage:
   acf_decode.py <file.acf> [--frame N] [--out OUT.png] [--all DIR]
 """
-import struct, sys, argparse, importlib.util
+import struct, argparse, importlib.util
 from PIL import Image
 
 _spec = importlib.util.spec_from_file_location("acf", __file__.replace("acf_decode.py","acf_inspect.py"))
@@ -271,8 +271,10 @@ class Frame:
                 nonlocal ui, flag, last
                 if flag: last = pad[ui] >> 4; flag = 0; ui += 1
                 else: last = pad[ui] & 15; flag += 1
-            base_ui = ui  # bank byte already read at ui; advance past it lazily like C
-            # C reads bank from *unaligned_stream (no advance) then nibbles advance; trailing fixup
+            # bank byte already read at ui; advance past it lazily like C, which
+            # reads bank from *unaligned_stream (no advance) then lets the nibbles
+            # advance, with a trailing fixup
+
             ui += 0
             def emit(setter):
                 nonlocal flag
@@ -306,7 +308,6 @@ class Frame:
                 if flag[0]: last = pad[ui] >> 4; flag[0] = 0; ui += 1
                 else: last = pad[ui] & 15; flag[0] += 1
             # bank uses pad[start_ui]; nibbles read from start_ui (same byte!) — matches C aliasing
-            seq = []
             if order in ('h','v'):
                 outer = range(8)
                 for o in outer:

--- a/scripts/dev/acf_inspect.py
+++ b/scripts/dev/acf_inspect.py
@@ -14,7 +14,7 @@ Chunks are contiguous (next tag immediately follows the previous payload).
 Usage:
   acf_inspect.py <file.acf> [--max N] [--dump-palette OUT] [--dump TAG:N OUT]
 """
-import struct, sys, argparse
+import struct, argparse
 from collections import Counter
 
 def walk(data):

--- a/scripts/dev/build-android.sh
+++ b/scripts/dev/build-android.sh
@@ -70,7 +70,7 @@ cmake -S "${REPO_DIR}" -B "${BUILD_DIR}" \
     -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384"
 
 # ---- Step 2: Build native library ----------------------------------------
-cmake --build "${BUILD_DIR}" -- -j$(nproc)
+cmake --build "${BUILD_DIR}" -- -j"$(nproc)"
 
 echo ""
 echo "=== Native library built ==="

--- a/scripts/dev/build-sdl3-android.sh
+++ b/scripts/dev/build-sdl3-android.sh
@@ -52,7 +52,7 @@ cmake -S "${SDL3_SRC}" -B "${SDL3_BUILD}" -G Ninja \
     -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384"
 
 # Build
-cmake --build "${SDL3_BUILD}" -- -j$(nproc)
+cmake --build "${SDL3_BUILD}" -- -j"$(nproc)"
 
 # Install
 cmake --install "${SDL3_BUILD}" --prefix "${SDL3_INSTALL}"

--- a/scripts/dev/flow_dump.py
+++ b/scripts/dev/flow_dump.py
@@ -23,7 +23,6 @@ def main():
     assert len(d) % REC.size == 0, f"{len(d)} not a multiple of {REC.size}"
     n = len(d) // REC.size
     print(f"{len(d)} bytes, {n} flows ({REC.size} bytes each)")
-    used = {}
     for i in range(n):
         v = REC.unpack_from(d, i * REC.size)
         s16s, coul, rng, flags = v[:15], v[15], v[16], v[17]

--- a/scripts/dev/hqr_inspect.py
+++ b/scripts/dev/hqr_inspect.py
@@ -11,7 +11,7 @@ HQR format (see LIB386/SYSTEM/HQFILE.CPP, HQR.H):
 Usage:
   hqr_inspect.py <file.hqr> [--entry N] [--limit N] [--dump OUT]
 """
-import struct, sys, argparse
+import struct, argparse
 
 def expand_lz(src, decomp_size, min_bloc):
     """Port of ExpandLZ (LIB386/SYSTEM/LZ.CPP). min_bloc = CompressMethod + 1."""

--- a/scripts/dev/iso_bin.py
+++ b/scripts/dev/iso_bin.py
@@ -30,7 +30,7 @@ Examples:
   iso_bin.py LBA2.GOG --tree | grep -i '\\.HQR$'
   iso_bin.py GAME.GOG --extract /STAGE00/RUN0/SCENE.HQR out.hqr
 """
-import struct, sys, argparse
+import struct, argparse
 
 SECTOR = 2352
 USER = 2048
@@ -96,7 +96,7 @@ def parse_dir_records(data):
                 break
             i = nxt
             continue
-        ext_attr = data[i + 1]
+        _ext_attr = data[i + 1]  # extended attribute length, unused by this reader
         lba = struct.unpack_from("<I", data, i + 2)[0]
         size = struct.unpack_from("<I", data, i + 10)[0]
         flags = data[i + 25]

--- a/scripts/dev/lba1_bkg_repack.py
+++ b/scripts/dev/lba1_bkg_repack.py
@@ -118,8 +118,8 @@ def main():
            "Brk_Start": brk_start, "Max_Brk": brks}
     print(f"  synthesized T_BKG_HEADER: Gri_Start={gri_start} Grm_Start={grm_start} "
           f"Bll_Start={bll_start} Brk_Start={brk_start} Max_Brk={brks} (total {total} entries)")
-    print(f"  per-grid T_GRI_HEADER: My_Bll = grid index (style N <-> grid N), My_Grm = none, "
-          f"UsedBlock[32] = computed from the grid's block usage")
+    print("  per-grid T_GRI_HEADER: My_Bll = grid index (style N <-> grid N), My_Grm = none, "
+          "UsedBlock[32] = computed from the grid's block usage")
     # validate the arithmetic + a sample resolution
     ok_layout = (gri_start <= grm_start <= bll_start <= brk_start < total
                  and brk_start == grids + 0 + blls and syn["Max_Brk"] == brks)

--- a/scripts/packaging/bundle-android.sh
+++ b/scripts/packaging/bundle-android.sh
@@ -180,8 +180,9 @@ if [[ -n "$ALL_JAVA_FILES" && -x "$D8" ]]; then
     javac -d "$STAGING/obj" \
         -classpath "$SDK_ROOT/platforms/android-34/android.jar" \
         $ALL_JAVA_FILES 2>&1
+    mapfile -t CLASS_FILES < <(find "$STAGING/obj" -name '*.class')
     "$D8" --lib "$SDK_ROOT/platforms/android-34/android.jar" \
-        --output "$STAGING" $(find "$STAGING/obj" -name '*.class') 2>&1
+        --output "$STAGING" "${CLASS_FILES[@]}" 2>&1
     rm -rf "$STAGING/obj"
 fi
 

--- a/tests/SNAPSHOT/bisect_polyrec.sh
+++ b/tests/SNAPSHOT/bisect_polyrec.sh
@@ -16,7 +16,7 @@ CPP_BIN="${3:-./replay_polyrec_cpp}"
 
 ASM_OUT=$(mktemp /tmp/polyrec_bisect_asm_XXXXXX.raw)
 CPP_OUT=$(mktemp /tmp/polyrec_bisect_cpp_XXXXXX.raw)
-trap "rm -f '$ASM_OUT' '$CPP_OUT'" EXIT
+trap 'rm -f "$ASM_OUT" "$CPP_OUT"' EXIT
 
 # Helper: replay N draw calls and compare
 compare_at() {

--- a/tests/SNAPSHOT/compare_polyrec.sh
+++ b/tests/SNAPSHOT/compare_polyrec.sh
@@ -13,7 +13,7 @@ CPP_BIN="${3:-./replay_polyrec_cpp}"
 
 ASM_OUT=$(mktemp /tmp/polyrec_asm_XXXXXX.raw)
 CPP_OUT=$(mktemp /tmp/polyrec_cpp_XXXXXX.raw)
-trap "rm -f '$ASM_OUT' '$CPP_OUT'" EXIT
+trap 'rm -f "$ASM_OUT" "$CPP_OUT"' EXIT
 
 echo "=== Polygon recording replay comparison ==="
 echo "Recording: $REC"

--- a/tests/automation/camlib.sh
+++ b/tests/automation/camlib.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Shared helpers for the follow-camera fixtures.
 #
 # The Auto camera is analog, so what needs asserting is rarely a single end state: it is the

--- a/tests/automation/lib.sh
+++ b/tests/automation/lib.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Shared helpers for the CLI control-harness tests.
 #
 # These drive the real engine binary, so they need retail game data and a display.
@@ -239,7 +240,7 @@ seed_menu_save_dir() {
 # An empty LBA2_TEST_SAVE runs without --load, for the one surface whose subject
 # is the absence of a save: the main menu a new install shows.
 ui_compare() {
-    local args="" golden="" out= shaA shaB rc=0
+    local args="" golden="" out="" shaA shaB rc=0
     while [ $# -gt 1 ]; do args="${args:+$args }$1"; shift; done
     golden="$1"
     out="$(mktemp -t "${TESTNAME:-ui}.XXXXXX.png")"
@@ -286,7 +287,7 @@ ui_compare() {
 # truth, there is no per-width golden to regenerate.
 ui_compare_wide() {
     local res="$1"; shift
-    local args="" golden="" out= py_rc
+    local args="" golden="" out="" py_rc
     while [ $# -gt 1 ]; do args="${args:+$args }$1"; shift; done
     golden="$1"
     python3 -c "from PIL import Image" 2>/dev/null \

--- a/tests/automation/test_exec.sh
+++ b/tests/automation/test_exec.sh
@@ -3,7 +3,7 @@
 # command splitting. NOTE: only non-modal commands work headless — commands that open
 # a cinematic/video/dialogue (give <item>, playvideo, credits, slide) block a --exit run
 # because nothing dismisses them. `cube` and `give clover` are non-modal.
-TESTNAME=exec
+TESTNAME="exec"
 . "$(dirname "$0")/lib.sh"
 precheck
 need_save


### PR DESCRIPTION
## What & why

Three of the analysis tools this repo needs were already configured and never ran: `.clang-tidy` with its runner script, the `linux_sanitize` (ASan) preset, and the `linux_clang` preset. Nothing checked the 66 shell scripts, 24 Python scripts or 18 workflow files at all. This turns on the cheap half of that list and fixes what it found.

Three commits, each self-contained.

### `build: disable type-based alias analysis`

Release presets build at `-O2` or above with LTO and strict aliasing on, while eleven sites type-pun through a pointer cast to reach a field's packed halves: `*(U32 *)&current->V_MapU` in `POLYCLIP.CPP`, the same shape in `AFF_OBJ.CPP` and `HQRRESS.CPP`. Watcom defined that, ISO C++ does not, so gcc and clang are entitled to reorder or fold those loads. The exposure sits in the polygon clipper and the object renderer, which is the code least tolerant of a silent codegen change.

`-fno-strict-aliasing` only removes optimisations, so it cannot introduce a behaviour change that was not already resting on undefined behaviour.

### `ci(linux): run the host tests under AddressSanitizer`

New `sanitize` job on the existing preset. The suite was already clean under ASan when this landed, so the job costs no cleanup and can only go red on a heap overflow, use-after-free or leak that a change introduces. It builds `host_tests` and not `lba2cc`: the `build` job already covers the game target, and no CI job has the retail data to run it.

### `ci: lint the shell, Python and workflows, and build through clang`

New `Lint` workflow with `shellcheck`, `actionlint` and `ruff` jobs, plus a `build-clang` job on the existing preset. Settings live in `.shellcheckrc` and `ruff.toml` so a local run matches CI.

25 findings fixed so the gates are green on arrival:

| Tool | Fixed |
|---|---|
| shellcheck (12) | unquoted `$(nproc)`, traps expanding filenames at definition time instead of on signal, `local out=` with a trailing space, and both sourced libraries under `tests/automation` declaring no shell, which left shellcheck unable to analyse either at all |
| actionlint (3) | two `$(nproc)` quotings and an `ls`-parse in `reusable-build-android.yml` |
| ruff (10) | four unused `sys` imports, four dead locals, two f-strings with nothing to interpolate |

The gate has already earned its keep once: rebasing onto current `main` brought in `tests/automation/camlib.sh` from #512, which lands with the same missing shell directive `lib.sh` had. That is the ratchet working on the first try.

One of those is more than lint appeasement: the `d8` call in `bundle-android.sh` passed an unquoted `$(find ...)`, which split on any class path containing a space. It now collects into an array.

## Notes for reviewers

**Two suppressions, documented rather than fixed.** `SC1091` because the sourced paths are computed at run time, and `SC2034` because the control-harness tests set `TESTNAME` for `lib.sh` to read after the source, which reads as a dead assignment one file at a time. Ruff pins its selection to `F` and `E9` rather than tracking its default set, which has grown between releases. The Python style rules stay out: this repo has never adopted a formatter, and switching them on would be a reformat rather than a lint.

**Linter versions are pinned.** A gate that changes its mind on someone else's release schedule reddens a branch nobody touched, and the first thing that teaches contributors is to stop reading it.

**None of the new checks are required** by the ruleset, so nothing here can block a merge until someone decides it should.

**Deliberately not in this PR**, in rough order of value:

- `-Wall -Wextra` behind a checked-in baseline. 446 unique diagnostics today, 220 after suppressing `-Wunknown-pragmas` (138, all Watcom `#pragma aux`), `-Wunused-parameter` (72) and `-Wmissing-field-initializers` (10). Removing lines from that baseline is the unit of incremental cleanup.
- Triage of roughly 24 high-signal findings the tools already surface: 11 `-Wmaybe-uninitialized` including two on the compressed-save path, 4 signed-shift-by-31 in `POLYLINE.CPP`, a union read/write overlap in `INTERDEP.CPP`, and `INVENT.CPP:769` indexing `TabInv[numinv]` outside the `FLAG_DONT_USE` guard that protects the line above it.
- clang-tidy as a diff-scoped gate. Needs `cert-msc30/50` (the shared `rand()` stream) and `cert-err34-c` suppressed at config level first, or it fires 84 times on deliberate 1997 idiom.
- UBSan, a coverage map, and fuzz targets for the HQR / ISO9660 / save parsers.

## Checklist

- [x] Build passes on my platform (Linux): gcc Release and the clang preset each build `lba2cc` + `host_tests` with 54/54 `host_quick` passing, and 54/54 pass again under ASan with no sanitizer reports
- [x] If LIB386 / 3DEXT touched: ASM equivalence tests pass (`./run_tests_docker.sh`). No usable container runtime on my box, so this is the required `test` check passing on this branch rather than a local run. It is the check that matters for the aliasing flag, since that changes codegen for every LIB386 translation unit
- [x] If behavior changes: none intended, `-fno-strict-aliasing` only removes optimisations
- [x] Docs updated in the same PR: `docs/CI.md` workflow map, and the `linux_clang` preset description
- [x] French comments and ASCII art preserved in any modified files