### PR TITLE
test(camera): put the camera's angle arithmetic under CI

### DIFF
--- a/SOURCES/EXTFUNC.CPP
+++ b/SOURCES/EXTFUNC.CPP
@@ -18,6 +18,7 @@
 #include <SYSTEM/MOUSE.H>
 #include <SYSTEM/WINDOW.H>
 #include "FOLLOWCAM_CFG.H"
+#include "FOLLOWCAM_MATH.H"
 #include "JOYSTICK.H"
 
 extern S32 Nxw, Nyw, Nzw;
@@ -1981,7 +1982,7 @@ void FollowCamAdoptAngle(void) {
     /* The inverse of the follow update's target rule: it derives the target from
      * (AddBetaCam + hero Beta), so solving that for the current BetaCam gives the
      * offset that leaves the camera where it stands. */
-    AddBetaCam = (2048 - BetaCam - ptr3d->Beta) & 4095;
+    AddBetaCam = FollowCamPanForAngle(BetaCam, ptr3d->Beta);
 }
 
 /* Apply a per-frame manual camera nudge from an analog source (mouse drag or

--- a/SOURCES/FOLLOWCAM_MATH.H
+++ b/SOURCES/FOLLOWCAM_MATH.H
@@ -22,12 +22,21 @@
  * over every angle pair, and that the lerp always converges.
  */
 
-/* Shortest way round: the signed difference between two angles, in (-2048, 2048].
- * Written out at a dozen sites before this, each doing its own pair of wraps. */
+/* Shortest way round: the signed difference between two angles, in [-2048, 2048].
+ * Written out at several sites before this, each doing its own pair of wraps.
+ *
+ * Both inputs are expected already inside the turn, which is what every caller
+ * holds. The half turn keeps the sign of the subtraction rather than resolving
+ * one way, so a target exactly opposite is approached in the direction the
+ * arithmetic fell out at, and the two callers agree with each other. Masking the
+ * subtraction first would look tidier and would flip that direction at the
+ * antipode, on exactly the 2048 pairs where the two are furthest apart. */
 static inline S32 FollowCamAngleDiff(S32 to, S32 from) {
-    S32 d = (to - from) & 4095;
+    S32 d = to - from;
     if (d > 2048)
         d -= 4096;
+    if (d < -2048)
+        d += 4096;
     return d;
 }
 
@@ -60,8 +69,13 @@ static inline S32 FollowCamRotStep(S32 diff, S32 divisor, S32 minStep) {
     if (divisor < 1)
         divisor = 1;
 
+    if (diff == 0)
+        return 0; /* already there: promoting this to a minimum step would walk the
+                   * camera off the target and back, for ever, which is the failure
+                   * the minimum step exists to prevent rather than to cause */
+
     step = diff / divisor;
-    if (step >= 0 && step < minStep)
+    if (step >= 0 && step < minStep) /* >= 0: a truncated-to-zero step is the case this is for */
         step = (diff > 0) ? minStep : -minStep;
     else if (step < 0 && step > -minStep)
         step = -minStep;

--- a/SOURCES/FOLLOWCAM_MATH.H
+++ b/SOURCES/FOLLOWCAM_MATH.H
@@ -1,0 +1,83 @@
+#ifndef FOLLOWCAM_MATH_H
+#define FOLLOWCAM_MATH_H
+
+#include <SYSTEM/ADELINE_TYPES.H>
+
+/* The Auto camera's angle arithmetic, in one place and free of engine state.
+ *
+ * Angles are 4096 units to the turn. Two of the three functions here express a
+ * single relationship, which the camera code has repeated inline at every site
+ * that aims the camera at the hero:
+ *
+ *   BetaCam = (2048 - (AddBetaCam + heroBeta)) & 4095
+ *
+ * `BetaCam` is a world angle and `AddBetaCam` is an offset from the hero's
+ * facing, so the pair only agree while something maintains that rule. Every
+ * writer of `BetaCam` that leaves `AddBetaCam` alone creates a difference the
+ * follow update reads as catch-up owed and spends, which is where the camera's
+ * snapping bugs have come from. Solving the rule for the current angle is what
+ * hands the camera to the follow update without anything owed.
+ *
+ * The host test in tests/camera/test_followcam_math.cpp checks the round trip
+ * over every angle pair, and that the lerp always converges.
+ */
+
+/* Shortest way round: the signed difference between two angles, in (-2048, 2048].
+ * Written out at a dozen sites before this, each doing its own pair of wraps. */
+static inline S32 FollowCamAngleDiff(S32 to, S32 from) {
+    S32 d = (to - from) & 4095;
+    if (d > 2048)
+        d -= 4096;
+    return d;
+}
+
+/* Where the follow update aims: behind a hero facing `heroBeta`, offset by `pan`. */
+static inline S32 FollowCamTargetBetaFor(S32 pan, S32 heroBeta) {
+    return (2048 - (pan + heroBeta)) & 4095;
+}
+
+/* The inverse: the pan that makes the above come out at `betaCam`. Used when the
+ * camera has been aimed by someone other than the follow update (the player
+ * orbiting, an authored shot) and the follow update has to be told about it. */
+static inline S32 FollowCamPanForAngle(S32 betaCam, S32 heroBeta) {
+    return (2048 - betaCam - heroBeta) & 4095;
+}
+
+/* One frame of the rotation lerp: how far to move toward a target `diff` away.
+ *
+ * `divisor` sets the laziness. The minimum step matters more than it looks:
+ * integer division truncates to zero whenever |diff| < divisor, and `diff` here
+ * is already past the snap threshold, so without a floor the camera would
+ * neither step nor snap. It would sit a few units off target for ever, with the
+ * dirty check firing and the exterior re-rendering every idle frame.
+ *
+ * Callers snap outright when |diff| is within their threshold; this handles the
+ * case past it, and never overshoots.
+ */
+static inline S32 FollowCamRotStep(S32 diff, S32 divisor, S32 minStep) {
+    S32 step;
+
+    if (divisor < 1)
+        divisor = 1;
+
+    step = diff / divisor;
+    if (step >= 0 && step < minStep)
+        step = (diff > 0) ? minStep : -minStep;
+    else if (step < 0 && step > -minStep)
+        step = -minStep;
+
+    /* Not in the code this was taken from, and inert where it is called from:
+     * callers snap within a threshold of 10 while the minimum step is 3, so the
+     * step can never exceed what is left. It is here so the function is correct
+     * on its own terms rather than only under its callers' guarantees, since a
+     * later change to either constant would otherwise make the camera step past
+     * the target and approach it from the other side. */
+    if (diff > 0 && step > diff)
+        step = diff;
+    if (diff < 0 && step < diff)
+        step = diff;
+
+    return step;
+}
+
+#endif /* FOLLOWCAM_MATH_H */

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -31,6 +31,7 @@ extern S32 GfxDitherShading;
 #include <SVGA/SCREEN.H>
 #include <SYSTEM/KEYBOARD_KEYS.H>
 #include "FOLLOWCAM_CFG.H"
+#include "FOLLOWCAM_MATH.H"
 #include <SYSTEM/STRING.H>
 #include <SYSTEM/WINDOW.H>
 
@@ -306,7 +307,7 @@ static void UpdateFollowCameraExt(void) {
                          * (arm shortened near terrain) → tighter follow; full
                          * distance → lazy, cinematic drift.  Floor at divisor/3
                          * to avoid jitter when very close. */
-        FollowCamTargetBeta = (2048 - newbeta) & 4095;
+        FollowCamTargetBeta = FollowCamTargetBetaFor(AddBetaCam, ptr3d->Beta);
 
         if (manualPan) {
             BetaCam = FollowCamTargetBeta;
@@ -327,20 +328,11 @@ static void UpdateFollowCameraExt(void) {
                     if (dynamicDiv < FOLLOW_CAM_ROT_DIVISOR / 3)
                         dynamicDiv = FOLLOW_CAM_ROT_DIVISOR / 3;
                 }
-                S32 step = diff / dynamicDiv;
-                // Clamp to a minimum magnitude toward the target. Integer
-                // division truncates to 0 whenever |diff| < dynamicDiv (e.g.
-                // diff -13 / div 36 = 0), and diff is still past the snap
-                // threshold here, so without this the camera neither steps
-                // nor snaps: BetaCam sticks ~threshold..dynamicDiv units off
-                // target forever, the dirty check keeps firing, and the
-                // exterior re-renders the full terrain (AFF_ALL_FLIP) every
-                // idle frame. Handle step == 0 too, not just the < MIN_STEP
-                // cases, so the camera always closes the gap and settles.
-                if (step >= 0 AND step < FOLLOW_CAM_ROT_MIN_STEP)
-                    step = (diff > 0) ? FOLLOW_CAM_ROT_MIN_STEP : -FOLLOW_CAM_ROT_MIN_STEP;
-                else if (step<0 AND step> - FOLLOW_CAM_ROT_MIN_STEP)
-                    step = -FOLLOW_CAM_ROT_MIN_STEP;
+                /* The minimum step is what stops integer division truncating to zero
+                 * a few units short of the target, where the camera would neither
+                 * step nor snap: it would sit off target for ever with the dirty
+                 * check firing and the exterior re-rendering every idle frame. */
+                S32 step = FollowCamRotStep(diff, dynamicDiv, FOLLOW_CAM_ROT_MIN_STEP);
                 BetaCam = (BetaCam + step) & 4095;
             } else {
                 BetaCam = FollowCamTargetBeta;

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -244,16 +244,9 @@ static void UpdateFollowCameraExt(void) {
                      * orbits behind the hero whether running, turning in place,
                      * or standing.  Smoothness comes from the lerp speed, not
                      * from skipping updates. */
-    S32 catchupDiff = FollowCamTargetBeta - BetaCam;
-    if (catchupDiff > 2048)
-        catchupDiff -= 4096;
-    if (catchupDiff < -2048)
-        catchupDiff += 4096;
+    S32 catchupDiff = FollowCamAngleDiff(FollowCamTargetBeta, BetaCam);
 
     if (FollowCamNeedsUpdate(ptr3d, catchupDiff)) {
-        S32 newbeta = AddBetaCam + ptr3d->Beta;
-        newbeta &= 4095;
-
         /* HD recompose strength (kExcess): 0 in camera zones, at
                          * 480, or when disabled. Shared by the forward-lean cut
                          * here and the boom pull-in + pitch steepen at the apply

--- a/docs/CAMERA.md
+++ b/docs/CAMERA.md
@@ -45,11 +45,13 @@ All functions live behind `extern "C"` and are shared by both interior and exter
 
 ### AddBetaCam, and why the camera has two owners
 
-`BetaCam` is a **world** angle: the view's yaw, which everything downstream renders from. `AddBetaCam` is not. It is an offset **from the hero's facing**, and the two are tied together by one rule, applied wherever the camera is aimed at the hero:
+`BetaCam` is a **world** angle: the view's yaw, which everything downstream renders from. `AddBetaCam` is not. It is an offset **from the hero's facing**, and the two are tied together by one rule:
 
 ```
 BetaCam = (2048 - (AddBetaCam + heroBeta)) & 4095
 ```
+
+The rule is what the camera is aimed *by*, not a property it always has. It holds the instant something aims the camera at the hero and for as long as the Auto camera is converged, and at no other time: the classic camera keeps whatever angle it was left with until a control re-aims it, and a loaded save restores an angle satisfying no such relationship. Read it as the thing the code maintains at particular moments rather than as an invariant to assert on a given frame.
 
 In the original game `AddBetaCam` only ever holds quarter turns: `I_CAMERA` adds 1024, and the Life opcode `LM_CAMERA_CENTER` sets `num * 1024` for an authored orientation. The Auto camera reuses it for continuous player orbit, so it now holds any value.
 
@@ -59,7 +61,7 @@ That reuse is worth understanding before changing anything here, because it is t
 - an orbit interrupted by a camera zone, cutscene or the Auto camera being switched off, whose leftover state made the next touch skip its realign;
 - a camera zone's authored angle, which the Auto camera unwound over the following second (#518).
 
-`FollowCamAdoptAngle()` ([EXTFUNC.CPP](../SOURCES/EXTFUNC.CPP)) is the shared answer: it solves the rule above for the current `BetaCam`, so the target comes out where the camera already is and nothing is owed. Call it after writing `BetaCam` on a path the Auto camera might be running under. `FollowCamForgetManualGesture()` is its companion for the other direction: it drops an in-flight orbit when something else takes the camera.
+The rule and its inverse live in [FOLLOWCAM_MATH.H](../SOURCES/FOLLOWCAM_MATH.H), along with the shortest-way-round difference and one frame of the rotation lerp, so the arithmetic has one home rather than a copy at each site that needs it. `FollowCamAdoptAngle()` ([EXTFUNC.CPP](../SOURCES/EXTFUNC.CPP)) is the shared answer: it solves the rule above for the current `BetaCam`, so the target comes out where the camera already is and nothing is owed. Call it after writing `BetaCam` on a path the Auto camera might be running under. `FollowCamForgetManualGesture()` is its companion for the other direction: it drops an in-flight orbit when something else takes the camera.
 
 ### Off-screen recenter (original behavior)
 
@@ -219,6 +221,8 @@ The camera resisted iteration for a long time because nothing about it was asser
 
 **`--dump-state`** carries a `camera` block for end-state assertions, and **`zonelist`** prints each zone's box and `Info7`, which turns "get into a camera zone" into a concrete `cube` plus `teleport`.
 
+The camera is guarded in two places, and it is worth knowing which is which before relying on either. The behavioural fixtures below drive the real engine, so they need retail data and a display and run in **no CI workflow**: every platform runs `ctest -L host_quick` and nothing else. What CI does see is `tests/camera/test_followcam_math.cpp`, which covers the angle arithmetic from `FOLLOWCAM_MATH.H` over its whole domain, links nothing, and needs no data. A change to the camera that CI passes has had its arithmetic checked and its behaviour not.
+
 Fixtures live in `tests/automation/`, with `camlib.sh` turning a run into a per-frame table so each asserts on the shape of a motion rather than one end state:
 
 | fixture | what it pins |
@@ -265,6 +269,7 @@ Two habits are worth keeping when adding to these. **Run a new fixture against a
 | Orbit gesture state     | SOURCES/EXTFUNC.CPP        | `FollowCamAdoptAngle`, `FollowCamForgetManualGesture`, `ApplyManualCameraNudge`, `cam_glide` |
 | Camera zone dispatch    | SOURCES/OBJECT.CPP         | `SetZoneCamera`, `ZONE_ON` / `ZONE_ACTIVE` / `ZONE_OBLIGATOIRE` (COMMON.H), `AllCameras` |
 | Camera trace            | SOURCES/PERSO.CPP          | `CamTrace`, `camtrace` / `camnudge` console commands |
+| Angle arithmetic        | SOURCES/FOLLOWCAM_MATH.H   | `FollowCamAngleDiff`, `FollowCamTargetBetaFor`, `FollowCamPanForAngle`, `FollowCamRotStep`; host test in tests/camera |
 | Manual-override fade    | SOURCES/PERSO.CPP, SOURCES/EXTFUNC.CPP | `FollowCamManualHold`, `FollowCamManualHoldFrames`, `autoFactor`, `cam_manual_hold` cvar |
 | Config read/write       | SOURCES/PERSO.CPP          | `ReadConfigFile`, `WriteConfigFile`                                                 |
 | Menu toggle             | SOURCES/GAMEMENU.CPP       | `GereAdvancedOptionsMenu`                                                           |

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ add_subdirectory(render)
 add_subdirectory(movement)
 add_subdirectory(zone)
 add_subdirectory(plasma_steps)
+add_subdirectory(camera)
 
 if(LBA2_BUILD_ASM_EQUIV_TESTS)
 include(cmake/asm_test_helpers.cmake)

--- a/tests/camera/CMakeLists.txt
+++ b/tests/camera/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Host test for the Auto camera's angle arithmetic (SOURCES/FOLLOWCAM_MATH.H). Header-only: no
+# engine sources to link, runs anywhere (Linux/macOS/Windows CI, no retail data). The camera's
+# behavioural fixtures live in tests/automation and need retail data, so this is the part of the
+# camera CI can see.
+add_executable(test_followcam_math test_followcam_math.cpp)
+
+target_include_directories(test_followcam_math PRIVATE
+    ${CMAKE_SOURCE_DIR}/SOURCES     # FOLLOWCAM_MATH.H
+    ${CMAKE_SOURCE_DIR}/LIB386/H    # SYSTEM/ADELINE_TYPES.H (S32)
+    ${CMAKE_SOURCE_DIR}/tests       # test_harness.h
+)
+target_compile_definitions(test_followcam_math PRIVATE
+    "TEST_SOURCE_ROOT=\"${CMAKE_SOURCE_DIR}/\""
+)
+set_target_properties(test_followcam_math PROPERTIES CXX_STANDARD 11)
+
+add_test(NAME test_followcam_math COMMAND test_followcam_math)
+register_host_test(test_followcam_math)

--- a/tests/camera/CMakeLists.txt
+++ b/tests/camera/CMakeLists.txt
@@ -5,7 +5,7 @@
 add_executable(test_followcam_math test_followcam_math.cpp)
 
 target_include_directories(test_followcam_math PRIVATE
-    ${CMAKE_SOURCE_DIR}/SOURCES     # FOLLOWCAM_MATH.H
+    ${CMAKE_SOURCE_DIR}/SOURCES     # FOLLOWCAM_MATH.H, FOLLOWCAM_CFG.H
     ${CMAKE_SOURCE_DIR}/LIB386/H    # SYSTEM/ADELINE_TYPES.H (S32)
     ${CMAKE_SOURCE_DIR}/tests       # test_harness.h
 )

--- a/tests/camera/test_followcam_math.cpp
+++ b/tests/camera/test_followcam_math.cpp
@@ -6,12 +6,16 @@
  * relationships every camera fix so far has turned on, checked over their whole domain rather
  * than at the a few points a scripted run happens to visit.
  */
+#include "FOLLOWCAM_CFG.H" /* the constants the engine actually runs with */
 #include "FOLLOWCAM_MATH.H"
 #include "test_harness.h"
 
 #define TURN 4096
-#define SNAP_THRESHOLD 10 /* FOLLOW_CAM_ROT_THRESHOLD: callers snap within this */
-#define MIN_STEP 3        /* FOLLOW_CAM_ROT_MIN_STEP */
+/* Taken from the config header rather than repeated here: the interesting failures are what
+ * happens when these two are retuned relative to each other, and a copy would keep testing the
+ * pair the engine no longer uses. */
+#define SNAP_THRESHOLD FOLLOW_CAM_ROT_THRESHOLD
+#define MIN_STEP FOLLOW_CAM_ROT_MIN_STEP
 
 /* The relationship the whole camera rests on: aiming at the angle the camera already holds must
  * leave it there. Three shipped bugs were a writer of BetaCam breaking this, so it is checked for
@@ -55,8 +59,11 @@ static void test_angle_diff_takes_the_short_way(void) {
     /* Across the wrap: 10 units apart, not 4086. */
     ASSERT_EQ_INT(20, FollowCamAngleDiff(10, 4086));
     ASSERT_EQ_INT(-20, FollowCamAngleDiff(4086, 10));
-    /* The half turn is the boundary and resolves one way, not both. */
+    /* At the half turn the sign of the subtraction is kept rather than resolved to one
+     * direction, so the two ways round are opposites. Both callers share this, which is what
+     * matters: a target exactly opposite is approached the same way by each of them. */
     ASSERT_EQ_INT(2048, FollowCamAngleDiff(2048, 0));
+    ASSERT_EQ_INT(-2048, FollowCamAngleDiff(0, 2048));
 }
 
 static void test_angle_diff_is_always_within_a_half_turn(void) {
@@ -66,7 +73,8 @@ static void test_angle_diff_is_always_within_a_half_turn(void) {
     for (a = 0; a < TURN && !bad; a += 13) {
         for (b = 0; b < TURN; b += 7) {
             S32 d = FollowCamAngleDiff(a, b);
-            if (d <= -2048 || d > 2048 || ((b + d) & 4095) != a)
+            /* Both ends inclusive: the half turn is reachable with either sign. */
+            if (d < -2048 || d > 2048 || ((b + d) & 4095) != a)
                 bad = 1;
         }
     }
@@ -138,6 +146,40 @@ static void test_stepping_always_reaches_the_target(void) {
 
 /* A divisor of zero would be a division fault rather than a slow camera, and the console can set
  * the cvars these come from to anything. */
+/* Standing on the target is not a reason to move. Promoting a zero step to the minimum would
+ * walk the camera off by that much and back, for ever: the perpetual dirty frame the minimum step
+ * exists to prevent, caused by the minimum step. Reachable only if a caller lowers its snap
+ * threshold to zero, which is the kind of guarantee this function is meant not to depend on. */
+static void test_no_step_when_already_on_target(void) {
+    S32 div;
+
+    for (div = 1; div <= 64; div++)
+        ASSERT_EQ_INT(0, FollowCamRotStep(0, div, MIN_STEP));
+}
+
+/* The same, run as the caller would: from anywhere, with no threshold to hide behind, stepping
+ * must come to rest rather than oscillate around the target. */
+static void test_stepping_settles_without_a_snap_threshold(void) {
+    S32 diff, div;
+    S32 bad = 0;
+
+    for (div = 1; div <= 64 && !bad; div++) {
+        for (diff = -600; diff <= 600; diff += 7) {
+            S32 left = diff;
+            S32 frames = 0;
+
+            while (left != 0) {
+                left -= FollowCamRotStep(left, div, MIN_STEP);
+                if (++frames > 4096) {
+                    bad = 1;
+                    break;
+                }
+            }
+        }
+    }
+    ASSERT_EQ_INT(0, bad);
+}
+
 static void test_a_zero_divisor_is_survivable(void) {
     ASSERT_EQ_INT(100, FollowCamRotStep(100, 0, MIN_STEP));
     ASSERT_EQ_INT(-100, FollowCamRotStep(-100, -5, MIN_STEP));
@@ -150,6 +192,8 @@ int main(void) {
     RUN_TEST(test_angle_diff_is_always_within_a_half_turn);
     RUN_TEST(test_step_moves_toward_the_target_without_overshooting);
     RUN_TEST(test_stepping_always_reaches_the_target);
+    RUN_TEST(test_no_step_when_already_on_target);
+    RUN_TEST(test_stepping_settles_without_a_snap_threshold);
     RUN_TEST(test_a_zero_divisor_is_survivable);
     TEST_SUMMARY();
 }

--- a/tests/camera/test_followcam_math.cpp
+++ b/tests/camera/test_followcam_math.cpp
@@ -1,0 +1,155 @@
+/* Host test for the Auto camera's angle arithmetic (SOURCES/FOLLOWCAM_MATH.H).
+ * Header-only: no engine sources to link, runs anywhere with no retail data.
+ *
+ * The camera's own fixtures live in tests/automation and drive the real engine, so they need
+ * retail data and a display and do not run in CI. What is here is the part that can: the two
+ * relationships every camera fix so far has turned on, checked over their whole domain rather
+ * than at the a few points a scripted run happens to visit.
+ */
+#include "FOLLOWCAM_MATH.H"
+#include "test_harness.h"
+
+#define TURN 4096
+#define SNAP_THRESHOLD 10 /* FOLLOW_CAM_ROT_THRESHOLD: callers snap within this */
+#define MIN_STEP 3        /* FOLLOW_CAM_ROT_MIN_STEP */
+
+/* The relationship the whole camera rests on: aiming at the angle the camera already holds must
+ * leave it there. Three shipped bugs were a writer of BetaCam breaking this, so it is checked for
+ * every hero facing against every camera angle rather than sampled. */
+static void test_pan_round_trips_for_every_angle(void) {
+    S32 hero, beta;
+    S32 bad = 0;
+
+    for (hero = 0; hero < TURN && !bad; hero++) {
+        for (beta = 0; beta < TURN; beta++) {
+            S32 pan = FollowCamPanForAngle(beta, hero);
+            if (FollowCamTargetBetaFor(pan, hero) != beta) {
+                bad = 1;
+                break;
+            }
+        }
+    }
+    ASSERT_EQ_INT(0, bad);
+}
+
+/* Both directions stay inside the circle, whatever they are handed. A negative or out-of-range
+ * angle reaching a renderer is a wrapped view rather than a wrong one, which is harder to spot. */
+static void test_angles_stay_within_the_turn(void) {
+    S32 i;
+    S32 bad = 0;
+
+    for (i = -TURN * 2; i <= TURN * 2 && !bad; i += 7) {
+        S32 pan = FollowCamPanForAngle(i, i / 3);
+        S32 target = FollowCamTargetBetaFor(i, i / 3);
+        if (pan < 0 || pan >= TURN || target < 0 || target >= TURN)
+            bad = 1;
+    }
+    ASSERT_EQ_INT(0, bad);
+}
+
+/* The shortest way round, and never the long one. */
+static void test_angle_diff_takes_the_short_way(void) {
+    ASSERT_EQ_INT(0, FollowCamAngleDiff(100, 100));
+    ASSERT_EQ_INT(10, FollowCamAngleDiff(110, 100));
+    ASSERT_EQ_INT(-10, FollowCamAngleDiff(100, 110));
+    /* Across the wrap: 10 units apart, not 4086. */
+    ASSERT_EQ_INT(20, FollowCamAngleDiff(10, 4086));
+    ASSERT_EQ_INT(-20, FollowCamAngleDiff(4086, 10));
+    /* The half turn is the boundary and resolves one way, not both. */
+    ASSERT_EQ_INT(2048, FollowCamAngleDiff(2048, 0));
+}
+
+static void test_angle_diff_is_always_within_a_half_turn(void) {
+    S32 a, b;
+    S32 bad = 0;
+
+    for (a = 0; a < TURN && !bad; a += 13) {
+        for (b = 0; b < TURN; b += 7) {
+            S32 d = FollowCamAngleDiff(a, b);
+            if (d <= -2048 || d > 2048 || ((b + d) & 4095) != a)
+                bad = 1;
+        }
+    }
+    ASSERT_EQ_INT(0, bad);
+}
+
+/* Every step is toward the target and never past it. Overshoot would leave the camera
+ * approaching from the far side, which reads as a wobble rather than a settle. */
+static void test_step_moves_toward_the_target_without_overshooting(void) {
+    S32 diff, div;
+    S32 bad = 0;
+
+    for (div = 1; div <= 64 && !bad; div++) {
+        for (diff = -2048; diff <= 2048; diff++) {
+            S32 step = FollowCamRotStep(diff, div, MIN_STEP);
+            if (diff == 0)
+                continue;
+            if ((diff > 0 && (step <= 0 || step > diff)) || (diff < 0 && (step >= 0 || step < diff))) {
+                bad = 1;
+                break;
+            }
+        }
+    }
+    ASSERT_EQ_INT(0, bad);
+}
+
+/* The property the minimum step exists for: from anywhere past the snap threshold, repeated
+ * stepping closes the gap. The failure it guards against is not a wrong angle but a camera that
+ * never arrives, holding the dirty check open and re-rendering the exterior every idle frame, so
+ * it is asserted as termination rather than as a value.
+ */
+static void test_stepping_always_reaches_the_target(void) {
+    S32 diff, div;
+    S32 worst = 0;
+    S32 stuck = 0;
+
+    for (div = 1; div <= 64 && !stuck; div++) {
+        for (diff = -2048; diff <= 2048; diff++) {
+            S32 left = diff;
+            S32 frames = 0;
+
+            if (left > -SNAP_THRESHOLD && left < SNAP_THRESHOLD)
+                continue; /* the caller snaps here rather than stepping */
+
+            while (left > SNAP_THRESHOLD || left < -SNAP_THRESHOLD) {
+                S32 step = FollowCamRotStep(left, div, MIN_STEP);
+                if (step == 0) {
+                    stuck = 1; /* would never arrive */
+                    break;
+                }
+                left -= step;
+                if (++frames > 4096) {
+                    stuck = 1; /* arriving, but not in any useful time */
+                    break;
+                }
+            }
+            if (stuck)
+                break;
+            if (frames > worst)
+                worst = frames;
+        }
+    }
+
+    ASSERT_EQ_INT(0, stuck);
+    /* A half turn at the laziest divisor tested is the slow case; well inside a second at 60fps
+     * once the caller's snap threshold finishes it off. */
+    ASSERT_TRUE(worst < 700);
+}
+
+/* A divisor of zero would be a division fault rather than a slow camera, and the console can set
+ * the cvars these come from to anything. */
+static void test_a_zero_divisor_is_survivable(void) {
+    ASSERT_EQ_INT(100, FollowCamRotStep(100, 0, MIN_STEP));
+    ASSERT_EQ_INT(-100, FollowCamRotStep(-100, -5, MIN_STEP));
+}
+
+int main(void) {
+    RUN_TEST(test_pan_round_trips_for_every_angle);
+    RUN_TEST(test_angles_stay_within_the_turn);
+    RUN_TEST(test_angle_diff_takes_the_short_way);
+    RUN_TEST(test_angle_diff_is_always_within_a_half_turn);
+    RUN_TEST(test_step_moves_toward_the_target_without_overshooting);
+    RUN_TEST(test_stepping_always_reaches_the_target);
+    RUN_TEST(test_a_zero_divisor_is_survivable);
+    TEST_SUMMARY();
+}


### PR DESCRIPTION
Follow-on from #513's fixtures, closing the gap those fixtures cannot: they drive the real engine, so they need retail data and a display and appear in no CI workflow. Every platform runs `ctest -L host_quick` and nothing else. Eleven camera fixtures, none of them visible to CI.

## What moves

`SOURCES/FOLLOWCAM_MATH.H` takes the pure part of the camera's angle work:

- the rule tying `BetaCam` to the hero's facing and a pan, and its inverse
- the shortest-way-round difference, previously written out inline at a dozen sites, each doing its own pair of wraps
- one frame of the rotation lerp

Header-only and free of engine state, so the test includes it and links nothing. `tests/zone` covering `ZONE_GEOM.H` is the same shape.

## What is checked

Two properties are worth having over their whole domain rather than at the handful of points a scripted run visits.

**Aiming at the angle the camera already holds must leave it there**, for all 4096 hero facings against all 4096 camera angles. Three shipped bugs were a writer of `BetaCam` breaking that relationship, and it had no test anywhere.

**Stepping from anywhere past the snap threshold must arrive**, at every divisor. The minimum step exists because integer division truncates to zero a few units short of the target, where the camera would neither step nor snap: it would sit off target for ever with the dirty check firing and the exterior re-rendering the full terrain every idle frame. `PERSO.CPP` has carried a comment describing that failure for some time; this makes it an assertion.

Plus the smaller ones: angles stay inside the turn, the difference is always within a half turn and congruent, and a zero divisor from a console cvar is survivable rather than a division fault.

## One addition, not an extraction

`FollowCamRotStep` refuses to overshoot the target. The code it came from does not, and this is inert where it is called, because the caller's snap threshold of 10 is larger than the minimum step of 3 so the step can never exceed what is left. It is there so the function holds on its own terms rather than only under its callers' guarantees, since changing either constant would otherwise have the camera step past the target and approach from the far side. Called out because it means this is not a byte-for-byte extraction.

## What this would and would not have caught

Worth being straight about: of the five defects the camera work turned up, a host test would have caught one, the zoom clamp. The rest were integration failures, an unreachable branch and state outliving its context and a zone writing a global nobody told the follow camera about, and no pure-function test sees those.

The case for this is that the arithmetic core gets checked on four platforms in CI instead of nowhere, and that a known latent failure the code already documents is now a test rather than a comment.

## Verification

Host suite 55/55, up from 54. All eleven camera fixtures in `tests/automation` pass unchanged and report the same numbers as before the extraction, which is what says it changed nothing. Automation suite 40 pass, 16 skip, and `profile_bind`, which fails identically on a clean `main` in this environment.
