### PR TITLE
chore(tooling): index the external tools, and probe for them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ Apply these behavior rules on every non-trivial task:
 | New subsystem or reference doc | Create docs/<name>.md; add to docs/README.md; update in same commit | docs/README.md |
 | Writing a plan, design trail, or research writeup before the work | Put it in `docs/plan/`, not `docs/`. Add it to the "Plans & research" table in docs/README.md with a status. `docs/` is what the engine does today; `docs/plan/` is what was proposed and why. When a plan lands, mark it Implemented and fold the durable parts into the reference doc; a plan must never be the only description of shipped behaviour | docs/README.md "Plans & research" |
 | Adding, moving, or removing a script under scripts/ | Add or update its row in scripts/README.md in the same commit | scripts/README.md |
+| Making a script or workflow depend on a new external tool | Add its row to docs/TOOLING.md **and** a probe to `scripts/dev/check-tooling.sh` in the same commit. Never restate a version in the doc — cite the file that pins it | docs/TOOLING.md |
 | Any code that affects documented behavior | Update the doc in the same commit | Principle 1 |
 | Fixing a bug | If the affected logic is pure-data, extract it to a pure function and add a host test. Otherwise add a manual repro hook (console command, debug flag) | CONTRIBUTING.md "Doing good work here" |
 | Editing docs (any `.md`) | Sentence-case headings; bold for structure only (list-item / paragraph leads, table row labels), not mid-sentence emphasis; verify file/line refs; from `docs/`, link to source with `../SOURCES/...` / `../LIB386/...` | "Editing docs" below; CONTRIBUTING.md "Doing good work here" |
@@ -212,3 +213,4 @@ both: e.g. `fix(credits): ... (#65) (#66)`. Reference issues in the PR
 - [docs/FEATURE_WORKFLOW.md](docs/FEATURE_WORKFLOW.md) — Reasoning and docs for big features (console, headless, menu, camera)
 - [docs/README.md](docs/README.md) — Full documentation index
 - [scripts/README.md](scripts/README.md) — Catalogue of developer, CI, and packaging scripts (maintained vs. spike)
+- [docs/TOOLING.md](docs/TOOLING.md) — External tools the repo expects, tiered by what breaks without them; `scripts/dev/check-tooling.sh` probes them

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,11 @@ cmake -B build
 cmake --build build
 ```
 
+To find out what your machine is missing before you hit it, run
+`./scripts/dev/check-tooling.sh` (or `make check-tooling`). It probes every
+external tool the repo uses and exits non-zero only when the clone genuinely
+cannot build; the full tiered index is in [docs/TOOLING.md](docs/TOOLING.md).
+
 The default build includes SDL3-based audio and Smacker FMV playback. Override with `-DSOUND_BACKEND=null -DMVIDEO_BACKEND=null` for a minimal build; see the build options table in the README.
 
 To run the game you need retail data (not in the repo); see [docs/GAME_DATA.md](docs/GAME_DATA.md).

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Convenience targets — delegate to CMake and scripts (see docs/GAME_DATA.md).
-.PHONY: help clean build run build-run test tests test-docker format-check docs-links save-probe-lz-selftest savegame-corpus
+.PHONY: help clean build run build-run test tests test-docker format-check docs-links check-tooling save-probe-lz-selftest savegame-corpus
 
 MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(shell "$(MAKEFILE_DIR)scripts/dev/repo_root.sh" 2>/dev/null || echo "$(MAKEFILE_DIR)")
@@ -20,6 +20,7 @@ help:
 	@echo "  make test-docker    - ./run_tests_docker.sh (ASM suite; requires Docker)"
 	@echo "  make format-check   - scripts/ci/check-format.sh"
 	@echo "  make docs-links     - scripts/ci/check-docs-links.sh (needs lychee for the link half)"
+	@echo "  make check-tooling  - report which external tools this clone has (docs/TOOLING.md)"
 	@echo "  make save-probe-lz-selftest - build save_decompress + run LZ golden self-test"
 	@echo "  make savegame-corpus - run bundled save corpus harness (retail game data required)"
 
@@ -48,6 +49,9 @@ format-check:
 
 docs-links:
 	@bash "$(REPO_ROOT)/scripts/ci/check-docs-links.sh"
+
+check-tooling:
+	@bash "$(REPO_ROOT)/scripts/dev/check-tooling.sh"
 
 save-probe-lz-selftest:
 	$(CMAKE) -S "$(REPO_ROOT)" -B "$(BUILD_DIR)" -G Ninja -DCMAKE_BUILD_TYPE=Debug \

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Download the `lba2cc-<version>-android-arm64-v8a.apk` (or `armeabi-v7a`). Requir
 
 On macOS, install with `brew install ninja sdl3`.
 
+Run `./scripts/dev/check-tooling.sh` to see what your machine is missing. That covers the build; the tools needed for testing, linting, packaging, Android, and releasing are indexed by tier in [docs/TOOLING.md](docs/TOOLING.md).
+
 ### First clone
 
 1. `make` or `make help` — lists convenience targets (`build`, `run`, `clean`, `test`, …).

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ The engine mapped as a whole: layers, the engine/game membrane, and the on-disk 
 
 | Doc | Description |
 |-----|-------------|
+| [TOOLING.md](TOOLING.md) | Every external tool the repo expects, tiered by what breaks without it: build & run, pass review, per lane, nice to have. Version floors are cited, never restated. `scripts/dev/check-tooling.sh` probes the lot. |
 | [WINDOWS.md](WINDOWS.md) | Building on Windows with MSYS2; game files, toolchain. |
 | [ANDROID.md](ANDROID.md) | Building, packaging, and running on Android (arm64-v8a / armeabi-v7a): NDK + SDL3 cross-build, APK bundler, 16 KB pages, game-data placement, touch overlay. |
 | [GAME_DATA.md](GAME_DATA.md) | Retail game files: `LBA2_GAME_DIR`, `--game-dir`, discovery order, dev layouts. |

--- a/docs/TOOLING.md
+++ b/docs/TOOLING.md
@@ -1,0 +1,301 @@
+# Tooling
+
+Index of the external tools this repository expects, and which of them you
+actually need. Companion to [scripts/README.md](../scripts/README.md), which
+catalogues the scripts *we* ship; this doc covers the tools *they* assume you
+have.
+
+Run the check instead of reading the tables:
+
+```bash
+./scripts/dev/check-tooling.sh     # or: make check-tooling
+```
+
+It probes every tool below, reports what is missing, and exits non-zero only
+when the clone genuinely cannot build. `--tier 1` narrows it, `--quiet` shows
+only rows needing attention, `--strict` also fails on tier 2.
+
+## How the tiers work
+
+Tools are grouped by what breaks without them, not by how useful they are.
+"Optional" would put the Android NDK (a hard requirement for one lane) in the
+same bucket as `actionlint` (never required by anything), so it isn't used here.
+
+| Tier | Test | Consequence |
+|------|------|-------------|
+| **1 — Build & run** | no binary without it | `check-tooling.sh` exits non-zero |
+| **2 — Pass review** | CI fails you without it | warning; `--strict` exits non-zero |
+| **3 — Per lane** | required only if you work on that lane | reported |
+| **4 — Faster, not required** | nothing breaks | reported |
+
+Two rules keep the tables from going stale, and both matter more than the
+tables themselves:
+
+- **No version literals here.** Every floor and pin lives in the file that owns
+  it, named in the Version owner column. `check-tooling.sh` parses those same
+  files, so the doc, the script, and the build cannot disagree about a version —
+  there is only ever one copy.
+- **No probe commands here.** How a tool is detected lives in
+  `check-tooling.sh`. A second copy in prose is a second thing to forget.
+
+## Tier 1 — build & run
+
+Without all five there is no `lba2cc` binary. The root
+[README](../README.md#prerequisites) states the same set for players building
+from source.
+
+| Tool | Needed for | Version owner | Install |
+|------|-----------|---------------|---------|
+| CMake | every build path | [../CMakeLists.txt](../CMakeLists.txt#L1) (`cmake_minimum_required`) | distro package; the `ubuntu-latest` runner already satisfies the floor |
+| Ninja | all [CMakePresets.json](../CMakePresets.json) presets and `make build` use the Ninja generator | — | `apt install ninja-build`, `brew install ninja`, `pacman -S mingw-w64-ucrt-x86_64-ninja` |
+| C/C++ compiler | C++98 dialect; see [CODESTYLE.md](../CODESTYLE.md) | — | GCC or Clang. MSVC is not supported |
+| SDL3 | `find_package(SDL3 CONFIG)`; shared by default, static for release packaging | see note below | `brew install sdl3`, `pacman -S mingw-w64-ucrt-x86_64-SDL3`; most distros need a source build |
+| git | the format and clang-tidy scripts enumerate files with `git ls-files` | — | distro package |
+
+**SDL3 has no single version owner.** The release-build pin is duplicated across
+four code sites — [docker/Dockerfile.test](../docker/Dockerfile.test#L32),
+[reusable-build-android.yml](../.github/workflows/reusable-build-android.yml#L126),
+[build-linux-tarball.sh](../scripts/dev/build-linux-tarball.sh#L91), and
+[build-sdl3-android.sh](../scripts/dev/build-sdl3-android.sh#L39) — and the
+Dockerfile comment asks you to keep the four in sync when bumping. Local
+development builds against whatever SDL3 your system provides and does not care
+about the pin; only bundled and containerised builds do.
+
+GNU Make is not in the table: it only drives the [Makefile](../Makefile)
+shortcuts, and plain `cmake` works without it.
+
+**On Windows all five hang off the MSYS2 environment.** In the plain `MSYS`
+shell, cmake, ninja and gcc are simply not on `PATH`, so every row above fails at
+once and the cause is invisible. `check-tooling.sh` reports the active `MSYSTEM`
+first for exactly that reason — it should say `UCRT64`. See
+[WINDOWS.md](WINDOWS.md).
+
+## Tier 2 — pass review
+
+CI enforces these, so a gap here means a red PR rather than a broken clone. Most
+rows are conditional on what your change touches — C/C++, shell, Python,
+workflows, or `LIB386/`. Lychee is the exception: `docs-links.yml` is
+deliberately not path-filtered, so it gates every PR including a docs-only one.
+
+| Tool | Needed for | Version owner | Install |
+|------|-----------|---------------|---------|
+| clang-format | C/C++ — `format.yml`, `make format-check`, the optional pre-commit hook | [clang-format-select.sh](../scripts/ci/clang-format-select.sh#L18) (`CLANG_FORMAT_MAJOR`) | the format scripts print the exact package name for the pinned major when they refuse to run — [check-format.sh](../scripts/ci/check-format.sh#L13) |
+| lychee | any change — `docs-links.yml` checks every relative link and `#anchor` in tracked markdown, via `make docs-links` | [docs-links.yml](../.github/workflows/docs-links.yml#L25) (`LYCHEE_VERSION`) | `cargo install lychee`, or the release binary CI downloads |
+| shellcheck | shell — the `shellcheck` job over every tracked `*.sh` | [lint.yml](../.github/workflows/lint.yml#L31) (`SHELLCHECK_VERSION`) | distro package, or the release tarball CI uses |
+| ruff | Python — the `ruff` job over every tracked `*.py` | [lint.yml](../.github/workflows/lint.yml#L33) (`RUFF_VERSION`) | `pipx install ruff` |
+| actionlint | workflows — the `actionlint` job, which also shells out to shellcheck for every `run:` body | [lint.yml](../.github/workflows/lint.yml#L32) (`ACTIONLINT_VERSION`) | release binary |
+| Python 3 | [filter-format-files.py](../scripts/ci/filter-format-files.py) gates the format check; also the save probes and corpus harness | — | distro package |
+| Docker | `LIB386/` — [run_tests_docker.sh](../run_tests_docker.sh), the ASM equivalence suite | — | Docker Engine or Docker Desktop |
+
+The linters take their rule selection from checked-in config —
+[.shellcheckrc](../.shellcheckrc), [ruff.toml](../ruff.toml) — so a local run
+matches CI. The one exception is shellcheck severity, which it only accepts on
+the command line: CI passes `-S warning`, so add that locally or you will see
+info and style findings the gate ignores.
+
+Without lychee, `make docs-links` still runs its second half — a grep for
+`docs/<name>.md` paths named by bare path in source, tests and CMake, which a
+link checker cannot see — and skips the link half with a warning rather than
+failing. Easy to mistake for a pass.
+
+The format scripts refuse to run a non-matching major rather than silently
+disagreeing with CI, so install the exact version the owner file names. Only
+stdlib Python is needed here; [Pillow](#tier-4--faster-not-required) is tier 4.
+
+The package name is not guessable on MSYS2, and the scripts' own error message
+covers Debian and macOS only: there it is
+`pacman -S mingw-w64-ucrt-x86_64-clang-tools-extra`, and the binary is unversioned
+(`clang-format`, never `clang-format-N`). `check-tooling.sh` prints the right
+one for your platform.
+
+Two things about the container:
+
+- **Presence is not the question.** A Docker Desktop install can leave a `docker`
+  on `PATH` in WSL that resolves fine and then fails at exec, which
+  [verify-release.sh](../scripts/dev/verify-release.sh#L73) documents and
+  `check-tooling.sh` mirrors by calling `docker info`.
+- **Podman is not a drop-in.** Both scripts invoke `docker` by name, so podman
+  needs a shim or alias on `PATH`. The commands themselves are compatible —
+  [run_tests_docker.sh](../run_tests_docker.sh) only uses `images -q`,
+  `build --platform` and `run --rm --platform`, all of which podman accepts. The
+  harder case is [verify-release.sh](../scripts/dev/verify-release.sh#L141),
+  which runs `--privileged tonistiigi/binfmt` to register arm64 emulation;
+  rootless podman cannot do that, and the script already falls back to skipping
+  the arm64 artifact. Neither path is verified against podman, so treat it as
+  unsupported-but-probably-fine rather than tested.
+
+Everything the suite needs *inside* the image — UASM, 32-bit multilib, both SDL3
+builds — is pinned and fetched by
+[docker/Dockerfile.test](../docker/Dockerfile.test), not by you. That is the
+point of running it in a container.
+
+## Tier 3 — per lane
+
+Hard requirements with a narrow audience. Nothing here matters until you work on
+that specific lane.
+
+### ASM equivalence on the host
+
+The container path above is the supported one. Building the suite natively needs
+all three, and `check-tooling.sh` expects most hosts to lack the last two.
+
+| Tool | Needed for | Version owner | Install |
+|------|-----------|---------------|---------|
+| `objcopy` | `LBA2_BUILD_ASM_EQUIV_TESTS=ON` (default ON when tests are enabled) | — | binutils |
+| 32-bit runtime | linking the 32-bit equivalence targets | — | `gcc-multilib g++-multilib` |
+| UASM | `ENABLE_ASM=ON` only | [docker/Dockerfile.test](../docker/Dockerfile.test) (`ARG UASM_VERSION`) | the image fetches it; see [TESTING.md](TESTING.md) |
+
+`make test` sets `LBA2_BUILD_ASM_EQUIV_TESTS=OFF`, so none of this is needed for
+the host-only pass.
+
+### Releasing
+
+Maintainer lane; see [RELEASING.md](RELEASING.md).
+
+| Tool | Needed for | Version owner | Install |
+|------|-----------|---------------|---------|
+| `gh` (authenticated) | release upload and edit, [verify-release.sh](../scripts/dev/verify-release.sh) | — | [cli.github.com](https://cli.github.com) |
+| `git-cliff` | `git cliff --prepend` for CHANGELOG; not needed for a first release | — | `cargo install git-cliff` or a release binary |
+| `tar` | Linux tarball bundling, artifact verification | — | distro package |
+
+### Platform artifacts
+
+One bundler per platform, each with its own host requirement.
+
+| Tool | Needed for | Version owner | Install |
+|------|-----------|---------------|---------|
+| `zip` or Python 3 | [bundle-windows.sh](../scripts/packaging/bundle-windows.sh#L104) prefers `zip`, falls back to the stdlib `zipfile` | — | distro package |
+| mingw-w64 | the `cross_linux2win` preset and [cmake/mingw-w64-i686.cmake](../cmake/mingw-w64-i686.cmake); Unix hosts only, so the probe skips it on Windows | — | `apt install mingw-w64`, `pacman -S mingw-w64-gcc` |
+| MSYS2 UCRT64 | native Windows builds — the recommended local path, bit-for-bit CI's toolchain. Probed via `MSYSTEM`, see the tier 1 note | — | [WINDOWS.md](WINDOWS.md) |
+| `hdiutil`, `xcrun` | DMG creation; [bundle-macos.sh](../scripts/packaging/bundle-macos.sh#L64) hard-requires a macOS host | — | Xcode command-line tools |
+
+The AppImage is the exception: [make-appimage.sh](../scripts/packaging/make-appimage.sh)
+calls `pacman`, `get-debloated-pkgs`, and `quick-sharun`, and runs inside the
+`ghcr.io/pkgforge-dev/archlinux` container in CI. It has no local dry-run on a
+non-Arch host, unlike the other three bundlers.
+
+### Android
+
+See [ANDROID.md](ANDROID.md).
+
+| Tool | Needed for | Version owner | Install |
+|------|-----------|---------------|---------|
+| Android NDK | native build; set `ANDROID_NDK` | [build-android.sh](../scripts/dev/build-android.sh#L8) (header) and its default path at [line 28](../scripts/dev/build-android.sh#L28) | Android Studio SDK manager or the NDK zip |
+| SDK build-tools | `aapt2`, `zipalign`, `apksigner` — [bundle-android.sh](../scripts/packaging/bundle-android.sh#L77) picks the highest installed | — | SDK command-line tools |
+| JDK (`javac`, `keytool`) | compiles the SDL3 Java activity to `classes.dex`; generates the debug keystore | [reusable-build-android.yml](../.github/workflows/reusable-build-android.yml#L55) (`java-version`) | Temurin, or any distro JDK at that version |
+| `adb` | installing and reading logs on a device | — | SDK platform-tools |
+
+### Game-data folder picker (Linux runtime)
+
+Not a build dependency — it's what the shipped binary calls when it needs to ask
+where your retail data is. `zenity` or an `xdg-desktop-portal` backend; the
+per-distro table with the reasoning is in
+[GAME_DATA.md](GAME_DATA.md#picker-backends-per-environment).
+
+## Tier 4 — faster, not required
+
+Nothing in this section is wired into CI or any script's happy path. Each entry
+either degrades gracefully or is purely for your own loop.
+
+| Tool | What it buys you | Notes |
+|------|------------------|-------|
+| clang-tidy + `run-clang-tidy` | memory-safety and UB checks via [run-clang-tidy.sh](../scripts/ci/run-clang-tidy.sh) | scope in [.clang-tidy](../.clang-tidy). The only linter with no CI job, so nothing enforces it. Needs `compile_commands.json` |
+| Pillow | screenshot comparison in the automation suite | [lib.sh](../tests/automation/lib.sh#L189) skips image asserts when it is absent, so the suite passes either way |
+| ImageMagick | PPM to PNG in [render_polyrec.sh](../tests/SNAPSHOT/render_polyrec.sh#L81) | without it the PPMs are kept and conversion is skipped |
+| `act` | runs CI jobs locally | Linux jobs only; the macOS and Windows runners cannot be emulated |
+| `gdb` / `lldb` | debugging | the `linux_clang` and `linux_sanitize` presets pair with it |
+
+## Engine-internal tooling
+
+Everything above is a binary you install. The engine also ships a lot of its own
+instrumentation — polyrec, the control harness, the console, the trace commands —
+and that is what you actually reach for when debugging the game rather than the
+build.
+
+It is deliberately **not** tiered here, for two reasons. Nothing needs
+installing, so "what breaks without it" has no meaning. And it changes on a
+different clock: a PR that adds a console command would age this doc, while the
+external tool list moves once a year. So this section routes; it never lists
+individual commands.
+
+Prefer the live enumerators over any doc — they are generated from the code and
+cannot drift:
+
+```bash
+lba2cc --help                                   # player-facing flags
+lba2cc --help-all                               # every flag, grouped
+lba2cc --headless --exec "cmdlist" --tick 2 --exit   # every console command
+lba2cc --headless --exec "varlist" --tick 2 --exit   # every cvar
+```
+
+| Capability | What it is for | Where it is documented |
+|-----------|----------------|------------------------|
+| Control harness | boot, restore a save, run commands, advance N ticks, dump state or a screenshot, exit — all in one invocation. The backbone of headless verification | [CONTROL.md](CONTROL.md) |
+| Debug console | ~40 commands and a set of cvars, always available (no build flag) | [CONSOLE.md](CONSOLE.md) |
+| Polyrec | polygon record/replay; byte-compares ASM against C++ draw calls, with a bisect driver for first divergence | [POLYREC.md](POLYREC.md) |
+| Trace commands | per-subsystem logging you toggle at runtime rather than rebuilding | [CONSOLE.md](CONSOLE.md), [TIMING.md](TIMING.md) |
+| Perftrace | per-frame timing ring buffer for frame-pacing work | [PERFTRACE.md](PERFTRACE.md) |
+| Adeline debug tools | the original 1997 developer tools, behind `DEBUG_TOOLS=ON` | [DEBUG.md](DEBUG.md) |
+| Automation suite | the shell suite that drives the harness for regression | [CONTROL.md](CONTROL.md), [TESTING.md](TESTING.md) |
+| Savegame corpus | replays a corpus of real saves through the load path | [SAVEGAME.md](SAVEGAME.md) |
+
+The one place the two axes meet is tier 4: Pillow and ImageMagick are external
+packages that only exist to make the *internal* harnesses more useful, and both
+degrade to a skip when absent.
+
+## By task
+
+| I want to… | Tiers | Extra |
+|-----------|-------|-------|
+| Build and play | 1 | retail game data — [GAME_DATA.md](GAME_DATA.md) |
+| Fix a bug in `SOURCES/` | 1 + clang-format | `make test` for the host pass |
+| Touch `LIB386/` | 1 + 2 | the container runs the ASM suite for you |
+| Edit a script or workflow | 1 + shellcheck / ruff / actionlint | run `shellcheck -S warning` to match the gate |
+| Edit docs only | lychee | `make docs-links`; the [docs-only CI gate](CI.md) covers `build` and `test`, but the link check still runs |
+| Run the control harness | 1 | retail data; Pillow for image asserts — [CONTROL.md](CONTROL.md) |
+| Build for Android | 1 + Android lane | — |
+| Cut a release | 1 + releasing + the target platform's bundler | [RELEASING.md](RELEASING.md) |
+| Poke at disc images or HQR data | 1 + Python 3 | stdlib only; the two art scripts and the ACF decoder need Pillow |
+
+## Deliberately not required
+
+Named here so nobody adds them by accident:
+
+- **A dependency manager** (Nix, devenv, mise, asdf, vcpkg, Conan). Contributors
+  are on Linux, macOS, Windows/MSYS2, and WSL, and the tool set is small enough
+  that per-platform package managers stay cheaper than a lockfile everyone has
+  to adopt.
+- **A pinned compiler.** The engine targets C++98 across GCC and Clang on four
+  platforms; pinning one compiler would hide exactly the portability breaks CI
+  exists to catch. See [COMPILER_NOTES.md](COMPILER_NOTES.md) and
+  [PLATFORM.md](PLATFORM.md).
+- **Node, Rust, or Go toolchains.** `git-cliff` ships prebuilt binaries; nothing
+  else needs them.
+- **Third-party Python packages**, with one exception. Pillow is the only one,
+  and it is needed by exactly three asset scripts — `art_catalog_screen.py`,
+  `art_treatment_preview.py`, `acf_decode.py` — plus the automation suite's
+  optional image asserts. Everything else, including the save probes and the
+  corpus harness, runs on a bare `python3`. Keep it that way: a new script that
+  needs numpy needs a conversation first.
+
+## Keeping this current
+
+Same contract as [scripts/README.md](../scripts/README.md) and
+[docs/README.md](README.md): when you make a script or workflow depend on a new
+external tool, add its row here and a probe to
+[check-tooling.sh](../scripts/dev/check-tooling.sh) in the same commit. There is
+a row for this in the [AGENTS.md](../AGENTS.md#when-modifying-x-do-y) table.
+
+What actually rots in a doc like this is versions and per-distro install lines,
+not the tool list. So:
+
+- **Never write a version number in this file.** Add it to the Version owner
+  column as a link to the file that pins it, and teach `check-tooling.sh` to
+  parse that file. A version stated in two places is already drifting.
+- **Only write an install command where the obvious one is wrong.** `apt install
+  cmake` earns nothing. The four-way portal-backend split in
+  [GAME_DATA.md](GAME_DATA.md#picker-backends-per-environment) earns its space
+  because guessing there breaks D-Bus.
+- **If a tool has no probe, it does not belong in tiers 1–3.** Those tiers are
+  claims about whether work is possible, and an unprobed claim is the one that
+  goes stale silently.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,6 +27,7 @@ not maintained tooling.
 |--------|--------------|------------|
 | [dev/build-and-run.sh](dev/build-and-run.sh) | Build and run `lba2cc` from any working directory; resolves repo root and game data. | `make run` |
 | [dev/repo_root.sh](dev/repo_root.sh) | Print the absolute repository root (directory with the top-level `CMakeLists.txt`). | `Makefile` |
+| [dev/check-tooling.sh](dev/check-tooling.sh) | Probe the external tools the repo expects, tier by tier; non-zero only when the clone cannot build. Reads every version floor from the file that pins it. | `make check-tooling`, [TOOLING.md](../docs/TOOLING.md) |
 | [dev/build-android.sh](dev/build-android.sh) | Build the engine for Android (arm64-v8a default, armeabi-v7a via `--abi`). | manual ([ANDROID.md](../docs/ANDROID.md)) |
 | [dev/build-sdl3-android.sh](dev/build-sdl3-android.sh) | Cross-build SDL3 for Android and install it to a known prefix (prerequisite for `build-android.sh`). | manual ([ANDROID.md](../docs/ANDROID.md)) |
 | [dev/check-16k-align.sh](dev/check-16k-align.sh) | Verify an Android APK is safe on 16 KB memory-page devices (segment alignment + uncompressed `.so`). | CI (android), [ANDROID.md](../docs/ANDROID.md) |

--- a/scripts/dev/check-tooling.sh
+++ b/scripts/dev/check-tooling.sh
@@ -1,0 +1,529 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# check-tooling.sh — report which external tools this clone can and cannot use
+#
+# The executable half of docs/TOOLING.md. Tools are grouped by what breaks
+# without them, not by how nice they are to have:
+#
+#   Tier 1  build & run     — no binary without it            (exit 1 if missing)
+#   Tier 2  pass review     — CI fails you without it         (warn; --strict fails)
+#   Tier 3  per lane        — required only for one task       (report)
+#   Tier 4  faster, not required                               (report)
+#
+# Version floors and pins are READ FROM THE FILE THAT OWNS THEM, never
+# duplicated here — so this script cannot drift from the build the way a
+# hand-maintained list would. The owner file is named in each row's detail.
+#
+# Usage:
+#   scripts/dev/check-tooling.sh              # all tiers
+#   scripts/dev/check-tooling.sh --tier 1     # one tier only (repeatable)
+#   scripts/dev/check-tooling.sh --strict     # also exit non-zero on tier-2 gaps
+#   scripts/dev/check-tooling.sh --quiet      # only rows that need attention
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Every version floor below is parsed out of a file under REPO_ROOT. If the
+# root is wrong the report degrades to defaults instead of saying so, so fail
+# loudly here rather than printing a plausible but unanchored table.
+if [ ! -f "$REPO_ROOT/CMakeLists.txt" ]; then
+    echo "check-tooling.sh: cannot find the repo root (looked in '$REPO_ROOT')" >&2
+    exit 2
+fi
+
+# ---- Options --------------------------------------------------------------
+STRICT=0
+QUIET=0
+WANT_TIERS=""
+
+# Print the header block above verbatim, minus the rule lines. Derived from
+# the file rather than a line range so editing the header cannot desync --help.
+usage() {
+    awk 'NR > 1 {
+        if ($0 !~ /^#/) exit
+        if ($0 ~ /^# *-{10,}$/) next
+        sub(/^# ?/, ""); print
+    }' "$0"
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --tier) WANT_TIERS="${WANT_TIERS}${2} "; shift 2 ;;
+        --tier=*) WANT_TIERS="${WANT_TIERS}${1#*=} "; shift ;;
+        --strict) STRICT=1; shift ;;
+        --quiet|-q) QUIET=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "check-tooling.sh: unknown argument '$1' (try --help)" >&2; exit 2 ;;
+    esac
+done
+
+want_tier() {
+    [ -z "$WANT_TIERS" ] && return 0
+    case " $WANT_TIERS " in *" $1 "*) return 0 ;; *) return 1 ;; esac
+}
+
+# ---- Output ---------------------------------------------------------------
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+    C_OK=$'\033[32m'; C_WARN=$'\033[33m'; C_BAD=$'\033[31m'
+    C_DIM=$'\033[2m'; C_HEAD=$'\033[1m'; C_OFF=$'\033[0m'
+else
+    C_OK=""; C_WARN=""; C_BAD=""; C_DIM=""; C_HEAD=""; C_OFF=""
+fi
+
+TIER1_GAPS=0
+TIER2_GAPS=0
+CUR_TIER=0
+
+# Headings print lazily, on the first row that survives filtering, so a tier
+# the caller filtered out (or that --quiet emptied) leaves no stray title.
+PENDING_HEADING=""
+
+heading() {
+    CUR_TIER="$1"
+    PENDING_HEADING="$(printf '\n%sTier %s — %s%s' "$C_HEAD" "$1" "$2" "$C_OFF")"
+}
+
+# row <status> <name> <detail>
+#   status: ok | gap | info   (gap = absent or wrong version)
+row() {
+    local status="$1" name="$2" detail="${3:-}"
+    # Only count gaps in tiers the caller asked about, so --tier 1 --strict
+    # cannot fail on a tier-2 gap it never showed.
+    if [ "$status" = gap ] && want_tier "$CUR_TIER"; then
+        case "$CUR_TIER" in
+            1) TIER1_GAPS=$((TIER1_GAPS + 1)) ;;
+            2) TIER2_GAPS=$((TIER2_GAPS + 1)) ;;
+        esac
+    fi
+    want_tier "$CUR_TIER" || return 0
+    [ "$QUIET" = 1 ] && [ "$status" = ok ] && return 0
+
+    if [ -n "$PENDING_HEADING" ]; then
+        printf '%s\n' "$PENDING_HEADING"
+        PENDING_HEADING=""
+    fi
+
+    local label color
+    case "$status" in
+        ok)   label="ok     "; color="$C_OK" ;;
+        gap)  case "$CUR_TIER" in
+                  1) label="MISSING"; color="$C_BAD" ;;
+                  *) label="absent "; color="$C_WARN" ;;
+              esac ;;
+        *)    label="--     "; color="$C_DIM" ;;
+    esac
+    printf '  %s%s%s  %-22s %s%s%s\n' \
+        "$color" "$label" "$C_OFF" "$name" "$C_DIM" "$detail" "$C_OFF"
+}
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# first_of <tool>... — echo the first tool on PATH, empty if none
+first_of() {
+    local t
+    for t in "$@"; do
+        if have "$t"; then echo "$t"; return 0; fi
+    done
+    return 1
+}
+
+# ver_ge <have> <want> — semantic-ish compare via sort -V
+ver_ge() {
+    [ "$1" = "$2" ] && return 0
+    [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" = "$2" ]
+}
+
+# ---- Pins, read from their owner files ------------------------------------
+# Each of these is the single source of truth for that version in the repo.
+# If a parse fails we say so rather than silently comparing against nothing.
+CMAKE_MIN="$(sed -n 's/^cmake_minimum_required(VERSION \([0-9][0-9.]*\)).*/\1/p' \
+    "$REPO_ROOT/CMakeLists.txt" 2>/dev/null | head -1)"
+
+CLANG_FORMAT_MAJOR=""
+if [ -r "$REPO_ROOT/scripts/ci/clang-format-select.sh" ]; then
+    # shellcheck disable=SC1091
+    CLANG_FORMAT_MAJOR="$(sed -n 's/^CLANG_FORMAT_MAJOR=\([0-9]*\).*/\1/p' \
+        "$REPO_ROOT/scripts/ci/clang-format-select.sh" | head -1)"
+fi
+
+UASM_PIN="$(sed -n 's/^ARG UASM_VERSION=//p' "$REPO_ROOT/docker/Dockerfile.test" 2>/dev/null)"
+SDL3_PIN="$(sed -n 's/.*--branch \(release-[0-9][0-9.]*\).*/\1/p' \
+    "$REPO_ROOT/docker/Dockerfile.test" 2>/dev/null | head -1)"
+NDK_MIN="$(sed -n 's/.*Android NDK \(r[0-9]*+\).*/\1/p' \
+    "$REPO_ROOT/scripts/dev/build-android.sh" 2>/dev/null | head -1)"
+JDK_VER="$(sed -n "s/^ *java-version: *['\"]\{0,1\}\([0-9][0-9.]*\)['\"]\{0,1\} *$/\1/p" \
+    "$REPO_ROOT/.github/workflows/reusable-build-android.yml" 2>/dev/null | head -1)"
+
+# The three linter versions the Lint workflow pins. Read them the same way as
+# every other floor so this script tracks a bump without being edited.
+lint_pin() {
+    sed -n "s/^ *$1: *['\"]\{0,1\}\([0-9][0-9.]*\)['\"]\{0,1\} *$/\1/p" \
+        "$REPO_ROOT/.github/workflows/lint.yml" 2>/dev/null | head -1
+}
+SHELLCHECK_PIN="$(lint_pin SHELLCHECK_VERSION)"
+ACTIONLINT_PIN="$(lint_pin ACTIONLINT_VERSION)"
+RUFF_PIN="$(lint_pin RUFF_VERSION)"
+LYCHEE_PIN="$(sed -n "s/^ *LYCHEE_VERSION: *['\"]\{0,1\}v\{0,1\}\([0-9][0-9.]*\)['\"]\{0,1\} *$/\1/p" \
+    "$REPO_ROOT/.github/workflows/docs-links.yml" 2>/dev/null | head -1)"
+
+# pin_note <local> <pinned> — say how the local version relates to CI's pin.
+pin_note() {
+    if [ -z "$2" ]; then echo "$1"
+    elif [ "$1" = "$2" ]; then echo "$1 — matches the CI pin"
+    else echo "$1 — CI pins $2"
+    fi
+}
+
+case "$(uname -s)" in
+    Linux)   HOST=linux ;;
+    Darwin)  HOST=macos ;;
+    MINGW*|MSYS*|CYGWIN*) HOST=windows ;;
+    *)       HOST=other ;;
+esac
+
+printf '%sTooling check%s  %s(%s, host: %s)%s\n' \
+    "$C_HEAD" "$C_OFF" "$C_DIM" "$REPO_ROOT" "$HOST" "$C_OFF"
+
+# ---------------------------------------------------------------------------
+# Tier 1 — build & run
+# ---------------------------------------------------------------------------
+heading 1 "build & run"
+
+# On Windows the whole toolchain hangs off which MSYS2 environment the shell
+# came up in. In plain MSYS, cmake/gcc/ninja are simply not on PATH and every
+# row below fails with no hint as to why, so name the environment first.
+if [ "$HOST" = windows ]; then
+    case "${MSYSTEM:-}" in
+        UCRT64|MINGW64|MINGW32|CLANG64|CLANGARM64)
+            row info "MSYS2 environment" "MSYSTEM=$MSYSTEM" ;;
+        "")
+            row info "MSYS2 environment" "MSYSTEM unset — expected UCRT64 (docs/WINDOWS.md)" ;;
+        *)
+            row info "MSYS2 environment" "MSYSTEM=$MSYSTEM is not a toolchain env; use UCRT64 (docs/WINDOWS.md)" ;;
+    esac
+fi
+
+if have cmake; then
+    v="$(cmake --version 2>/dev/null | sed -n '1s/.*version \([0-9][0-9.]*\).*/\1/p')"
+    if [ -z "$CMAKE_MIN" ]; then
+        row ok "cmake" "$v (could not read the floor from CMakeLists.txt)"
+    elif ver_ge "$v" "$CMAKE_MIN"; then
+        row ok "cmake" "$v — floor $CMAKE_MIN (CMakeLists.txt)"
+    else
+        row gap "cmake" "$v is below the $CMAKE_MIN floor (CMakeLists.txt)"
+    fi
+else
+    row gap "cmake" "need ${CMAKE_MIN:-3.23}+ — see docs/TOOLING.md"
+fi
+
+if have ninja; then
+    row ok "ninja" "$(ninja --version 2>/dev/null)"
+else
+    row gap "ninja" "every CMakePresets.json preset uses the Ninja generator"
+fi
+
+if cxx="$(first_of "${CXX:-}" c++ g++ clang++)"; then
+    row ok "C++ compiler" "$cxx $("$cxx" --version 2>/dev/null | sed -n '1s/.*) \{0,1\}\([0-9][0-9.]*\).*/\1/p')"
+else
+    row gap "C++ compiler" "need a C++98-capable GCC or Clang"
+fi
+
+sdl3_ver=""
+if have pkg-config && pkg-config --exists sdl3 2>/dev/null; then
+    sdl3_ver="$(pkg-config --modversion sdl3 2>/dev/null) (pkg-config)"
+elif have cmake; then
+    # The build uses find_package(SDL3 CONFIG), so ask CMake the same way
+    # rather than guessing at install prefixes.
+    probe="$(mktemp -d 2>/dev/null)" || probe=""
+    if [ -n "$probe" ]; then
+        cat > "$probe/CMakeLists.txt" <<'PROBE'
+cmake_minimum_required(VERSION 3.16)
+project(sdl3probe NONE)
+find_package(SDL3 CONFIG REQUIRED)
+message(STATUS "SDL3PROBE=${SDL3_VERSION}")
+PROBE
+        if out="$(cmake -S "$probe" -B "$probe/b" 2>/dev/null)"; then
+            sdl3_ver="$(printf '%s\n' "$out" | sed -n 's/.*SDL3PROBE=\([0-9][0-9.]*\).*/\1/p' | head -1)"
+            sdl3_ver="${sdl3_ver:-found} (CMake config)"
+        fi
+        rm -rf "$probe"
+    fi
+fi
+if [ -n "$sdl3_ver" ]; then
+    row ok "SDL3" "$sdl3_ver"
+else
+    row gap "SDL3" "shared library + CMake config; release builds pin ${SDL3_PIN:-a release tag}"
+fi
+
+if have git; then
+    row ok "git" "$(git --version 2>/dev/null | sed -n 's/git version //p')"
+else
+    row gap "git" "the format and tidy scripts enumerate files with git ls-files"
+fi
+
+# ---------------------------------------------------------------------------
+# Tier 2 — pass review
+# ---------------------------------------------------------------------------
+heading 2 "pass review (CI fails you without these)"
+
+# The package that provides clang-format is named differently on every
+# platform, and only Debian ships a version-suffixed binary. Name the pinned
+# major and the local package rather than a binary that cannot exist here.
+case "$HOST" in
+    linux)   cf_pkg="apt install clang-format-${CLANG_FORMAT_MAJOR}" ;;
+    macos)   cf_pkg="brew install clang-format" ;;
+    windows) cf_pkg="pacman -S mingw-w64-ucrt-x86_64-clang-tools-extra" ;;
+    *)       cf_pkg="install clang-format ${CLANG_FORMAT_MAJOR}" ;;
+esac
+
+if [ -z "$CLANG_FORMAT_MAJOR" ]; then
+    row gap "clang-format" "could not read CLANG_FORMAT_MAJOR from scripts/ci/clang-format-select.sh"
+elif cf="$(first_of "clang-format-${CLANG_FORMAT_MAJOR}" clang-format)"; then
+    cfv="$("$cf" --version 2>/dev/null | sed -n 's/.*clang-format version \([0-9][0-9.]*\).*/\1/p')"
+    cfmaj="${cfv%%.*}"
+    if [ "$cfmaj" = "$CLANG_FORMAT_MAJOR" ]; then
+        row ok "clang-format" "$cfv — pinned major $CLANG_FORMAT_MAJOR (scripts/ci/clang-format-select.sh)"
+    else
+        row gap "clang-format" "found $cfv, need major $CLANG_FORMAT_MAJOR; the format scripts refuse other majors — $cf_pkg"
+    fi
+else
+    row gap "clang-format" "need major $CLANG_FORMAT_MAJOR — $cf_pkg"
+fi
+
+# docs-links.yml is deliberately not path-filtered, so this one gates every PR,
+# a docs-only one included. Without it `make docs-links` skips its link half
+# with a warning and still exits 0, which reads as a pass.
+if have lychee; then
+    row ok "lychee" "$(pin_note "$(lychee --version 2>/dev/null | sed -n 's/^lychee //p')" "$LYCHEE_PIN") — make docs-links"
+else
+    row gap "lychee" "docs-links.yml checks every markdown link and #anchor${LYCHEE_PIN:+ (CI pins $LYCHEE_PIN)}"
+fi
+
+# The Lint workflow gates shell, Python and workflow files the way format.yml
+# gates C/C++. Each is only needed if your change touches that file type.
+if have shellcheck; then
+    row ok "shellcheck" "$(pin_note "$(shellcheck --version 2>/dev/null | sed -n 's/^version: //p')" "$SHELLCHECK_PIN"); run with -S warning"
+else
+    row gap "shellcheck" "the Lint workflow checks every tracked *.sh${SHELLCHECK_PIN:+ (CI pins $SHELLCHECK_PIN)}"
+fi
+if have ruff; then
+    row ok "ruff" "$(pin_note "$(ruff --version 2>/dev/null | sed -n 's/^ruff //p')" "$RUFF_PIN")"
+else
+    row gap "ruff" "the Lint workflow checks every tracked *.py${RUFF_PIN:+ (CI pins $RUFF_PIN)} — pipx install ruff"
+fi
+if have actionlint; then
+    row ok "actionlint" "$(pin_note "$(actionlint --version 2>/dev/null | head -1)" "$ACTIONLINT_PIN")"
+else
+    row gap "actionlint" "the Lint workflow checks .github/workflows${ACTIONLINT_PIN:+ (CI pins $ACTIONLINT_PIN)}"
+fi
+
+if have python3; then
+    row ok "python3" "$(python3 --version 2>/dev/null | sed -n 's/Python //p') — filter-format-files.py, save probes, corpus harness"
+else
+    row gap "python3" "scripts/ci/filter-format-files.py gates the format check"
+fi
+
+# run_tests_docker.sh invokes `docker` by name. On WSL a Docker Desktop
+# install can leave a shim that resolves on PATH and then fails at exec,
+# so presence alone is not the question — see verify-release.sh.
+if have docker; then
+    if docker info >/dev/null 2>&1; then
+        row ok "container runtime" "docker daemon reachable — ./run_tests_docker.sh"
+    else
+        row gap "container runtime" "docker resolves but the daemon is unreachable; the ASM suite cannot run"
+    fi
+elif have podman; then
+    # Podman speaks every subcommand run_tests_docker.sh uses, but the script
+    # calls `docker` by name, so it needs a shim. Say whether podman itself is
+    # even usable before suggesting one.
+    if podman info >/dev/null 2>&1; then
+        row gap "container runtime" "podman works, but run_tests_docker.sh calls 'docker' by name — shim or alias it"
+    else
+        row gap "container runtime" "podman found but not usable ('podman info' fails); the ASM suite cannot run"
+    fi
+else
+    row gap "container runtime" "./run_tests_docker.sh needs Docker for the ASM equivalence suite"
+fi
+
+# ---------------------------------------------------------------------------
+# Tier 3 — per lane
+# ---------------------------------------------------------------------------
+heading 3 "per lane (required only if you work on that lane)"
+
+# ASM equivalence built on the host instead of in the container
+if have objcopy; then
+    row ok "objcopy" "LBA2_BUILD_ASM_EQUIV_TESTS=ON on the host"
+else
+    row gap "objcopy" "binutils — only for a host build with LBA2_BUILD_ASM_EQUIV_TESTS=ON"
+fi
+if printf 'int main(void){return 0;}' | \
+   "${cxx:-c++}" -m32 -x c - -o /dev/null >/dev/null 2>&1; then
+    row ok "32-bit runtime" "-m32 links — host ASM equivalence possible"
+elif [ "$HOST" = windows ]; then
+    # UCRT64 and MINGW64 are 64-bit only; 32-bit is a separate MSYS2
+    # environment, not a package you add to this one.
+    row gap "32-bit runtime" "-m32 is unsupported here; 32-bit needs the MINGW32 environment"
+else
+    row gap "32-bit runtime" "gcc-multilib/g++-multilib; the container has it, hosts usually don't"
+fi
+if have uasm; then
+    row ok "uasm" "$(uasm -? </dev/null 2>&1 | head -1)"
+else
+    row gap "uasm" "ENABLE_ASM=ON only; the container fetches ${UASM_PIN:-the pinned build} itself"
+fi
+
+# Releasing
+if have gh; then
+    if gh auth status >/dev/null 2>&1; then
+        row ok "gh" "authenticated — release upload, verify-release.sh"
+    else
+        row gap "gh" "installed but not authenticated (gh auth login); verify-release.sh requires auth"
+    fi
+else
+    row gap "gh" "docs/RELEASING.md, scripts/dev/verify-release.sh"
+fi
+if have git-cliff; then
+    row ok "git-cliff" "CHANGELOG generation (docs/RELEASING.md)"
+else
+    row gap "git-cliff" "only from the second release on (docs/RELEASING.md)"
+fi
+if have tar; then
+    row ok "tar" "linux tarball bundling, verify-release.sh"
+else
+    row gap "tar" "scripts/packaging/bundle-linux-tarball.sh"
+fi
+if have zip; then
+    row ok "zip" "windows ZIP bundling"
+elif have python3; then
+    row ok "zip (python3 fallback)" "bundle-windows.sh falls back to python3 zipfile"
+else
+    row gap "zip" "bundle-windows.sh needs zip or python3"
+fi
+
+# Cross-compiling Windows artifacts from a Unix host. Meaningless on Windows,
+# where the native MSYS2 presets are the supported path instead.
+if [ "$HOST" != windows ]; then
+    if have i686-w64-mingw32-gcc; then
+        row ok "mingw-w64" "cmake --preset cross_linux2win"
+    else
+        row gap "mingw-w64" "only for the cross_linux2win preset (docs/RELEASING.md)"
+    fi
+fi
+
+# macOS-only bundling
+if [ "$HOST" = macos ]; then
+    if have hdiutil; then
+        row ok "hdiutil" "DMG creation (bundle-macos.sh)"
+    else
+        row gap "hdiutil" "bundle-macos.sh requires a macOS host"
+    fi
+    if have xcrun; then
+        row ok "xcrun" "Xcode command-line tools"
+    else
+        row gap "xcrun" "xcode-select --install"
+    fi
+fi
+
+# Android
+ndk_dir="${ANDROID_NDK:-}"
+if [ -z "$ndk_dir" ]; then
+    ndk_dir="$(ls -d "$HOME"/Android/Sdk/ndk/* 2>/dev/null | sort -V | tail -1)"
+fi
+if [ -n "$ndk_dir" ] && [ -d "$ndk_dir" ]; then
+    # NDK install dirs are versioned 28.2.13676358, where the major is the "r".
+    ndk_name="$(basename "$ndk_dir")"
+    ndk_have="${ndk_name%%.*}"
+    ndk_want="${NDK_MIN#r}"; ndk_want="${ndk_want%+}"
+    if [ -n "$ndk_want" ] && [ -n "${ndk_have##*[!0-9]*}" ] \
+       && [ "$ndk_have" -lt "$ndk_want" ] 2>/dev/null; then
+        row gap "Android NDK" "r$ndk_have found, need $NDK_MIN (scripts/dev/build-android.sh)"
+    else
+        row ok "Android NDK" "r$ndk_have — floor ${NDK_MIN:-r28+} (scripts/dev/build-android.sh)"
+    fi
+else
+    row gap "Android NDK" "need ${NDK_MIN:-r28+}; set ANDROID_NDK (docs/ANDROID.md)"
+fi
+sdk_root="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}}"
+bt="$(ls -d "$sdk_root"/build-tools/* 2>/dev/null | sort -V | tail -1)"
+if [ -n "$bt" ]; then
+    row ok "Android build-tools" "$(basename "$bt") — aapt2, zipalign, apksigner"
+else
+    row gap "Android build-tools" "APK bundling only (scripts/packaging/bundle-android.sh)"
+fi
+if have javac; then
+    row ok "javac" "$(javac -version 2>&1 | sed -n 's/javac //p') — compiles the SDL3 Java activity into classes.dex"
+else
+    row gap "javac" "JDK${JDK_VER:+ $JDK_VER} (reusable-build-android.yml); APK bundling only"
+fi
+if have adb; then
+    row ok "adb" "install and log on device"
+else
+    row gap "adb" "on-device install only (docs/ANDROID.md)"
+fi
+
+# Runtime, not build: the Linux game-data picker
+if [ "$HOST" = linux ]; then
+    if have zenity; then
+        row ok "zenity" "game-data folder picker"
+    elif ls /usr/share/dbus-1/services/org.freedesktop.impl.portal.desktop.* >/dev/null 2>&1; then
+        row ok "xdg-desktop-portal" "game-data folder picker"
+    else
+        row gap "folder picker" "zenity or an xdg-desktop-portal backend (docs/GAME_DATA.md)"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Tier 4 — faster, not required
+# ---------------------------------------------------------------------------
+heading 4 "faster, not required (nothing breaks without these)"
+
+if rct="$(first_of run-clang-tidy "run-clang-tidy-${CLANG_FORMAT_MAJOR:-18}")"; then
+    row ok "run-clang-tidy" "$rct — scripts/ci/run-clang-tidy.sh"
+else
+    row info "run-clang-tidy" "clang-tools-extra; never runs in CI (.clang-tidy)"
+fi
+if python3 -c "from PIL import Image" >/dev/null 2>&1; then
+    row ok "Pillow" "screenshot comparison in tests/automation"
+else
+    row info "Pillow" "pip install Pillow — image asserts skip without it (tests/automation/lib.sh)"
+fi
+if have convert || have magick; then
+    row ok "ImageMagick" "polyrec PPM to PNG (tests/SNAPSHOT/render_polyrec.sh)"
+else
+    row info "ImageMagick" "polyrec keeps the PPMs and skips PNG conversion"
+fi
+if have act; then
+    row ok "act" "run Linux CI jobs locally"
+else
+    row info "act" "Linux jobs only; macOS and Windows runners cannot be emulated"
+fi
+if dbg="$(first_of gdb lldb)"; then
+    row ok "debugger" "$dbg"
+else
+    row info "debugger" "gdb or lldb"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+plural() { [ "$1" = 1 ] && echo gap || echo gaps; }
+
+printf '\n'
+if [ "$TIER1_GAPS" -gt 0 ]; then
+    printf '%sTier 1 has %d %s — this clone cannot build and run.%s\n' \
+        "$C_BAD" "$TIER1_GAPS" "$(plural "$TIER1_GAPS")" "$C_OFF"
+elif want_tier 1; then
+    printf '%sTier 1 complete — this clone can build and run.%s\n' "$C_OK" "$C_OFF"
+fi
+if want_tier 2 && [ "$TIER2_GAPS" -gt 0 ]; then
+    printf '%sTier 2 has %d %s — CI will catch what you cannot check locally.%s\n' \
+        "$C_WARN" "$TIER2_GAPS" "$(plural "$TIER2_GAPS")" "$C_OFF"
+fi
+printf '%sTiers 3 and 4 are informational. Full table: docs/TOOLING.md%s\n' \
+    "$C_DIM" "$C_OFF"
+
+[ "$TIER1_GAPS" -gt 0 ] && exit 1
+[ "$STRICT" = 1 ] && [ "$TIER2_GAPS" -gt 0 ] && exit 1
+exit 0


### PR DESCRIPTION
## Why

The repo documents its own scripts exhaustively in `scripts/README.md` and says almost nothing about the tools those scripts assume you have. Prerequisites are spread across seven places — the root README, `WINDOWS.md`, `ANDROID.md`, `RELEASING.md`, `GAME_DATA.md`, `Dockerfile.test`, and one line in `AGENTS.md` — and several tools are documented nowhere at all: lychee, ruff, actionlint, Pillow, ImageMagick, act.

That is a discovery problem for a new contributor and for an agent, and it is the kind of gap that gets worse quietly.

## What

**`docs/TOOLING.md`** — an index tiered by *what breaks without each tool* rather than by how useful it is. "Optional" would put the Android NDK, a hard requirement for one lane, in the same bucket as a debugger, so the tiers are:

| Tier | Test | Consequence |
|------|------|-------------|
| 1 — Build & run | no binary without it | probe exits non-zero |
| 2 — Pass review | CI fails you | warning; `--strict` exits non-zero |
| 3 — Per lane | required only for that lane | reported |
| 4 — Faster, not required | nothing breaks | reported |

The top two are checkable, the bottom two only discoverable, and that split decides how each is maintained.

**`scripts/dev/check-tooling.sh`** — the executable half, wired up as `make check-tooling`. It probes every row and exits non-zero only when the clone genuinely cannot build, so a new contributor or an agent runs it instead of reading the tables. `--tier N`, `--quiet`, `--strict`.

Also a short **Engine-internal tooling** section that routes to polyrec, the control harness, the console and the rest. It deliberately lists no individual command — the engine already enumerates itself via `--help-all` and `cmdlist`, and duplicating 40 command names would age the doc on every PR that adds one.

## Keeping it honest

Neither file states a version. Every floor is parsed out of the file that owns it — `cmake_minimum_required`, `CLANG_FORMAT_MAJOR`, the three linter pins in `lint.yml`, `LYCHEE_VERSION`, `java-version`, `ARG UASM_VERSION` — and the doc cites that file rather than copying the number. A version written in two places is already drifting.

Three rules fall out of that, and they are in the doc: no version literals, no probe commands in prose, and no row in tiers 1–3 without a probe behind it. There is a new row in the `AGENTS.md` "When modifying X, do Y" table so a future tool dependency lands in both files in one commit.

The one row that cannot work this way is SDL3: its release pin is duplicated across four sites and kept in sync by hand. The doc says so rather than pretending there is an owner.

## Verification

Both environments this project builds in.

**Linux** — all CI gates pass locally: `shellcheck -S warning` over every tracked `*.sh`, `check-docs-links.sh` with the pinned lychee (1139 links, 0 errors), `actionlint`, the format check, `make help`.

**Windows, MSYS2 UCRT64** — this is what earned its keep. Four things were wrong and are now fixed:

- the `mingw-w64` row probed a *cross*-compiler, meaningless on a Windows host
- the 32-bit and clang-format hints named Debian packages that cannot exist there
- the NDK check passed an r27 install against an r28+ floor
- `--help` had drifted from its own header

Windows also motivated reporting `MSYSTEM` first. In the plain `MSYS` shell the whole toolchain is off `PATH`, so every tier-1 row fails at once with no visible cause:

```
  --       MSYS2 environment      MSYSTEM=MSYS is not a toolchain env; use UCRT64 (docs/WINDOWS.md)
  MISSING  cmake / ninja / C++ compiler / SDL3
Tier 1 has 4 gaps — this clone cannot build and run.
```

Writing this also caught three stale claims about our own CI, now corrected: shellcheck and actionlint are gates (they were in the nice-to-have tier), ruff was missing entirely, and lychee gates *every* PR including docs-only, because `docs-links.yml` is deliberately not path-filtered.

## Not included

- **Podman as a first-class alternative.** `run_tests_docker.sh` only uses `images -q`, `build --platform` and `run --rm --platform`, all of which podman accepts, so a `${CONTAINER_ENGINE:-docker}` variable would be a four-site change. I could not verify it — podman on my box fails with a store-config mismatch — and an untested container change in the test driver is not worth guessing at. The harder case is `verify-release.sh`, which needs `--privileged` for arm64 binfmt. The doc records this as unsupported-but-probably-fine rather than tested.
- **A consistency test** asserting the doc's tier 1–2 rows and the probe list are the same set. It is the check that would catch "wired a new tool into CI, forgot the doc" — the failure mode a written rule cannot catch — but it is more scaffolding than the doc it guards, so it is a separate conversation.
- **A dependency manager.** No Nix, devenv, mise or vcpkg. The doc has a section saying so, and why, so it does not get re-litigated by accident.
