### PR TITLE
fix(asm-port): 64-bit imul/idiv translated as 32-bit, swept

### DIFF
--- a/LIB386/OBJECT/AFF_OBJ.CPP
+++ b/LIB386/OBJECT/AFF_OBJ.CPP
@@ -1065,8 +1065,12 @@ S32 Sphere(U32 typePoly, void *poly) {
         S16 z = Obj_ListRotatedPoints[sphere->P1].Z;
         if (z + PosZWr == 0) // ASM @@SkipSphere: point on the camera Z plane
             return 0;
-        radius *= LFactorX;
-        radius /= z + PosZWr;
+        // ASM: one-operand `imul [LFactorX]` puts the product in EDX:EAX and
+        // `idiv ebp` consumes all 64 bits. Shipping focal lengths (600..1024)
+        // keep this inside 32 bits for any real radius, so this is the same
+        // arithmetic in practice, but match the original's width rather than
+        // rely on that. Same class as the clip products in POLYLINE.CPP.
+        radius = (S32)((S64)radius * LFactorX / (z + PosZWr));
     }
 
     // @@Return_Radius:
@@ -1121,8 +1125,12 @@ S32 Sphere_Transp(U32 typePoly, void *poly) {
         S16 z = Obj_ListRotatedPoints[sphere->P1].Z;
         if (z + PosZWr == 0) // ASM @@SkipSphere: point on the camera Z plane
             return 0;
-        radius *= LFactorX;
-        radius /= z + PosZWr;
+        // ASM: one-operand `imul [LFactorX]` puts the product in EDX:EAX and
+        // `idiv ebp` consumes all 64 bits. Shipping focal lengths (600..1024)
+        // keep this inside 32 bits for any real radius, so this is the same
+        // arithmetic in practice, but match the original's width rather than
+        // rely on that. Same class as the clip products in POLYLINE.CPP.
+        radius = (S32)((S64)radius * LFactorX / (z + PosZWr));
     }
 
     TYPE_PT p1 = Obj_ListProjectedPoints[sphere->P1];

--- a/LIB386/pol_work/POLYLINE.CPP
+++ b/LIB386/pol_work/POLYLINE.CPP
@@ -79,7 +79,7 @@ void Line_ZBuffer(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
                     return;
                 }
 
-                Z1 += (ClipYMin - y0) * DZ / diffY;
+                Z1 += (S32)((S64)(ClipYMin - y0) * DZ / diffY);
                 y0 = ClipYMin;
                 continue;
             }
@@ -90,21 +90,21 @@ void Line_ZBuffer(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
                     return;
                 }
 
-                Z1 += (ClipYMax - y0) * DZ / diffY;
+                Z1 += (S32)((S64)(ClipYMax - y0) * DZ / diffY);
                 y0 = ClipYMax;
                 continue;
             }
 
             // @@DX_Y1b:
             if (y1 < ClipYMin) {
-                Z2 += (ClipYMin - y1) * DZ / diffY;
+                Z2 += (S32)((S64)(ClipYMin - y1) * DZ / diffY);
                 y1 = ClipYMin;
                 continue;
             }
 
             // @@DX_Y2:
             if (y1 > ClipYMax) {
-                Z2 += (ClipYMax - y1) * DZ / diffY;
+                Z2 += (S32)((S64)(ClipYMax - y1) * DZ / diffY);
                 y1 = ClipYMax;
                 continue;
             }
@@ -120,7 +120,7 @@ void Line_ZBuffer(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
                     return;
                 }
 
-                Z1 -= (x0 - ClipXMin) * DZ / diffX;
+                Z1 -= (S32)((S64)(x0 - ClipXMin) * DZ / diffX);
                 x0 = ClipXMin;
                 continue;
             }
@@ -131,21 +131,21 @@ void Line_ZBuffer(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
                     return;
                 }
 
-                Z1 -= (x0 - ClipXMax) * DZ / diffX;
+                Z1 -= (S32)((S64)(x0 - ClipXMax) * DZ / diffX);
                 x0 = ClipXMax;
                 continue;
             }
 
             // @@DY_X1b:
             if (x1 < ClipXMin) {
-                Z2 -= (x1 - ClipXMin) * DZ / diffX;
+                Z2 -= (S32)((S64)(x1 - ClipXMin) * DZ / diffX);
                 x1 = ClipXMin;
                 continue;
             }
 
             // @@DY_X2:
             if (x1 > ClipXMax) {
-                Z2 -= (x1 - ClipXMax) * DZ / diffX;
+                Z2 -= (S32)((S64)(x1 - ClipXMax) * DZ / diffX);
                 x1 = ClipXMax;
                 continue;
             }
@@ -154,7 +154,7 @@ void Line_ZBuffer(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
                 return;
             }
 
-            Z1 -= (x0 - ClipXMin) * DZ / diffX;
+            Z1 -= (S32)((S64)(x0 - ClipXMin) * DZ / diffX);
             y0 -= (x0 - ClipXMin) * diffY / diffX;
             x0 = ClipXMin;
             continue;
@@ -165,21 +165,21 @@ void Line_ZBuffer(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
                 return;
             }
 
-            Z1 -= (x0 - ClipXMax) * DZ / diffX;
+            Z1 -= (S32)((S64)(x0 - ClipXMax) * DZ / diffX);
             y0 -= (x0 - ClipXMax) * diffY / diffX;
             x0 = ClipXMax;
             continue;
         }
         // @@Clip_X1:
         else if (x1 < ClipXMin) {
-            Z2 -= (x1 - ClipXMin) * DZ / diffX;
+            Z2 -= (S32)((S64)(x1 - ClipXMin) * DZ / diffX);
             y1 -= (x1 - ClipXMin) * diffY / diffX;
             x1 = ClipXMin;
             continue;
         }
         // @@Clip_X2:
         else if (x1 > ClipXMax) {
-            Z2 -= (x1 - ClipXMax) * DZ / diffX;
+            Z2 -= (S32)((S64)(x1 - ClipXMax) * DZ / diffX);
             y1 -= (x1 - ClipXMax) * diffY / diffX;
             x1 = ClipXMax;
             continue;
@@ -189,7 +189,7 @@ void Line_ZBuffer(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
             if (y1 < ClipYMin) {
                 return;
             }
-            Z1 += (ClipYMin - y0) * DZ / diffY;
+            Z1 += (S32)((S64)(ClipYMin - y0) * DZ / diffY);
             x0 += (ClipYMin - y0) * diffX / diffY;
             y0 = ClipYMin;
             continue;
@@ -200,21 +200,21 @@ void Line_ZBuffer(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
                 return;
             }
 
-            Z1 += (ClipYMax - y0) * DZ / diffY;
+            Z1 += (S32)((S64)(ClipYMax - y0) * DZ / diffY);
             x0 += (ClipYMax - y0) * diffX / diffY;
             y0 = ClipYMax;
             continue;
         }
         // @@Clip_Y1:
         else if (y1 < ClipYMin) {
-            Z2 += (ClipYMin - y1) * DZ / diffY;
+            Z2 += (S32)((S64)(ClipYMin - y1) * DZ / diffY);
             x1 += (ClipYMin - y1) * diffX / diffY;
             y1 = ClipYMin;
             continue;
         }
         // @@Clip_Y2:
         else if (y1 > ClipYMax) {
-            Z2 += (ClipYMax - y1) * DZ / diffY;
+            Z2 += (S32)((S64)(ClipYMax - y1) * DZ / diffY);
             x1 += (ClipYMax - y1) * diffX / diffY;
             y1 = ClipYMax;
             continue;
@@ -385,7 +385,7 @@ void Line_ZBuffer_NZW(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
                     return;
                 }
 
-                Z1 += (ClipYMin - y0) * DZ / diffY;
+                Z1 += (S32)((S64)(ClipYMin - y0) * DZ / diffY);
                 y0 = ClipYMin;
                 continue;
             }
@@ -396,21 +396,21 @@ void Line_ZBuffer_NZW(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
                     return;
                 }
 
-                Z1 += (ClipYMax - y0) * DZ / diffY;
+                Z1 += (S32)((S64)(ClipYMax - y0) * DZ / diffY);
                 y0 = ClipYMax;
                 continue;
             }
 
             // @@DX_Y1b:
             if (y1 < ClipYMin) {
-                Z2 += (ClipYMin - y1) * DZ / diffY;
+                Z2 += (S32)((S64)(ClipYMin - y1) * DZ / diffY);
                 y1 = ClipYMin;
                 continue;
             }
 
             // @@DX_Y2:
             if (y1 > ClipYMax) {
-                Z2 += (ClipYMax - y1) * DZ / diffY;
+                Z2 += (S32)((S64)(ClipYMax - y1) * DZ / diffY);
                 y1 = ClipYMax;
                 continue;
             }
@@ -426,7 +426,7 @@ void Line_ZBuffer_NZW(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
                     return;
                 }
 
-                Z1 -= (x0 - ClipXMin) * DZ / diffX;
+                Z1 -= (S32)((S64)(x0 - ClipXMin) * DZ / diffX);
                 x0 = ClipXMin;
                 continue;
             }
@@ -437,21 +437,21 @@ void Line_ZBuffer_NZW(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
                     return;
                 }
 
-                Z1 -= (x0 - ClipXMax) * DZ / diffX;
+                Z1 -= (S32)((S64)(x0 - ClipXMax) * DZ / diffX);
                 x0 = ClipXMax;
                 continue;
             }
 
             // @@DY_X1b:
             if (x1 < ClipXMin) {
-                Z2 -= (x1 - ClipXMin) * DZ / diffX;
+                Z2 -= (S32)((S64)(x1 - ClipXMin) * DZ / diffX);
                 x1 = ClipXMin;
                 continue;
             }
 
             // @@DY_X2:
             if (x1 > ClipXMax) {
-                Z2 -= (x1 - ClipXMax) * DZ / diffX;
+                Z2 -= (S32)((S64)(x1 - ClipXMax) * DZ / diffX);
                 x1 = ClipXMax;
                 continue;
             }
@@ -460,7 +460,7 @@ void Line_ZBuffer_NZW(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
                 return;
             }
 
-            Z1 -= (x0 - ClipXMin) * DZ / diffX;
+            Z1 -= (S32)((S64)(x0 - ClipXMin) * DZ / diffX);
             y0 -= (x0 - ClipXMin) * diffY / diffX;
             x0 = ClipXMin;
             continue;
@@ -471,21 +471,21 @@ void Line_ZBuffer_NZW(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
                 return;
             }
 
-            Z1 -= (x0 - ClipXMax) * DZ / diffX;
+            Z1 -= (S32)((S64)(x0 - ClipXMax) * DZ / diffX);
             y0 -= (x0 - ClipXMax) * diffY / diffX;
             x0 = ClipXMax;
             continue;
         }
         // @@Clip_X1:
         else if (x1 < ClipXMin) {
-            Z2 -= (x1 - ClipXMin) * DZ / diffX;
+            Z2 -= (S32)((S64)(x1 - ClipXMin) * DZ / diffX);
             y1 -= (x1 - ClipXMin) * diffY / diffX;
             x1 = ClipXMin;
             continue;
         }
         // @@Clip_X2:
         else if (x1 > ClipXMax) {
-            Z2 -= (x1 - ClipXMax) * DZ / diffX;
+            Z2 -= (S32)((S64)(x1 - ClipXMax) * DZ / diffX);
             y1 -= (x1 - ClipXMax) * diffY / diffX;
             x1 = ClipXMax;
             continue;
@@ -495,7 +495,7 @@ void Line_ZBuffer_NZW(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
             if (y1 < ClipYMin) {
                 return;
             }
-            Z1 += (ClipYMin - y0) * DZ / diffY;
+            Z1 += (S32)((S64)(ClipYMin - y0) * DZ / diffY);
             x0 += (ClipYMin - y0) * diffX / diffY;
             y0 = ClipYMin;
             continue;
@@ -506,21 +506,21 @@ void Line_ZBuffer_NZW(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
                 return;
             }
 
-            Z1 += (ClipYMax - y0) * DZ / diffY;
+            Z1 += (S32)((S64)(ClipYMax - y0) * DZ / diffY);
             x0 += (ClipYMax - y0) * diffX / diffY;
             y0 = ClipYMax;
             continue;
         }
         // @@Clip_Y1:
         else if (y1 < ClipYMin) {
-            Z2 += (ClipYMin - y1) * DZ / diffY;
+            Z2 += (S32)((S64)(ClipYMin - y1) * DZ / diffY);
             x1 += (ClipYMin - y1) * diffX / diffY;
             y1 = ClipYMin;
             continue;
         }
         // @@Clip_Y2:
         else if (y1 > ClipYMax) {
-            Z2 += (ClipYMax - y1) * DZ / diffY;
+            Z2 += (S32)((S64)(ClipYMax - y1) * DZ / diffY);
             x1 += (ClipYMax - y1) * diffX / diffY;
             y1 = ClipYMax;
             continue;

--- a/tests/pol_work/test_polyline.cpp
+++ b/tests/pol_work/test_polyline.cpp
@@ -13,6 +13,10 @@
 
 void Line_ZBuffer_NZW(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2);
 extern "C" void asm_Line(S32 x0, S32 y0, S32 x1, S32 y1, S32 col);
+extern "C" void asm_LineZBuf(S32 x0, S32 y0, S32 z0,
+                             S32 x1, S32 y1, S32 z1,
+                             S32 col);
+void Line_ZBuffer(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2);
 extern "C" void asm_LineZBufNZW(S32 x0, S32 y0, S32 z0,
                                 S32 x1, S32 y1, S32 z1,
                                 S32 col);
@@ -200,6 +204,63 @@ static void test_asm_equiv_random(void) {
     }
 }
 
+/* zrange bounds the endpoint depths. Line_ZBuffer shifts them to 16.16, so
+   DZ is (z2-z1)<<16 and the clip multiplies that by an overshoot of up to 300.
+   For the product to stay inside 32 bits the depths have to be tiny: 300 *
+   (100<<16) is already 2.0e9. A "small" range of +-32768 therefore overflows
+   just as hard as an engine-scale one, which is the trap. */
+static int linezbuf_sweep(S32 zrange, const char *label) {
+    const U8 fogged_color = 0xA7;
+    static U16 asm_zbuf[LINEZBUFNZW_SIZE];
+    static U16 cpp_zbuf[LINEZBUFNZW_SIZE];
+    int diffs = 0;
+
+    rng_seed(0x5A17C0DE);
+
+    for (int i = 0; i < 300; i++) {
+        S32 x0 = (S32)(rng_next() % (LINEZBUFNZW_W + 600)) - 300;
+        S32 y0 = (S32)(rng_next() % (LINEZBUFNZW_H + 600)) - 300;
+        S32 x1 = (S32)(rng_next() % (LINEZBUFNZW_W + 600)) - 300;
+        S32 y1 = (S32)(rng_next() % (LINEZBUFNZW_H + 600)) - 300;
+
+        S32 z0 = zrange ? ((S32)(rng_next() % (U32)(2 * zrange)) - zrange) : 0;
+        S32 z1 = zrange ? ((S32)(rng_next() % (U32)(2 * zrange)) - zrange) : 0;
+
+        setup_linezbufnzw_screen(fogged_color);
+        Fill_Flag_NZW = FALSE;
+        for (U32 k = 0; k < LINEZBUFNZW_SIZE; k++)
+            linezbufnzw_zbuffer[k] = (U16)((k * 2654435761u) >> 17);
+        Line_ZBuffer(x0, y0, x1, y1, 302, z0, z1);
+        memcpy(cpp_linezbufnzw_buf, (U8 *)Log, LINEZBUFNZW_SIZE);
+        memcpy(cpp_zbuf, linezbufnzw_zbuffer, sizeof(cpp_zbuf));
+
+        setup_linezbufnzw_screen(fogged_color);
+        Fill_Flag_NZW = FALSE;
+        for (U32 k = 0; k < LINEZBUFNZW_SIZE; k++)
+            linezbufnzw_zbuffer[k] = (U16)((k * 2654435761u) >> 17);
+        asm_LineZBuf(x0, y0, z0, x1, y1, z1, 302);
+        memcpy(asm_linezbufnzw_buf, (U8 *)Log, LINEZBUFNZW_SIZE);
+        memcpy(asm_zbuf, linezbufnzw_zbuffer, sizeof(asm_zbuf));
+
+        if (memcmp(asm_linezbufnzw_buf, cpp_linezbufnzw_buf, LINEZBUFNZW_SIZE) != 0 ||
+            memcmp(asm_zbuf, cpp_zbuf, sizeof(asm_zbuf)) != 0)
+            diffs++;
+    }
+
+    printf("    [%-22s] zrange=%-8d diverging: %d/300\n", label, (int)zrange, diffs);
+    return diffs;
+}
+
+static void test_asm_equiv_linezbuf_z(void) {
+    /* Graded on purpose. The first two ran green before the clip products were
+       widened to 64 bits and the last two did not, so a regression here says
+       which side of the 32-bit boundary broke. */
+    ASSERT_EQ_INT(0, linezbuf_sweep(0, "zero Z"));
+    ASSERT_EQ_INT(0, linezbuf_sweep(50, "tiny Z, no overflow"));
+    ASSERT_EQ_INT(0, linezbuf_sweep(2000, "moderate Z"));
+    ASSERT_EQ_INT(0, linezbuf_sweep(32768, "large Z"));
+}
+
 int main(void) {
     RUN_TEST(test_horizontal);
     RUN_TEST(test_vertical);
@@ -211,6 +272,7 @@ int main(void) {
     RUN_TEST(test_asm_equiv_clipped);
     RUN_TEST(test_asm_equiv_linezbufnzw_vertical_polyrec_0013_dc4333);
     RUN_TEST(test_asm_equiv_random);
+    RUN_TEST(test_asm_equiv_linezbuf_z);
     TEST_SUMMARY();
     return test_failures != 0;
 }


### PR DESCRIPTION
One translation class, swept across the tree. One-operand `imul r/m32` puts a **64-bit** product in EDX:EAX and a following `idiv` consumes all 64 bits, so C's `S32 a * b / c` cannot express it: the product truncates first. The two-operand form (`imul eax, ebx`) does truncate to 32 bits and maps to `*` correctly, so the comma is the tell.

Correct translation is `(S32)((S64)a * b / c)`.

## The sweep

Every one-operand `imul`/`mul` whose product reaches a divide, across all `.ASM` in the tree. 271 one-operand multiplies exist; only the 95 feeding a divide matter, since a product whose high half is never read is just a 32-bit multiply.

| ASM file | sites | C state |
| --- | --- | --- |
| `LIB386/pol_work/POLYLINE.ASM` | 56 | was 32-bit, **fixed here** |
| `SOURCES/3DEXT/LINERAIN.ASM` | 24 | already `S64` |
| `LIB386/pol_work/POLY.ASM` | 12 | already `S64` |
| `LIB386/3D/REGLE3.ASM` | 2 | already `S64`, with a comment naming the hazard |
| `LIB386/OBJECT/AFF_OBJ.ASM` | 1 | was 32-bit, **fixed here** |

Three of five were handled deliberately; `REGLE3.CPP` even documents the reasoning. These two were the misses.

## POLYLINE: live

`Line_ZBuffer` scales endpoint depths to 16.16 and then walks the depth by the clip overshoot in 32-bit. Since `DZ` is a 16.16 delta, the product leaves 32 bits at very ordinary depths and the C lands somewhere the original does not.

The regression test is graded by depth magnitude, which is what makes the cause legible rather than just the symptom:

| endpoint depth | clip product | before | after |
| --- | --- | --- | --- |
| 0 | n/a | 0/300 diverging | 0/300 |
| ±50 | fits in 32 bits | 0/300 | 0/300 |
| ±2000 | overflows | 119/300 | 0/300 |
| ±32768 | overflows | 52/300 | 0/300 |

600 cases agree byte for byte while the product fits, and divergence starts exactly where the arithmetic says it should. A fully unclipped line interpolates identically in both before and after, so the difference was confined to the clipping paths.

Only the `DZ` products are widened; the `diffX`/`diffY` ones are screen-sized and cannot overflow.

## AFF_OBJ: latent

`Sphere()`'s 3D branch computes `radius * LFactorX / (Zrot + PosZWr)` in 32-bit. Shipping focal lengths are 600 to 1024, so overflow needs a sphere radius over two million model units where the test's extreme case is 65535. Same arithmetic in practice; included because the original's width is what the code should say, and `tests/render/test_sphere_radius.cpp` already models this branch as 64-bit in its own reference.

## Why the suite did not catch either

`test_asm_equiv_random` drives `Line()`, which takes no Z, and the only `Line_ZBuffer_NZW` case is pinned at `z1 = z2 = 0`, the one value that zeroes the term. The `polyrec` snapshot replay reaches the ASM Z variants too and also stayed quiet, so its captured corpus holds no steep-Z line crossing a clip edge. For the sphere, the reference model was already correct and the inputs were simply too small to overflow.

Both halves of the new test compare the z-buffer as well as the framebuffer: the fixture starts every depth at `0xFFFF` and fogs to a constant colour, so a pixels-only comparison cannot see depth at all. An earlier version of this test passed while one side was being fed depths off by 50,000,000.

Full ASM equivalence suite green: 152/152.
