### PR TITLE
fix(res): sub-640x480 modes corrupt memory on every cube load and UI open

### DIFF
--- a/SOURCES/GRILLE.CPP
+++ b/SOURCES/GRILLE.CPP
@@ -623,6 +623,16 @@ void InitBufferCube() {
     if (realbll < BkgHeader.Max_Size_Bll)
         realbll = BkgHeader.Max_Size_Bll;
 
+    /*	LoadUsedBrick() scratches its brick renumbering table into Screen at a
+        fixed offset (OFFSET_BUFFER_FLAG), from a time when the framebuffer was
+        always 640x480. The render resolution is now a player setting, and the
+        catalog offers 320x200, 320x240 and 400x300, all of them smaller than
+        where that table ends. Floor the framebuffer allocation so the table
+        stays inside it, otherwise the memset runs off the end of Screen and
+        into BufferMaskBrick, BufMap and TabBlock on every cube load. */
+    if (ListMem[MEM_SCREEN].Size < (S32)(OFFSET_BUFFER_FLAG + MAX_BRICK_GAME * 2L))
+        ListMem[MEM_SCREEN].Size = (S32)(OFFSET_BUFFER_FLAG + MAX_BRICK_GAME * 2L);
+
     ListMem[MEM_BUFFER_MASK_BRICK].Size = BkgHeader.Max_Size_Mask_Brick_Cube;
     ListMem[MEM_BUF_MAP].Size = realgri + RECOVER_AREA;
     ListMem[MEM_TAB_BLOCK].Size = realbll + RECOVER_AREA;

--- a/SOURCES/HOLOGLOB.CPP
+++ b/SOURCES/HOLOGLOB.CPP
@@ -778,7 +778,11 @@ U8 *LoadHoloMalloc_HQR(const char *name, S32 index) {
 
     size = HQF_ResSize(name, index);
 
-    pt = HoloMalloc(size);
+    /*	HQF_LoadClose() lands the compressed read at ptrdest + SizeFile -
+        CompressedSizeFile + RECOVER_AREA, so the destination has to hold
+        SizeFile + RECOVER_AREA, not SizeFile. Without the margin each load
+        runs past its own slot, and the last one past ScreenAux entirely. */
+    pt = HoloMalloc(size + RECOVER_AREA);
 
     if (!Load_HQR(name, pt, index))
         TheEndCheckFile(name);

--- a/SOURCES/INVENT.CPP
+++ b/SOURCES/INVENT.CPP
@@ -2306,9 +2306,31 @@ void GereArdoise() {
 
 //──────────────────────────────────────────────────────────────────────────
 
+/*	Les 4 angles se lisent/ecrivent directement dans Log, 5 lignes par angle.
+    The UI is authored on a 640x480 canvas and centred rather than scaled, so
+    below that size the frame coordinates fall outside the framebuffer:
+    INV_LEFT_OFFSET is (ModeDesiredX - 640) / 2, which goes negative, and the
+    inner height is a fixed 413. At 320x240 the inventory frame spans x
+    -152..471, y 8..421 against a 240-line buffer, and these corner copies walk
+    off Log. Skip the save and the restore together when the frame does not fit,
+    which is a no-op at every size the layout was authored for. */
+static S32 AnglesFitInLog(S32 x0, S32 y0, S32 x1, S32 y1) {
+    if (x0 < 0 OR y0 < 0)
+        return FALSE;
+    if (x1 >= (S32)ModeDesiredX OR y1 >= (S32)ModeDesiredY)
+        return FALSE;
+    if (x1 < 4 OR y1 < 4) //	les angles bas/droite partent de x1-4 et y1-4
+        return FALSE;
+
+    return TRUE;
+}
+
 void BackupAngles(S32 x0, S32 y0, S32 x1, S32 y1) {
     U8 *dest = PtrBackupAngles;
     U8 *src;
+
+    if (!AnglesFitInLog(x0, y0, x1, y1))
+        return;
     // Log row pitch — was hardcoded 640 (correct at the original 4:3 framebuffer);
     // now derive from TabOffLine so the per-row arithmetic below tracks the
     // back buffer's actual width. Phase 3 Tier-1 fix; see
@@ -2384,6 +2406,10 @@ void RestoreAngles(S32 x0, S32 y0, S32 x1, S32 y1) {
     U8 *src = PtrBackupAngles;
     U8 *dest;
     const S32 stride = TabOffLine[1]; // Log row pitch — see BackupAngles above.
+
+    //	Meme test que BackupAngles: sans sauvegarde, rien a restaurer
+    if (!AnglesFitInLog(x0, y0, x1, y1))
+        return;
 
     //----- Angle Superieur Gauche
     dest = (U8 *)Log + TabOffLine[y0] + x0;

--- a/SOURCES/MEM.CPP
+++ b/SOURCES/MEM.CPP
@@ -57,7 +57,15 @@ T_MEM ListMem[] = {
 void Mem_ConfigureScreenBuffers(U32 resX, U32 resY) {
     const S32 pixels = (S32)resX * (S32)resY;
     ListMem[MEM_PTR_ZBUFFER].Size = pixels * 2; // Z-buffer: 2 bytes per pixel
+    /* The holomap bump-allocates its globe, mapping and text resources out of
+       ScreenAux (InitHoloMalloc points PtHoloMalloc straight at it) against a
+       budget of the historical 640x480 framebuffer. That budget does not shrink
+       with the render resolution, so hold a floor under ScreenAux or opening
+       the holomap at one of the catalog's smaller modes walks off the end of it
+       and into the buffer that follows. */
     ListMem[MEM_SCREEN_AUX].Size = pixels + RECOVER_AREA;
+    if (ListMem[MEM_SCREEN_AUX].Size < (S32)(640L * 480L + RECOVER_AREA))
+        ListMem[MEM_SCREEN_AUX].Size = (S32)(640L * 480L + RECOVER_AREA);
     ListMem[MEM_BUFSPEAK].Size = pixels + RECOVER_AREA;
     ListMem[MEM_SCREEN].Size = pixels + RECOVER_AREA;
 }


### PR DESCRIPTION
`RES_CATALOG.CPP` offers **320x200, 320x240 and 400x300** under "advanced", and `RES_MIN_W`/`RES_MIN_H` allow down to 320x200. Everything below 640x480 corrupts memory, because the widescreen work generalised the code upward from the authored 640x480 canvas and nothing generalised it downward.

Three mechanisms, one per commit.

**Brick renumbering table.** `LoadUsedBrick` scratches its 40000-byte table at `Screen + OFFSET_BUFFER_FLAG`, a fixed 153800 from when the framebuffer was always 640x480. The framebuffer therefore has to be at least 193800 bytes. At 320x240 `Screen` is 77344, so the memset starts roughly 76 KB past the end and writes 40000 bytes into `BufferMaskBrick`, `BufMap` and `TabBlock`. **That is every cube load**, so picking one of these modes and walking through a door shreds the mask, the map and the block table. `InitBufferCube()` already patches the `ListMem` sizes before `InitMainBuffer()` runs and the runtime switch rebuilds through the same path, so flooring the framebuffer entry there covers both boot and switches. Repro is two commands: `resolution 320x240; cube 26`.

**Holomap arena.** `InitHoloMalloc` points `PtHoloMalloc` straight at `ScreenAux` and bump-allocates the globe, mapping and text resources through it against a budget that assumes 640x480 and does not shrink with the render resolution. Opening the holomap at 320x240 overflows a 77600-byte `ScreenAux` on the first load, every run. The same commit fixes `LoadHoloMalloc_HQR` sizing its allocation at `SizeFile` when `HQF_LoadClose` writes `SizeFile + RECOVER_AREA`, which is the same defect class as #552 and applies at all resolutions, though above 640x480 the overrun lands in the slot the next resource is about to occupy.

**UI frame corners.** `BackupAngles`/`RestoreAngles` read and write `Log` directly at a frame's four corners with no bounds test. The UI is authored on a 640x480 canvas and centred rather than scaled, so `INV_LEFT_OFFSET` is `(ModeDesiredX - 640) / 2` and goes negative below 640, while the inner height is a fixed 413. At 320x240 the inventory frame spans x -152..471 and y 8..421 against a 240-line buffer. Opening the inventory, the options screen or the holomap then walks off `Log`: heap overflow at 320x240, SEGV at 320x200. The save and the restore share one predicate, since a restore that replays a backup which was never taken is its own bug.

## Verification

Before/after under ASan with the `MainBuffer` regions allocated separately, since in the shipping arena none of these leave the allocation and no sanitizer reports them. Each has a minimal repro that faults on the pre-fix binary and is clean after, and a combined sweep across 320x200, 320x240 and 400x300 with cube loads, inventory, options and holomap reports nothing.

For the corner-copy guard specifically, the captured inventory and options screens at 640x480 are **byte identical** before and after, with `--fixed-dt 16` so the comparison means something. My first version of that guard rejected frames under 12 px tall, which silently stopped drawing the config rows' corners; the pixel comparison is what caught it.

## Still open, and deliberately not in this PR

These modes are memory-safe now but the UI still lays itself out beyond the screen there: negative offsets, a 413 px frame on a 240 px screen. That is a product question rather than a safety one. Either clamp the layout, or raise `RES_MIN_W`/`RES_MIN_H` to the authored canvas and drop the three modes from the catalog, which is a one-line change matching what the layout code actually assumes but removes advertised modes.

Worth weighing against how rarely these modes are used: the value here is mostly in closing a class, not in fixing something players hit.
