### PR TITLE
ci(docs): share the link-check settings with local runs

### DIFF
--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -45,9 +45,11 @@ jobs:
 
   external:
     name: External URLs
-    # Weekly only. ~580 external URLs, 446 of them github.com; running this per
-    # PR trips the unauthenticated rate limit and trains people to ignore a red
-    # check. A rotted URL is worth knowing about, just not on every push.
+    # Weekly only. Not for speed -- the full run takes about 30 seconds and
+    # stays well inside GitHub's rate limit even unauthenticated. It is that a
+    # third-party host being down would fail a PR that did not touch it, which
+    # trains people to ignore a red check. A rotted URL is worth knowing
+    # about, just not on every push.
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ dist/
 /build_logs/
 .tmp/
 
+# lychee --cache writes this; useful locally, never worth committing
+.lycheecache
+
 # Python (e.g. scripts/save_probe.py)
 __pycache__/
 *.py[cod]

--- a/LIB386/libsmacker/README.md
+++ b/LIB386/libsmacker/README.md
@@ -3,6 +3,6 @@
 C library for decoding .smk Smacker Video files (as used in LBA2).
 
 - **License:** GNU LGPL 2.1. See [COPYING.txt](COPYING.txt).
-- **Origin:** [libsmacker](https://github.com/digitalcreations/smacker) by Greg Kennedy (and others).
+- **Origin:** [libsmacker](https://libsmacker.sourceforge.net/) by Greg Kennedy (and others).
 
 This replaces the proprietary RAD Game Tools Smacker SDK for video playback in the community build.

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,34 @@
+# Shared settings for the documentation link check.
+#
+# lychee picks this up automatically when it runs from the repo root, which
+# scripts/ci/check-docs-links.sh guarantees with a cd. So a bare `lychee
+# docs/FOO.md` in a terminal applies the same rules CI does, and there is one
+# place to change them.
+#
+# Checking semantics belong here. The script keeps only the flags that should
+# differ between a terminal and a CI log: --offline and --no-progress.
+
+# Verify that #anchor targets exist, not just that the file or page does.
+# Anchors rot silently when a heading is reworded.
+include_fragments = "anchor-only"
+
+# Per-host politeness. lychee 0.24 caps concurrent requests per host and
+# spaces them out, backing off further when a server signals a rate limit.
+# These are the floor it starts from, restated rather than inherited so a
+# change to lychee's defaults cannot quietly widen them.
+host_concurrency = 10
+host_request_interval = "50ms"
+
+# github.com is 332 of the 350 unique external URLs, so it is the only host
+# with any real chance of throttling us. It does not currently: a full
+# --external run finishes in about 30 seconds with no 429s, unauthenticated.
+# If that changes, this is the knob.
+#
+# [hosts."github.com"]
+# concurrency = 4
+# request_interval = "250ms"
+
+# URLs that are reachable but cannot be checked from CI (login walls, hosts
+# that reject HEAD) belong here. None needed so far.
+#
+# exclude = []

--- a/lychee.toml
+++ b/lychee.toml
@@ -2,7 +2,7 @@
 #
 # lychee picks this up automatically when it runs from the repo root, which
 # scripts/ci/check-docs-links.sh guarantees with a cd. So a bare `lychee
-# docs/FOO.md` in a terminal applies the same rules CI does, and there is one
+# README.md` in a terminal applies the same rules CI does, and there is one
 # place to change them.
 #
 # Checking semantics belong here. The script keeps only the flags that should

--- a/scripts/ci/check-docs-links.sh
+++ b/scripts/ci/check-docs-links.sh
@@ -6,9 +6,14 @@ set -euo pipefail
 # two different breakage classes and neither tool sees the other's.
 #
 #   1. lychee over tracked markdown: relative links and #anchors. Offline by
-#      default -- the tree holds ~580 external URLs, 446 of them github.com,
-#      and an unauthenticated run trips GitHub's rate limit long before it
-#      finishes. Pass --external to check those instead (the weekly job does).
+#      default -- the tree holds ~350 unique external URLs, 332 of them
+#      github.com. Checking those needs the network and can only fail for
+#      reasons outside the change under review, so it is not a PR gate. Pass
+#      --external to check them instead (the weekly job does).
+#
+#      Shared settings live in lychee.toml at the repo root, so a bare lychee
+#      run in a terminal behaves the same way. Only --offline and
+#      --no-progress are set here, because only those should differ.
 #
 #   2. A grep for docs/<name>.md paths mentioned in NON-markdown files. Source
 #      comments, tests, scripts and CMake point at docs by bare path, which is
@@ -29,7 +34,7 @@ status=0
 
 # --- 1. markdown links and anchors ------------------------------------------
 if command -v lychee >/dev/null 2>&1; then
-    lychee_args=(--no-progress --include-fragments)
+    lychee_args=(--no-progress)
     if [ "$external" -eq 1 ]; then
         echo "Checking external URLs (slow, network-dependent)..."
     else


### PR DESCRIPTION
The docs link check already runs lychee in CI, but the rules lived in the
script's argument array. A bare `lychee docs/FOO.md` in a terminal therefore
did not match what CI enforced.

Move the checking semantics to `lychee.toml` at the repo root. lychee
discovers it on its own and `check-docs-links.sh` already `cd`s to the top
level, so both paths read the same file. The script keeps `--offline` and
`--no-progress`, the two flags that should differ between a terminal and a
CI log.

The config is deliberately small. The per-host throttle block and the
`exclude` list are commented out because nothing needs them yet.

## Two comment claims were wrong

**URL counts.** The comments said ~580 external URLs, 446 of them
github.com. The real figures are 350 unique external (427 occurrences), 332
of them github.com (396 occurrences). 580/446 does not reproduce under
`--dump`, `--include-verbatim`, or a grep across all tracked files.

**Rate limiting.** The comments said an unauthenticated external run trips
GitHub's rate limit before finishing, which was the stated reason the job is
weekly-only. Measured at CI's own defaults, unauthenticated:

```
🔍 1662 Total (in 29s) 🔗 775 Unique ✅ 1662 OK 🚫 0 Errors
```

29 seconds, no 429s. lychee 0.24 caps per-host concurrency and spaces
requests out by default, backing off further when a server pushes back, so
the anonymous path is no longer the hazard it used to be.

The job stays weekly, but the comment now gives a reason that survives: a
third-party host being down would fail a PR that never touched it. Moving it
onto the PR path is a policy call now rather than a technical one.

## Also here

- `LIB386/libsmacker/README.md` pointed at `digitalcreations/smacker`, which
  is gone and 404s. Repointed at `libsmacker.sourceforge.net`, the project's
  own home and where the GitHub mirrors say they imported from. This was the
  only real breakage in 350 URLs.
- `.lycheecache` added to `.gitignore`. Caching is deliberately *not* in the
  shared config: it stores final status only, so a cached run loses redirect
  and status detail, and a stale entry could mask a newly broken link. Right
  flag for local iteration, wrong default for the weekly pass.

## Checks

Both modes green, `actionlint` and `shellcheck` clean.
