### PR TITLE
docs(control): a fresh start opens a modal without being asked

### DIFF
--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -196,6 +196,37 @@ Console output is mirrored to stdout, so any command's output is readable from a
   `give <item>` (the found-object cinematic), `playvideo`, `credits`, and `slide`. Use
   non-modal commands: `cube`, `give clover`, `timer`, cvars, `status`. (`give clover`
   takes a different code path with no cinematic.)
+- **A fresh start walks into a modal on its own, at about 4s of sim time.** The point above
+  is about modals *you* open. The opening scene opens one by itself: object 4's Life script
+  runs a `MESSAGE` opcode roughly four seconds in, `Dial` spins in `SpeakAnimation` waiting
+  for a dismiss that headless never sends, and because that loop retires no ticks, `--tick N`
+  never reaches N. The run does not fail, it spins on one core until the timeout.
+
+  It is the clock that decides, not the tick count, so raising `--fixed-dt` does not buy
+  headroom: the wall is ~3.9s of simulated time either way (244 ticks at `--fixed-dt 16`
+  survive, 248 do not; 480 at dt 8 survive, 520 do not).
+
+  Three ways past it:
+
+  ```bash
+  # Start somewhere else: --load lands in another cube and never meets the script.
+  lba2cc --headless --load "021 Palace" --fixed-dt 16 --tick 600 --exit
+
+  # Let the demo reel auto-advance its modals.
+  lba2cc --headless --demo --fixed-dt 16 --tick 300 --exit
+
+  # Or dismiss it: arm esc just before the dialogue opens.
+  lba2cc --headless --fixed-dt 16 --exec-at 240 "key esc 40" --tick 300 --exit
+  ```
+
+  Arming the key early does **not** work. `--exec "key esc 400"` from tick 1 still hangs:
+  the modal latches on entry through `InitWaitNoInput`, and a key already held when it opens
+  never registers as a press. The press has to land *inside* the modal, which is what the
+  `polls` argument is for. `key return` does not dismiss a dialogue; `esc` does.
+
+  Run with `--verbose` and the last line before the hang names the modal
+  (`[control] modal: Dial(...)`), which is faster than reaching for a debugger. Those markers
+  go to **stderr**, not `adeline.log`.
 - **`--exec` fires on the first tick, which races a scene change.** A `cube` change applies
   on the *next* frame, so `--exec "cube 154; teleport actor 3"` runs the teleport in the
   **old** cube and the pending change then resets the hero to the new cube's spawn. Nothing


### PR DESCRIPTION
## What & why

`CONTROL.md` warns that modal commands block a headless run. It does not say that a fresh start opens a modal on its own. The opening scene's object 4 runs a `MESSAGE` Life opcode about four seconds in; `Dial` spins in `SpeakAnimation` waiting for a dismiss headless never sends, and that loop retires no ticks, so `--tick N` never reaches N. A bare `lba2cc --headless --fixed-dt 16 --tick 300 --exit` spins on one core until its timeout.

Every property of this points away from the cause, which is why it is worth a doc entry rather than a one-line aside:

- The symptom is a timeout, so it reads as machine load. It is not: the process is at 100% of one core, not blocked.
- It looks like a tick budget, but the wall is ~3.9s of *simulated* time. Raising `--fixed-dt` buys no headroom: 244 ticks survive at dt 16 and 248 do not; 480 survive at dt 8 and 520 do not.
- It looks like missing instrumentation, but `--verbose` already prints `[control] modal: Dial(...)` as the last line before the hang. Those markers go to **stderr**, not `adeline.log`, which is how I managed to miss them while looking straight at the logs.

## Notes for reviewers

The note records three ways past it and, deliberately, the two that look like they should work and do not:

| | |
|---|---|
| `--load "021 Palace" --tick 600` | ok, lands in another cube |
| `--demo --tick 300` | ok, the reel auto-advances modals |
| `--exec-at 240 "key esc 40" --tick 300` | ok |
| `--exec "key esc 400"` from tick 1 | **hangs** — the modal latches on entry via `InitWaitNoInput`, so a key already held never registers as a press |
| `--exec-at 240 "key return 40"` | **hangs** — `return` does not dismiss a dialogue, `esc` does |

All five verified against Release and Debug builds of the current tip. That mattered: an earlier run of the same table gave a clean "works on Debug, fails on Release" split, which was an artifact of testing a binary built before #511 landed the `key` command. It has no `key` verb at all, so the press was a no-op.

No code change. The `key` recipe depends on #511, which is already on main.

## Checklist

- [x] Build passes on my platform (Linux): docs-only change; the commands in the note were each run against fresh Release and Debug builds
- [x] If LIB386 / 3DEXT touched: not touched
- [x] If behavior changes: none, documentation only
- [x] Docs updated in the same PR: this is the docs change
- [x] French comments and ASCII art preserved in any modified files