### PR TITLE
fix(camera): stop a large manual-hold turning the override into its opposite

### DIFF
--- a/SOURCES/FOLLOWCAM.CPP
+++ b/SOURCES/FOLLOWCAM.CPP
@@ -207,9 +207,21 @@ void UpdateFollowCameraExt(void) {
                          * 100 (full assist) when no hold. */
         if (FollowCamManualHold > 0)
             FollowCamManualHold--;
+        /* The console sets cvars without going through the config's range check,
+         * so clamp where it is used, as the orbit glide does in EXTFUNC. Both
+         * bounds are load-bearing here rather than tidiness: the hold counter is
+         * seeded from the frame count, so an unbounded cam_manual_hold makes
+         * `hold * 100` leave S32, and the negative product that follows drives
+         * the fade to full assist exactly when the player has asked for none. */
+        S32 holdFrames = FollowCamManualHoldFrames;
+        if (holdFrames > FOLLOW_CAM_MANUAL_HOLD_MAX)
+            holdFrames = FOLLOW_CAM_MANUAL_HOLD_MAX;
+        S32 hold = FollowCamManualHold;
+        if (hold > holdFrames)
+            hold = holdFrames;
         S32 autoFactor = 100;
-        if (FollowCamManualHoldFrames > 0)
-            autoFactor = 100 - FollowCamManualHold * 100 / FollowCamManualHoldFrames;
+        if (holdFrames > 0)
+            autoFactor = 100 - hold * 100 / holdFrames;
         if (autoFactor < 0)
             autoFactor = 0;
         if (autoFactor > 100)
@@ -471,6 +483,8 @@ void FollowCam_ReadConfig(void) {
     FollowCamManualHoldFrames = DefFileBufferReadValueDefault("FollowCamManualHoldFrames", FOLLOW_CAM_MANUAL_HOLD_DEFAULT);
     if (FollowCamManualHoldFrames < 0)
         FollowCamManualHoldFrames = 0;
+    if (FollowCamManualHoldFrames > FOLLOW_CAM_MANUAL_HOLD_MAX)
+        FollowCamManualHoldFrames = FOLLOW_CAM_MANUAL_HOLD_MAX;
     FollowCamHoldAngle = DefFileBufferReadValueDefault("FollowCamHoldAngle", FOLLOW_CAM_HOLD_ANGLE_DEFAULT) ? TRUE : FALSE;
 }
 

--- a/SOURCES/FOLLOWCAM_CFG.H
+++ b/SOURCES/FOLLOWCAM_CFG.H
@@ -26,6 +26,9 @@
  * control wins while the player is driving and the assist fades back in after.
  * Seeds the runtime FollowCamManualHoldFrames global (cvar cam_manual_hold). */
 #define FOLLOW_CAM_MANUAL_HOLD_DEFAULT 45 /* frames the auto-assist yields after a manual camera nudge (~0.75s) */
+/* Ceiling on the above. Ten seconds at 60fps, matching the re-engage delay's
+ * bound, and low enough that the fade's `hold * 100` cannot leave S32. */
+#define FOLLOW_CAM_MANUAL_HOLD_MAX 600
 
 /* Hold-angle (free-camera) mode ---------------------------------------------*/
 /* When on, the manual camera rotation (AddBetaCam) is never auto-recentered


### PR DESCRIPTION
A defect found while reviewing #540, fixed on its own rather than folded into a refactor.

**Stacked on #542** only because the code it touches lives in FOLLOWCAM.CPP there; on `main` the same lines are in PERSO.CPP. Happy to rebase it onto `main` as a standalone fix if that is preferred.

## The defect

The manual-override fade computes `FollowCamManualHold * 100 / FollowCamManualHoldFrames`, and the hold counter is seeded straight from the frame count, so both operands are whatever the setting says.

`FollowCamManualHoldFrames` was the one FollowCam key with no upper bound. The cfg read rejects negatives only, and the `cam_manual_hold` cvar bypasses the cfg's range checks entirely. Past roughly 21.5 million the multiply leaves S32; the wrapped negative pushes `autoFactor` above 100, the existing clamp pulls it back to 100, and 100 means full auto-assist.

So the player nudges the camera to take control, and the HD pitch steepen and the ground-lift re-aim come back at **full** strength instead of yielding. The setting inverts the behaviour it exists to provide.

## Measured, not argued

With `cam_manual_hold 30000000` and a `camnudge` to arm the hold, `autoFactor` read from the running engine:

| | autoFactor |
|---|---|
| current code | **100** (assist at full; override ignored) |
| with this fix | **0** (override respected) |

At the default 45 frames the two agree exactly, so this is a no-op for every value reachable through the menu.

Worth recording how this was confirmed, because two oracles failed first. `camtrace` cannot see it: the fade's effect on `AlphaCam` is applied for the render and restored immediately, so the trace and `--dump-state` both report the logical value and show nothing. A screenshot A/B also came out identical, even though the same oracle does respond to `cam_hd 0`. The reading that settled it was instrumenting `autoFactor` directly in both builds.

## The fix

Bound it in the two places this codebase already bounds such a setting:

- an upper clamp where the cfg is read, beside the existing negative check, matching every sibling key (`FollowCamReengageFrames <= 600`, `FollowCamGroundClearance <= 20000`, `FollowCamOrbitGlide <= MAX`);
- a clamp where the value is used, because the console sets cvars without the cfg's range checks. This is the same treatment `FollowCamOrbitGlide` already gets in EXTFUNC.CPP, for the same stated reason.

`FOLLOW_CAM_MANUAL_HOLD_MAX` is 600, ten seconds at 60fps, matching the re-engage delay's bound and far below where the arithmetic can overflow.

## Verification

150/150 in the ASM-vs-CPP container; camera fixtures pass; clang-format clean.
