### PR TITLE
ci(sanitize): add UndefinedBehaviorSanitizer to the host-test job

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -129,11 +129,16 @@ jobs:
       - name: Verify Binary
         run: test -f build-clang/SOURCES/lba2cc && echo "Clang build successful"
 
-  # AddressSanitizer over the same host tests the build job runs. The suite was
-  # already clean when this job was added, so it can only ever fail on something
-  # new: a heap overflow, a use-after-free, or a leak introduced by a change.
-  # That also makes it a host stand-in for Android MTE, which is what the
-  # linux_sanitize preset was written for.
+  # Address and UndefinedBehavior sanitizers over the same host tests the build
+  # job runs. The suite was clean under both when this job was written, so it can
+  # only ever fail on something new: a heap overflow, a use-after-free, a leak,
+  # or the undefined arithmetic UBSan covers. ASan here is also a host stand-in
+  # for Android MTE, which is what the linux_sanitize preset was written for.
+  #
+  # The preset compiles with -fno-sanitize-recover=undefined on purpose. UBSan's
+  # default is to print a diagnostic and carry on, which exits zero and makes the
+  # gate a decoration: findings scroll past in a green run. With recovery off, a
+  # finding aborts the test and ctest goes red.
   #
   # host_tests only, not lba2cc. The build job already proves the game target
   # compiles, and nothing here can run it without retail data, so a second full
@@ -167,7 +172,9 @@ jobs:
       - name: Build
         run: cmake --build build-asan --target host_tests
 
-      - name: Host tests under AddressSanitizer
+      - name: Host tests under Address + UndefinedBehavior sanitizers
+        env:
+          UBSAN_OPTIONS: print_stacktrace=1
         run: cd build-asan && ctest -L host_quick --output-on-failure
 
   # The demo SKU compiles a different set of sources: ~60 #ifdef DEMO sites the

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -68,14 +68,14 @@
     {
       "name": "linux_sanitize",
       "inherits": "linux",
-      "displayName": "Linux (host tests, AddressSanitizer)",
-      "description": "64-bit host tests built with AddressSanitizer -- a host stand-in for Android MTE on heap-overflow / use-after-free.",
+      "displayName": "Linux (host tests, Address + UndefinedBehavior sanitizers)",
+      "description": "64-bit host tests under ASan (a host stand-in for Android MTE on heap-overflow / use-after-free) and UBSan. Alignment checking is off on purpose: see the CMAKE_C_FLAGS comment in docs/CI.md.",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "LBA2_BUILD_TESTS": "ON",
-        "CMAKE_C_FLAGS": "-fsanitize=address -fno-omit-frame-pointer -g",
-        "CMAKE_CXX_FLAGS": "-fsanitize=address -fno-omit-frame-pointer -g",
-        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address"
+        "CMAKE_C_FLAGS": "-fsanitize=address,undefined -fno-sanitize=alignment -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g",
+        "CMAKE_CXX_FLAGS": "-fsanitize=address,undefined -fno-sanitize=alignment -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address,undefined"
       }
     },
     {

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -19,7 +19,7 @@ ties both tiers together — path filtering, the docs-only gate, and the
 
 | Workflow | Tier | Trigger | Job(s) | What it does |
 |---|---|---|---|---|
-| `linux.yml` | Validation | push, PR, dispatch | `build`, `build-clang`, `build-demo`, `sanitize` | Configure (`linux` preset), build `lba2cc` + `host_tests`, run `ctest -L host_quick`; the same through clang and for the demo SKU; and the host tests once more under AddressSanitizer |
+| `linux.yml` | Validation | push, PR, dispatch | `build`, `build-clang`, `build-demo`, `sanitize` | Configure (`linux` preset), build `lba2cc` + `host_tests`, run `ctest -L host_quick`; the same through clang and for the demo SKU; and the host tests once more under Address + UndefinedBehavior sanitizers |
 | `macos.yml` | Validation | push, PR, dispatch | `build` | Same, on `macos-latest` (`macos_arm64` preset) |
 | `windows.yml` | Validation | push, PR, dispatch | `build` | Same, on Windows MSYS2 UCRT64 (`windows_ucrt64` preset) |
 | `test.yml` | Validation | push, PR, dispatch | `test` | Docker: `./run_tests_docker.sh` — full ASM↔C++ equivalence suite (Linux only, slow) |
@@ -36,11 +36,33 @@ files nor Docker. The Docker job (`test.yml`) builds a 32-bit UASM image
 and replays polyrec captures; it does not run the host discovery tests.
 
 `linux.yml`'s `sanitize` job re-runs the host tests against the
-`linux_sanitize` preset. The suite was clean under AddressSanitizer when
-the job landed, so a red result there means a change introduced a heap
-overflow, a use-after-free, or a leak. It builds `host_tests` only: the
-`build` job already covers the game target, and no CI job has the retail
-data needed to run it.
+`linux_sanitize` preset, which builds under AddressSanitizer and
+UndefinedBehaviorSanitizer together. The suite was clean under both when
+the job landed, so a red result means a change introduced a heap overflow,
+a use-after-free, a leak, or undefined arithmetic. It builds `host_tests`
+only: the `build` job already covers the game target, and no CI job has the
+retail data needed to run it.
+
+Two flags in that preset are load-bearing and worth not "tidying away".
+
+`-fno-sanitize-recover=undefined` turns a UBSan finding into an abort.
+UBSan's default is to print a diagnostic and continue, which exits zero:
+the run stays green and the finding scrolls past in the log. Without this
+flag the job is a decoration rather than a gate. If you want to *explore*
+rather than gate, rebuild without it so a run reports every site instead of
+stopping at the first.
+
+`-fno-sanitize=alignment` switches off the misaligned-access check. That
+one is not noise-suppression, it is a deferred decision: a headless
+playthrough under UBSan reports 326 distinct misaligned load/store/member
+sites, and every one of them is the same 1997 pattern of reading a packed
+file or bytecode buffer through a cast pointer. `LbaReadWord` and friends in
+`SAVEGAME.CPP`, `GET_S16` in `DISKFUNC.CPP` and `FICHE.CPP`, and structs
+overlaid directly onto scene data in `OBJECT.CPP`. Fixing them is a real
+piece of work with no observed x86 symptom, so the check stays off until
+someone takes the class on deliberately; leaving it on would mean the gate
+could never be green. Everything else UBSan checks is on, and the
+playthrough found zero of it.
 
 ## Triggers: push and pull request
 


### PR DESCRIPTION
## What & why

The `sanitize` job already builds the host tests under ASan. This adds UBSan to the same preset, so the job covers undefined arithmetic as well as memory errors. It costs no cleanup: the suite is clean under both today.

The reason to trust that is a measurement rather than a hope. I drove the headless harness through eleven scenarios against retail data (boot, three save loads, the `--save-load-test` round trip, two cube changes, demo attract, `--dump-state`, `--screenshot`), and UBSan reported **zero** signed-overflow, shift, or other undefined arithmetic in any of them. That was not the expected result. A port of 1997 x86 sources looked likely to depend on wrap-around somewhere, and I had written down that this would be the noisy one.

Since "zero findings" is also what a misconfigured sanitizer build reports, I checked it against a positive control compiled with the identical flag set. It caught signed overflow and left-shift-of-negative, so the zero is real.

## Notes for reviewers

**`-fno-sanitize-recover=undefined` is the load-bearing flag.** UBSan's default is to print a diagnostic and carry on. The process then exits zero, ctest passes, and the finding scrolls past inside a green run: the gate would be a decoration. With recovery off, a finding aborts. I verified this rather than assuming it, by planting a signed overflow in `tests/zone/test_zone_geom.cpp`, confirming `ctest` returned 8 with the diagnostic attached, and reverting.

**`-fno-sanitize=alignment` is a deferred decision, not noise-suppression**, and the comment in `docs/CI.md` exists so it does not get tidied away by someone who assumes otherwise. The same playthrough reports **326 distinct misaligned load/store/member sites** across 9 files. Every one is the same 1997 pattern: reading a packed file or bytecode buffer through a cast pointer.

- 268 are cursor casts. `LbaReadWord` / `LbaReadLong` / `LbaWriteWord` / `LbaWriteLong` in `SAVEGAME.CPP` (155), `GET_S16` / `GET_U32` in `DISKFUNC.CPP` (49) and `FICHE.CPP` (18), plus direct casts in the script interpreters.
- 58 are struct overlay: a `T_ZONE *` pointed straight into the packed scene buffer and its members read directly (`ptrz->Info5` in `OBJECT.CPP`).

Eight macro bodies would retire 222 of those without touching a call site, which is tempting, but it fixes the individually-safe scalar loads and leaves the struct-overlay sites, where the compiler can see adjacent members and merge them into the paired accesses that actually break on ARM. Taking the class on properly is its own piece of work with no observed x86 symptom behind it, so the check stays off until someone decides to. Left on, this gate could never be green.

**Scope of the measurement.** The zero came from harness runs against retail data. CI has none, so what this job actually gates is the host tests and whatever they reach. That is narrower than what I measured, and worth knowing when reading a green tick.

## Checklist

- [x] Build passes on my platform (Linux): 54/54 `host_quick` under the new preset, zero ASan and zero UBSan findings
- [x] If LIB386 / 3DEXT touched: no source changes in this PR, only build flags and CI wiring; the required `test` check covers the ASM equivalence suite
- [x] If behavior changes: none. No shipping build uses this preset
- [x] Docs updated in the same PR: `docs/CI.md` workflow map, and a section on why both flags are the way they are
- [x] French comments and ASCII art preserved in any modified files
