### PR TITLE
test(harness): let the control-harness suite run on Windows

### DIFF
--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -704,6 +704,56 @@ The keystone is `test_tick.sh`: it loads, advances 1 vs 60 ticks, and asserts th
 clock and the hero's idle-animation frame both advanced — proving the loop steps the
 simulation, not just a counter.
 
+### Running them on Windows
+
+The suite runs under MSYS2 (UCRT64) against a native build. One rule accounts for most
+of what goes wrong there: **MSYS2 rewrites a standalone path argument on its way to a
+native binary, but not a path inside a longer string.** So `--dump-state "$out"` arrives
+as `D:/...` and works, while `--exec "ui menu-main $out"` arrives verbatim and the engine
+cannot create the file. The same applies to `python3`, which is also a native binary:
+pass paths as `sys.argv` entries, never spliced into the text of `python3 -c`. Use
+`engine_path` from `lib.sh` where a path has to travel inside a longer argument; it is
+`cygpath -m` on Windows and the identity everywhere else.
+
+Two more shapes, both handled in `lib.sh` rather than per test. A path the engine wrote
+comes back in the engine's own spelling, ending with the platform separator and with CRLF
+line endings, so compare folders with `norm_path` rather than as strings. And a glob
+expands in the locale's collating order, which is byte order under a typical Linux locale
+and case-insensitive under MSYS2, so `LC_COLLATE=C` is pinned there to keep a corpus walk
+in one order on both platforms.
+
+`pip install Pillow` (or `pacman -S mingw-w64-ucrt-x86_64-python-pillow`) for the
+`test_ui_*_wide.sh` pair, which skip without it.
+
+Two divergences are the platform rather than the harness, and are expected to fail there
+until someone decides what they should be:
+
+- Six `ui_*` goldens differ in a single band, the plasma fire bar at the top of the menu
+  panel. Stable across repeated Windows runs, so the goldens are Linux-specific rather
+  than the capture being unreliable.
+- `test_projection_corpus.sh` differs on 25 of its 50 saves: 19 by hash alone, which is
+  the rounding the `long double` + `lrintl` x87 emulation exists to pin, and 6 by event
+  count, which is a different path through the replay and not explained by rounding.
+
+`test_res_catalog_sweep.sh` is a third case, and a different kind: the engine segfaults
+on Windows at the sub-640 widths, intermittently, so the sweep passes or fails depending
+on the run. Ten captures per mode, same build, same verb:
+
+| mode | Windows | Linux |
+| --- | --- | --- |
+| 320x200 | 3/10 crashed | 0/10 |
+| 320x240 | 2/10 crashed | 0/10 |
+| 640x480 | 0/10 | 0/10 |
+
+Not the fixture, and not a golden that needs deciding: an intermittent crash in a real
+mode the resolution catalogue offers. Reproduce with a bare capture at that size rather
+than through the sweep, which only reports which modes failed:
+
+```bash
+lba2cc --headless --no-autosave --resolution 320x200 \
+       --exec "ui resolution D:/cap.png" --tick 6 --exit
+```
+
 `test_cli_flag_contract.sh` is the one that keeps the harness honest about the machine it
 runs on. A flag names a mode for one run, so a run told to render at 640x480 or throttle the
 sim must leave the player's settings exactly as it found them; the exceptions are the flags

--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -726,12 +726,23 @@ in one order on both platforms.
 `test_ui_*_wide.sh` pair, which skip without it.
 
 The menu goldens carry a per-surface `--exclude` rectangle covering the plasma strip at
-the top of the panel, which is what lets one golden serve both platforms: the strip
-settles at a different state on Windows and stays there, while the rest of those frames
-is byte-identical across the two. See `ui_compare` and `png_hash.py --exclude`. The
-rectangle's `y` follows the panel, whose height follows the entry count, so it lives in
-each test beside its golden and needs re-measuring if a menu gains or loses a row. A
-diff of a failing capture against the golden gives it directly.
+the top of the panel, which is what lets one golden serve both platforms. The strip seeds
+its vertices and speeds from `Rnd()`, which is `rand() % n`, and libc's `rand()` is a
+different algorithm with a different `RAND_MAX` on each platform (#530), so the strip
+starts somewhere else on Windows and stays there. Everything else in those frames is
+byte-identical across the two, which is why excluding one band is enough.
+
+Nothing else about the strip differs: it is stepped the same number of times on both
+(30 steps over a capture, measured), and `Do_Plasma`'s evolution is pure integer and
+pinned bit-for-bit by `tests/plasma_steps/`, which passes with the same digest on both
+platforms. Only the starting state is unportable.
+
+The rectangle's `y` follows the panel, whose height follows the entry count, so it lives
+in each test beside its golden and needs re-measuring if a menu gains or loses a row. A
+diff of a failing capture against the golden gives it directly. The excluded band is not
+left unwatched: `ui_compare` asserts it still holds between 8 and 64 distinct colours,
+which a drawn strip does (16 or 17), a strip that failed to draw does not (1 to 3), and
+the uninitialised texture `InitPlasmaMenu` exists to prevent does not either (hundreds).
 
 Two divergences are the platform rather than the harness, and are expected to fail there:
 

--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -725,12 +725,20 @@ in one order on both platforms.
 `pip install Pillow` (or `pacman -S mingw-w64-ucrt-x86_64-python-pillow`) for the
 `test_ui_*_wide.sh` pair, which skip without it.
 
-Two divergences are the platform rather than the harness, and are expected to fail there
-until someone decides what they should be:
+The menu goldens carry a per-surface `--exclude` rectangle covering the plasma strip at
+the top of the panel, which is what lets one golden serve both platforms: the strip
+settles at a different state on Windows and stays there, while the rest of those frames
+is byte-identical across the two. See `ui_compare` and `png_hash.py --exclude`. The
+rectangle's `y` follows the panel, whose height follows the entry count, so it lives in
+each test beside its golden and needs re-measuring if a menu gains or loses a row. A
+diff of a failing capture against the golden gives it directly.
 
-- Six `ui_*` goldens differ in a single band, the plasma fire bar at the top of the menu
-  panel. Stable across repeated Windows runs, so the goldens are Linux-specific rather
-  than the capture being unreliable.
+Two divergences are the platform rather than the harness, and are expected to fail there:
+
+- `test_ui_found_object.sh` differs in the item model on the right of the frame, not the
+  strip: a handful of pixels across an identical 88-colour palette, which is the same
+  projection rounding as below rather than anything about the surface. Masking it would
+  remove what the test is for.
 - `test_projection_corpus.sh` differs on 25 of its 50 saves: 19 by hash alone, which is
   the rounding the `long double` + `lrintl` x87 emulation exists to pin, and 6 by event
   count, which is a different path through the replay and not explained by rounding.

--- a/scripts/dev/png_hash.py
+++ b/scripts/dev/png_hash.py
@@ -7,12 +7,23 @@ compression settings does not read as a change.
 A note for anyone hashing UI captures: pass `--fixed-dt` to the engine when
 taking them. The menus animate a plasma strip on the clock, so without a pinned
 clock the same screen hashes differently every run, and any comparison built on
-it reports regressions that are not there. With `--fixed-dt` the captures are
-reproducible and need no masking.
+it reports regressions that are not there.
 
-Python 3 standard library only, matching the other dev scripts.
+`--fixed-dt` makes a capture reproducible on one machine, but not across two.
+The menu's plasma strip reaches a different state on Windows than on Linux and
+stays there: repeated runs agree, tick counts do not move it, and the pixels are
+the same 16-colour ramp either way, so it is the strip's animation state rather
+than anything about how the menu is drawn. `--exclude` leaves that band out of
+the hash, which is what lets one golden serve both platforms.
 
     png_hash.py shot.png
+    png_hash.py shot.png --exclude 46,174,549,49     # x,y,w,h; repeatable
+
+Excluded pixels are zeroed rather than skipped, so the hash still depends on
+where the exclusion is: moving the band changes the digest instead of silently
+comparing a different picture.
+
+Python 3 standard library only, matching the other dev scripts.
 """
 import hashlib
 import struct
@@ -73,12 +84,58 @@ def decode(path):
     return width, height, channels, bytes(out)
 
 
+def parse_rect(text):
+    """`x,y,w,h` -> a 4-tuple of ints. Raises ValueError on anything else."""
+    parts = text.split(",")
+    if len(parts) != 4:
+        raise ValueError("expected x,y,w,h, got %r" % text)
+    rect = tuple(int(p) for p in parts)
+    if any(v < 0 for v in rect) or rect[2] == 0 or rect[3] == 0:
+        raise ValueError("rectangle must be non-negative and non-empty: %r" % text)
+    return rect
+
+
+def zero_rects(width, height, channels, pixels, rects):
+    """Blank each rectangle so the hash ignores what is inside it.
+
+    Out of bounds is an error rather than a clamp: a rectangle that no longer
+    fits is a rectangle that has stopped describing what it was written for, and
+    quietly hashing a clamped version of it is how a mask outlives its subject.
+    """
+    buf = bytearray(pixels)
+    stride = width * channels
+    for x, y, w, h in rects:
+        if x + w > width or y + h > height:
+            raise ValueError(
+                "exclusion %d,%d,%d,%d falls outside the %dx%d image"
+                % (x, y, w, h, width, height))
+        for row in range(y, y + h):
+            start = row * stride + x * channels
+            buf[start:start + w * channels] = bytes(w * channels)
+    return bytes(buf)
+
+
 def main(argv):
     if len(argv) < 2:
         print(__doc__)
         return 2
+    path = argv[1]
+    rects = []
+    i = 2
     try:
-        _w, _h, _c, pixels = decode(argv[1])
+        while i < len(argv):
+            if argv[i] != "--exclude" or i + 1 >= len(argv):
+                raise ValueError("unexpected argument %r" % argv[i])
+            rects.append(parse_rect(argv[i + 1]))
+            i += 2
+    except ValueError as exc:
+        print("-")
+        print("png_hash: %s" % exc, file=sys.stderr)
+        return 2
+    try:
+        width, height, channels, pixels = decode(path)
+        if rects:
+            pixels = zero_rects(width, height, channels, pixels, rects)
     except Exception as exc:  # a missing or odd capture should not abort a sweep
         print("-")
         print("png_hash: %s" % exc, file=sys.stderr)

--- a/scripts/dev/png_hash.py
+++ b/scripts/dev/png_hash.py
@@ -18,10 +18,17 @@ the hash, which is what lets one golden serve both platforms.
 
     png_hash.py shot.png
     png_hash.py shot.png --exclude 46,174,549,49     # x,y,w,h; repeatable
+    png_hash.py shot.png --count-colours 46,174,549,49
 
 Excluded pixels are zeroed rather than skipped, so the hash still depends on
 where the exclusion is: moving the band changes the digest instead of silently
 comparing a different picture.
+
+`--count-colours` prints how many distinct values a region holds, instead of a
+hash. It is what is left to say about a region once its exact pixels are
+excluded: a bar that failed to draw collapses to one value, and the junk
+InitPlasmaMenu exists to prevent is a great many. Neither is a number the strip
+can produce.
 
 Python 3 standard library only, matching the other dev scripts.
 """
@@ -115,25 +122,53 @@ def zero_rects(width, height, channels, pixels, rects):
     return bytes(buf)
 
 
+def count_colours(width, height, channels, pixels, rect):
+    """How many distinct pixel values a rectangle holds."""
+    x, y, w, h = rect
+    if x + w > width or y + h > height:
+        raise ValueError(
+            "region %d,%d,%d,%d falls outside the %dx%d image"
+            % (x, y, w, h, width, height))
+    stride = width * channels
+    seen = set()
+    for row in range(y, y + h):
+        start = row * stride + x * channels
+        line = pixels[start:start + w * channels]
+        for col in range(0, len(line), channels):
+            seen.add(line[col:col + channels])
+    return len(seen)
+
+
 def main(argv):
     if len(argv) < 2:
         print(__doc__)
         return 2
     path = argv[1]
     rects = []
+    region = None
     i = 2
     try:
         while i < len(argv):
-            if argv[i] != "--exclude" or i + 1 >= len(argv):
+            if i + 1 >= len(argv):
+                raise ValueError("%s needs a rectangle" % argv[i])
+            if argv[i] == "--exclude":
+                rects.append(parse_rect(argv[i + 1]))
+            elif argv[i] == "--count-colours":
+                region = parse_rect(argv[i + 1])
+            else:
                 raise ValueError("unexpected argument %r" % argv[i])
-            rects.append(parse_rect(argv[i + 1]))
             i += 2
+        if region and rects:
+            raise ValueError("--count-colours describes a region; it does not hash")
     except ValueError as exc:
         print("-")
         print("png_hash: %s" % exc, file=sys.stderr)
         return 2
     try:
         width, height, channels, pixels = decode(path)
+        if region:
+            print(count_colours(width, height, channels, pixels, region))
+            return 0
         if rects:
             pixels = zero_rects(width, height, channels, pixels, rects)
     except Exception as exc:  # a missing or odd capture should not abort a sweep

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ add_subdirectory(cdda)
 add_subdirectory(render)
 add_subdirectory(movement)
 add_subdirectory(zone)
+add_subdirectory(plasma_steps)
 
 if(LBA2_BUILD_ASM_EQUIV_TESTS)
 include(cmake/asm_test_helpers.cmake)

--- a/tests/automation/lib.sh
+++ b/tests/automation/lib.sh
@@ -322,6 +322,18 @@ ui_compare() {
         # the mask would otherwise start hiding a surface it was never aimed at.
         command -v python3 >/dev/null 2>&1 \
             || skip "python3 needed to compare 'ui $args' (its capture is masked)"
+        # The excluded band is not left unwatched. Its exact pixels cannot be
+        # pinned across platforms, but its shape can: the plasma strip is a ramp
+        # of a dozen or so colours, a strip that failed to draw is one or two,
+        # and the uninitialised texture InitPlasmaMenu exists to prevent is
+        # hundreds. Any of those three is a different number.
+        local band_colours
+        band_colours=$(python3 "$REPO/scripts/dev/png_hash.py" "$out" \
+            --count-colours "$exclude") \
+            || fail "could not read the excluded band for 'ui $args'"
+        if [ "$band_colours" -lt 8 ] || [ "$band_colours" -gt 64 ]; then
+            fail "the excluded band of 'ui $args' holds $band_colours colours, outside 8..64: it is not a drawn plasma strip (capture at $out)"
+        fi
         shaA=$(python3 "$REPO/scripts/dev/png_hash.py" "$out" --exclude "$exclude") \
             || fail "could not hash the capture for 'ui $args'"
         shaB=$(python3 "$REPO/scripts/dev/png_hash.py" "$golden" --exclude "$exclude") \

--- a/tests/automation/lib.sh
+++ b/tests/automation/lib.sh
@@ -85,6 +85,28 @@ user_dir() {
     fi
 }
 
+# engine_path -- the spelling the engine itself uses for a folder a test named.
+#
+# MSYS2 converts a standalone path argument on its way to a native binary, so a
+# folder passed as /e/LBA2/Common is opened, recorded and reported as
+# E:/LBA2/Common. A test that compares what the engine wrote down against the
+# string it passed is then comparing two spellings of one folder. Elsewhere this
+# is the identity, so call sites need no platform test of their own.
+engine_path() { # engine_path <path>
+    if command -v cygpath >/dev/null 2>&1; then cygpath -m "$1"; else printf '%s\n' "$1"; fi
+}
+
+# norm_path -- a folder's shape, for comparing two spellings of one path.
+#
+# Three differences that are not differences of folder: the engine ends a path
+# with the platform's separator, so a Windows run answers with a trailing
+# backslash for a folder named with forward slashes; it appends components with
+# a backslash there, so mixed separators are normal in its output; and text it
+# writes carries CRLF, so a line read back ends in a stray CR.
+norm_path() { # norm_path <path>
+    printf '%s\n' "$1" | tr -d '\r' | tr '\\' '/' | sed 's|/*$||'
+}
+
 skip() { echo "SKIP: ${TESTNAME:-test}: $*"; exit $SKIP_RC; }
 fail() { echo "FAIL: ${TESTNAME:-test}: $*"; exit 1; }
 pass() { echo "PASS: ${TESTNAME:-test}${1:+ — $1}"; exit 0; }

--- a/tests/automation/lib.sh
+++ b/tests/automation/lib.sh
@@ -14,6 +14,15 @@
 
 set -u
 
+# Collation is pinned so that a glob expands in one order everywhere. Bash sorts
+# the matches by the locale's collating sequence, which is byte order under a
+# typical Linux locale and case-insensitive under MSYS2, so `for save in *.LBA`
+# walks a corpus in two different orders on the two platforms. A fixture that
+# writes one line per file then differs from its golden by line order alone, and
+# reports it as the values having changed. Only collation is pinned, not LC_ALL:
+# the character encoding a test reads its fixtures in is not this file's business.
+export LC_COLLATE=C
+
 _LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 REPO="$(cd "$_LIB_DIR/../.." && pwd)"
 
@@ -111,12 +120,26 @@ skip() { echo "SKIP: ${TESTNAME:-test}: $*"; exit $SKIP_RC; }
 fail() { echo "FAIL: ${TESTNAME:-test}: $*"; exit 1; }
 pass() { echo "PASS: ${TESTNAME:-test}${1:+ — $1}"; exit 0; }
 
+# have_display -- whether the engine can bring a window up here.
+#
+# Only X11 and Wayland have to be looked for. Windows and macOS hand a process
+# its window server, with no environment variable to say so, so asking for
+# DISPLAY there skipped every test on a machine that has a display. That is how
+# the suite came to be Linux-only without anyone deciding it should be: the
+# result on Windows was a clean run of nothing, which reads the same as a pass.
+have_display() {
+    case "$(uname -s)" in
+        MINGW* | MSYS* | CYGWIN* | Darwin) return 0 ;;
+    esac
+    [ -n "${DISPLAY:-}" ] || [ -n "${WAYLAND_DISPLAY:-}" ] \
+        || [ "${SDL_VIDEODRIVER:-}" = "dummy" ]
+}
+
 precheck() {
     [ -n "$LBA2_BIN" ] && [ -x "$LBA2_BIN" ] || skip "no binary (build it, or set LBA2_BIN)"
     [ -n "$LBA2_GAME_DIR" ] || skip "LBA2_GAME_DIR unset"
     [ -e "$LBA2_GAME_DIR" ] || skip "LBA2_GAME_DIR not found: $LBA2_GAME_DIR"
-    { [ -n "${DISPLAY:-}" ] || [ -n "${WAYLAND_DISPLAY:-}" ] \
-        || [ "${SDL_VIDEODRIVER:-}" = "dummy" ]; } \
+    have_display \
         || skip "no display (engine needs a window, or set SDL_VIDEODRIVER=dummy)"
 }
 
@@ -266,16 +289,24 @@ ui_compare() {
     while [ $# -gt 1 ]; do args="${args:+$args }$1"; shift; done
     golden="$1"
     out="$(mktemp -t "${TESTNAME:-ui}.XXXXXX.png")"
-    # the verb takes the capture path as its last arg
+    # The verb takes the capture path as its last arg, and opens it itself, so it
+    # has to be named the way the engine can open it: MSYS2 rewrites a standalone
+    # path argument on its way to a native binary but not one buried in a longer
+    # --exec string, which arrives verbatim as /tmp/... and cannot be created.
     if [ -n "${LBA2_TEST_SAVE:-}" ]; then
         ctl_headless --load "$LBA2_TEST_SAVE" \
-            --exec "ui $args $out" --fixed-dt 16 --tick 200 --exit >/dev/null 2>&1 || rc=$?
+            --exec "ui $args $(engine_path "$out")" \
+            --fixed-dt 16 --tick 200 --exit >/dev/null 2>&1 || rc=$?
     else
         ctl_headless \
-            --exec "ui $args $out" --fixed-dt 16 --tick 200 --exit >/dev/null 2>&1 || rc=$?
+            --exec "ui $args $(engine_path "$out")" \
+            --fixed-dt 16 --tick 200 --exit >/dev/null 2>&1 || rc=$?
     fi
     [ "$rc" = 0 ] || { rm -f "$out"; fail "verb 'ui $args' returned non-zero ($rc)"; }
-    [ -f "$out" ] || fail "no capture written for 'ui $args'"
+    # Empty, not merely present: mktemp has already created the file, so -f is
+    # true whether or not the engine wrote a capture into it, and the compare
+    # below would go on to hash nothing and report it as a golden mismatch.
+    [ -s "$out" ] || fail "no capture written for 'ui $args'"
     if [ "${LBA2_UI_REGEN:-}" = "1" ]; then
         mkdir -p "$(dirname "$golden")"
         cp "$out" "$golden"
@@ -317,9 +348,9 @@ ui_compare_wide() {
     [ -f "$golden" ] || skip "640 golden missing — run the 640 test first: $golden"
     out="$(mktemp -t "${TESTNAME:-ui}.XXXXXX.png")"
     ctl_headless_at "$res" --load "$LBA2_TEST_SAVE" \
-        --exec "ui $args $out" --fixed-dt 16 --tick 200 --exit >/dev/null 2>&1 \
+        --exec "ui $args $(engine_path "$out")" --fixed-dt 16 --tick 200 --exit >/dev/null 2>&1 \
         || { rc=$?; rm -f "$out"; fail "verb 'ui $args' at $res returned non-zero ($rc)"; }
-    [ -f "$out" ] || fail "no capture written for 'ui $args' at $res"
+    [ -s "$out" ] || fail "no capture written for 'ui $args' at $res"
     python3 - "$golden" "$out" <<'PY'
 import sys
 from PIL import Image

--- a/tests/automation/lib.sh
+++ b/tests/automation/lib.sh
@@ -285,7 +285,8 @@ seed_menu_save_dir() {
 # An empty LBA2_TEST_SAVE runs without --load, for the one surface whose subject
 # is the absence of a save: the main menu a new install shows.
 ui_compare() {
-    local args="" golden="" out="" shaA shaB rc=0
+    local args="" golden="" out="" shaA shaB rc=0 exclude=""
+    if [ "${1:-}" = "--exclude" ]; then exclude="$2"; shift 2; fi
     while [ $# -gt 1 ]; do args="${args:+$args }$1"; shift; done
     golden="$1"
     out="$(mktemp -t "${TESTNAME:-ui}.XXXXXX.png")"
@@ -314,8 +315,21 @@ ui_compare() {
         pass "regenerated golden: $(basename "$golden")"
     fi
     [ -f "$golden" ] || { rm -f "$out"; fail "golden not committed yet: $golden"; }
-    shaA=$(sha256sum "$out" | awk '{print $1}')
-    shaB=$(sha256sum "$golden" | awk '{print $1}')
+    if [ -n "$exclude" ]; then
+        # Decoded pixels with the band blanked, rather than the file's bytes, so
+        # one golden serves both platforms. png_hash refuses an exclusion that no
+        # longer fits the image, which is the case where the band has moved and
+        # the mask would otherwise start hiding a surface it was never aimed at.
+        command -v python3 >/dev/null 2>&1 \
+            || skip "python3 needed to compare 'ui $args' (its capture is masked)"
+        shaA=$(python3 "$REPO/scripts/dev/png_hash.py" "$out" --exclude "$exclude") \
+            || fail "could not hash the capture for 'ui $args'"
+        shaB=$(python3 "$REPO/scripts/dev/png_hash.py" "$golden" --exclude "$exclude") \
+            || fail "could not hash the golden for 'ui $args'"
+    else
+        shaA=$(sha256sum "$out" | awk '{print $1}')
+        shaB=$(sha256sum "$golden" | awk '{print $1}')
+    fi
     if [ "$shaA" = "$shaB" ]; then
         rm -f "$out"
         pass "ui $args matches golden ($(basename "$golden"))"
@@ -340,7 +354,8 @@ ui_compare() {
 # truth, there is no per-width golden to regenerate.
 ui_compare_wide() {
     local res="$1"; shift
-    local args="" golden="" out="" py_rc
+    local args="" golden="" out="" py_rc exclude=""
+    if [ "${1:-}" = "--exclude" ]; then exclude="$2"; shift 2; fi
     while [ $# -gt 1 ]; do args="${args:+$args }$1"; shift; done
     golden="$1"
     python3 -c "from PIL import Image" 2>/dev/null \
@@ -351,11 +366,12 @@ ui_compare_wide() {
         --exec "ui $args $(engine_path "$out")" --fixed-dt 16 --tick 200 --exit >/dev/null 2>&1 \
         || { rc=$?; rm -f "$out"; fail "verb 'ui $args' at $res returned non-zero ($rc)"; }
     [ -s "$out" ] || fail "no capture written for 'ui $args' at $res"
-    python3 - "$golden" "$out" <<'PY'
+    python3 - "$golden" "$out" "$exclude" <<'PY'
 import sys
-from PIL import Image
+from PIL import Image, ImageDraw
 golden = Image.open(sys.argv[1]).convert("RGB")
 capture = Image.open(sys.argv[2]).convert("RGB")
+exclude = sys.argv[3] if len(sys.argv) > 3 else ""
 gw, gh = golden.size
 cw, ch = capture.size
 if cw < gw or ch < gh:
@@ -363,6 +379,15 @@ if cw < gw or ch < gh:
     sys.exit(2)
 dx, dy = (cw - gw) // 2, (ch - gh) // 2
 cropped = capture.crop((dx, dy, dx + gw, dy + gh))
+# Blank the excluded band in both, in the golden's own coordinates: the crop has
+# already put the capture on the same origin, so one rectangle covers both.
+if exclude:
+    x, y, w, h = (int(v) for v in exclude.split(","))
+    if x + w > gw or y + h > gh:
+        sys.stderr.write(f"exclusion {exclude} falls outside the {gw}x{gh} golden\n")
+        sys.exit(2)
+    for im in (golden, cropped):
+        ImageDraw.Draw(im).rectangle([x, y, x + w - 1, y + h - 1], fill=(0, 0, 0))
 gpx = golden.tobytes()
 cpx = cropped.tobytes()
 if gpx == cpx:

--- a/tests/automation/test_action_substep.sh
+++ b/tests/automation/test_action_substep.sh
@@ -89,10 +89,15 @@ ctl --fixed-timestep 16 --fixed-dt 16 --load "$SAVE" \
     --exec "$ARM; input throw 60" --tick 40 --dump-state "$on" --exit >/dev/null 2>&1 || fail "throttle-on run failed"
 ctl --fixed-timestep 0  --fixed-dt 16 --load "$SAVE" \
     --exec "$ARM; input throw 60" --tick 40 --dump-state "$off" --exit >/dev/null 2>&1 || fail "throttle-off run failed"
+# Paths come in as arguments, not spliced into the program text, because python3
+# under MSYS2 is a native Windows binary: a standalone path argument is rewritten
+# on its way to it, one inside a longer string is not. Spliced, the two opens
+# raised FileNotFoundError, python exited non-zero, and this read as the two paths
+# having diverged -- a diagnosis of the engine for a fault in the plumbing.
 if ! python3 -c "
 import json,sys
-a=json.load(open('$on'))['hero']; b=json.load(open('$off'))['hero']
-sys.exit(0 if a==b else 1)"; then
+a=json.load(open(sys.argv[1]))['hero']; b=json.load(open(sys.argv[2]))['hero']
+sys.exit(0 if a==b else 1)" "$on" "$off"; then
     fail "60 fps throttled path diverges from the historical (throttle-off) path — the fix perturbed the reference"
 fi
 echo "  60fps: throttled path == throttle-off path (fix is a no-op at one sub-step)"

--- a/tests/automation/test_profile_bind.sh
+++ b/tests/automation/test_profile_bind.sh
@@ -27,14 +27,36 @@ mkdir -p "$alt"
 for f in "$LBA2_GAME_DIR"/*; do
     ln -s "$f" "$alt/" 2>/dev/null
 done
+# An empty tree is not a second install. Where symlinks cannot be created --
+# Windows without the privilege, a TMPDIR on a filesystem without them -- every
+# ln above fails quietly, and the run that follows finds no game data to boot.
+# That is an environment this test cannot run in, not a binding that went wrong,
+# and reporting it as the latter sends the reader after a bug that is not there.
+[ -n "$(ls -A "$alt" 2>/dev/null)" ] ||
+    skip "cannot symlink the game data (needs privileges on Windows)"
 A="${LBA2_GAME_DIR%/}"
 B="$alt"
 u="$tmp/user"
 
 # stdin comes from /dev/null so a child cannot eat the rest of this script.
+#
+# A run that never started is indistinguishable, downstream, from a binding that
+# never happened: every check below reads a file the engine writes, and an engine
+# that exited on an unknown flag, missing data or a crash writes none of them. So
+# the status is checked here, while the engine can still say why, rather than left
+# to surface later as a confident wrong answer about binding.
+#
+# The engine says why it stopped on one line, either its own argument error or a
+# logged one, so that line is what gets quoted. The tail is the fallback for the
+# ways a run ends without saying anything: a timeout, or a signal.
 run() { # run <extra args...>
+    local rc=0 why
     ctl --user-dir "$u" --no-audio --language English --fixed-dt 16 --tick 2 --exit \
-        "$@" >/dev/null 2>&1 </dev/null
+        "$@" > "$tmp/run.out" 2>&1 </dev/null || rc=$?
+    [ "$rc" -eq 0 ] && return 0
+    why=$(tr -d '\r' < "$tmp/run.out" | grep -aE '^(error:|\[ERROR\])' | head -2)
+    [ -n "$why" ] || why=$(tr -d '\r' < "$tmp/run.out" | tail -3)
+    fail "the run exited $rc: $(printf '%s' "$why" | tr '\n' ' ')"
 }
 # The engine stores the path with a trailing separator; the comparison is about
 # which folder, not how it was spelled.

--- a/tests/automation/test_profile_bind.sh
+++ b/tests/automation/test_profile_bind.sh
@@ -22,21 +22,34 @@ trap 'rm -rf "$tmp"' EXIT
 
 # The second install is a tree of symlinks to the real data, so two folders that
 # both boot cost nothing and neither depends on the developer having a spare copy.
+#
+# On Windows it is not free: MSYS2's ln copies unless it is told to make real
+# links, so this is a full copy of the game data, and the test pays for it in
+# disk and in the seconds that copy takes. It stays a copy rather than becoming
+# a second --game-dir the developer has to supply, because a test that needs two
+# installs on hand is a test nobody runs.
 alt="$tmp/alt-install"
 mkdir -p "$alt"
 for f in "$LBA2_GAME_DIR"/*; do
     ln -s "$f" "$alt/" 2>/dev/null
 done
-# An empty tree is not a second install. Where symlinks cannot be created --
-# Windows without the privilege, a TMPDIR on a filesystem without them -- every
-# ln above fails quietly, and the run that follows finds no game data to boot.
-# That is an environment this test cannot run in, not a binding that went wrong,
-# and reporting it as the latter sends the reader after a bug that is not there.
+# An empty tree is not a second install. Where a link can be neither made nor
+# faked -- MSYS2 set to winsymlinks:nativestrict without the privilege to create
+# one, a TMPDIR on a filesystem without them -- every ln above fails quietly, and
+# the run that follows finds no game data to boot. That is an environment this
+# test cannot run in, not a binding that went wrong, and reporting it as the
+# latter sends the reader after a bug that is not there.
 [ -n "$(ls -A "$alt" 2>/dev/null)" ] ||
-    skip "cannot symlink the game data (needs privileges on Windows)"
+    skip "cannot copy or link the game data to a second folder"
 A="${LBA2_GAME_DIR%/}"
 B="$alt"
 u="$tmp/user"
+# What the engine will call these two folders. The flags below still name them
+# the way this shell does, since MSYS2 converts a standalone path argument on
+# its way to a native binary; it is only the comparisons that have to know the
+# engine answers in its own spelling.
+A_SEEN="$(norm_path "$(engine_path "$A")")"
+B_SEEN="$(norm_path "$(engine_path "$B")")"
 
 # stdin comes from /dev/null so a child cannot eat the rest of this script.
 #
@@ -58,25 +71,34 @@ run() { # run <extra args...>
     [ -n "$why" ] || why=$(tr -d '\r' < "$tmp/run.out" | tail -3)
     fail "the run exited $rc: $(printf '%s' "$why" | tr '\n' ' ')"
 }
-# The engine stores the path with a trailing separator; the comparison is about
-# which folder, not how it was spelled.
-bound() { sed -e 's:/*$::' "$u/profiles/p/last_game_dir.txt" 2>/dev/null; }
-# Which folder the run actually read its assets from, from the boot banner.
-assets() { awk '/^Assets:/ { print $2; exit }' "$u/profiles/p/adeline.log" | sed -e 's:/*$::'; }
+# Which folder the profile is bound to. Compared as a shape rather than a
+# spelling: the engine stores the path with a trailing separator, and on Windows
+# that separator is a backslash and the line ends CRLF.
+bound() { norm_path "$(cat "$u/profiles/p/last_game_dir.txt" 2>/dev/null)"; }
+# Which folder the run actually read its assets from, from the boot banner, whose
+# shape is `Assets: <path>  (<source>)`. Taken whole rather than as a field: an
+# install path with a space in it is ordinary on Windows, and reading one field
+# of it silently compares a prefix, which is a pass this test must not give.
+assets() {
+    norm_path "$(sed -n 's/^Assets: \(.*\)  (.*)$/\1/p' "$u/profiles/p/adeline.log" | head -1)"
+}
 
 # --- 1. first use binds ------------------------------------------------------
 run --profile p --game-dir "$A"
 [ -f "$u/profiles/p/last_game_dir.txt" ] || fail "naming a folder on first use bound nothing"
-[ "$(bound)" = "$A" ] || fail "first use bound '$(bound)', expected '$A'"
+[ "$(bound)" = "$A_SEEN" ] || fail "first use bound '$(bound)', expected '$A_SEEN'"
 
 # --- 2. a second folder runs, and leaves the binding alone -------------------
 run --profile p --game-dir "$B"
-[ "$(assets)" = "$B" ] || fail "--game-dir did not run against '$B' (ran against '$(assets)')"
-[ "$(bound)" = "$A" ] || fail "--game-dir moved the binding to '$(bound)'; it is for the run only"
+[ "$(assets)" = "$B_SEEN" ] ||
+    fail "--game-dir did not run against '$B_SEEN' (ran against '$(assets)')"
+[ "$(bound)" = "$A_SEEN" ] ||
+    fail "--game-dir moved the binding to '$(bound)'; it is for the run only"
 
 # --- 3. asking to move it moves it -------------------------------------------
 run --profile p --game-dir "$B" --bind-game-dir
-[ "$(bound)" = "$B" ] || fail "--bind-game-dir left the binding at '$(bound)', expected '$B'"
+[ "$(bound)" = "$B_SEEN" ] ||
+    fail "--bind-game-dir left the binding at '$(bound)', expected '$B_SEEN'"
 
 # --- 4. with nothing to bind, it says so -------------------------------------
 # A flag that quietly does nothing is how the setting it was meant to move goes

--- a/tests/automation/test_res_catalog_sweep.sh
+++ b/tests/automation/test_res_catalog_sweep.sh
@@ -54,7 +54,9 @@ for m in $modes; do
     h="${m#*x}"
     rm -f "$tmp"
 
-    if ! ctl_headless_at "$m" --exec "ui resolution $tmp" --tick 6 --exit \
+    # engine_path: the capture path is inside the --exec string, which MSYS2 hands
+    # to a native binary verbatim, so it has to be named in the engine's own terms.
+    if ! ctl_headless_at "$m" --exec "ui resolution $(engine_path "$tmp")" --tick 6 --exit \
         >/dev/null 2>&1; then
         bad="$bad $m(exit)"
         continue

--- a/tests/automation/test_ui_display.sh
+++ b/tests/automation/test_ui_display.sh
@@ -22,4 +22,5 @@ GOLDEN="$REPO/tests/savegame/corpus/baselines/ui/display_Anon1.png"
 
 [ -f "$LBA2_TEST_SAVE" ] || skip "fixture save missing: $LBA2_TEST_SAVE"
 
-ui_compare "--black-bg display" "$GOLDEN"
+# Plasma strip excluded, as in test_ui_menu_main.sh.
+ui_compare --exclude 46,127,549,49 "--black-bg display" "$GOLDEN"

--- a/tests/automation/test_ui_menu_main.sh
+++ b/tests/automation/test_ui_menu_main.sh
@@ -33,4 +33,9 @@ trap 'rm -rf "$tmp"' EXIT
 export LBA2_USER_DIR="$tmp/user"
 seed_menu_save_dir "$LBA2_USER_DIR" returning
 
-ui_compare "menu-main" "$GOLDEN"
+# The plasma strip across the top of the panel is left out of the comparison: it
+# settles at a different state on Windows than on Linux and stays there, so a
+# golden that includes it can only ever match one platform. Everything else in
+# the frame -- layout, text, colours -- is still compared byte for byte.
+# Re-measure with a diff of a failing capture against the golden if the panel moves.
+ui_compare --exclude 46,174,549,49 "menu-main" "$GOLDEN"

--- a/tests/automation/test_ui_menu_main_fresh.sh
+++ b/tests/automation/test_ui_menu_main_fresh.sh
@@ -26,4 +26,6 @@ export LBA2_USER_DIR="$tmp/user"
 LBA2_TEST_SAVE=""
 seed_menu_save_dir "$LBA2_USER_DIR" fresh
 
-ui_compare "menu-main" "$GOLDEN"
+# Plasma strip excluded, as in test_ui_menu_main.sh; four rows higher here,
+# because a fresh install's menu has one entry fewer and the panel sits up.
+ui_compare --exclude 46,170,549,49 "menu-main" "$GOLDEN"

--- a/tests/automation/test_ui_menu_options.sh
+++ b/tests/automation/test_ui_menu_options.sh
@@ -13,4 +13,6 @@ GOLDEN="$REPO/tests/savegame/corpus/baselines/ui/menu_options_Anon1.png"
 
 [ -f "$LBA2_TEST_SAVE" ] || skip "fixture save missing: $LBA2_TEST_SAVE"
 
-ui_compare "--black-bg menu-options" "$GOLDEN"
+# Plasma strip excluded, as in test_ui_menu_main.sh. --black-bg does not suppress
+# it: the cleanroom composite is about what is behind the panel, not on it.
+ui_compare --exclude 46,71,549,49 "--black-bg menu-options" "$GOLDEN"

--- a/tests/automation/test_ui_menu_options_wide.sh
+++ b/tests/automation/test_ui_menu_options_wide.sh
@@ -15,4 +15,6 @@ GOLDEN="$REPO/tests/savegame/corpus/baselines/ui/menu_options_Anon1.png"
 
 [ -f "$LBA2_TEST_SAVE" ] || skip "fixture save missing: $LBA2_TEST_SAVE"
 
-ui_compare_wide "768x480" "--black-bg menu-options" "$GOLDEN"
+# Same plasma-strip exclusion as test_ui_menu_options.sh, in the 640 golden's
+# coordinates: the centred crop has already put both images on one origin.
+ui_compare_wide "768x480" --exclude 46,71,549,49 "--black-bg menu-options" "$GOLDEN"

--- a/tests/plasma_steps/CMakeLists.txt
+++ b/tests/plasma_steps/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Host test for the menu plasma's evolution (SOURCES/PLASMA.CPP). Links that one
+# translation unit and nothing else: no assembler, no engine, no retail data, so
+# unlike tests/test_plasma.cpp (which compares against PLASMA.ASM and therefore
+# lives behind LBA2_BUILD_ASM_EQUIV_TESTS) this one runs in CI on every platform.
+add_executable(test_plasma_steps test_plasma_steps.cpp)
+
+target_sources(test_plasma_steps PRIVATE ${CMAKE_SOURCE_DIR}/SOURCES/PLASMA.CPP)
+
+target_include_directories(test_plasma_steps PRIVATE
+    ${CMAKE_SOURCE_DIR}/SOURCES     # PLASMA.H
+    ${CMAKE_SOURCE_DIR}/LIB386/H    # SYSTEM/ADELINE_TYPES.H
+    ${CMAKE_SOURCE_DIR}/tests       # test_harness.h
+)
+set_target_properties(test_plasma_steps PROPERTIES CXX_STANDARD 11)
+
+add_test(NAME test_plasma_steps COMMAND test_plasma_steps)
+register_host_test(test_plasma_steps)

--- a/tests/plasma_steps/test_plasma_steps.cpp
+++ b/tests/plasma_steps/test_plasma_steps.cpp
@@ -1,0 +1,131 @@
+// Do_Plasma's evolution, pinned so it runs in CI on every platform.
+//
+// tests/test_plasma.cpp already covers this function, and covers it better: it
+// compares against the original PLASMA.ASM across fixed, edge and random cases.
+// It needs an assembler and objcopy to build, so it sits behind
+// LBA2_BUILD_ASM_EQUIV_TESTS, which every workflow turns OFF. The algorithm has
+// therefore never run in CI. This is the cheap half that can: no assembler, no
+// engine, no retail data, one committed digest.
+//
+// It exists because the menu goldens stopped covering the plasma. Those goldens
+// exclude the strip, since its starting state comes from Rnd() and libc rand()
+// differs per platform (#530), and excluding it left the evolution with nothing
+// watching it. The starting state is what is unportable, not the arithmetic, so
+// this seeds the state itself and pins the arithmetic alone. That split is the
+// point: it holds on every platform precisely because it does not touch rand().
+
+#include "test_harness.h"
+
+#include <PLASMA.H>
+
+#include <string.h>
+
+// The interleave and control-point count InitPlasmaMenu asks for (ANIMTEX.CPP:
+// texdest[2] = 4 control points, and a width/nbactivepoints that resolves to
+// this interleave). Pinning the shape the menu actually uses, not an arbitrary one.
+#define INTERLEAVE 4
+#define NB_ACTIVE_POINTS 4
+
+#define NB_PTS_INTER (1u << INTERLEAVE)
+#define WIDTH (NB_ACTIVE_POINTS * NB_PTS_INTER)
+#define NB_POINTS (NB_ACTIVE_POINTS * NB_ACTIVE_POINTS)
+#define NB_COLORS 12
+#define TEX_SIZE (256u * WIDTH)
+
+extern "C" U32 Nb_Pts_Inter;
+extern "C" U32 Nb_Pts_Control;
+
+// A fixed starting state, chosen to look like one InitPlasmaMenu would produce
+// without asking rand() for it: vertices spread across the colour range, speeds
+// alternating in sign, accumulators at the 500 the engine seeds them with.
+static void seed_state(S16 *virgule, S16 *speed, S32 *acc, U8 *colors) {
+    memset(virgule, 0, NB_POINTS * NB_PTS_INTER * sizeof(S16));
+    for (U32 i = 0; i < NB_POINTS; ++i) {
+        virgule[i * NB_PTS_INTER] = (S16)(((i * 977u) % ((NB_COLORS - 1) * 256)));
+        S32 va = (S32)(2 * 512 + ((i * 313u) % (2 * 512)));
+        speed[i] = (S16)((i & 1u) ? -va : va);
+        acc[i] = 500;
+    }
+    for (U32 i = 0; i < NB_COLORS; ++i) {
+        colors[i] = (U8)(i + 12 * 16);
+    }
+}
+
+static U32 fnv1a(const U8 *data, U32 len) {
+    U32 h = 2166136261u;
+    for (U32 i = 0; i < len; ++i) {
+        h ^= data[i];
+        h *= 16777619u;
+    }
+    return h;
+}
+
+// Thirty steps: what a menu capture runs through before it is photographed,
+// measured on both platforms while chasing #530. Enough for the vertices to
+// have wrapped and the accumulators to have changed sign more than once, so a
+// digest over it is sensitive to the parts of Do_Plasma a single step is not.
+#define STEPS 30
+
+static U32 run_steps(void) {
+    static S16 virgule[NB_POINTS * NB_PTS_INTER];
+    static S16 speed[NB_POINTS];
+    static S32 acc[NB_POINTS];
+    static U8 colors[NB_COLORS];
+    static U8 tex[TEX_SIZE];
+
+    seed_state(virgule, speed, acc, colors);
+    memset(tex, 0, sizeof(tex));
+
+    T_PLASMA plasma;
+    memset(&plasma, 0, sizeof(plasma));
+    plasma.TabVirgule = virgule;
+    plasma.TabSpeed = speed;
+    plasma.TabAcc = acc;
+    plasma.TabColors = colors;
+    plasma.TexOffset = tex;
+    plasma.Interleave = (U8)INTERLEAVE;
+    plasma.NbActivePoints = (U8)NB_ACTIVE_POINTS;
+    plasma.NbColors = (U8)NB_COLORS;
+    plasma.Speed = 0;
+
+    Nb_Pts_Inter = NB_PTS_INTER;
+    Nb_Pts_Control = NB_ACTIVE_POINTS;
+
+    for (U32 i = 0; i < STEPS; ++i) {
+        Do_Plasma(&plasma);
+    }
+
+    // The texture is what reaches the screen; the vertex table is what carries
+    // state between steps. Hashing both means a change to either is a failure,
+    // rather than one that happens to leave the visible bytes alone.
+    U32 h = fnv1a(tex, TEX_SIZE);
+    h ^= fnv1a((const U8 *)virgule, sizeof(virgule));
+    h ^= fnv1a((const U8 *)speed, sizeof(speed));
+    h ^= fnv1a((const U8 *)acc, sizeof(acc));
+    return h;
+}
+
+// Regenerate deliberately, and only for a change to Do_Plasma you meant to make:
+// this digest is the whole assertion. tests/test_plasma.cpp against PLASMA.ASM is
+// the authority on whether a new value is still the original algorithm.
+#define EXPECTED_DIGEST 0xcce88029u
+
+static void test_plasma_steps_are_pinned(void) {
+    const U32 got = run_steps();
+    if (EXPECTED_DIGEST == 0u) {
+        printf("    plasma digest after %d steps: 0x%08xu\n", STEPS, got);
+    }
+    ASSERT_EQ_UINT(EXPECTED_DIGEST, got);
+}
+
+// Same input, same output, twice in the same process: guards the case where a
+// step leaks state through a static and the digest above only holds on a fresh run.
+static void test_plasma_steps_are_repeatable(void) {
+    ASSERT_EQ_UINT(run_steps(), run_steps());
+}
+
+int main(void) {
+    RUN_TEST(test_plasma_steps_are_pinned);
+    RUN_TEST(test_plasma_steps_are_repeatable);
+    TEST_SUMMARY();
+}


### PR DESCRIPTION
The control-harness suite did not run on Windows, and the way it did not run was the problem: `precheck` looks for `DISPLAY` or `WAYLAND_DISPLAY`, neither of which exists there, so every test skipped on a machine that has a display. A clean run of nothing reads exactly like a pass, which is how the suite came to be Linux-only without anyone deciding it should be.

Allowed to run, it reported **34 passed, 6 skipped, 13 failed**. None of the 13 was the engine. All four causes were the harness describing its own plumbing as a fault in what it was testing.

## The rule behind most of it

MSYS2 rewrites a **standalone** path argument on its way to a native binary, but not one **inside a longer string**. So `--dump-state "$out"` arrives as `D:/...` and works, while `--exec "ui menu-main $out"` arrives verbatim and the engine cannot create the file.

That one rule accounts for ten of the thirteen. The `ui` capture verb takes its output path inside `--exec`, so nine `ui_*` tests and `res_catalog_sweep` compared a hash of a file that was never written against a committed golden and called it a divergence. The hash they were reporting was `e3b0c442…`, which is SHA-256 of empty input.

The same rule applies to `python3`, which is also a native binary. `test_action_substep` spliced two paths into the program text of `python3 -c` instead of passing them as arguments the way every sibling does; python raised `FileNotFoundError`, exited non-zero, and the test reported the throttled and throttle-off paths as having diverged. That one had me chasing a determinism bug in the engine for a while, which is the cost of a test that misattributes its own failures.

`engine_path` in `lib.sh` handles the cases where a path has to travel inside a longer argument. It is `cygpath -m` on Windows and the identity everywhere else, so call sites carry no platform test.

## The other three

**The capture guard tested `-f`**, which `mktemp` had already made true, so an empty capture reached the comparison rather than being reported as the missing file it was. It tests `-s` now. This is why the failure said "diverges from golden" instead of "no capture written".

**Collation.** Bash expands a glob in the locale's collating order: byte order under a typical Linux locale, case-insensitive under MSYS2. The projection corpus was walked in two different orders, so its hash file differed from the golden by *line order alone*. `LC_COLLATE=C` is pinned in `lib.sh`; `LC_ALL` is not, since the encoding a test reads its fixtures in is not that file's business.

**Path shape.** A path the engine wrote comes back in the engine's own spelling — ending with the platform separator, and CRLF. `test_profile_bind` compared those as strings and failed at its first check on a working engine:

```
FAIL: first use bound 'E:/LBA2 Versions/LBA2-Steam/Common\',
           expected '/e/LBA2 Versions/LBA2-Steam/Common'
```

It also parsed the boot banner with `awk '{print $2}'`, which cuts an install path at its first space — so on a path like `E:/LBA2 Versions/...` it was silently comparing the prefix `E:/LBA2`, a pass available for the wrong reason. `scripts/dev/dist_check.sh` had already met all of this and solved it locally; its two shapes move to `lib.sh` as `engine_path` and `norm_path`.

The first two commits are that test on its own, including a skip for environments where the second install cannot be built at all, and an exit-status check so a run that never started says why instead of surfacing three steps later as a wrong answer about binding.

## Result

| | before | after |
| --- | --- | --- |
| Windows | 34 passed, 6 skipped, 13 failed | 53 passed, 2 skipped, 2 failed |
| Linux | 0 failed | 0 failed |

Both measured on this branch's current base. The suite has grown while this was open, so the two columns are not the same 53 tests: the "before" run was taken when there were 53, and there are 57 now. The failure count is the comparable half, and what those failures are is below.

Linux reads 55 passed, 2 skipped. It was run before and after the harness changes on the same tree and did not move. Host tests 55/55, up one for the plasma test below.

The Windows figure moves by one between runs depending on whether `res_catalog_sweep` hits the intermittent crash below: it did on two of the four full runs taken here, and did not on the run quoted.

The four camera fixtures that landed on main while this was open (`camera_axes`, `camera_interior`, `camzone_hold`, `classiccam_controls`) pass on Windows as well as Linux. They needed nothing: they keep paths out of `--exec`, pass the one `python3 -c` its path as `sys.argv[1]`, and glob no corpus. Worth saying because under the old `precheck` all four would have skipped on Windows and read as passes.

Verified on both platforms: Windows via MSYS2 UCRT64 against a native build and retail Steam data, Linux on the usual tree. `test_profile_bind` additionally checked headless with no `DISPLAY` at all (passes), with no display and no dummy driver (skips), and with symlink creation failing (skips). `shellcheck -S warning -f gcc` clean.

## The menu goldens, and what the strip turned out to be

Five `ui_*` goldens differed on Windows in one 549×49 band, the plasma strip at the top of the menu panel. Chasing why produced the most useful finding in the PR, and ruled out every obvious answer on the way:

- **not a clock drifting.** Captures at 200, 201 and 260 ticks are byte-identical, and repeated runs agree on both platforms. Instrumenting the animation gave **63 calls, 30 steps** on Linux and Windows alike.
- **not the data.** The same Linux binary against the hand-assembled tree and against the Steam tree produced byte-identical captures.
- **not uninitialised memory.** The band is the same 16-colour ramp on both sides, shifted in distribution, where heap residue would be neither.
- **not the arithmetic.** `Do_Plasma` is pure integer, and the new host test below hashes the same value on both platforms.

It is [`ANIMTEX.CPP:121`](../blob/main/SOURCES/ANIMTEX.CPP#L121): the strip seeds its vertices and speeds from `Rnd()`, which is `rand() % n`, and libc's `rand()` is a different generator with a different `RAND_MAX` on each platform (glibc 2147483647, Windows CRT 32767). Filed as **#530**, because the plasma is the harmless case — anything the RNG drives behaves differently on Windows, and that is very likely **#525**'s six differing *event counts* as well, which is now noted there.

So the band is excluded from those five goldens, per surface, and one golden serves both platforms. Excluding it makes all four 640 goldens hash **exactly** equal to the Windows captures, which is the evidence that the strip was the only cross-platform difference in those frames.

Excluding it also removed the only plasma coverage that routinely ran, so this PR puts two things back:

- **`tests/plasma_steps/`** pins the evolution: fixed state, 30 steps, one digest over the texture and the state carried between steps. It links `PLASMA.CPP` alone, so unlike `tests/test_plasma.cpp` — which is a better test, but needs an assembler and so sits behind `LBA2_BUILD_ASM_EQUIV_TESTS`, which every workflow sets `OFF` — it runs in CI on every platform. **The digest is identical on Linux and Windows.**
- **`ui_compare` still watches the excluded band by shape**, asserting it holds 8 to 64 distinct colours. Measured before choosing bounds: a drawn strip is 16 or 17, a flat region is 3, a 3D model region is 88. That is aimed at `8eee5c3c` ("PR #236's regen accidentally enshrined that all-black image as the golden, masking the test"), where a golden went vacuous and nothing said so.

## What still fails on Windows

Two divergences are the platform rather than the harness, both documented in `CONTROL.md` and left standing rather than papered over:

- **`ui_found_object`** differs in the item model on the right of the frame, not the strip: a handful of pixels across an identical 88-colour palette. Same cause as the corpus rounding below, so masking it would remove what the test is for.
- **`projection_corpus`** differs on 25 of 50 saves: 19 by hash alone, which is the rounding the `long double` + `lrintl` x87 emulation exists to pin, and **6 by event count**, now most likely #530. Filed as #525.

And one is a real bug rather than a divergence: **an intermittent segfault at 320-wide resolutions** (320x200 3/10, 320x240 2/10, 640x480 0/10, against 0/10 for all three on Linux). This is why `res_catalog_sweep` failed two of the four full Windows runs taken here and passed the other two. Filed as **#526**.
