### PR TITLE
fix(tools): fail fast when docker is installed but unusable

### DIFF
--- a/docs/TOOLING.md
+++ b/docs/TOOLING.md
@@ -114,6 +114,26 @@ Two things about the container:
   on `PATH` in WSL that resolves fine and then fails at exec, which
   [verify-release.sh](../scripts/dev/verify-release.sh#L73) documents and
   `check-tooling.sh` mirrors by calling `docker info`.
+  [run_tests_docker.sh](../run_tests_docker.sh) checks the same thing before it
+  does any work, because otherwise a setup problem surfaces as a confusing
+  failure from the first real docker call.
+
+  On WSL the usual cause is that **Docker Desktop is running fine and its WSL
+  integration is off for your distro.** `/mnt/wsl/docker-desktop/cli-tools` is
+  mounted whatever the setting, so `docker` resolves and prints client info,
+  but no `/var/run/docker.sock` is created and the daemon is unreachable:
+
+  ```
+  failed to connect to the docker API at unix:///var/run/docker.sock
+  ```
+
+  Confirm the daemon itself is healthy through the Windows binary —
+  `"/mnt/c/Program Files/Docker/Docker/resources/bin/docker.exe" info` — then fix
+  it in Docker Desktop under Settings > Resources > WSL Integration, enabling
+  your distro. A working integration leaves `/var/run/docker.sock` owned by the
+  `docker` group. Pointing `DOCKER_HOST` at the proxy socket under
+  `shared-sockets/host-services/` looks tempting and is a dead end: it is
+  `root:root`, and being in the `docker` group does not reach it.
 - **Podman is not a drop-in.** Both scripts invoke `docker` by name, so podman
   needs a shim or alias on `PATH`. The commands themselves are compatible —
   [run_tests_docker.sh](../run_tests_docker.sh) only uses `images -q`,

--- a/run_tests_docker.sh
+++ b/run_tests_docker.sh
@@ -72,6 +72,25 @@ if [ "${RENDER_INDIVIDUALLY}" = "true" ] && [ "${RENDER_MODE}" != "true" ]; then
     exit 1
 fi
 
+# Resolving on PATH is not enough to know docker works. On WSL the CLI is a
+# symlink into Docker Desktop's mounted cli-tools, so it resolves and even
+# prints client info while integration is switched off for the distro and no
+# /var/run/docker.sock exists at all. Without this check that surfaces as a
+# confusing failure from the first real docker call, which reads as a problem
+# with the test suite rather than with the setup.
+if ! command -v docker >/dev/null 2>&1; then
+    echo "ERROR: docker is not on PATH. See docs/TOOLING.md." >&2
+    exit 1
+fi
+if ! docker info >/dev/null 2>&1; then
+    echo "ERROR: docker is installed but not usable ('docker info' failed)." >&2
+    echo "  On WSL, check that Docker Desktop's WSL integration is enabled for" >&2
+    echo "  this distro (Settings > Resources > WSL Integration); the CLI" >&2
+    echo "  resolves even when it is off. Otherwise start the daemon." >&2
+    echo "  Diagnose with: docker info" >&2
+    exit 1
+fi
+
 # ── Build Docker image (skip if already cached) ──────────────────────────────
 IMAGE_EXISTS=$(docker images -q "${IMAGE_NAME}" 2>/dev/null)
 if [ "$FORCE_REBUILD" = true ] || [ -z "$IMAGE_EXISTS" ]; then

--- a/scripts/dev/check-tooling.sh
+++ b/scripts/dev/check-tooling.sh
@@ -332,7 +332,7 @@ if have docker; then
     if docker info >/dev/null 2>&1; then
         row ok "container runtime" "docker daemon reachable — ./run_tests_docker.sh"
     else
-        row gap "container runtime" "docker resolves but the daemon is unreachable; the ASM suite cannot run"
+        row gap "container runtime" "docker resolves but the daemon is unreachable; on WSL check Docker Desktop's WSL integration (docs/TOOLING.md)"
     fi
 elif have podman; then
     # Podman speaks every subcommand run_tests_docker.sh uses, but the script


### PR DESCRIPTION
`run_tests_docker.sh` went straight to `docker images -q`, so a docker that resolves on `PATH` but cannot reach a daemon failed at the first real call, several steps in, with a message about the docker API. That reads as a problem with the test suite rather than with the machine's setup.

It now checks `docker info` before doing any work — after argument validation, so a mistyped flag is still reported as a mistyped flag.

```
ERROR: docker is installed but not usable ('docker info' failed).
  On WSL, check that Docker Desktop's WSL integration is enabled for
  this distro (Settings > Resources > WSL Integration); the CLI
  resolves even when it is off. Otherwise start the daemon.
  Diagnose with: docker info
```

## Why that wording

The error names the cause that actually produces this on WSL, which took a while to pin down: **Docker Desktop can be running and perfectly healthy while its WSL integration is switched off for your distro.** `/mnt/wsl/docker-desktop/cli-tools` is mounted either way, so `docker` resolves and prints client info, but no `/var/run/docker.sock` is created. You can confirm the daemon is fine through the Windows binary while every Linux-side call fails, which is a genuinely confusing state to be in.

`docs/TOOLING.md` records the whole shape of it, including one dead end worth signposting: pointing `DOCKER_HOST` at the proxy socket under `shared-sockets/host-services/` looks like the fix and is not — it is `root:root`, and being in the `docker` group does not reach it. The fix is the integration checkbox, which leaves `/var/run/docker.sock` owned by the `docker` group.

## Verification

Found and fixed on a host in exactly that state. After restoring WSL integration, the ASM suite runs **150/150 green in 17.9s** and the preflight passes without comment. The missing-docker path was checked with `docker` hidden from `PATH`.

`shellcheck -S warning` over every tracked `*.sh`, and `check-docs-links.sh` with the pinned lychee (1206 links, 0 errors).

## Scope note

This PR started out adding `CONTAINER_ENGINE` so the suite could run under podman, and that part has been cut. The motivation was a docker that appeared broken — and docker was not broken, it was misconfigured, which is what this PR now addresses. Podman support was never verified end to end on any machine: rootless podman needs a subuid range delegated to the user, and the one host that tried does not have one, so the image build dies in `apt` with `setgroups` errors. Claiming support we cannot demonstrate would contradict TOOLING.md's own rule about not documenting what nothing checks, and a `docker` shim on `PATH` already works as a workaround. If someone who can produce a green podman run wants it, it is about fourteen lines and should land with that run attached.

What is left here is engine-agnostic, small, and verified.
