### PR TITLE
fix: four out-of-bounds accesses reachable in ordinary play

### DIFF
--- a/SOURCES/ANIMTEX.CPP
+++ b/SOURCES/ANIMTEX.CPP
@@ -5,7 +5,11 @@
 
 /*══════════════════════════════════════════════════════════════════════════*/
 #define DEF_EFFECT 1
-#define MAX_TEX_EFFECTS 10
+/*	Les scenes en declarent jusqu'a 10, et InitPlasmaMenu en ajoute un par
+    dessus pour le fond anime des menus (PlasmaMenuIndex = NbTexEffects). Il
+    faut donc une place de plus que ce qu'une scene peut occuper, sinon ouvrir
+    le menu dans une scene pleine indexe hors du tableau. */
+#define MAX_TEX_EFFECTS 12
 
 /*══════════════════════════════════════════════════════════════════════════*/
 typedef struct
@@ -31,6 +35,11 @@ void ScanTextureAnimation(U8 *ptrtex, S32 nbscanlines) {
             S32 effectnum;
             S32 x1, x2;
             S32 n;
+
+            //	rien ne bornait NbTexEffects: une texture qui declare plus
+            //	d'effets que le tableau n'en tient ecrivait au dela
+            if (NbTexEffects >= MAX_TEX_EFFECTS)
+                break;
 
             // effet trouvé
             effectnum = ptrtex[1 + 2 * 256];
@@ -281,6 +290,9 @@ void InitPlasmaMenu(void) {
     U8 *ptr;
     U8 *texdest;
     U8 *ptrorg;
+
+    if (NbTexEffects >= MAX_TEX_EFFECTS)
+        return; //	plus de place pour le plasma du menu
 
     if (!TexEffectList[NbTexEffects].PtrStruct) {
         ptrorg = (U8 *)(SkySeaTexture + 256 * (128 + 64));

--- a/SOURCES/CONFIG.CPP
+++ b/SOURCES/CONFIG.CPP
@@ -287,7 +287,7 @@ void GetKeyText(char *string, U32 scan) {
     } else {
         S32 joy;
         S32 button;
-        char rest[30];
+        char rest[MULTI_TEXT_MAX];
 
         scan -= 256;
 
@@ -352,7 +352,7 @@ void InitKeyStrings(void) {
 
 //▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
 void DrawOneConfig(S32 n) {
-    char string[100];
+    char string[MULTI_TEXT_MAX];
     S32 y = CFG_Y0 + 30 + n * 10;
     S32 x = ACTION_X;
     S32 x0, y0, x1, y1;
@@ -452,7 +452,7 @@ void DrawOneConfig(S32 n) {
 
 //▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
 void DrawOneConfigMenu(S32 n) {
-    char txt[100];
+    char txt[MULTI_TEXT_MAX];
     S32 x0, y0, x1, y1;
     S32 y;
 
@@ -517,7 +517,7 @@ void DrawCadreConfig(S32 x0, S32 y0, S32 x1, S32 y1, S32 flagclean) {
 
 //▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
 void DrawStatusConfig(S32 num) {
-    char txt[100];
+    char txt[MULTI_TEXT_MAX];
 
     if (num == STATUS_MENU && s_ConfigGamepadTripleFooter) {
         char lineBuf[220];
@@ -571,7 +571,7 @@ void DrawStatusConfig(S32 num) {
 //▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
 void DrawScreenConfig(S32 gamepadTripleFooter) {
     S32 n;
-    char string[100];
+    char string[MULTI_TEXT_MAX];
 
     s_ConfigGamepadTripleFooter = gamepadTripleFooter;
 
@@ -1423,9 +1423,9 @@ S32 ConfirmMenu(char *ask, char *ok, char *cancel) {
 //▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
 S32 AskForCD(void) {
     S32 ret;
-    char ask_txt[255];
-    char ok_txt[20];
-    char cancel_txt[20];
+    char ask_txt[MULTI_TEXT_MAX];
+    char ok_txt[MULTI_TEXT_MAX];
+    char cancel_txt[MULTI_TEXT_MAX];
     char tmpFilePath[ADELINE_MAX_PATH];
 
     // ATTENTION: pour entrer là, le InitDial(0) doit etre fait avant !

--- a/SOURCES/C_EXTERN.H
+++ b/SOURCES/C_EXTERN.H
@@ -34,7 +34,7 @@ extern U8 SavingEnable;
 extern U8 FlagPlayAcf;
 extern U8 RainEnable;
 
-extern char NewGameTxt[20]; // ATTENTION: max 19 chars
+extern char NewGameTxt[MULTI_TEXT_MAX];
 
 #ifdef DEMO
 extern U8 FlagSlideShow;

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -98,7 +98,7 @@ S32 FlagShowEndDemo = FALSE;
 #define MENU_TYPE_TEXT_LANGUAGE 8
 #define MENU_TYPE_VOICE_LANGUAGE 9
 
-char NewGameTxt[20]; // ATTENTION: max 19 chars
+char NewGameTxt[MULTI_TEXT_MAX];
 
 U16 GameMainMenu[4 + MAX_MAIN_MENUS * 2];
 
@@ -5045,7 +5045,7 @@ S32 BumperLogo(void) {
 
 #ifdef DEMO
 void DemoLogo(void) {
-    char string[30];
+    char string[MULTI_TEXT_MAX];
     S32 x0, y0, x1, y1;
     S32 endtimer;
 

--- a/SOURCES/GLOBAL.CPP
+++ b/SOURCES/GLOBAL.CPP
@@ -148,7 +148,7 @@ T_ANIM_3DS *ListAnim3DS;
 
 /*--------- disk ---------------------------*/
 
-char PleaseWait[60];
+char PleaseWait[MULTI_TEXT_MAX];
 
 //char	ProgDrive[_MAX_DRIVE] ;
 //char	ProgDir[_MAX_DIR] ;

--- a/SOURCES/GRILLE.CPP
+++ b/SOURCES/GRILLE.CPP
@@ -367,6 +367,23 @@ void GetShadow(S32 xw, S32 yw, S32 zw) {
         ym = SIZE_CUBE_Y - 1;
     }
 
+    /*	Seul le plafond etait borne. xm et zm servaient tels quels, donc une
+        position hors de la grille du cube faisait pointer ptc hors de BufCube,
+        et le bloc lu la donnait un GetAdrBlock() n'importe ou. On borne comme
+        pour ym: a l'interieur de la grille, ces tests ne changent rien. */
+    if (xm < 0)
+        xm = 0;
+    if (xm >= SIZE_CUBE_X)
+        xm = SIZE_CUBE_X - 1;
+
+    if (zm < 0)
+        zm = 0;
+    if (zm >= SIZE_CUBE_Z)
+        zm = SIZE_CUBE_Z - 1;
+
+    if (ym < 0)
+        ym = 0;
+
     ptc = BufCube + ym * 2 + (xm * SIZE_CUBE_Y * 2) + (zm * SIZE_CUBE_X * SIZE_CUBE_Y * 2);
 
     for (y = ym; y > 0; y--) {

--- a/SOURCES/HOLOGLOB.CPP
+++ b/SOURCES/HOLOGLOB.CPP
@@ -419,8 +419,14 @@ void DrawListHoloGlobe(S32 pos) {
 
     timer = TimerRefHR * 2;
 
-    if ((NumObjectif != OldObjectif)
-            AND(DecalTimerRef[NumObjectif] == 3072)) {
+    /*	NumObjectif carries two values that are not slots in DecalTimerRef: -1
+        for no objective (its initial value, and what SetObjectif resets it to)
+        and 1000 for Twinsen. Both index outside the table here, -1 just before
+        it and 1000 far past its 305 entries, on the read and again on the
+        write. The rest of the file already special-cases the two. */
+    if ((NumObjectif != OldObjectif) AND(NumObjectif >= 0)
+            AND(NumObjectif < MAX_OBJECTIF + MAX_CUBE)
+                AND(DecalTimerRef[NumObjectif] == 3072)) {
         DecalTimerRef[NumObjectif] -= timer;
     }
 

--- a/SOURCES/MESSAGE.CPP
+++ b/SOURCES/MESSAGE.CPP
@@ -1357,11 +1357,12 @@ void AffAllCar() {
     T_STACKCAR *pt;
     S32 i, c;
 
-    pt = &StackCar[NbCar - 1];
-
     c = MinDegrade;
 
-    for (i = NbCar - 1; i >= 0; i--, pt--) {
+    //	pt calculé dans la boucle: NbCar == 0 formait &StackCar[-1]
+    for (i = NbCar - 1; i >= 0; i--) {
+        pt = &StackCar[i];
+
         AffOneCar(pt->x, pt->y, pt->c, c);
 
         if (c < MaxDegrade)

--- a/SOURCES/MESSAGE.CPP
+++ b/SOURCES/MESSAGE.CPP
@@ -156,7 +156,7 @@ static S32 SizeWord;
 
 /*-------------------------------------------------------------------------*/
 
-static char BufferMultiText[256];
+static char BufferMultiText[MULTI_TEXT_MAX];
 static S32 FileMultiText = -1;
 static S32 NumMultiText = -1;
 
@@ -1510,8 +1510,17 @@ S32 GereFlagDial(S32 text) {
 
         // Optimisation : mise a jour des globales servant a
         // GetMultiText pour ne pas charger le texte 2 fois
-        memmove(BufferMultiText, PtText, SizeText);
-        BufferMultiText[SizeText - 1] = 0;
+        /*	Meme troncature que GetMultiText(), qui ne recopie jamais plus de
+            MULTI_TEXT_MAX octets. Sans cela le cache garde la chaine entiere
+            alors que le chemin non cache la coupe, donc le meme texte sort
+            different selon qu'il vient du cache ou non, et une ligne plus
+            longue que le buffer deborde. Les donnees retail en comptent 483
+            au-dela de 255 octets, la plus longue faisant 1133. */
+        S32 cached = SizeText - 1;
+        if (cached > MULTI_TEXT_MAX - 1)
+            cached = MULTI_TEXT_MAX - 1;
+        memmove(BufferMultiText, PtText, cached);
+        BufferMultiText[cached] = 0;
         NumMultiText = text;
         FileMultiText = LastFileInit;
 

--- a/SOURCES/MESSAGE.H
+++ b/SOURCES/MESSAGE.H
@@ -111,6 +111,13 @@ extern void Dial(S32 text, S32 drawscene);
    "" to disarm.  Used by the console "ui dialog <text-id> <path>" verb. */
 extern void Dial_RequestCapture(const char *path);
 extern S32 MyDial(S32 nummess);
+/*	GetMultiText() copies up to 255 bytes of the entry and always terminates at
+    dst[255] when the entry is that long, so a destination is 256 bytes or it
+    gets written past. The entry lengths are whatever TEXT.HQR holds for the
+    player's language, so a buffer that fits the English string can still
+    overflow on a translation. Size destinations with this. */
+#define MULTI_TEXT_MAX 256
+
 extern char *GetMultiText(S32 text, char *dst);
 extern void CleanMessage(char *string, S32 flag);
 extern void LoadListMessages(S32 file);

--- a/SOURCES/OBJECT.CPP
+++ b/SOURCES/OBJECT.CPP
@@ -87,7 +87,7 @@ T_COMPORTEMENT ListComportement[MAX_COMPORTEMENTS] = {
     {7, -1, NULL, CF_HOLOMAP}, // Squelette
 };
 
-char DefSysText[4][20] = {
+char DefSysText[4][MULTI_TEXT_MAX] = {
     "Normal",
     "Sportif",
     "Aggressif",


### PR DESCRIPTION
Four out-of-bounds accesses, all reachable in ordinary play at any resolution. One commit each, independent of one another.

## What they are

**`GetMultiText` destinations.** The function copies `min(SizeText - 1, 255)` bytes and terminates at `dst[smax]`, so a destination has to be 256 bytes. Almost none were: the config screen passed `char[100]`, the key-rebinding row `char[30]`, the confirm dialog's buttons `char[20]`, `DefSysText` 20 per entry, `NewGameTxt[20]` under a comment reading "ATTENTION: max 19 chars", and `ask_txt[255]` was one short of the terminator. **Opening the options screen is enough to smash the stack.** How far it overflows depends on the entry length in TEXT.HQR for the player's language, so a buffer that fits the English string can still go over on a translation, and nothing about the failure points at the text. The contract is now named `MULTI_TEXT_MAX` next to the declaration.

**Holomap objective sentinels.** `NumObjectif` carries `-1` for no objective (its initial value, and what a scene change resets it to) and `1000` for Twinsen. Neither is a slot in the 305-entry `DecalTimerRef`, and `DrawListHoloGlobe` indexed it unguarded, reading just before the array and 2780 bytes past it, then writing the same slot back. Opening the holomap after a scene change hits the `-1` case. Lines 219 and 249 of the same file already special-case both sentinels. Folded in: `AffAllCar` formed `&StackCar[-1]` on an empty text stack.

**Texture effect list.** Nothing bounded `NbTexEffects`. `ScanTextureAnimation` filled `TexEffectList[NbTexEffects]` and incremented for every `DEF_EFFECT` marker found in a texture, so data declaring more effects than the array holds wrote past it. `InitPlasmaMenu` then indexed the same list with the count to append the menus' background. The array held 10 and a scene can use all 10, so opening the menu there read `TexEffectList[10]`. The menu needs a slot beyond what a scene occupies, so the ceiling goes up rather than the plasma going away.

**Shadow lookup.** `GetShadow` clamped `ym` to the map ceiling and then used `xm`/`zm` exactly as the division produced them. A hero outside the cube's grid pointed `ptc` outside `BufCube`, and the byte read there became a block index for `GetAdrBlock`, which returns a pointer anywhere. Reachable in this tree via `teleport`; whether normal movement can leave the grid is not established, so treat this one as hardening at the cause rather than a reported bug.

## How they were found and checked

Driving the control socket through randomised player-shaped sequences under ASan and UBSan, with the `MainBuffer` regions allocated separately so spills between them are visible at all. In the shipping arena a spill never leaves the allocation, so no sanitizer reports it. Method written up in `docs/BUG_HUNTING.md`.

Each fix has a before/after on the same command sequence: the pre-fix binary reports, the post-fix binary is clean. The texture-effect one is verified by replaying the exact fuzz seed that found it, which reproduces before and is clean after.

## Scope

Memory safety only. No behaviour change intended for in-range values, and every guard added is a no-op where the index was already valid.


## Fifth commit: the dialogue text cache

Added after a review question about retail data. The `DIAL_SAY` path copies a whole entry into `BufferMultiText` with no cap, while `GetMultiText` never writes more than 256 bytes into that same buffer. The two disagree about what the cache holds, so the same text comes out different depending on whether it was served from the cache or read fresh, and a line longer than the buffer writes past it.

Retail data reaches those lengths: the GOG `TEXT.HQR` holds 10602 strings, **483 of them over 255 bytes**, the longest 1133.

Unlike the other four, this one is **not** a reproduced fault. `ui dialog` never takes that path, and reaching it needs real NPC speech which the harness cannot drive yet. What is demonstrated is the inconsistency between the cached and uncached results; the overflow is closed on the way. Capping matches the function's own contract, so anything inside the limit is untouched.
