### PR TITLE
docs(camera): correct what the HD recompose says about authored camera shots

### DIFF
--- a/SOURCES/FOLLOWCAM.CPP
+++ b/SOURCES/FOLLOWCAM.CPP
@@ -194,11 +194,15 @@ void UpdateFollowCameraExt(void) {
     S32 catchupDiff = FollowCamAngleDiff(FollowCamTargetBeta, BetaCam);
 
     if (FollowCamNeedsUpdate(ptr3d, catchupDiff)) {
-        /* HD recompose strength (kExcess): 0 in camera zones, at
-                         * 480, or when disabled. Shared by the forward-lean cut
-                         * here and the boom pull-in + pitch steepen at the apply
-                         * below, so the whole recompose is a no-op at 480. */
-        S32 hdExcess = CameraZone ? 0 : FollowCamHDExcess();
+        /* HD recompose strength (kExcess): 0 at 480 or when disabled. Shared by
+                         * the forward-lean cut here and the boom pull-in + pitch steepen at
+                         * the apply below, so the whole recompose is a no-op at 480.
+                         *
+                         * Not gated on CameraZone. This function has one caller and it sits
+                         * inside `if (!CameraZone)`, so a camera zone never reaches here to
+                         * be tested for: it keeps the follow camera from running at all,
+                         * rather than running it with the correction switched off. */
+        S32 hdExcess = FollowCamHDExcess();
 
         /* Manual-override fade: a manual nudge set FollowCamManualHold
                          * (EXTFUNC), driving the auto-assist strength to 0 so the

--- a/SOURCES/FOLLOWCAM_MATH.H
+++ b/SOURCES/FOLLOWCAM_MATH.H
@@ -100,8 +100,14 @@ static inline S32 FollowCamRotStep(S32 diff, S32 divisor, S32 minStep) {
  * The apply path scales its boom pull-in, pitch steepen and forward-lean cut by
  * this, so the whole recompose is an exact no-op wherever this returns 0. Two
  * things make it 0: a render height at or below 480, and the recompose being
- * switched off. Camera zones pass 0 separately, so an authored shot is never
- * recomposed.
+ * switched off.
+ *
+ * Those are the only two. An authored camera shot is not exempt: the frame a
+ * camera zone claims the view is one the follow camera does not run on at all, so
+ * the zone's own write reaches the screen as authored, and every frame the shot
+ * holds after that is recomposed like any other. Exempting an authored shot for
+ * real would mean keeping it out of the apply path for as long as it holds the
+ * view, which is not what happens today.
  *
  * The correction grows linearly with height, which over-steepens at 1080p. `cap`
  * bounds the result so tall resolutions converge on a fixed correction instead


### PR DESCRIPTION
`FollowCamHDExcessFor` documents an exemption that does not exist:

> Camera zones pass 0 separately, so an authored shot is never recomposed.

`UpdateFollowCameraExt` has one caller and it sits inside `if (!CameraZone)`, so the `CameraZone ? 0` the comment refers to cannot be true when it is evaluated.

The behaviour is close to the opposite: a camera zone stops the follow camera running for that one frame, so the zone's write reaches the screen as authored and every frame the shot holds after that is recomposed like any other.

Drops the dead test, corrects the comment on the rule and on the apply path. Making the exemption real is a behaviour change and not this PR.

No behaviour change: camtrace A/B at 1920x1080 with `cam_hd 1`, where the recompose is live, identical for all 115 frames.
