### PR TITLE
refactor(settings): move the boot cvars onto their declaration

### DIFF
--- a/SOURCES/CONFIG_FILE.CPP
+++ b/SOURCES/CONFIG_FILE.CPP
@@ -81,12 +81,6 @@ static S32 ForcedTexFilter(void) {
 /* The boot and display settings, declared once. Row order is the cfg's key
  * order, which is user-visible: lba2.cfg is rewritten in this order.
  *
- * No cvar column: these are still registered by hand in CONSOLE/CONSOLE_CMD.CPP,
- * so naming them here as well would declare a cvar nothing registers and put a
- * second copy of each help string in the tree. Moving them over means deciding
- * what the console should do with a value the row's rule would reject, which is
- * its own change.
- *
  * Three of these can be forced for one run by a flag, and must not be left
  * behind for the next: the stored column keeps what the cfg held and the writer
  * persists that instead. Language is not here because it is written as a name
@@ -102,13 +96,19 @@ static const T_SETTING BootSettings[] = {
     {"FullScreen", NULL, NULL, &VideoFullScreen, SETTING_OR_DEFAULT, TRUE, 0, 1, NULL, NULL, NULL},
     {"DisplayFullScreen", NULL, NULL, &DisplayFullScreen, SETTING_OR_DEFAULT, FALSE, 0, 1, NULL, NULL, NULL},
     {"VSync", NULL, NULL, &DisplayVSync, SETTING_OR_DEFAULT, TRUE, 0, 1, &StoredVSync, ForcedVSync, NULL},
-    {"DitherShading", NULL, NULL, &GfxDitherShading, SETTING_OR_DEFAULT, FALSE, 0, 1, NULL, NULL, NULL},
-    {"TextureFilter", NULL, NULL, &PolyTexFilter, SETTING_OR_DEFAULT, POLY_TEX_FILTER_OFF,
-     POLY_TEX_FILTER_OFF, POLY_TEX_FILTER_BILINEAR, &StoredTexFilter, ForcedTexFilter, NULL},
+    {"DitherShading", NULL, "gfx_dither", &GfxDitherShading, SETTING_OR_DEFAULT, FALSE, 0, 1, NULL, NULL,
+     "Ordered dither on Gouraud shade rows (softens 16-step banding)"},
+    {"TextureFilter", NULL, "gfx_texfilter", &PolyTexFilter, SETTING_OR_DEFAULT, POLY_TEX_FILTER_OFF,
+     POLY_TEX_FILTER_OFF, POLY_TEX_FILTER_BILINEAR, &StoredTexFilter, ForcedTexFilter,
+     "Texture filtering: 0 off, 1 horizontal, 2 bilinear"},
     {"FixedTimestep", NULL, NULL, &FixedTimestep, SETTING_OR_DEFAULT, 16, 0, 100,
      &StoredFixedTimestep, ForcedFixedTimestep, NULL},
 };
 #define BOOT_SETTING_COUNT ((S32)(sizeof(BootSettings) / sizeof(BootSettings[0])))
+
+void ConfigFile_RegisterCvars(void) {
+    Settings_RegisterCvars(BootSettings, BOOT_SETTING_COUNT);
+}
 
 const T_SETTING *ConfigFile_Setting(const char *key) {
     S32 i;

--- a/SOURCES/CONFIG_FILE.H
+++ b/SOURCES/CONFIG_FILE.H
@@ -30,6 +30,11 @@ extern S32 WriteConfigValue(const char *ident, S32 value);
  * the player's own language back rather than persisting the override. */
 extern void ConfigFile_NoteBootLanguage(S32 language);
 
+/* The console cvars these settings own, registered from Console_RegisterAll.
+ * Their ranges and rules travel with them, so the console cannot set a value the
+ * config file would reject. */
+extern void ConfigFile_RegisterCvars(void);
+
 /* The declaration for a boot key, by its lba2.cfg name, or NULL for a key this
  * file does not own. For anything that has to state a setting's range or default
  * outside the table: ask, rather than writing the numbers down in a second place

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -2391,6 +2391,5 @@ void Console_RegisterAll(void) {
     Console_RegisterCvar("cam_smooth", &ManualCameraSmoothing, CONSOLE_CVAR_INT, "Manual orbit lerp divisor (1 = snap, higher = laggier)");
     Console_RegisterCvar("cam_glide", &FollowCamOrbitGlide, CONSOLE_CVAR_INT, "Orbit follow-through: % of orbit speed kept per frame after release (0 = stop dead)");
     FollowCam_RegisterCvars();
-    Console_RegisterCvar("gfx_dither", &GfxDitherShading, CONSOLE_CVAR_BOOL, "Ordered dither on Gouraud shade rows (softens 16-step banding)");
-    Console_RegisterCvar("gfx_texfilter", &PolyTexFilter, CONSOLE_CVAR_INT, "Texture filtering: 0 off, 1 horizontal, 2 bilinear");
+    ConfigFile_RegisterCvars();
 }

--- a/SOURCES/SETTINGS.CPP
+++ b/SOURCES/SETTINGS.CPP
@@ -62,12 +62,18 @@ void Settings_RegisterCvars(const T_SETTING *table, S32 count) {
         const T_SETTING *s = &table[i];
         if (s->cvar == NULL)
             continue;
-        /* A toggle reads as a bool in the console (no arg toggles it); everything
-         * else takes a number. The console hands the typed value here rather than
-         * interpreting it, so a setting answers the console and the config file
-         * the same way. */
+        /* A setting with two states reads as a bool in the console, so a bare
+         * `name` toggles it and `help` says 0|1. That is a question about how
+         * many values it has, not about which rule coerces them: a row that
+         * treats out of range as unset is still a toggle when its range is 0..1,
+         * and typing it as an integer would silently turn its toggle into a
+         * print. Everything else takes a number.
+         *
+         * The console hands the typed value here rather than interpreting it, so
+         * a setting answers the console and the config file the same way. */
+        const S32 two_valued = (s->type == SETTING_TRUTHY) OR(s->min == 0 AND s->max == 1);
         Console_RegisterCvarCoerced(s->cvar, s->value,
-                                    (s->type == SETTING_TRUTHY) ? CONSOLE_CVAR_BOOL : CONSOLE_CVAR_INT,
+                                    two_valued ? CONSOLE_CVAR_BOOL : CONSOLE_CVAR_INT,
                                     Settings_ApplyFromConsole, (void *)s, s->help);
     }
 }


### PR DESCRIPTION
The last two cvars whose settings already had a row. #543 left them hand-registered because the console imposed a clamp whichever rule the row declared, and a clamp is the wrong answer for both of them; #548 removed that obstacle.

## What moves

`gfx_dither` and `gfx_texfilter` had their range and rule declared in `BootSettings` while a separate registration in CONSOLE_CMD.CPP named them again, with a second copy of each help string free to drift. Both now register from the table, as the camera's do.

**The visible fix is at the console.** Both settings treat out of range as *unset*:

```
gfx_texfilter 99   ->  0     (filtering off; was 99, written straight through)
gfx_dither 5       ->  0     (unchanged)
```

99 put `PolyTexFilter` outside `POLY_TEX_FILTER_OFF..BILINEAR`, so the fillers took a branch nobody declared. The config file has always refused that value. The console refuses it now too.

## The part that needed care

Registering by rule alone would have broken something quieter. A setting with two states has to stay a console **bool**, so that a bare `gfx_dither` toggles it and `help` prints `0|1`. Only `SETTING_TRUTHY` was mapped that way, so `gfx_dither` (declared `SETTING_OR_DEFAULT` over `0..1`) would have become an integer whose no-arg form printed instead of toggling, and whose help line changed.

How many values a setting has and which rule coerces them are different questions. A row with a range of `0..1` is a toggle whatever its rule, and `Settings_RegisterCvars` now says so.

## Verification

Against the previous commit, all identical:

- **`varlist` + `cmdlist` + `help gfx_dither` + `help gfx_texfilter`**, 102 lines. That covers the two behaviours a careless move would have changed: the usage text and the bool/int form.
- Written `lba2.cfg` on a plain boot, and under `--vsync off --fixed-timestep 33`.
- A cfg of out-of-range values, which is the only oracle that can see a coercion change.
- camtrace at 1920x1080 with `cam_hd 1`, 77 frames.

The single difference is the `gfx_texfilter 99` line above, taken deliberately.

Probes are read-only on purpose: asking a bool cvar for its value *toggles* it, so `varlist` and `help` are used rather than invoking each name. 151/151 in the container, clang-format and both docs checks clean.

## Where this leaves the settings work

Every setting that has an owning module is now declared once and reached through that declaration by the config file and the console. What remains outside is the group with no module to own it: the mouse and gamepad camera settings belong to the manual-camera path in EXTFUNC.CPP, and moving them needs either an extraction there or an explicit decision to relax the ownership rule. That is a design call rather than a loose end.
