### PR TITLE
test(camera): pin the two shapes a camera zone comes in

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -1963,10 +1963,23 @@ static void cmd_zonelist(int argc, const char *argv[]) {
             continue;
         int inside = ZonePointInBox(hero->Obj.X, hero->Obj.Y, hero->Obj.Z, ptrz->X0, ptrz->Y0,
                                     ptrz->Z0, ptrz->X1, ptrz->Y1, ptrz->Z1);
-        Console_Print("  [%2d] %-8s Num=%-4d box=(%d,%d,%d)-(%d,%d,%d) info=%d,%d,%d,%d%s",
+        /* Info7 is the flag word that decides whether a zone does anything, and for a camera
+           zone it decides how often: ZONE_ON is the enable, ZONE_OBLIGATOIRE re-aims the camera
+           every frame the hero is inside, and without it the zone fires once and latches
+           ZONE_ACTIVE until he leaves. Printing the raw byte as well as the names, since a zone
+           may carry bits this does not name. */
+        char flags[64];
+        snprintf(flags, sizeof(flags), "%s%s%s%s",
+                 (ptrz->Info7 & ZONE_INIT_ON) ? "init_on " : "",
+                 (ptrz->Info7 & ZONE_ON) ? "on " : "",
+                 (ptrz->Info7 & ZONE_ACTIVE) ? "active " : "",
+                 (ptrz->Info7 & ZONE_OBLIGATOIRE) ? "forced " : "");
+
+        Console_Print("  [%2d] %-8s Num=%-4d box=(%d,%d,%d)-(%d,%d,%d) info=%d,%d,%d,%d flags=0x%02x %s%s",
                       (int)n, ZoneTypeName(ptrz->Type), (int)ptrz->Num, (int)ptrz->X0, (int)ptrz->Y0,
                       (int)ptrz->Z0, (int)ptrz->X1, (int)ptrz->Y1, (int)ptrz->Z1, (int)ptrz->Info0,
-                      (int)ptrz->Info1, (int)ptrz->Info2, (int)ptrz->Info3, inside ? "  <-- HERO" : "");
+                      (int)ptrz->Info1, (int)ptrz->Info2, (int)ptrz->Info3, (unsigned)ptrz->Info7,
+                      flags, inside ? " <-- HERO" : "");
     }
 }
 

--- a/tests/automation/camlib.sh
+++ b/tests/automation/camlib.sh
@@ -46,7 +46,13 @@ cam_run() {
 cam_tsv() {
     python3 - "$1" <<'PY'
 import sys
-KEYS = ("heroBeta", "add", "beta", "target", "step", "delay", "orbit", "moving")
+# Every field the trace carries. Values are taken from the token after their label, so the order
+# here is the column order and not an assumption about the line, but a field the trace emits and
+# this does not name is simply invisible to the fixtures: a query for it comes back empty and
+# reads as "the thing never happened" rather than as an error. Keep this in step with the
+# Log_Info call in PERSO.CPP.
+KEYS = ("heroBeta", "add", "beta", "target", "step", "delay", "orbit", "moving",
+        "zone", "forced", "cine", "follow", "ext", "vue", "alpha", "dist")
 print("\t".join(KEYS))
 for line in open(sys.argv[1], errors="replace"):
     if not line.startswith("[INFO] [cam]"):

--- a/tests/automation/test_camzone_model.sh
+++ b/tests/automation/test_camzone_model.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Camera zones come in two shapes, and the difference is a flag in the authored data.
+#
+# A zone carrying ZONE_OBLIGATOIRE re-aims the camera on every frame the hero is inside it, so it
+# holds the view for as long as he stays. Without that flag the dispatch latches ZONE_ACTIVE after
+# the first fire and does not fire again, so the zone re-aims the camera once on entry and then
+# leaves it alone; leaving the box clears the latch, so walking back in re-aims it again. Both
+# shapes are in the shipped data and the non-forced one is by far the more common, so a fixture
+# that only ever saw a forced zone would be describing the exception.
+#
+# Constructed rather than found: `cube` moves to a scene known to hold each shape and `teleport`
+# puts the hero in and out of the box, so neither case depends on a save being parked somewhere
+# particular.
+#
+# Local-only (needs retail data + the tracked corpus save). Not in host_quick CI.
+TESTNAME=camzone_model
+. "$(dirname "$0")/lib.sh"
+. "$(dirname "$0")/camlib.sh"
+cam_precheck
+
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+# zone_frames <log> -- how many frames a camera zone re-aimed the camera on, and the longest
+# unbroken run of them. A forced zone gives one long run; a latching one gives single frames.
+zone_frames() {
+    cam_col "$1" zone | awk '
+        { if ($1 == 1) { total++; run++; if (run > best) best = run } else run = 0 }
+        END { print total + 0, best + 0 }'
+}
+
+# --- forced: cube 97 zone 1, flags 0x0b, holds the view while the hero is inside -------------
+ctl_headless --load "$CAM_SAVE" --fixed-dt 16 \
+    --exec "cam_follow 1; camtrace 1" \
+    --exec-at 20 "teleport 15000 1000 21000" \
+    --tick 120 --exit > "$log" 2>&1 || fail "forced-zone run: exit $?"
+
+read -r total best < <(zone_frames "$log")
+[ "$total" -gt 0 ] || fail "forced camera zone never engaged: the teleport missed the box"
+[ "$best" -ge 30 ] \
+    || fail "forced camera zone held the view for only $best consecutive frames (expected it to hold throughout)"
+
+forced_total="$total"
+
+# --- latching: cube 90 zone 48, flags 0x03, fires once per entry ------------------------------
+# Out of the box, back in, out and back in again: two entries, so a zone that re-arms on leaving
+# is distinguishable from one that simply fired once and stopped.
+ctl_headless --load "$CAM_SAVE" --fixed-dt 16 \
+    --exec "cube 90" \
+    --exec-at 15 "cam_follow 1; camtrace 1" \
+    --exec-at 40 "teleport 18000 3900 8000" \
+    --exec-at 70 "teleport 13000 4000 8000" \
+    --exec-at 100 "teleport 18000 3900 8000" \
+    --exec-at 130 "teleport 13000 4000 8000" \
+    --tick 190 --exit > "$log" 2>&1 || fail "latching-zone run: exit $?"
+
+read -r total best < <(zone_frames "$log")
+
+[ "$total" -ge 2 ] \
+    || fail "latching camera zone fired $total time(s) across two entries: leaving does not re-arm it"
+[ "$best" -eq 1 ] \
+    || fail "latching camera zone held the view for $best consecutive frames (expected one per entry)"
+
+pass "forced zone held $forced_total frames; latching zone fired $total times, longest run $best"


### PR DESCRIPTION
Step 2 of #513: settle how camera zones actually behave, and pin it.

## The model

A camera zone comes in two shapes, decided by `Info7`:

- **`ZONE_OBLIGATOIRE`** re-aims the camera on every frame the hero is inside the box, so it holds the view for as long as he stays.
- **Without it**, the dispatch latches `ZONE_ACTIVE` after the first fire and does not fire again, so the zone re-aims the camera once on entry and then leaves it alone. Leaving the box clears the latch (`OBJECT.CPP`, the branch for the hero being outside), so walking back in re-aims it again.

`ZONE_ON` is the enable, set at scene load from `ZONE_INIT_ON`. A zone without it never fires at all.

Measured: a forced zone held the view for 96 consecutive frames; a latching zone fired exactly twice across two entries, one frame each. `test_camzone_model.sh` constructs both with `cube` and `teleport` rather than depending on a save being parked somewhere particular.

The non-forced shape is the common one. Across a dozen cubes only one scene's camera zones carried the flag, so a fixture that met a forced zone first would be describing the exception.

## zonelist prints Info7

The one field it withheld was the one that decides all of the above. It now prints the raw byte and names the bits.

That also explains an oddity that had this model wrong twice from source alone: the camera zone the corpus save sits in carries `ZONE_OBLIGATOIRE` but not `ZONE_ON`, so it never fires, and the camera behaves as though the hero were nowhere near it.

## camlib learns the new fields

`camtrace` gained fields when it moved to the main loop in #517, and `camlib.sh` was not updated with it. A name it does not carry is not an error: the query comes back empty, which reads in a fixture as the thing never having happened. The zone fixture's first run duly reported that a zone it had just walked into had never engaged.

## Found on the way

The Auto camera unwinds a latching zone's authored angle instead of holding it, filed as #518. The zone cuts `BetaCam` to the authored angle and the Auto camera then lerps back to its own hero-relative target over about 40 frames; with `cam_follow 0` the angle stays put. Deliberately not encoded as a fixture here, since that is the bug rather than the contract.

## Verification

Automation suite 36 pass, 16 skip, and `profile_bind`, which fails identically on a clean `main` in this environment. All seven camera fixtures pass.
