### PR TITLE
fix(harness): let skipmodals cover the found-object cinematic

### DIFF
--- a/SOURCES/INVENT.CPP
+++ b/SOURCES/INVENT.CPP
@@ -1764,7 +1764,11 @@ void DoFoundObj(S32 numvar) {
 
         MyGetInput();
 
-        if (!DemoSlide AND(MyKey == K_ESC OR Input & I_MENUS) AND !flag) {
+        /* Console `skipmodals`: the found-object cinematic waits on a keypress
+           that a headless run never sends, so `give` hangs the whole session.
+           Treat it as Esc, exactly as the dialogue modal does in MESSAGE.CPP;
+           the put-away animation then drives flag to 2 on its own timer. */
+        if (!DemoSlide AND(MyKey == K_ESC OR Input & I_MENUS OR DbgSkipModals) AND !flag) {
             //			esc  = TRUE 				;
             StopSpeak();
             flag = 1;


### PR DESCRIPTION
`skipmodals` aborts dialogue modals so a headless run does not wedge, but it never reached `DoFoundObj`. Picking anything up opens the found-object cinematic, which waits on a keypress no headless session sends, so a single `give` hung the run and every command after it timed out.

This treats the flag as Esc there, exactly as `MESSAGE.CPP` already does for dialogue. The put-away animation then drives the modal to completion on its own timer, so the loop exits without input.

## Why it matters beyond the one command

It was quietly capping automated coverage. A fuzz run that hit `give` in its first few actions explored a fraction of its intended depth and reported a "death" that was only the socket timing out. Runs nominally 40 actions deep were exploring about five, and the waves looked productive the whole time.

With this in place the same driver reached its full depth and immediately turned up defects the earlier waves could not have reached, since they were ending before they got there.

Anything else automating an item pickup was truncated at the same point.

## Check

`skipmodals 1; give tunic; give sabre; cube 10; status; exit` hangs until the timeout before, and runs to completion after.
