### PR TITLE
refactor(ui): give the authored UI canvas one place to be placed

### DIFF
--- a/SOURCES/COMPORTE.CPP
+++ b/SOURCES/COMPORTE.CPP
@@ -9,6 +9,7 @@
 #include "C_EXTERN.H"
 
 #include "INPUT.H"
+#include "UI_LAYOUT.H" /* UI_VCENTER_OFS */
 
 #include <SVGA/SCREEN.H>
 #include <SVGA/VIDEO.H>

--- a/SOURCES/DEFINES.H
+++ b/SOURCES/DEFINES.H
@@ -248,25 +248,15 @@
 #define SCREEN_SHADE_LVL 8 // Shade sous les menus
 
 /*──────────────────────────────────────────────────────────────────────────*/
-/* UI vertical re-anchor (widescreen / tall framebuffers)
+/* UI canvas placement (UI_CANVAS_H, UI_VCENTER_OFS, UI_VBOTTOM_OFS,
+ * UI_CENTER_X) moved to UI_LAYOUT.H, where the rule is one expression with a
+ * host test rather than a macro defined among the game's constants.
  *
- * The 2D UI was authored against a 480-tall 4:3 canvas. X was already routed
- * through ModeDesiredX/2; these do the same for Y. On a taller framebuffer
- * (ModeDesiredY > 480) they float the authored canvas so it stays vertically
- * centred (UI_VCENTER_OFS) or pinned to the bottom edge (UI_VBOTTOM_OFS).
- * Both are 0 when ModeDesiredY == 480, so the classic 4:3 layout is
- * byte-identical. These read ModeDesiredY (SVGA/SCREEN.H) live on every
- * expansion; never cache the result, or it goes stale after a runtime
- * resolution switch (Res_Switch). See docs/WIDESCREEN.md.
- *
- * Clamped to >= 0: below the 480 canvas (e.g. --resolution 320x200) the
- * authored UI does not fit, and a negative offset would push draws to a
- * negative Y, an out-of-bounds index in the unclamped TabOffLine[] row lookup
- * (BackupAngles and friends). There we fall back to the canvas-top origin,
- * matching the pre-re-anchor behaviour. */
-#define UI_CANVAS_H 480
-#define UI_VCENTER_OFS ((S32)ModeDesiredY > UI_CANVAS_H ? ((S32)ModeDesiredY - UI_CANVAS_H) / 2 : 0)
-#define UI_VBOTTOM_OFS ((S32)ModeDesiredY > UI_CANVAS_H ? (S32)ModeDesiredY - UI_CANVAS_H : 0)
+ * The files that place UI now include UI_LAYOUT.H directly, so their include
+ * lists say they do. That is a convention, not a wall: this header includes
+ * INVENT.H and GAMEMENU.H, which include UI_LAYOUT.H, so anything that reaches
+ * C_EXTERN.H can still use the macros without asking for them. Breaking that
+ * chain means untangling DEFINES.H itself, which is its own job. */
 
 /*──────────────────────────────────────────────────────────────────────────*/
 /*──────────────────────────────────────────────────────────────────────────*/

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -28,6 +28,7 @@
 #include <SYSTEM/MOUSE.H>
 
 #include "GAMEMENU_MOUSE.H"
+#include "UI_LAYOUT.H" /* UI_VCENTER_OFS / UI_VBOTTOM_OFS: authored-canvas placement */
 
 #include <dirent.h>
 #include <stdint.h>

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -28,7 +28,7 @@
 #include <SYSTEM/MOUSE.H>
 
 #include "GAMEMENU_MOUSE.H"
-#include "UI_LAYOUT.H" /* UI_VCENTER_OFS / UI_VBOTTOM_OFS: authored-canvas placement */
+#include "UI_LAYOUT.H" /* UI_CENTER_X, UI_VCENTER_OFS */
 
 #include <dirent.h>
 #include <stdint.h>
@@ -55,7 +55,7 @@
 /* Top-left X of the SCREEN_SAVE_WIDTH-wide save thumbnail when it should be
    horizontally centred on the framebuffer. At 640 this resolves to 240 (the
    historical literal); at wider widths it tracks ModeDesiredX/2. */
-#define SAVE_THUMB_X ((S32)ModeDesiredX / 2 - SCREEN_SAVE_WIDTH / 2)
+#define SAVE_THUMB_X (UI_CENTER_X - SCREEN_SAVE_WIDTH / 2)
 /* Top of the save thumbnail on the save/load list screen (ChoosePlayerName).
    The historical literal is 50, on the 480-tall canvas; UI_VCENTER_OFS floats
    it with the rest of that screen on a taller framebuffer (0 at 480). The
@@ -1131,7 +1131,7 @@ void DrawCadreNewGame(void) {
 
     DrawCadreSave(SAVE_THUMB_X, SAVE_THUMB_Y);
 
-    x = (S32)ModeDesiredX / 2 - dx / 2;
+    x = UI_CENTER_X - dx / 2;
     y = SAVE_THUMB_Y + (SCREEN_SAVE_HEIGHT) / 2 - dy / 2;
 
     AffGraph(0, x, y, ptr);
@@ -1147,8 +1147,8 @@ void DrawCadreNewGame(void) {
 
 static S32 GameMenuSaveListHitTest(U32 mx, U32 my, S32 nb, S32 start, S32 *outSel) {
     S32 n;
-    S32 x0 = (S32)ModeDesiredX / 2 - GM_MENU_HALF_WIDTH_SAVE;
-    S32 x1 = (S32)ModeDesiredX / 2 + GM_MENU_HALF_WIDTH_SAVE;
+    S32 x0 = UI_CENTER_X - GM_MENU_HALF_WIDTH_SAVE;
+    S32 x1 = UI_CENTER_X + GM_MENU_HALF_WIDTH_SAVE;
 
     for (n = 0; n < NB_GAME_CHOICE; n++) {
         S32 y;
@@ -1205,7 +1205,7 @@ S32 InputPlayerName(S32 choice, char *name) {
 
     len = strlen(PlayerName);
 
-    x = (S32)ModeDesiredX / 2;
+    x = UI_CENTER_X;
     y = Y_START_CHOICE + choice * 60;
 
     ManageTime();
@@ -1236,11 +1236,11 @@ S32 InputPlayerName(S32 choice, char *name) {
                 CursorActif = FALSE;
         }
 
-        DrawOneString((S32)ModeDesiredX / 2, y, PlayerName, 1);
+        DrawOneString(UI_CENTER_X, y, PlayerName, 1);
         BoxUpdate();
 
         if (flag == 1) {
-            x = (S32)ModeDesiredX / 2 + SizeFont(PlayerName) / 2;
+            x = UI_CENTER_X + SizeFont(PlayerName) / 2;
             flag = 0;
         }
 
@@ -1303,10 +1303,10 @@ S32 InputPlayerName(S32 choice, char *name) {
                 /* Max input cursor X = original 550 = centre(320) + 230 px. Keep the
                    same 230 px half-width at any resolution so the name-entry field
                    visible area stays at its authored 460 px width. */
-                if (x < (S32)ModeDesiredX / 2 + 230 AND akey >= 32 AND akey <= 122) {
+                if (x < UI_CENTER_X + 230 AND akey >= 32 AND akey <= 122) {
                     PlayerName[len++] = (char)akey;
                     PlayerName[len] = '\0';
-                    x = (S32)ModeDesiredX / 2 + SizeFont(PlayerName) / 2;
+                    x = UI_CENTER_X + SizeFont(PlayerName) / 2;
                 }
                 break;
             }
@@ -1453,7 +1453,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
         ManageTime();
 
         if (flag == 3) {
-            DrawSingleString((S32)ModeDesiredX / 2, 25 + UI_VCENTER_OFS, (char *)GetMultiText(mess, string));
+            DrawSingleString(UI_CENTER_X, 25 + UI_VCENTER_OFS, (char *)GetMultiText(mess, string));
             flag = 1;
         }
 
@@ -1476,7 +1476,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                 else if ((start + NB_GAME_CHOICE < nb) AND(n == NB_GAME_CHOICE - 1))
                     draw |= ARROW_ID;
 
-                DrawOneString((S32)ModeDesiredX / 2, Y_START_CHOICE + 60 * n, ptrlist[n + start], draw);
+                DrawOneString(UI_CENTER_X, Y_START_CHOICE + 60 * n, ptrlist[n + start], draw);
             }
 
             draw = 1;
@@ -1508,7 +1508,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                     sdraw |= ARROW_SG;
                 else if ((start + NB_GAME_CHOICE < nb) AND(sn == NB_GAME_CHOICE - 1))
                     sdraw |= ARROW_ID;
-                DrawOneString((S32)ModeDesiredX / 2, Y_START_CHOICE + 60 * sn, ptrlist[select], sdraw);
+                DrawOneString(UI_CENTER_X, Y_START_CHOICE + 60 * sn, ptrlist[select], sdraw);
             }
         }
 
@@ -1631,7 +1631,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                             start++;
                         }
                     } else {
-                        DrawOneString((S32)ModeDesiredX / 2, ys, ptrlist[select - 1], (draw & 0xFFFFFFFE));
+                        DrawOneString(UI_CENTER_X, ys, ptrlist[select - 1], (draw & 0xFFFFFFFE));
                     }
                     flag = 1;
 
@@ -1650,7 +1650,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                     if (select < start) {
                         start--;
                     } else {
-                        DrawOneString((S32)ModeDesiredX / 2, ys, ptrlist[select + 1], (draw & 0xFFFFFFFE));
+                        DrawOneString(UI_CENTER_X, ys, ptrlist[select + 1], (draw & 0xFFFFFFFE));
                     }
                     flag = 1;
                     if (flagnew AND select == nb - 1)
@@ -1663,7 +1663,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
             }
         }
 
-        DrawOneString((S32)ModeDesiredX / 2, ys, ptrlist[select], draw);
+        DrawOneString(UI_CENTER_X, ys, ptrlist[select], draw);
         BoxUpdate();
 
         if (Input & I_DOWN OR MyKey == K_GRAY_DOWN) {
@@ -1674,7 +1674,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                         start++;
                     }
                 } else {
-                    DrawOneString((S32)ModeDesiredX / 2, ys, ptrlist[select - 1], (draw & 0xFFFFFFFE));
+                    DrawOneString(UI_CENTER_X, ys, ptrlist[select - 1], (draw & 0xFFFFFFFE));
                 }
                 flag = 1;
 
@@ -1693,7 +1693,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                 if (select < start) {
                     start--;
                 } else {
-                    DrawOneString((S32)ModeDesiredX / 2, ys, ptrlist[select + 1], (draw & 0xFFFFFFFE));
+                    DrawOneString(UI_CENTER_X, ys, ptrlist[select + 1], (draw & 0xFFFFFFFE));
                 }
                 flag = 1;
                 if (flagnew AND select == nb - 1)
@@ -1720,7 +1720,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                         if (start >= (nb - (NB_GAME_CHOICE - 1)))
                             start = nb - NB_GAME_CHOICE;
                     } else {
-                        DrawOneString((S32)ModeDesiredX / 2, ys, ptrlist[oldselect], (draw & 0xFFFFFFFE));
+                        DrawOneString(UI_CENTER_X, ys, ptrlist[oldselect], (draw & 0xFFFFFFFE));
                     }
                     flag = 1;
 
@@ -1743,7 +1743,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                     if (select < start) {
                         start = select;
                     } else {
-                        DrawOneString((S32)ModeDesiredX / 2, ys, ptrlist[oldselect], (draw & 0xFFFFFFFE));
+                        DrawOneString(UI_CENTER_X, ys, ptrlist[oldselect], (draw & 0xFFFFFFFE));
                     }
                     flag = 1;
                     if (flagnew AND select == nb - 1)
@@ -1761,7 +1761,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                     select = 0;
 
                     if (start == 0) {
-                        DrawOneString((S32)ModeDesiredX / 2, ys, ptrlist[oldselect], (draw & 0xFFFFFFFE));
+                        DrawOneString(UI_CENTER_X, ys, ptrlist[oldselect], (draw & 0xFFFFFFFE));
                     } else
                         start = 0;
 
@@ -1782,7 +1782,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
                 select = nb - 1;
 
                 if (start == (nb - NB_GAME_CHOICE)) {
-                    DrawOneString((S32)ModeDesiredX / 2, ys, ptrlist[oldselect], (draw & 0xFFFFFFFE));
+                    DrawOneString(UI_CENTER_X, ys, ptrlist[oldselect], (draw & 0xFFFFFFFE));
                 } else {
                     start = nb - NB_GAME_CHOICE;
                     if (start < 0)
@@ -2027,7 +2027,7 @@ S32 ChoosePlayerName(S32 mess, S32 flagflip, S32 flagnew) {
 
         for (n = 0; n < NB_GAME_CHOICE; n++) {
             if ((n + start) != select) {
-                ClearOneString((S32)ModeDesiredX / 2, Y_START_CHOICE + 60 * n);
+                ClearOneString(UI_CENTER_X, Y_START_CHOICE + 60 * n);
             }
         }
     }
@@ -2349,10 +2349,10 @@ void DrawGameMenu(U16 *ptrmenu, S32 justone) {
             // when set, the green marker row, so the marker persists and animates
             // between full redraws instead of being drawn once and cleared.
             if (n == selected || n == s_menuMarkRow) {
-                DrawOneChoice((S32)ModeDesiredX / 2, y, type, num, sel);
+                DrawOneChoice(UI_CENTER_X, y, type, num, sel);
             }
         } else {
-            DrawOneChoice((S32)ModeDesiredX / 2, y, type, num, sel);
+            DrawOneChoice(UI_CENTER_X, y, type, num, sel);
         }
 
         y += HAUTEUR_STANDARD + MENU_SPACE;
@@ -3546,7 +3546,7 @@ S32 DeleteSavedGame(void) {
 
     // Delete-save confirmation: float the name + preview with SavedConfirmMenu
     // (which floats via DrawGameMenu) so the whole screen stays coherent. No-op at 480.
-    DrawOneString((S32)ModeDesiredX / 2, 80 + UI_VCENTER_OFS, PlayerName, 2);
+    DrawOneString(UI_CENTER_X, 80 + UI_VCENTER_OFS, PlayerName, 2);
     ptr = LoadGameScreen();
     if (ptr)
         DrawScreenSave(ptr, SAVE_THUMB_X, 130 + UI_VCENTER_OFS);
@@ -5060,8 +5060,8 @@ void DemoLogo(void) {
     ColorFont(LBAWHITE);
 
     // cadre
-    x0 = (S32)ModeDesiredX / 2 - SizeFont(string) / 2 - 50;
-    x1 = (S32)ModeDesiredX / 2 + SizeFont(string) / 2 + 50;
+    x0 = UI_CENTER_X - SizeFont(string) / 2 - 50;
+    x1 = UI_CENTER_X + SizeFont(string) / 2 + 50;
     y0 = (S32)ModeDesiredY / 2 - 25;
     y1 = (S32)ModeDesiredY / 2 + 25;
     //      ShadeBoxBlk( 0, 0, 639, 479, SCREEN_SHADE_LVL ) ;

--- a/SOURCES/GAMEMENU.H
+++ b/SOURCES/GAMEMENU.H
@@ -2,6 +2,7 @@
 #define GAMEMENU_H
 
 #include "MENU_LABELS.H"
+#include "UI_LAYOUT.H" /* UI_CENTER_X */
 
 #ifdef DEMO
 extern S32 FlagShowEndDemo;
@@ -21,14 +22,15 @@ extern void InitMenuIncrustText(const char *text, S32 sprite, S32 time);
 extern void DrawFireBar(S32 xmin, S32 ymin, S32 xmax, S32 ymax, S32 coul);
 /*--------------------------------------------------------------------------*/
 /* Plasma/fire highlight bar on the active menu option. Sits horizontally
-   centred on the screen, LargeurMenu wide. The bar's x-range mirrors the
-   DrawOneString/DrawOneChoice box (x ± LargeurMenu/2) — those callers
-   already centre at ModeDesiredX/2 post-C2, so this macro tracks the same
-   anchor or the highlight slides off the menu items at wider widths. */
-#define DrawFire(y, coul) DrawFireBar((S32)ModeDesiredX / 2 - LargeurMenu / 2, \
-                                      y,                                       \
-                                      (S32)ModeDesiredX / 2 + LargeurMenu / 2, \
-                                      y + HAUTEUR_STANDARD,                    \
+   centred, LargeurMenu wide. The bar's x-range mirrors the
+   DrawOneString/DrawOneChoice box (x ± LargeurMenu/2), and those callers centre
+   on UI_CENTER_X, so this macro has to use the same anchor or the highlight
+   slides off the menu items. LargeurMenu is 550, so in the sub-640 modes both
+   ends of the bar hang off the screen and SetClip trims them. */
+#define DrawFire(y, coul) DrawFireBar(UI_CENTER_X - LargeurMenu / 2, \
+                                      y,                             \
+                                      UI_CENTER_X + LargeurMenu / 2, \
+                                      y + HAUTEUR_STANDARD,          \
                                       coul)
 /*--------------------------------------------------------------------------*/
 extern int my_sort_function(const void *a, const void *b);

--- a/SOURCES/GAMEMENU_MOUSE.CPP
+++ b/SOURCES/GAMEMENU_MOUSE.CPP
@@ -1,6 +1,7 @@
 #include "GAMEMENU_MOUSE.H"
 
 #include "C_EXTERN.H"
+#include "UI_LAYOUT.H" /* UI_VCENTER_OFS / UI_VBOTTOM_OFS: authored-canvas placement */
 
 #include <SYSTEM/MOUSE.H>
 #include <SYSTEM/WINDOW.H>

--- a/SOURCES/GAMEMENU_MOUSE.CPP
+++ b/SOURCES/GAMEMENU_MOUSE.CPP
@@ -1,7 +1,7 @@
 #include "GAMEMENU_MOUSE.H"
 
 #include "C_EXTERN.H"
-#include "UI_LAYOUT.H" /* UI_VCENTER_OFS / UI_VBOTTOM_OFS: authored-canvas placement */
+#include "UI_LAYOUT.H" /* UI_CENTER_X, UI_VCENTER_OFS */
 
 #include <SYSTEM/MOUSE.H>
 #include <SYSTEM/WINDOW.H>
@@ -11,10 +11,11 @@ extern U16 GameMainMenu[];
 
 #define GM_HAUTEUR_STANDARD 50
 #define GM_MENU_SPACE 6
-// Menu centre X. Must track DrawGameMenu's draw (DrawOneChoice at
-// ModeDesiredX/2); was hardcoded 320, so mouse clicks missed the menu at any
-// width != 640. Matches GameMenuSaveListHitTest's ModeDesiredX/2 convention.
-#define GM_MENU_XMID ((S32)ModeDesiredX / 2)
+// Menu centre X. Must track DrawGameMenu's draw (DrawOneChoice at the same
+// anchor); was hardcoded 320, so mouse clicks missed the menu at any width
+// != 640. UI_CENTER_X is that anchor named once in UI_LAYOUT.H, so the hit
+// test cannot drift from the draw again.
+#define GM_MENU_XMID UI_CENTER_X
 #define GM_MENU_HALF_WIDTH 275
 
 static int s_menuMouseRefCount = 0;

--- a/SOURCES/HOLOGLOB.CPP
+++ b/SOURCES/HOLOGLOB.CPP
@@ -5,6 +5,7 @@
 #include "C_EXTERN.H" // include LBA2
 #include "DIRECTORIES.H"
 #include "INPUT.H"
+#include "UI_LAYOUT.H" /* UI_VCENTER_OFS */
 
 #include <FILEIO/SAVEPNG.H>
 #include <SVGA/SCREEN.H>

--- a/SOURCES/INVENT.CPP
+++ b/SOURCES/INVENT.CPP
@@ -4,6 +4,7 @@
 #include "DIRECTORIES.H"
 #include "INPUT.H"
 #include "IMAGE_LOAD.H"
+#include "UI_LAYOUT.H" /* UI_VCENTER_OFS */
 
 #include <FILEIO/SAVEPNG.H>
 #include <SVGA/SCREEN.H>

--- a/SOURCES/INVENT.H
+++ b/SOURCES/INVENT.H
@@ -1,6 +1,8 @@
 #ifndef INVENT_H
 #define INVENT_H
 
+#include "UI_LAYOUT.H" /* UI_VCENTER_OFS */
+
 /*#ifdef	LBA_EDITOR
 #define	BODY_SORT_PROTECT    "F:\\projet\\lba2\\graph\\3D\\throw\\protect1.O4D"
 #else
@@ -30,7 +32,7 @@
    literal (10/8/0/...). The iso-relative INV_ZOOM box centres on
    ModeDesiredX/2 - 3 (matches the historical 317 anchor at 640). */
 #define INV_LEFT_OFFSET (((S32)ModeDesiredX - 640) / 2)
-#define INV_TOP_OFFSET UI_VCENTER_OFS // vertical twin of INV_LEFT_OFFSET; shared with the other UI surfaces (DEFINES.H, clamped >= 0)
+#define INV_TOP_OFFSET UI_VCENTER_OFS // vertical twin of INV_LEFT_OFFSET; shared with the other UI surfaces (UI_LAYOUT.H, clamped >= 0)
 #define INV_START_X (INV_START_X_MARGIN + INV_LEFT_OFFSET)
 #define INV_START_Y (INV_START_Y_MARGIN + INV_TOP_OFFSET)
 

--- a/SOURCES/MESSAGE.CPP
+++ b/SOURCES/MESSAGE.CPP
@@ -22,6 +22,7 @@
 #include <SVGA/SCREEN.H>
 #include <SVGA/VIDEO.H>
 #include "DIRECTORIES.H"
+#include "UI_LAYOUT.H" /* UI_VCENTER_OFS, UI_VBOTTOM_OFS */
 #include <SYSTEM/KEYBOARD_KEYS.H>
 #include <SYSTEM/LOG.H>
 #include <SYSTEM/STRING.H>

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -33,6 +33,7 @@ extern S32 GfxDitherShading;
 #include <SYSTEM/KEYBOARD_KEYS.H>
 #include "FOLLOWCAM.H"
 #include "FOLLOWCAM_CFG.H" /* the *_DEFAULT tunables, read and written by the cfg below */
+#include "UI_LAYOUT.H"     /* UI_VCENTER_OFS */
 #include <SYSTEM/STRING.H>
 #include <SYSTEM/WINDOW.H>
 

--- a/SOURCES/UI_LAYOUT.H
+++ b/SOURCES/UI_LAYOUT.H
@@ -1,0 +1,85 @@
+#ifndef UI_LAYOUT_H
+#define UI_LAYOUT_H
+
+#include <SYSTEM/ADELINE_TYPES.H>
+
+/* Where the authored UI canvas sits inside the framebuffer, in one place and
+ * free of engine state.
+ *
+ * The 2D UI was authored against a 640x480 4:3 canvas and still is: every menu
+ * coordinate, panel width and text anchor in the game is a literal measured
+ * against that canvas. The framebuffer underneath it is whatever the player
+ * chose, from 320x200 to 1920x1080, and reconciling the two is this header.
+ *
+ * The two axes do not answer it the same way, which is the thing to understand
+ * before using either:
+ *
+ *   X centres on the framebuffer at every size. A surface too wide to fit is
+ *   drawn centred and clipped at both edges, which keeps its middle (where the
+ *   text is) on screen.
+ *
+ *   Y centres on the framebuffer only where the canvas fits, and falls back to
+ *   the canvas-top origin below that, never to a negative offset.
+ *
+ * The asymmetry is not an oversight. A negative Y reaches the row-offset lookup
+ * (TabOffLine[], indexed unclamped by BackupAngles and the pixel-shift macros)
+ * and indexes it out of bounds, so it is a write outside the framebuffer rather
+ * than a draw off the edge of it. A negative X has no equivalent: it goes
+ * through SetClip, which clamps it to ClipWindowXMin. Mirroring the Y clamp onto
+ * X was tried and is wrong: it anchors the canvas at 0 and puts its centre at
+ * 320, which is off the right edge of a 320-wide framebuffer, so the menu text
+ * leaves the screen.
+ *
+ * Reading the live dimensions is deliberate: never cache what these return, or
+ * the value goes stale after a runtime resolution switch (Res_Switch).
+ *
+ * The host test in tests/ui_layout/test_ui_layout.cpp checks both axes over
+ * every dimension the resolution catalogue can produce.
+ */
+
+/* The height of the canvas the 2D UI is authored against. Not a resolution: the
+ * framebuffer is RESOLUTION_X/Y (SYSTEM/RESOLUTION.H) and this is the coordinate
+ * space the UI literals live in. They differ whenever the player is not at
+ * 640x480, which is the whole reason this header exists.
+ *
+ * There is no width twin because nothing needs one: X centres on the framebuffer
+ * at every size, so the authored 640 never enters the arithmetic. */
+#define UI_CANVAS_H 480
+
+/* Where the canvas starts inside a framebuffer `modeH` tall, and the same pinned
+ * to the bottom edge for the surfaces authored against it (the dialogue box, the
+ * inventory bar).
+ *
+ * Clamped to >= 0 for the reason in the header comment above: below the canvas
+ * the authored UI does not fit, and the choice is between clipping it at the
+ * bottom (origin 0) and indexing the row table out of bounds. */
+static inline S32 UiCanvasOriginY(S32 modeH) {
+    return modeH > UI_CANVAS_H ? (modeH - UI_CANVAS_H) / 2 : 0;
+}
+
+static inline S32 UiCanvasBottomOfsY(S32 modeH) {
+    return modeH > UI_CANVAS_H ? modeH - UI_CANVAS_H : 0;
+}
+
+/* The horizontal anchor: the centre of the framebuffer, which is what nearly
+ * every 2D site asks for, either as a centred width or as an offset from it.
+ *
+ * This is what those sites already compute inline, and naming it is the whole
+ * change: a reader can no longer mistake it for the row stride or the iso
+ * projection origin, which are the other two things ModeDesiredX is used for. */
+static inline S32 UiCenterX(S32 modeW) {
+    return modeW / 2;
+}
+
+/* The live forms, bound to the framebuffer dimensions the engine is running at
+ * (ModeDesiredX / ModeDesiredY, SVGA/SCREEN.H). Macros rather than functions so
+ * this header stays free of engine state and can be host-tested; a caller needs
+ * SCREEN.H in scope, which every UI translation unit already has.
+ *
+ * UI_VCENTER_OFS and UI_VBOTTOM_OFS keep the names they were introduced with,
+ * so the sites that already use them are unchanged. */
+#define UI_VCENTER_OFS UiCanvasOriginY((S32)ModeDesiredY)
+#define UI_VBOTTOM_OFS UiCanvasBottomOfsY((S32)ModeDesiredY)
+#define UI_CENTER_X UiCenterX((S32)ModeDesiredX)
+
+#endif /* UI_LAYOUT_H */

--- a/docs/FEATURE_WORKFLOW.md
+++ b/docs/FEATURE_WORKFLOW.md
@@ -97,6 +97,62 @@ Truth hierarchy: code > this document > external sources.
 
 ---
 
+## Example 5: extract a subsystem from an original file
+
+**Goal:** Move something that grew inside a 1997 file into its own translation unit, or pull a rule
+that is spelled inline at many call sites into one place, without changing behaviour.
+
+**Reasoning:**
+
+1. **CODESTYLE.md first:** ["Where new code goes"](../CODESTYLE.md#where-new-code-goes) and
+   ["Features and surfaces"](../CODESTYLE.md#features-and-surfaces) say what the result has to look
+   like: a new subsystem gets its own TU, a module owns its own state, and a surface must not name a
+   feature's variables. What follows is the order to get there in, distilled from the two extractions
+   that have been done this way (the Auto camera, PRs #533/#540/#542/#544, and the cfg reader, #541).
+
+2. **Cut along the testable line first.** The part that reads no engine globals comes out before
+   anything moves, as a header with a host test. From then on the refactor has an oracle that runs on
+   every platform with no retail data. [SOURCES/FOLLOWCAM_MATH.H](../SOURCES/FOLLOWCAM_MATH.H) is the
+   worked example, tested by `tests/camera/test_followcam_math.cpp`, and it landed a full PR before
+   the module itself moved. If you cannot name that part, you are not ready to start.
+
+3. **Make the extracted part correct on its own terms.** A helper lifted out of one call site leans
+   on guarantees that caller happened to provide. Restore them inside the helper even where they are
+   inert today, and say in the comment that they are inert and why:
+   [`FollowCamRotStep`](../SOURCES/FOLLOWCAM_MATH.H) carries an overshoot clamp its two callers can
+   never trigger, because a later change to either constant would otherwise walk the camera past its
+   target.
+
+4. **Move before you change.** The commit that creates the file is a move: same lines, new home, no
+   edits. `refactor(camera): give the Auto camera its own file` is 472 insertions against 420
+   deletions across four files, and reviewing it is checking that nothing changed. What you want to
+   fix on the way gets its own commit afterwards.
+
+5. **Then ownership.** The header declares exactly what the `.CPP` defines, and the module's globals
+   come out of [SOURCES/C_EXTERN.H](../SOURCES/C_EXTERN.H) and
+   [SOURCES/GLOBAL.CPP](../SOURCES/GLOBAL.CPP). The mechanical test is the include list: after the
+   move, the files that genuinely use the module are the ones that had to add the include. For the
+   camera that was seven, against the ninety-odd that could previously reach it by accident.
+
+6. **Then surfaces, one entry point each.** The cfg reader, the console, the CLI table and the
+   options menu call into the module rather than naming its variables. Expect exactly one leak of
+   private state and give it a named entry point instead of widening the header; both extractions so
+   far found exactly one.
+
+7. **Bugs found on the way are not part of the refactor.** They get their own commit, test first and
+   allowed to fail, as in `test(camera): put the HD recompose rule under CI, and let two tests fail`
+   followed by the fix. A behaviour change buried in a move commit is invisible to review.
+
+8. **Write the rule down as you find it.** Three `docs(style)` commits landed inside those PRs, each
+   recording something the extraction had just taught. Later means never.
+
+**Docs to update:** the subsystem's own doc if the layout it describes moved, and
+[CODESTYLE.md](../CODESTYLE.md) if the extraction taught a rule that generalises. Run
+`scripts/ci/check-docs-symbols.py` afterwards: a doc naming a symbol in the file it has just left is
+exactly what that check exists to catch.
+
+---
+
 ## General workflow for big features
 
 1. **Read AGENTS.md** — principles, Never, When Modifying X Do Y.
@@ -106,3 +162,25 @@ Truth hierarchy: code > this document > external sources.
 5. **Preserve** — French comments, ASCII art; add new comments alongside.
 6. **Verify** — run tests, format check. For LIB386 changes, run equivalence tests.
 7. **When ambiguous** — ask the user before proceeding; do not guess.
+
+## General workflow for refactors
+
+The list above is feature-shaped: it assumes new behaviour and asks what to document. A refactor
+promises the opposite, so its risks are different.
+
+1. **Get an oracle before touching anything.** A refactor with no way to say "same as before" is a
+   rewrite. Host tests are the cheapest (no retail data, every platform); the UI goldens in
+   `tests/automation` and the projection corpus cover what needs a booted engine.
+2. **No behaviour change inside a refactor commit.** If a commit both moves code and fixes
+   something, split it. This repo reviews per commit rather than splitting PRs, and that only works
+   when each commit answers one question.
+3. **Convert one surface per commit, not one pattern per commit.** A sweep across every caller of a
+   thing is neither reviewable nor bisectable. One file or one screen at a time, each verifiable
+   against its own golden.
+4. **Scope by what the rule owns, not by what shares a variable.** `ModeDesiredX` is a UI anchor at
+   one site, a row stride at another and a projection origin at a third. Pulling all three into one
+   helper because they spell the same global would invent a relationship the code does not have.
+5. **Landing early is fine.** The rule having one home is the win; every caller reaching it is not a
+   precondition for merging. An unconverted site is a known cost, not a regression.
+6. **Before pushing:** `scripts/ci/check-format.sh`, `scripts/ci/check-docs-links.sh` and
+   `scripts/ci/check-docs-symbols.py` are what CI will run, and all three run locally.

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,7 +74,7 @@ The engine mapped as a whole: layers, the engine/game membrane, and the on-disk 
 |-----|-------------|
 | [BIT_EXACTNESS.md](BIT_EXACTNESS.md) | What "bit exact" / "byte identical" actually means here: the three kinds (format contract, ASM-parity oracle, regression tripwire), when byte-identity is the goal vs a proxy, and the rule for when a byte diff is acceptable. |
 | [CONTROLLER.md](CONTROLLER.md) | Manual camera (orbit, elevation, zoom) and the input sources that drive it: keyboard, mouse, gamepad. |
-| [FEATURE_WORKFLOW.md](FEATURE_WORKFLOW.md) | Reasoning and docs for big features: console commands, headless mode, menu changes, camera. |
+| [FEATURE_WORKFLOW.md](FEATURE_WORKFLOW.md) | Reasoning and docs for big features: console commands, headless mode, menu changes, camera. Plus the order to run a refactor in, and what a refactor has to promise. |
 | [AUDIO.md](AUDIO.md) | Audio system: AIL contract, SDL backend, sound scripting patterns, known issues. |
 | [MUSIC.md](MUSIC.md) | Music state machine: track routing, the `PlayMusic` decision + `NextMusic` deferred-switch queue, the two-layer pause/park model + `STREAM_PARK.H` seam, WAV vs OGG decode/cache, and the host test coverage. |
 | [ASM_TO_CPP_REFERENCE.md](ASM_TO_CPP_REFERENCE.md) | Which modules are ported from ASM to C++ in this fork. |

--- a/docs/WIDESCREEN.md
+++ b/docs/WIDESCREEN.md
@@ -104,7 +104,7 @@ This phase had two strands. The UI strand is done; the HD strand moved to its ow
 
 The C2 campaign above centred the 2D UI horizontally (`ModeDesiredX/2`) for a *wider* frame. It left UI height at the authored 480, so vertical positions stayed authored-pixel. This sweep (branch `fix/ui-vertical-centre`) does the Y axis, so the UI is also correct in a *taller* frame (`ModeDesiredY > 480`, reachable via `--resolution` and the `resolution` console verb even though the shipped widescreen modes stay 480-tall).
 
-The model is one 480-tall authored canvas floated into the live framebuffer. Two macros in `SOURCES/DEFINES.H`, both read live (never cache; they must survive a runtime `Res_Switch`) and both `0` at `ModeDesiredY == 480` so every site is behaviour-preserving at the classic resolution:
+The model is one 480-tall authored canvas floated into the live framebuffer. Two macros in [`SOURCES/UI_LAYOUT.H`](../SOURCES/UI_LAYOUT.H), both read live (never cache; they must survive a runtime `Res_Switch`) and both `0` at `ModeDesiredY == 480` so every site is behaviour-preserving at the classic resolution:
 
 - `UI_VCENTER_OFS = ((S32)ModeDesiredY - 480) / 2`, to float the canvas to the vertical middle.
 - `UI_VBOTTOM_OFS = (S32)ModeDesiredY - 480`, to pin to the bottom edge.

--- a/docs/WIDESCREEN.md
+++ b/docs/WIDESCREEN.md
@@ -106,8 +106,11 @@ The C2 campaign above centred the 2D UI horizontally (`ModeDesiredX/2`) for a *w
 
 The model is one 480-tall authored canvas floated into the live framebuffer. Two macros in [`SOURCES/UI_LAYOUT.H`](../SOURCES/UI_LAYOUT.H), both read live (never cache; they must survive a runtime `Res_Switch`) and both `0` at `ModeDesiredY == 480` so every site is behaviour-preserving at the classic resolution:
 
-- `UI_VCENTER_OFS = ((S32)ModeDesiredY - 480) / 2`, to float the canvas to the vertical middle.
-- `UI_VBOTTOM_OFS = (S32)ModeDesiredY - 480`, to pin to the bottom edge.
+- `UI_VCENTER_OFS = ((S32)ModeDesiredY - 480) / 2` where `ModeDesiredY > 480`, else `0`, to float the canvas to the vertical middle.
+- `UI_VBOTTOM_OFS = (S32)ModeDesiredY - 480` where `ModeDesiredY > 480`, else `0`, to pin to the bottom edge.
+
+Both clamps matter: without them a 200- or 240-tall framebuffer gives a negative
+offset, and the reason that is worse than a UI drawn off the bottom is below.
 
 Each surface's anchor mode mirrors how it reads on the 4:3 canvas:
 
@@ -128,6 +131,40 @@ Notes:
 - `INV_TOP_OFFSET` is the vertical twin of the pre-existing `INV_LEFT_OFFSET`. The slate's `PLAN_Y` overlays now track the slate art, which `DrawArdoise` already loads vertically centred via `Image_LoadCentered`; previously the art floated while the overlays stayed at the top.
 - `DialLetterboxInsetY` is the vertical twin of `DialLetterboxInset`. When a centred PCX backdrop is up (`Dial_Letterbox`), the text is inset to the picture on both axes instead of spilling into the letterbox bars. The backdrop stays a 640x480 centred letterbox (the project's cinematic convention), not scaled, since a fixed 4:3 pixel-art image cannot fill a taller frame without distortion or cropping.
 - Mouse hit-test: `GameMenuHitTestRow` is a separate copy of the `DrawGameMenu` layout math. It carried a hardcoded `320` X centre (a pre-existing widescreen bug the X campaign missed, so clicks missed the menu at any width other than 640) and no Y offset. Both now mirror the draw (`ModeDesiredX/2` plus `UI_VCENTER_OFS`). When floating a menu's draw, check for a duplicate hit-test doing the same math separately.
+
+
+#### Where the rule lives, and why the two axes differ
+
+Both halves of the placement rule are now in [`SOURCES/UI_LAYOUT.H`](../SOURCES/UI_LAYOUT.H),
+with a host test in `tests/ui_layout/` that CI runs on every platform. The
+horizontal anchor has a name there too, `UI_CENTER_X`, which is the same
+`ModeDesiredX / 2` the sites spelled inline; the game menu uses it, the other
+surfaces still spell it out.
+
+The axes are deliberately not symmetric, and the asymmetry is the part worth
+knowing before touching either:
+
+| | Above the canvas | Below the canvas |
+|---|---|---|
+| X | centres on the framebuffer | still centres on the framebuffer; wide panels hang off both edges and `SetClip` trims them |
+| Y | centres, or pins to the bottom | falls back to the canvas-top origin, never a negative offset |
+
+The Y clamp exists because a negative Y reaches `TabOffLine[]`, which
+`BackupAngles` and the pixel-shift macros index without a bounds check, so it is a
+write outside the framebuffer rather than a draw off the edge of it. X has no
+equivalent: a negative x goes through `SetClip`, which clamps it to
+`ClipWindowXMin`.
+
+Clamping X the same way was tried and reverted. It anchors the canvas at 0, which
+puts its centre at 320, off the right edge of a 320-wide framebuffer: the menu
+highlight bar starts at x=45 and runs past the right edge, and the item text goes
+with it. Captured at 320x240 before reverting. The narrow modes look correct as
+they are; the negative left edges (`-115` for the 550-wide menu bar, `-150` for
+the 620-wide keybinding panel) are clipped, not written.
+
+That leaves the intermittent sub-640 segfault reported in
+[CONTROL.md](CONTROL.md) unexplained: it is Windows-only, it does not reproduce
+on Linux at either narrow mode, and it is not this arithmetic.
 
 Verification: every site is `0` at 640x480 by construction and the host suite stays green. At tall res, captures confirm the menu block, holomap planet, and inventory wheel each translate by exactly `UI_VCENTER_OFS`, the holomap strip and dialogue box pin to the bottom, and the end-game text lands on its backdrop. The ask-choice list, action menu, found-object appear phase, and mouse hit-test have no headless capture path and were verified in-game.
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ add_subdirectory(movement)
 add_subdirectory(zone)
 add_subdirectory(plasma_steps)
 add_subdirectory(camera)
+add_subdirectory(ui_layout)
 add_subdirectory(settings)
 
 if(LBA2_BUILD_ASM_EQUIV_TESTS)

--- a/tests/ui_layout/CMakeLists.txt
+++ b/tests/ui_layout/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Host test for the authored UI canvas' placement rule (SOURCES/UI_LAYOUT.H). Header-only: no
+# engine sources to link, runs anywhere (Linux/macOS/Windows CI, no retail data). The UI's
+# behavioural fixtures are the golden captures in tests/automation and need retail data, so this
+# is the part of UI placement CI can see.
+add_executable(test_ui_layout test_ui_layout.cpp)
+
+target_include_directories(test_ui_layout PRIVATE
+    ${CMAKE_SOURCE_DIR}/SOURCES     # UI_LAYOUT.H
+    ${CMAKE_SOURCE_DIR}/LIB386/H    # SYSTEM/ADELINE_TYPES.H (S32)
+    ${CMAKE_SOURCE_DIR}/tests       # test_harness.h
+)
+target_compile_definitions(test_ui_layout PRIVATE
+    "TEST_SOURCE_ROOT=\"${CMAKE_SOURCE_DIR}/\""
+)
+set_target_properties(test_ui_layout PROPERTIES CXX_STANDARD 11)
+
+add_test(NAME test_ui_layout COMMAND test_ui_layout)
+register_host_test(test_ui_layout)

--- a/tests/ui_layout/test_ui_layout.cpp
+++ b/tests/ui_layout/test_ui_layout.cpp
@@ -1,0 +1,175 @@
+/* Host test for where the authored UI canvas sits in the framebuffer
+ * (SOURCES/UI_LAYOUT.H). Header-only: no engine sources to link, runs anywhere
+ * with no retail data.
+ *
+ * The UI's own fixtures are the golden captures in tests/automation, which boot
+ * the engine and need retail data and a display, so CI never sees them. What is
+ * here is the part it can see: the placement rule itself, checked at every
+ * dimension the resolution catalogue can produce rather than at the two sizes a
+ * capture happens to run at.
+ */
+#include "UI_LAYOUT.H"
+#include "test_harness.h"
+
+/* The bounds the engine accepts, from RES_CATALOG.H. Repeated rather than
+ * included because that header pulls in engine state; if they drift, the sweeps
+ * below simply cover a range wider than the engine can reach, which is the safe
+ * direction. */
+#define RES_MIN_W 320
+#define RES_MAX_W 1920
+#define RES_MIN_H 200
+#define RES_MAX_H 1200
+
+/* Every width the engine can be asked for is a multiple of 8. */
+#define W_STEP 8
+
+/* The classic mode is the one thing that must never move: at 640x480 the canvas
+ * is the framebuffer, so every offset is 0 and every authored literal lands
+ * exactly where it was authored. This is what makes the whole rule adoptable
+ * one site at a time. */
+static void test_the_classic_mode_is_untouched(void) {
+    ASSERT_EQ_INT(0, UiCanvasOriginY(480));
+    ASSERT_EQ_INT(0, UiCanvasBottomOfsY(480));
+    ASSERT_EQ_INT(320, UiCenterX(640));
+}
+
+/* The load-bearing half, and it is vertical only. A negative Y offset is not a UI
+ * that hangs off the edge, it is a write through an unclamped row-offset table,
+ * so the rule has to hold at every size and not merely at the ones a catalogue
+ * lists. X needs no such guarantee because SetClip clamps it, and demanding one
+ * would push the canvas centre off a narrow screen. */
+static void test_no_vertical_placement_is_ever_negative(void) {
+    S32 h;
+    S32 bad = 0;
+
+    for (h = 0; h <= RES_MAX_H; h++) {
+        if (UiCanvasOriginY(h) < 0 || UiCanvasBottomOfsY(h) < 0)
+            bad++;
+    }
+    ASSERT_EQ_INT(0, bad);
+}
+
+/* The canvas stays inside the framebuffer wherever it fits vertically, so a
+ * surface drawn at the origin for the canvas' full height ends on or before the
+ * last row. Below the canvas it cannot, and the test says so rather than
+ * pretending: the documented answer there is to clip at the bottom. */
+static void test_the_canvas_fits_vertically_wherever_it_can(void) {
+    S32 h;
+    S32 bad = 0;
+
+    for (h = UI_CANVAS_H; h <= RES_MAX_H; h++) {
+        if (UiCanvasOriginY(h) + UI_CANVAS_H > h)
+            bad++;
+        if (UiCanvasBottomOfsY(h) + UI_CANVAS_H > h)
+            bad++;
+    }
+    ASSERT_EQ_INT(0, bad);
+}
+
+/* What the conversion rests on: the named anchor and the ModeDesiredX / 2 the
+ * sites spell inline are the same number at every width, narrow ones included.
+ * If this fails, converting a site is a visible change rather than a rename, and
+ * the commit that does it is no longer behaviour-preserving.
+ *
+ * The narrow widths are in the sweep deliberately. Anchoring the canvas instead
+ * of the framebuffer was tried here, on the theory that a panel reaching 310
+ * left of centre wants clamping at 320 wide; it puts the canvas centre at 320,
+ * off the right edge, and the menu text with it. */
+static void test_center_matches_the_inline_spelling_at_every_legal_width(void) {
+    S32 w;
+    S32 bad = 0;
+
+    for (w = RES_MIN_W; w <= RES_MAX_W; w += W_STEP) {
+        if (UiCenterX(w) != w / 2)
+            bad++;
+    }
+    ASSERT_EQ_INT(0, bad);
+}
+
+/* Odd widths agree too, so the conversion cannot shift a site even if the
+ * multiple-of-8 rule the catalogue enforces is ever relaxed. */
+static void test_odd_widths_agree_as_well(void) {
+    ASSERT_EQ_INT(320, UiCenterX(641));
+    ASSERT_EQ_INT(324, UiCenterX(649));
+}
+
+/* Below the authored width a fixed-width panel runs off both edges, and the left
+ * edge goes negative. That is the drawing layer's problem, not this header's:
+ * SetClip clamps x to ClipWindowXMin, so the panel is clipped rather than written
+ * outside the framebuffer. Pinned here because the numbers look alarming enough
+ * to invite a clamp, and a clamp is the wrong answer.
+ *
+ * The narrow modes are 320x200, 320x240, 400x300 and 512x384 (RES_CATALOG.H). */
+static void test_a_wide_panel_hangs_off_both_edges_of_a_narrow_mode(void) {
+    /* GAMEMENU's 550-wide highlight bar, centred: -115 to 435 at 320 wide */
+    ASSERT_EQ_INT(-115, UiCenterX(320) - 275);
+    ASSERT_EQ_INT(435, UiCenterX(320) + 275);
+
+    /* CONFIG's 620-wide keybinding panel: -150 to 470 */
+    ASSERT_EQ_INT(-150, UiCenterX(320) - 310);
+    ASSERT_EQ_INT(470, UiCenterX(320) + 310);
+
+    /* and it is centred, which is what keeps the middle of the panel on screen */
+    ASSERT_EQ_INT(160, UiCenterX(320));
+    ASSERT_EQ_INT(200, UiCenterX(400));
+    ASSERT_EQ_INT(256, UiCenterX(512));
+}
+
+/* Short framebuffers were already clamped before this header existed; the point
+ * of the sweep is that moving the expression did not change any answer it gave. */
+static void test_short_framebuffers_fall_back_to_the_canvas_top(void) {
+    S32 h;
+    S32 bad = 0;
+
+    for (h = 0; h < UI_CANVAS_H; h++) {
+        if (UiCanvasOriginY(h) != 0 || UiCanvasBottomOfsY(h) != 0)
+            bad++;
+    }
+    ASSERT_EQ_INT(0, bad);
+    ASSERT_EQ_INT(0, UiCanvasOriginY(200));
+    ASSERT_EQ_INT(0, UiCanvasOriginY(240));
+}
+
+/* Tall and wide framebuffers centre. 1920x1080: 300 rows spare each side. */
+static void test_large_framebuffers_centre_the_canvas(void) {
+    ASSERT_EQ_INT(300, UiCanvasOriginY(1080));
+    ASSERT_EQ_INT(600, UiCanvasBottomOfsY(1080));
+    ASSERT_EQ_INT(960, UiCenterX(1920));
+
+    /* the shipped widescreen mode, where the canvas is as tall as the framebuffer */
+    ASSERT_EQ_INT(0, UiCanvasOriginY(480));
+    ASSERT_EQ_INT(384, UiCenterX(768));
+}
+
+/* Centring is monotonic: a bigger framebuffer never moves the UI left or up. A
+ * non-monotonic step would mean a resolution switch could walk the UI backwards. */
+static void test_placement_never_moves_backwards(void) {
+    S32 d;
+    S32 bad = 0;
+
+    for (d = 1; d <= RES_MAX_W; d++) {
+        if (UiCenterX(d) < UiCenterX(d - 1))
+            bad++;
+    }
+    for (d = 1; d <= RES_MAX_H; d++) {
+        if (UiCanvasOriginY(d) < UiCanvasOriginY(d - 1))
+            bad++;
+        if (UiCanvasBottomOfsY(d) < UiCanvasBottomOfsY(d - 1))
+            bad++;
+    }
+    ASSERT_EQ_INT(0, bad);
+}
+
+int main(void) {
+    RUN_TEST(test_the_classic_mode_is_untouched);
+    RUN_TEST(test_no_vertical_placement_is_ever_negative);
+    RUN_TEST(test_the_canvas_fits_vertically_wherever_it_can);
+    RUN_TEST(test_center_matches_the_inline_spelling_at_every_legal_width);
+    RUN_TEST(test_odd_widths_agree_as_well);
+    RUN_TEST(test_a_wide_panel_hangs_off_both_edges_of_a_narrow_mode);
+    RUN_TEST(test_short_framebuffers_fall_back_to_the_canvas_top);
+    RUN_TEST(test_large_framebuffers_centre_the_canvas);
+    RUN_TEST(test_placement_never_moves_backwards);
+    TEST_SUMMARY();
+    return test_failures != 0;
+}


### PR DESCRIPTION
## What & why

The 2D UI is authored against a 640x480 canvas and drawn into a framebuffer of
whatever size the player picked. Reconciling the two is one rule, and it was in
two places at once: the vertical half was a pair of clamped macros in
`SOURCES/DEFINES.H`, and the horizontal half was written out inline at each site
as `ModeDesiredX / 2` (455 reads of the mode dimensions across the tree, 87 of
them that halving).

This puts both halves in `SOURCES/UI_LAYOUT.H` under a host test, and converts
the game menu surface to the named anchor. It also adds the refactor recipe the
last two extractions followed to `docs/FEATURE_WORKFLOW.md`, which had only
feature-shaped examples.

Nothing changes on screen at any resolution. The four commits are meant to be
read one at a time.

## Notes for reviewers

**The two axes are deliberately not symmetric**, and that is most of what the
new header is for. Y is clamped at the canvas top below 480 because a negative
offset reaches `TabOffLine[]`, which `BackupAngles` and the pixel-shift macros
index without a bounds check, so it is a write outside the framebuffer. X is not
clamped, because a negative x goes through `SetClip`, which clamps it to
`ClipWindowXMin`.

Mirroring the Y clamp onto X was the original plan here, on the theory that a
620-wide panel at `-150` in the 320-wide modes wanted fixing. It was built, then
captured at 320x240: anchoring the canvas puts its centre at 320, off the right
edge of the screen, so the menu highlight bar started at x=45 and the item text
left the frame. Reverted, and the header, the test and `docs/WIDESCREEN.md` now
record it so the next reader does not repeat it.

That leaves the intermittent sub-640 segfault in `docs/CONTROL.md` unexplained.
It is Windows-only, does not reproduce on Linux at either narrow mode, and is
not this arithmetic.

**Deliberately out of scope:** the 44 uses of `ModeDesiredX` as a row stride and
the 112 full-framebuffer rect edges are different concepts that happen to share a
variable, and the iso projection origin carries its own alignment constraint.
Three sites inside the converted files are left alone for the same reason (the
two projection origins, and the saved-message overlay that is screen-centred in
both axes). The other UI surfaces (CONFIG, MESSAGE, INVENT, HOLOPLAN) are
one-surface-per-PR follow-ups.

### Verification

- `ctest -L host_quick`: 59/59, including the new `test_ui_layout` (9 tests, no
  retail data, runs on every platform).
- Menu goldens: `ui_menu_main`, `ui_menu_main_fresh`, `ui_menu_options`,
  `ui_menu_options_wide`, `ui_display`, plus `res_switch` and `res_switch_cfg`.
- Byte-identical captures against a build with only the converted files reverted,
  on `menu-main` and `menu-options` at 640x480, 768x480, 1280x720 and 1920x1080,
  and on `menu-main` at 320x240. Worth knowing: `ctl_headless` pins
  `--resolution 640x480`, `ui_compare_wide` is the only fixture that leaves it,
  and no committed golden covers HD or sub-640, so those tiers were checked by
  hand.
- Both oracles validated by breaking them: dropping the clamp fails 6 host
  assertions, shifting the anchor 4px fails the menu goldens.
- `check-format.sh`, `check-docs-links.sh`, `check-docs-symbols.py` clean.

## Checklist

- [x] Build passes on my platform (Linux)
- [x] If LIB386 / 3DEXT touched: ASM equivalence tests pass (`./run_tests_docker.sh`)
- [x] If behavior changes: opt-in via flag/cvar/config (preserves default game feel)
- [x] Docs updated in the same PR if behavior or workflow changed
- [x] French comments and ASCII art preserved in any modified files
