### PR TITLE
docs: correct the merge mode the PR conventions describe

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,8 @@
 PR title format: `<type>(<scope>): <summary>`
 Types: feat | fix | port | perf | refactor | docs | test | build | ci | chore
 Scope is optional. Example: `fix(credits): preserve gameplay state across console-invoked credits`
-The PR title becomes the squash-merged commit on main, so it lands in the changelog as-is.
+The PR title drives the changelog whatever the merge mode. `main` takes merge commits by
+default, so your own commit messages land on it too and are worth writing.
 See AGENTS.md "Commit & PR conventions".
 -->
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -35,9 +35,14 @@ jobs:
             ci
             chore
           requireScope: false
-          # Title must start with a type prefix; squash-merge turns the PR
-          # title into the single commit on main, so this is the only
-          # convention contributors need to follow.
+          # Title must start with a type prefix: git-cliff renders one
+          # changelog entry per PR from it, whatever the merge mode.
+          #
+          # main takes merge commits by default, so a branch's own commits
+          # land on it and their messages matter as much as this title.
+          # Squash is for a branch whose individual commits are not worth
+          # keeping (fixup churn), and it collapses them into the title.
+          # See docs/RELEASING.md "What git-cliff reads".
           subjectPattern: '^[A-Za-z0-9].+$'
           subjectPatternError: |
             The PR title subject (after the type prefix) must not be empty

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,12 @@ squash, or rebase), so the title has to follow
 <type>(<optional scope>): <summary>
 ```
 
+**`main` takes merge commits by default.** A branch's own commits land on
+`main` and stay there, so write each one for a reader who arrives at it from
+`git blame` with no memory of the PR. Squash is the exception rather than the
+rule: reach for it when a branch's individual commits are not worth keeping
+(fixup churn, "address review" churn), and it collapses them into the PR title.
+
 Allowed types:
 
 | Type       | Use for                                                     |
@@ -181,8 +187,10 @@ Allowed types:
 Scope is optional but useful (`fix(credits): ...`, `port(SORT): ...`).
 
 A lightweight CI check (`.github/workflows/pr-title.yml`) verifies the PR
-title format. **Individual commits inside the PR can be free-form** — only
-the PR title is enforced. Contributors do not need to edit `CHANGELOG.md`;
+title format. **Individual commits inside the PR are not format-checked:**
+only the PR title is enforced. That is about enforcement, not about care:
+under the default merge mode those commits are what `main` keeps.
+Contributors do not need to edit `CHANGELOG.md`;
 it is regenerated at release time. Use `chore:` for any PR you want kept
 out of the public changelog (formatting, tooling, internal cleanups).
 See [docs/RELEASING.md](docs/RELEASING.md).


### PR DESCRIPTION
Two files told contributors that `main` squash-merges. It does not: `main` takes merge commits, and a branch's commits land on it individually. `d275a134` and its neighbours on `main` are `Merge pull request #N from ...` with the PR title on the body's first line.

- `.github/PULL_REQUEST_TEMPLATE.md` — "The PR title becomes the squash-merged commit on main".
- `.github/workflows/pr-title.yml` — same claim, plus the conclusion drawn from it: that the title is therefore "the only convention contributors need to follow". That is backwards under merge commits, where a branch's own commit messages are exactly what `main` keeps.

`AGENTS.md` and `docs/RELEASING.md` were already correct. Both describe the changelog as merge-mode-agnostic, and RELEASING.md documents the `commit_preprocessors` rule in `cliff.toml` that rewrites GitHub's merge subject into the PR title *precisely so merge-commit mode groups correctly*. So the accurate account was already written down; the two stale claims just happened to sit in the files a contributor reads first.

Also records the preference the docs never stated anywhere: merge by default, squash as the exception for a branch whose individual commits are not worth keeping. Previously a contributor could read all four files and still not know which mode to pick.

## Why this is worth a PR

The comment is load-bearing rather than decorative. A reader who believes it concludes that only the PR title reaches `main`, and from there that a branch's commit messages do not matter and that per-commit `.git-blame-ignore-revs` entries are not available. Both conclusions are wrong, and neither is checkable without going and reading `main`'s history against the comment.

## Verification

`actionlint` clean on the changed workflow. `docs/RELEASING.md` and its "What `git-cliff` reads" section both exist as the new comment cites. No behaviour change: the `pr-title.yml` edit touches only comment lines, not the `types` list or `subjectPattern`.

