### PR TITLE
fix(camera): let an authored shot keep the camera it was given

### DIFF
--- a/SOURCES/C_EXTERN.H
+++ b/SOURCES/C_EXTERN.H
@@ -227,6 +227,7 @@ extern S32 ManualCameraOrbitActive; /* raised by EXTFUNC while a manual camera s
 extern S32 FollowCamReengageDelay;
 extern S32 FollowCamOrbitGlide;                 /* % of orbit speed kept per frame after the player lets go */
 extern void FollowCamForgetManualGesture(void); /* drop the in-flight orbit: nothing is owed across a discontinuity */
+extern void FollowCamAdoptAngle(void);          /* point the Auto camera's target at the angle the camera is already at */
 extern S32 GamepadCameraAnalog;                 /* right stick drives the camera analog in Auto cam (1=on) */
 extern S32 GamepadCameraSensX;                  /* right-stick orbit sensitivity (1-10) */
 extern S32 GamepadCameraSensY;                  /* right-stick elevation sensitivity (1-10) */

--- a/SOURCES/EXTFUNC.CPP
+++ b/SOURCES/EXTFUNC.CPP
@@ -1956,9 +1956,14 @@ void FollowCamForgetManualGesture(void) {
     DbgCamNudgeFrames = 0;
 }
 
-/* Start of an orbit gesture: fold the rotation the hero accumulated while the
- * camera was holding its angle into AddBetaCam, so the target the follow update
- * recomputes still comes out at the angle the camera is actually sitting at.
+/* Hand the Auto camera the angle the camera is currently at, so the target it
+ * recomputes comes out there rather than somewhere it will travel to.
+ *
+ * Two callers, one need. An orbit gesture starting: fold in the rotation the hero
+ * accumulated while the camera held its angle. A camera zone firing: adopt the
+ * angle the authored shot just chose. Both write BetaCam directly, and the follow
+ * update knows nothing of either, so without this it reads the difference as
+ * catch-up and spends it.
  *
  * AddBetaCam is an offset *from the hero's facing*, so a held BetaCam and a hero
  * who turns under it drift apart with nothing to discharge the difference. The
@@ -1970,7 +1975,7 @@ void FollowCamForgetManualGesture(void) {
  * With the camera already on target this changes nothing. With it still lerping
  * toward one, the pending catch-up is dropped as well -- a few degrees at most,
  * and the point: an orbit should start from the angle actually on screen. */
-static void AbsorbHeroTurnIntoPan(void) {
+void FollowCamAdoptAngle(void) {
     T_OBJ_3D *ptr3d = &ListObjet[NumObjFollow].Obj;
 
     /* The inverse of the follow update's target rule: it derives the target from
@@ -2004,7 +2009,7 @@ static S32 ApplyManualCameraNudge(S32 dBeta, S32 dAlpha, S32 dZoom) {
          * be reaching into a path this knows nothing about. */
         if (!ManualCameraOrbitActive AND !ManualCameraOrbitPrev
                 AND CubeMode == CUBE_EXTERIEUR AND !CameraZone AND !CinemaMode)
-            AbsorbHeroTurnIntoPan();
+            FollowCamAdoptAngle();
 
         AddBetaCam = (AddBetaCam - dBeta) & 4095;
         ManualCameraOrbitActive = TRUE;

--- a/SOURCES/OBJECT.CPP
+++ b/SOURCES/OBJECT.CPP
@@ -6291,6 +6291,15 @@ void SetZoneCamera(T_ZONE *ptrz) {
             GammaCam = ptrz->Info5;
             VueDistance = ptrz->Info6;
 
+            /* Tell the Auto camera the shot has taken the view, or it takes it
+             * straight back. Most camera zones re-aim once on entry and then latch,
+             * leaving the angle where they put it, which is what the classic camera
+             * shows. The Auto camera derives its own target from the hero's facing
+             * and never learns of this write, so it reads the authored angle as
+             * catch-up owed and lerps out of the shot over the next second. */
+            if (FollowCamera)
+                FollowCamAdoptAngle();
+
             SaveCamera();
 
             CameraCenter(0);

--- a/tests/automation/test_camzone_hold.sh
+++ b/tests/automation/test_camzone_hold.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# A camera zone's authored angle must survive the Auto camera being switched on.
+#
+# Most camera zones re-aim the camera once as the hero enters and then latch, leaving the angle
+# where they put it. The classic camera shows exactly that. The Auto camera derives its own target
+# from the hero's facing and is not told about the zone's write, so it used to read the authored
+# angle as catch-up owed and lerp out of the shot over the following second: a cut to the shot,
+# then a slide back to behind the hero.
+#
+# The assertion is that the two cameras agree on where the shot leaves the view. That states the
+# property rather than a number, so it survives anyone retuning the lerp, and it cannot pass by
+# the shot failing to happen, which is checked separately.
+#
+# Local-only (needs retail data + the tracked corpus save). Not in host_quick CI.
+TESTNAME=camzone_hold
+. "$(dirname "$0")/lib.sh"
+. "$(dirname "$0")/camlib.sh"
+cam_precheck
+
+auto="$(mktemp)"; classic="$(mktemp)"; orbit="$(mktemp)"
+trap 'rm -f "$auto" "$classic" "$orbit"' EXIT
+
+# Cube 90's zone at (10752,3900,3072)-(16896,5644,15872) carries ZONE_ON without
+# ZONE_OBLIGATOIRE, so it fires once on entry: step out of the box and back in to trigger it, then
+# hold still long enough for a drift to show.
+zone_run() { # <log> <extra first-tick cmds>
+    ctl_headless --load "$CAM_SAVE" --fixed-dt 16 \
+        --exec "cube 90" \
+        --exec-at 15 "camtrace 1; $2" \
+        --exec-at 40 "teleport 18000 3900 8000" \
+        --exec-at 70 "teleport 13000 4000 8000" \
+        --tick 160 --exit > "$1" 2>&1 || fail "run failed: exit $?"
+}
+
+zone_run "$auto" "cam_follow 1"
+zone_run "$classic" "cam_follow 0"
+
+fired="$(cam_col "$auto" zone | awk '$1 == 1 { n++ } END { print n + 0 }')"
+[ "$fired" -ge 1 ] || fail "the camera zone never fired: the teleport missed the box"
+
+auto_beta="$(cam_col "$auto" beta | tail -1)"
+classic_beta="$(cam_col "$classic" beta | tail -1)"
+
+[ "$auto_beta" = "$classic_beta" ] \
+    || fail "authored angle survives the classic camera at $classic_beta but the Auto camera left it at $auto_beta"
+
+# The shot holds, it is not nailed down: the player can still orbit away from it afterwards.
+ctl_headless --load "$CAM_SAVE" --fixed-dt 16 \
+    --exec "cube 90" \
+    --exec-at 15 "camtrace 1; cam_follow 1" \
+    --exec-at 40 "teleport 18000 3900 8000" \
+    --exec-at 70 "teleport 13000 4000 8000" \
+    --exec-at 100 "camnudge 20 0 10" \
+    --tick 160 --exit > "$orbit" 2>&1 || fail "orbit run failed: exit $?"
+
+moved="$(cam_col "$orbit" beta | tail -1)"
+[ "$moved" != "$auto_beta" ] \
+    || fail "the camera would not orbit away from the authored angle ($moved): the shot is stuck, not held"
+
+pass "both cameras left the shot at $auto_beta, and the stick still moved it to $moved"

--- a/tests/automation/test_camzone_hold.sh
+++ b/tests/automation/test_camzone_hold.sh
@@ -57,4 +57,28 @@ moved="$(cam_col "$orbit" beta | tail -1)"
 [ "$moved" != "$auto_beta" ] \
     || fail "the camera would not orbit away from the authored angle ($moved): the shot is stuck, not held"
 
-pass "both cameras left the shot at $auto_beta, and the stick still moved it to $moved"
+# How long the shot survives is cam_hold_angle's decision, and both of its answers have to keep
+# working. On (the default) is the free camera: the angle is held until the player moves it, which
+# is what the runs above cover. Off is the classic lazy drift, where the shot should be handed
+# back as the hero walks on rather than kept. Adopting the angle is what makes the second possible
+# at all: the drift acts on AddBetaCam, so a shot the Auto camera never adopted is a shot it has
+# no way to give back gradually.
+drift="$(mktemp)"
+ctl_headless --load "$CAM_SAVE" --fixed-dt 16 \
+    --exec "cube 90" \
+    --exec-at 15 "camtrace 1; cam_follow 1; cam_hold_angle 0" \
+    --exec-at 40 "teleport 18000 3900 8000" \
+    --exec-at 70 "teleport 13000 4000 8000" \
+    --exec-at 90 "input up 200" \
+    --tick 300 --exit > "$drift" 2>&1 || fail "drift run failed: exit $?"
+
+peak="$(cam_col "$drift" add | awk '{ a = $1; if (a > 2048) a -= 4096; if (a < 0) a = -a; if (a > m) m = a } END { print m + 0 }')"
+left="$(cam_col "$drift" add | tail -1 | awk '{ a = $1; if (a > 2048) a -= 4096; print (a < 0) ? -a : a }')"
+rm -f "$drift"
+
+[ "$peak" -gt 200 ] \
+    || fail "the shot never moved the camera off the hero-relative angle ($peak units): nothing to hand back"
+[ "$left" -lt 100 ] \
+    || fail "with cam_hold_angle off the shot was still $left units off centre after walking (never handed back)"
+
+pass "both cameras left the shot at $auto_beta, the stick moved it to $moved, and drift mode handed $peak units back to $left"


### PR DESCRIPTION
Closes #518.

Most camera zones carry `ZONE_ON` without `ZONE_OBLIGATOIRE`: they re-aim the camera once as the hero enters the box and then latch, leaving the angle where they put it. The classic camera shows exactly that. The Auto camera did not.

The zone writes `BetaCam`. The Auto camera derives its own target from `AddBetaCam + hero Beta` and is never told, so it read the authored angle as catch-up owed and spent it:

```
frame 63   zone=0  beta=1758  target=1874  step=3      auto camera settled
frame 64   zone=1  beta=1243  target=1874  step=-515   the zone re-aims the camera
frame 65   zone=0  beta=1260  target=1874  step=17     auto camera starts taking it back
frame 78   zone=0  beta=1454  target=1874  step=11     still returning to its own target
```

A cut into the shot, then a slide back to behind the hero over about a second. With `cam_follow 0` the angle simply stayed at 1243. So the scripted direction was applied and then discarded, for the majority of the zones that carry it, whenever the player had the Auto camera on.

## The change

Hand the angle to the Auto camera when the zone fires, so the target it recomputes is the one the shot chose:

```
frame 64   zone=1  beta=1243  target=1874  step=-515
frame 65   zone=0  beta=1243  target=1243  step=0
frame 76   zone=0  beta=1243  target=1243  step=0
```

This is the move the orbit path already makes at the start of a gesture, which is why the helper is now shared rather than private to it. Both are writers of `BetaCam` that the follow update knows nothing about, and both need the target pointed at where the camera actually is rather than where it was heading.

Forced zones were never affected, since they re-aim every frame and overwrite whatever the Auto camera did in between.

## Held, not nailed down

The player can still orbit away from an authored angle afterwards. The fixture asserts that alongside the shot surviving, because a fix that simply pinned the camera would satisfy the first half on its own and be worse than the bug.

`test_camzone_hold.sh` compares where the two cameras leave the shot rather than checking a particular angle. That states the property, survives anyone retuning the lerp, and cannot pass by the shot never firing, which is checked separately. Against the unfixed build it reports the classic camera leaving the shot at 1243 and the Auto camera at 1830.

## Verification

Host suite 54/54. Automation suite 37 pass, 16 skip, and `profile_bind`, which fails identically on a clean `main` in this environment.

## Not addressed here

How long an authored shot should survive is a design question this does not settle: it now holds until the player orbits away. If a shot should instead time out and return to the player's camera, that is a grace window on top of this, and it overlaps #361 and #350 on blending hand-overs deliberately.
