### PR TITLE
fix(tools): stop a host build tree from breaking the ASM suite

### DIFF
--- a/run_tests_docker.sh
+++ b/run_tests_docker.sh
@@ -158,7 +158,15 @@ docker run --rm \
         fi
         uasm -? </dev/null 2>&1 | head -1 || true
 
-        cp -a ${CONTAINER_SRC} /tmp/lba2
+        # Copy the source in, minus any build tree the host happens to have.
+        # A host build/ carries a CMakeCache.txt naming its host path, and cmake
+        # refuses to reuse a cache from a different directory -- so copying one
+        # in makes the configure below fail before a single test compiles. CI
+        # never hits this because it checks out fresh; a contributor who has
+        # ever run `make build` hits it every time.
+        mkdir -p /tmp/lba2
+        tar -C ${CONTAINER_SRC} --exclude=./build --exclude='./build-*' -cf - . \
+            | tar -C /tmp/lba2 -xf -
         cd /tmp/lba2
 
         AVAILABLE_PRESETS="$(cmake --list-presets 2>/dev/null || true)"


### PR DESCRIPTION
`./run_tests_docker.sh` is documented as the supported path for the full ASM↔C++ suite. It does not work in a clone that has ever been built in.

The in-container copy took the whole `-v` mount, so a host `build/` came along with its `CMakeCache.txt`. That cache records the host path it was generated in, cmake refuses to reuse a cache from a different directory, and the configure step failed before a single test compiled:

```
CMake Error: The current CMakeCache.txt directory /tmp/lba2/build/CMakeCache.txt is
different than the directory /home/.../build where CMakeCache.txt was created.
CMake Error: The source "/tmp/lba2/CMakeLists.txt" does not match the source
"/home/.../CMakeLists.txt" used to generate cache.
```

CI never sees it, because it checks out fresh. Anyone who has run `make build` sees it every time, and the workaround is to move your build tree aside — which is not obvious from the error, since it reads as a problem with the suite.

## The change

Copy through `tar` with excludes instead of `cp -a`:

```bash
mkdir -p /tmp/lba2
tar -C ${CONTAINER_SRC} --exclude=./build --exclude='./build-*' -cf - . | tar -C /tmp/lba2 -xf -
```

Only `build/` actually collides — it is the name the container configures into. `build-*` is excluded as well because those are the same class of thing and copying them is pure cost (124 MB in my clone across `build-asan`, `build-clang`, `build-demo`, `build-hosttest`). `out/` and `dist/` are deliberately left alone; they do not collide, and this keeps the change to the one thing causing the bug.

`tar` is in the image already (GNU tar 1.35), so this adds no dependency. Copy-then-delete would also work but moves gigabytes first.

## Verification

Same commit, two trees, one difference:

| Tree | Before | After |
|---|---|---|
| clone with five build trees | exit 1 at configure | **exit 0, 150/150 pass** |
| clean checkout (`git worktree add --detach`) | exit 0, 150/150 | exit 0, 150/150 |

The clean-checkout run is what isolated the cause: it was green while the working tree failed on the identical commit, which ruled out the suite and pointed at the copy.

`shellcheck -S warning` over every tracked `*.sh` passes.
