### PR TITLE
test(camera): pin elevation, zoom and the interior gate

### DIFF
--- a/SOURCES/EXTFUNC.CPP
+++ b/SOURCES/EXTFUNC.CPP
@@ -2380,15 +2380,22 @@ S32 GereExtKeys(U32 key)
             flag = 1;
         }
         /* Zoom: numpad / = closer, numpad * = further */
+        /* Clamp after stepping, not before. Testing the limit first lets the last step cross it
+         * by up to a step's worth, so the boom settles a little inside the hero at one end and
+         * past the far limit at the other. The mouse and stick reach the same value through
+         * ApplyManualCameraNudge, which clamps after, so the two routes disagreed about how far
+         * zoom goes. */
         if (CheckKey(K_NUMPAD_DIV)) {
-            if (FollowCamBaseDist > FOLLOW_CAM_DIST_MIN)
-                FollowCamBaseDist -= FOLLOW_CAM_ZOOM_STEP;
+            FollowCamBaseDist -= FOLLOW_CAM_ZOOM_STEP;
+            if (FollowCamBaseDist < FOLLOW_CAM_DIST_MIN)
+                FollowCamBaseDist = FOLLOW_CAM_DIST_MIN;
             FirstTime = AFF_ALL_FLIP;
             flag = 1;
         }
         if (CheckKey(K_NUMPAD_MUL)) {
-            if (FollowCamBaseDist < FOLLOW_CAM_DIST_MAX)
-                FollowCamBaseDist += FOLLOW_CAM_ZOOM_STEP;
+            FollowCamBaseDist += FOLLOW_CAM_ZOOM_STEP;
+            if (FollowCamBaseDist > FOLLOW_CAM_DIST_MAX)
+                FollowCamBaseDist = FOLLOW_CAM_DIST_MAX;
             FirstTime = AFF_ALL_FLIP;
             flag = 1;
         }

--- a/tests/automation/test_camera_axes.sh
+++ b/tests/automation/test_camera_axes.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Elevation and zoom: the two Auto-camera axes that are not orbit.
+#
+# Orbit has had all the attention because that is where the bugs were, and the other two axes go
+# through the same nudge with none of the coverage. Both have limits that matter: elevation past
+# its range puts the camera under the floor or overhead, and zoom past its range puts it inside
+# the hero or out where he is a speck. Both are also meant to leave the orbit alone, which is what
+# lets a player tilt or zoom without the follow re-engaging behind them.
+#
+# Local-only (needs retail data + the tracked corpus save). Not in host_quick CI.
+TESTNAME=camera_axes
+. "$(dirname "$0")/lib.sh"
+. "$(dirname "$0")/camlib.sh"
+cam_precheck
+
+ALPHA_MIN=150   # FOLLOW_CAM_ALPHA_MIN
+ALPHA_MAX=600   # FOLLOW_CAM_ALPHA_MAX
+DIST_MIN=7000   # FOLLOW_CAM_DIST_MIN, the boom's closest approach
+DIST_MAX=20000  # FOLLOW_CAM_DIST_MAX
+K_NUMPAD_DIV=84 # zoom in
+K_NUMPAD_MUL=85 # zoom out
+
+log="$(mktemp)"; state="$(mktemp)"
+trap 'rm -f "$log" "$state"' EXIT
+
+# --- elevation ------------------------------------------------------------------------------
+# Driven hard in both directions, long enough to sit on each limit.
+cam_run "$log" "" \
+    --exec-at 20 "camnudge 0 40 40" \
+    --exec-at 90 "camnudge 0 -40 60" \
+    --tick 180
+
+read -r lo hi < <(cam_col "$log" alpha | awk '
+    NR == 1 { lo = hi = $1 }
+    { if ($1 < lo) lo = $1; if ($1 > hi) hi = $1 }
+    END { print lo, hi }')
+
+[ "$hi" = "$ALPHA_MAX" ] \
+    || fail "tilting up stopped at $hi rather than the $ALPHA_MAX ceiling"
+[ "$lo" = "$ALPHA_MIN" ] \
+    || fail "tilting down stopped at $lo rather than the $ALPHA_MIN floor"
+
+# Elevation is not an orbit: it must not select the tight orbit lerp or re-arm the follow's
+# re-engage window, or tilting the camera would quietly change how it tracks the hero.
+orbited="$(cam_col "$log" orbit | awk '$1 == 1 { n++ } END { print n + 0 }')"
+[ "$orbited" -eq 0 ] \
+    || fail "tilting raised the manual-orbit flag on $orbited frame(s): elevation is being treated as an orbit"
+
+armed="$(cam_col "$log" delay | awk '$1 != 0 { n++ } END { print n + 0 }')"
+[ "$armed" -eq 0 ] \
+    || fail "tilting re-armed the re-engage window on $armed frame(s)"
+
+# --- zoom -----------------------------------------------------------------------------------
+# Read from --dump-state rather than the trace: the trace carries VueDistance, which is the
+# spring arm's eased length and overshoots slightly on its way to rest. FollowCamBaseDist is the
+# value the limits are applied to.
+zoom_to() { # <key> -> the resting boom length after holding it far longer than the range
+    ctl_headless --load "$CAM_SAVE" --fixed-dt 16 \
+        --exec "cam_follow 1" \
+        --exec-at 10 "key $1 100" \
+        --tick 130 --dump-state "$state" --exit > /dev/null 2>&1 || fail "zoom run: exit $?"
+    python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['camera']['base_dist'])" "$state"
+}
+
+near="$(zoom_to $K_NUMPAD_DIV)"
+far="$(zoom_to $K_NUMPAD_MUL)"
+
+[ "$near" = "$DIST_MIN" ] \
+    || fail "zooming in came to rest at $near rather than the $DIST_MIN floor"
+[ "$far" = "$DIST_MAX" ] \
+    || fail "zooming out came to rest at $far rather than the $DIST_MAX ceiling"
+
+pass "elevation held $ALPHA_MIN..$ALPHA_MAX without touching the orbit; zoom held $near..$far"

--- a/tests/automation/test_camera_interior.sh
+++ b/tests/automation/test_camera_interior.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# The Auto camera must stay out of interiors, whatever the player has it set to.
+#
+# Interiors are isometric: the camera holds a fixed orientation and the scene is drawn from a
+# tile-grid anchor, and the camera zones in an interior fire every frame to place it. The Auto
+# camera is a third-person follow for exterior perspective scenes and is gated to them, so an
+# interior with `cam_follow 1` has to look exactly like an interior with it off.
+#
+# The gate is a condition repeated at several call sites rather than a single switch, which is the
+# kind of thing that gets extended in one place and not the others. The symptom would be an
+# isometric scene whose camera slowly rotates behind the hero, which no golden or state dump would
+# obviously flag.
+#
+# Local-only (needs retail data + the tracked corpus save). Not in host_quick CI.
+TESTNAME=camera_interior
+. "$(dirname "$0")/lib.sh"
+. "$(dirname "$0")/camlib.sh"
+cam_precheck
+
+INTERIOR_CUBE=154
+
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+# Walk him about inside, with the Auto camera switched on. If its update runs at all, BetaCam
+# lerps toward the angle behind him and the fixed isometric orientation moves.
+ctl_headless --load "$CAM_SAVE" --fixed-dt 16 \
+    --exec "cube $INTERIOR_CUBE" \
+    --exec-at 15 "cam_follow 1; camtrace 1" \
+    --exec-at 30 "input up 120" \
+    --tick 180 --exit > "$log" 2>&1 || fail "run failed: exit $?"
+
+ext="$(cam_col "$log" ext | sort -u | tr -d '\n')"
+[ "$ext" = "0" ] \
+    || fail "cube $INTERIOR_CUBE did not stay an interior for the whole run (ext saw: $ext)"
+
+follow="$(cam_col "$log" follow | tail -1)"
+[ "$follow" = "1" ] \
+    || fail "the Auto camera was not actually enabled ($follow): the run proves nothing"
+
+walked="$(cam_col "$log" moving | awk '$1 == 1 { n++ } END { print n + 0 }')"
+[ "$walked" -gt 20 ] \
+    || fail "the hero barely moved ($walked frames): nothing for a follow camera to have followed"
+
+angles="$(cam_col "$log" beta | sort -u | wc -l)"
+[ "$angles" -eq 1 ] \
+    || fail "the camera angle moved across $angles values in an interior: the Auto camera is running there"
+
+pass "interior held one camera angle across $walked frames of walking with the Auto camera on"


### PR DESCRIPTION
Completes step 4 of #513, alongside #529 which pinned the classic camera's controls.

## Elevation and zoom

Orbit had all the attention because that is where the bugs were. These two go through the same nudge with none of the coverage, and both have limits that matter: elevation past its range puts the camera under the floor or overhead, zoom past its range puts it inside the hero or out where he is a speck.

Both are also asserted to leave the orbit alone. Tilting must not raise the manual-orbit flag or re-arm the re-engage window, which is what lets a player tilt without the follow quietly changing how it tracks.

## The limits did not hold

Pinning them turned that up. The keyboard zoom tested its limit **before** stepping, so the last press crossed it by up to a step's worth:

| | floor | ceiling |
| --- | --- | --- |
| before | 6950 | 20150 |
| limit | 7000 | 20000 |

The mouse and stick reach the same value through `ApplyManualCameraNudge`, which clamps **after** the change, so the two routes disagreed about how far zoom goes. Clamping after brings the keyboard into line. Small in absolute terms, but 7000 is documented as the distance that clears the hero's mesh, so the floor is the one that was meant to be exact.

## The interior gate

Interiors are isometric: fixed orientation, tile-grid anchor. The Auto camera is gated to exterior perspective scenes, but the gate is a condition repeated at several call sites rather than one switch, which is the kind of thing that gets extended in one place and not the others. The symptom would be an isometric scene whose camera slowly rotates behind the hero, which no golden or state dump would obviously flag.

The fixture walks the hero around an interior with `cam_follow 1` and asserts the camera holds exactly one angle throughout, having first checked that the Auto camera really was enabled and that the hero really moved.

## Not covered

The interior camera's own re-anchor, where it half-steps toward the hero once he leaves the visible area. It is gated on a render state a headless run does not reach: the camera stays on its tile anchor however far he walks, measured out to 6885 units away with no movement at all. There is nothing to assert against without either driving the render path or adding an observable for the anchor.

The hand-over out of a cutscene is also still uncovered. `CameraZone` hand-overs are covered by `camzone_hold` and `followcam_interrupt`; `CinemaMode` has no way to be driven from the harness.

## Verification

Automation suite 39 pass, 16 skip, and `profile_bind`, which fails identically on a clean `main` in this environment.

The axes fixture was run against the pre-fix clamp, where it reports the boom resting at 6950 rather than 7000. The interior fixture guards behaviour that already works and has no broken build to compare against; its own preconditions (Auto camera actually on, hero actually walking) are asserted so it cannot pass on a run where nothing happened.
