### PR TITLE
docs: add a bug hunting runbook, and say what ASan cannot see here

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,7 @@ both: e.g. `fix(credits): ... (#65) (#66)`. Reference issues in the PR
 - [CONTRIBUTING.md](CONTRIBUTING.md) — Contribution workflow, formatter mechanics, PR workflow
 - [.github/copilot-instructions.md](.github/copilot-instructions.md) — Detailed ASM↔CPP workflow, polyrec debugging, test patterns, common pitfalls
 - [docs/FEATURE_WORKFLOW.md](docs/FEATURE_WORKFLOW.md) — Reasoning and docs for big features (console, headless, menu, camera)
+- [docs/BUG_HUNTING.md](docs/BUG_HUNTING.md): finding defects nobody reported, with socket-driven fuzzing under sanitizers and the oracle checks that make a green result mean something
 - [docs/README.md](docs/README.md) — Full documentation index
 - [scripts/README.md](scripts/README.md) — Catalogue of developer, CI, and packaging scripts (maintained vs. spike)
 - [docs/TOOLING.md](docs/TOOLING.md) — External tools the repo expects, tiered by what breaks without them; `scripts/dev/check-tooling.sh` probes them

--- a/docs/BUG_HUNTING.md
+++ b/docs/BUG_HUNTING.md
@@ -1,0 +1,144 @@
+# Bug hunting runbook
+
+How to go looking for defects nobody has reported yet. Companion to
+[CRASH_INVESTIGATION.md](CRASH_INVESTIGATION.md), which is the process once you already have a
+crash; this doc is the process for producing one.
+
+Truth hierarchy: code > this document > external sources.
+
+The short version: drive the engine the way a player does, run it under sanitizers that can
+actually see the engine's memory, and distrust every green result until you have made it go red on
+purpose.
+
+## The rig
+
+Three parts, and the third is the one people miss.
+
+1. **The control socket.** `--listen <port>` plus `scripts/dev/lba2ctl.py` drives a live engine
+   from a script. See [CONTROL.md](CONTROL.md). Send a command, let frames run, then read state.
+   A command per PRESENT is the trap: the engine needs to actually tick between actions.
+
+2. **ASan and UBSan.** Configure with
+   `-fsanitize=address,undefined -fno-sanitize=alignment -fno-omit-frame-pointer -g`.
+   Turn the alignment check off. Misaligned access is endemic by design here (packed Adeline data,
+   `U16 *` casts on odd offsets) and floods roughly 160 reports before the title screen, which
+   buries everything else. It still matters for the arm64 builds, as its own exercise.
+
+3. **Un-merge the arena.** `InitMainBuffer()` in SOURCES/MEM.CPP hands eleven buffers out of a
+   single `Malloc`. A spill from one region into its neighbour never leaves that allocation, so
+   **no sanitizer will ever report it**. Give each region its own allocation behind a debug env
+   var and the redzones become real. Keep the deliberate aliases intact (`BufCube` and
+   `BufferBrick` live inside `PtrZBuffer`; `tabflag` is `Screen + OFFSET_BUFFER_FLAG`) or the
+   isolation invents faults that do not exist. Add a little slack per region: the original ASM
+   deliberately touches one element past a box edge, and that known quirk otherwise masks the
+   spill you are hunting.
+
+Neighbour order matters when reading a symptom. `TabBlock` sits immediately after `BufMap`, so a
+map load that overruns lands on block data.
+
+## Drive it like a player
+
+The deterministic sweeps in `tests/automation/` walk one axis at a time, which makes them good at
+pinning a known fault and bad at finding new ones. Players do not do that. They open the holomap
+mid-scene, change resolution from the options menu, pick something up, and wander into another
+cube, each against whatever state the last thing left behind.
+
+Randomise over that: scene changes, UI modals, runtime resolution, input, item pickups, behaviour
+changes, teleports, jingles, screenshots. Weight it toward the transitions that mix state.
+
+**Seed the generator and print the seed.** A seed replay is a better A/B than any repro sequence
+you derive by hand, and it costs nothing. Twice during this engine's hunt a hand-built sequence
+failed to reproduce something a seed replayed on demand.
+
+**Check how deep your runs actually got.** Any modal that waits for input will hang a headless
+run, the socket times out, and the driver logs a "death" a few actions in. Runs nominally forty
+actions deep were exploring about five, and the waves looked productive the whole time. `skipmodals`
+handles the dialogue and found-object paths; if you add a new modal, extend it.
+
+**Match the configuration to what people run.** Resolutions below 640x480 are catalogued but
+essentially unused, and a driver that spends a third of its budget there produces real bugs nobody
+will ever hit. Classic, widescreen and HD are where the risk is.
+
+## Oracle discipline
+
+This is the part that decides whether the campaign is worth anything. Every check must be shown
+capable of failing before its silence means a thing. Concretely, from this engine:
+
+- **A validator that reports nothing.** Poison one entry on purpose behind a debug env var and
+  confirm it fires. A load-time check over the cube map read clean on every cube, and only a
+  poison probe made "clean" evidence rather than an assumption.
+
+- **A comparison that cannot see the thing.** An ASM-versus-C test compared framebuffers while the
+  fixture filled the z-buffer with `0xFFFF` and fogged to a constant colour, so depth had no
+  observable effect. It passed happily while one side was fed depths off by fifty million. Compare
+  the z-buffer too, seeded with a gradient.
+
+- **A control that is not one.** "Small" inputs have to be sized from the arithmetic, not from
+  intuition. Depths of +-32768 look small, but `Line_ZBuffer` shifts them to 16.16, so the clip
+  product exceeds 32 bits before any multiply. That control diverged as hard as the real case and
+  briefly read as evidence against the hypothesis. The real boundary was +-100.
+
+- **A capture that is not deterministic.** `ui` screens animate. Any pixel comparison needs
+  `--fixed-dt 16`, or you are diffing noise. Verify by running the *same* binary twice before you
+  compare two binaries.
+
+- **A grep that finds sites but proves nothing.** Both misses in the 64-bit multiply sweep sat
+  beside code that already knew the hazard, one of them two lines under a previous fix for the same
+  function, with a test whose reference model was correct and whose inputs were too small to
+  overflow.
+
+The habit that catches all of these: after any green result, ask what would have to be broken for
+this to go red, then break it.
+
+## From a report to a cause
+
+**Bisect the trigger before diagnosing.** A fault that arrived after two resolution switches and a
+UI modal looked like a widescreen bug and was written up as one. The resolution switches were
+irrelevant: a `teleport` alone reproduced it. Reduce to the minimal command sequence first, then
+explain it.
+
+**Separate live from latent.** Both are worth fixing, but not with the same urgency, and saying
+which is which keeps a report honest. A 16.16 depth delta overflows at ordinary values; a sphere
+radius needs two million model units against a focal of 600 and never happens.
+
+**Watch for the observer.** A per-frame checksum over 200 KB perturbs timing enough that a
+one-in-three intermittent fault stops appearing. A clean run under heavy instrumentation is not the
+same as a fixed bug.
+
+## Before calling it a port bug
+
+Every `.CPP` under LIB386 has an `.ASM` twin. Read it before concluding the C is wrong, because
+sometimes the C is faithful and the original is what looks odd:
+
+- `BOXZBUF.ASM` ends its pixel loop with `inc` / `jle`, so it deliberately processes one element
+  past the box edge. ASan flags it; it is original behaviour and stays.
+- `POLYLINE.ASM` multiplies with one-operand `imul`, whose product lands in EDX:EAX, and divides
+  the full 64 bits with `idiv`. The C did it in 32-bit `int`. That one is a genuine mistranslation.
+
+That second case is a class worth checking on any new translation: **one-operand `imul` or `mul`
+feeding an `idiv` or `div` is 64-bit arithmetic that C's `S32 a * b / c` cannot express.** The
+two-operand form does truncate to 32 bits and maps to `*` correctly, so the comma is the tell.
+Correct translation is `(S32)((S64)a * b / c)`. All 95 such sites in the tree have been swept, but
+new ports should be checked against it.
+
+## Pinning it
+
+Bug fixes land with a regression test; see
+[CRASH_INVESTIGATION.md](CRASH_INVESTIGATION.md#after-the-fix-pin-it) for the mechanics and
+[TESTING.md](TESTING.md) for the harnesses.
+
+Two things worth adding when the bug was a numeric boundary:
+
+- **Grade the test.** Sweeping depth magnitudes with the divergence count printed per band turns a
+  red test into a diagnosis: it says which side of the boundary broke, not just that something did.
+- **Prove the fix is a no-op where it should be.** A bounds guard that also changes supported
+  configurations is a regression wearing a fix's clothing. Capture the affected screens before and
+  after with `--fixed-dt` and confirm they are byte identical.
+
+## Related files
+
+- [CRASH_INVESTIGATION.md](CRASH_INVESTIGATION.md): process once a crash exists
+- [CONTROL.md](CONTROL.md): the control socket and `lba2ctl.py`
+- [DEBUG.md](DEBUG.md): debug keys, bug saves, cheat codes
+- [TESTING.md](TESTING.md): test harnesses, ASM-vs-CPP builds, polyrec
+- [PLATFORM.md](PLATFORM.md): the hazard classes this port keeps hitting

--- a/docs/CRASH_INVESTIGATION.md
+++ b/docs/CRASH_INVESTIGATION.md
@@ -49,6 +49,19 @@ Run via `gdb --args ./build-asan/SOURCES/lba2cc --game-dir /path/to/data`.
 
 Without `abort_on_error=1`, ASan prints its report and calls `exit()`, which gdb passes through — you lose the live stack. With it, gdb stops at the moment of the bad access so you can interrogate state in place.
 
+### What ASan cannot see here
+
+`InitMainBuffer()` in SOURCES/MEM.CPP hands eleven buffers (`PtrZBuffer`, `ScreenAux`, `BufSpeak`,
+`Screen`, `BufferMaskBrick`, `BufMap`, `TabBlock`, ...) out of one `Malloc`. A write that runs off
+the end of one region lands in its neighbour without ever leaving that allocation, so **ASan reports
+nothing** and the corruption surfaces later as garbage data somewhere unrelated.
+
+If a fault looks like corrupted engine data rather than a bad pointer, allocate the regions
+separately and re-run: the redzones between them become real and the writer gets named on the first
+sweep. `BufCube` and `BufferBrick` deliberately live inside `PtrZBuffer`, and `tabflag` inside
+`Screen`, so keep those aliases or the isolation invents faults. Full recipe in
+[BUG_HUNTING.md](BUG_HUNTING.md#the-rig).
+
 ## Inspecting state at the crash
 
 When SIGSEGV hits, the cheap interrogation:

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,8 @@ The engine mapped as a whole: layers, the engine/game membrane, and the on-disk 
 | [DISC_IMAGE_SOURCE.md](DISC_IMAGE_SOURCE.md) | Reading retail assets straight from a raw ISO/BIN disc image (GOG `LBA2.GOG`): ISO9660 reader, mount + `OpenRead` fallback, in-image music. Plus the retail CD assessment (US "Twinsen's Odyssey" rip) and the plan for CD-DA music, other containers and multi-track cues. |
 | [DEBUG.md](DEBUG.md) | Original Adeline debug tools (DEBUG_TOOLS=ON): overlay, F9 screenshot, bug save/load, cheats, scene selection. |
 | [CONSOLE.md](CONSOLE.md) | Quake-style debug console (always available): backtick/F12, commands and cvars. |
+| [CRASH_INVESTIGATION.md](CRASH_INVESTIGATION.md) | Runbook for a crash you already have: ASan builds (preload or static link), inspecting state at the fault, reading ASan output, pointer-arithmetic traps, and pinning the fix with a regression test. |
+| [BUG_HUNTING.md](BUG_HUNTING.md) | Runbook for finding defects nobody has reported: driving the control socket through player-shaped sequences under ASan/UBSan, un-merging the memory arena so spills are visible at all, and the oracle discipline that decides whether a green result means anything. |
 | [CONTROL.md](CONTROL.md) | CLI control harness: drive the engine non-interactively (`--load`/`--exec`/`--tick`/`--dump-state`/`--screenshot`/`--exit`) for automation and regression. |
 | [RELEASING.md](RELEASING.md) | Maintainer recipe for cutting a release: versioning, the `1.0` bar, `git-cliff`, engine version vs `NUM_VERSION`. |
 | [CI.md](CI.md) | GitHub Actions workflows: validation vs release tiers, triggers, path filtering, the docs-only gate, branch protection. |


### PR DESCRIPTION
`CRASH_INVESTIGATION.md` covers the process once a crash exists. Nothing covered the other half: going looking for defects nobody has reported, which is a different activity with its own failure modes.

`docs/BUG_HUNTING.md` writes down the rig that worked and, more importantly, the part that decides whether any of it is worth anything.

## What is in it

**The rig.** Control socket driving player-shaped sequences; ASan plus UBSan with the alignment check off, since misaligned access is endemic by design here and floods ~160 reports before the title screen; and the memory arena un-merged so spills between the eleven `MainBuffer` regions are visible at all.

**Oracle discipline**, which is the section that earns the doc. Every check has to be shown capable of failing before its silence counts, and the examples are all real:

- a validator that read clean on every cube until a poison probe proved it could fire
- an ASM comparison that could not see depth at all, because the fixture filled the z-buffer with `0xFFFF` and fogged to a constant colour; it passed while one side was fed depths off by 50,000,000
- a control whose "small" inputs already overflowed, which briefly read as evidence against the very hypothesis it was meant to test
- a `ui` capture compared without `--fixed-dt`, which is diffing noise

**Two habits that cost real time.** Bisect a repro to its minimal trigger before explaining it: a fault that arrived after two resolution switches and a UI modal was written up as a widescreen bug and needed only a `teleport`. And read the `.ASM` twin before calling the C wrong: `BOXZBUF`'s one-past-the-edge access is original behaviour and stays, while `POLYLINE`'s 32-bit clip product is a genuine mistranslation.

## Also here

The arena caveat is repeated in `CRASH_INVESTIGATION.md`, because anyone reaching for ASan on this engine needs to know it cannot see spills between those buffers whether or not they arrive via the new doc.

Both runbooks are now in `docs/README.md` and `AGENTS.md`. `CRASH_INVESTIGATION.md` was never indexed anywhere, which is probably why it is easy to miss.

Docs only, no code.
