### PR TITLE
test(ui): assert the menu still lands right on a taller framebuffer

### DIFF
--- a/docs/WIDESCREEN.md
+++ b/docs/WIDESCREEN.md
@@ -247,6 +247,20 @@ golden (`ui_compare_wide` in `lib.sh`). No per-resolution goldens; the 640 golde
 stays the single source of truth, which keeps the test honest against future
 projection or UI changes.
 
+**Tall coverage.** `test_ui_menu_options_hd.sh` and `test_ui_menu_options_uhd.sh`
+run the same comparison at 1280×720 and 1920×1080. They exist because 480 was the
+tallest frame anything asserted against: `ui_compare_wide` already took a
+resolution argument, but every caller passed a 480-tall one, so nothing exercised
+the vertical float at all. Adding 3 lines to `UI_VCENTER_OFS` leaves the 640 and
+768 fixtures green and turns both of these red, which is the coverage they add.
+1080 is worth its own rung as the `ADELINE_MAX_Y_RES` boundary, where the float is
+300 lines rather than 120.
+
+`menu-main` is deliberately not covered above 640 at any height. It composites over
+the live sky rather than `--black-bg`, and a taller or wider frame shows more of
+that scene: the crop differs by ~133k pixels at 768×480 before anything about the
+UI has moved. Only the cleanroom captures can be compared this way.
+
 **Still not protected** at wider widths:
 
 - Dialog. The dialog text strip is full-framebuffer-width by design (it scales with

--- a/tests/automation/test_ui_menu_options_hd.sh
+++ b/tests/automation/test_ui_menu_options_hd.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# ui menu-options @ 1280x720: the first mode the resolution menu offers where the
+# framebuffer is taller than the 480-line authored canvas, so UI_VCENTER_OFS is
+# non-zero and the UI floats vertically as well as horizontally. Asserts the
+# centred 640x480 crop of the capture is byte-identical to the 640 golden.
+#
+# Pairs with test_ui_menu_options.sh (640 pinned) and _wide (768x480, which only
+# moves the UI horizontally). Until this test the goldens stopped at 768: the
+# helper took a resolution argument, nothing passed it one above 480 tall, and a
+# regression in the vertical float would have shown up only in manual play.
+#
+# menu-main is deliberately not covered at any width above 640. It renders over
+# the live sky scene rather than --black-bg, and a wider frame shows more of that
+# scene: the crop differs by ~133k pixels at 768 before anything about the UI has
+# moved. Only the cleanroom capture can be compared this way.
+TESTNAME=ui_menu_options_hd
+. "$(dirname "$0")/lib.sh"
+precheck
+
+LBA2_TEST_SAVE="$REPO/tests/savegame/corpus/saves/steam_classic_2023/Anon1.LBA"
+GOLDEN="$REPO/tests/savegame/corpus/baselines/ui/menu_options_Anon1.png"
+
+[ -f "$LBA2_TEST_SAVE" ] || skip "fixture save missing: $LBA2_TEST_SAVE"
+
+# Same plasma-strip exclusion as test_ui_menu_options.sh, in the 640 golden's
+# coordinates: the centred crop has already put both images on one origin.
+ui_compare_wide "1280x720" --exclude 46,71,549,49 "--black-bg menu-options" "$GOLDEN"

--- a/tests/automation/test_ui_menu_options_uhd.sh
+++ b/tests/automation/test_ui_menu_options_uhd.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# ui menu-options @ 1920x1080: the tallest framebuffer the engine accepts
+# (ADELINE_MAX_Y_RES, which sizes TabOffLine[]), and so the largest vertical
+# float the authored canvas ever sits at: UI_VCENTER_OFS is 300 here against
+# 120 at 720. Asserts the centred 640x480 crop of the capture is byte-identical
+# to the 640 golden.
+#
+# Pairs with test_ui_menu_options_hd.sh. Two rungs rather than one because this
+# is the boundary: a rounding or clamp error in the float that stays invisible
+# at 720 has 300 lines to show itself in here, and this is the mode where a row
+# table overrun would land outside the buffer rather than inside the next one.
+TESTNAME=ui_menu_options_uhd
+. "$(dirname "$0")/lib.sh"
+precheck
+
+LBA2_TEST_SAVE="$REPO/tests/savegame/corpus/saves/steam_classic_2023/Anon1.LBA"
+GOLDEN="$REPO/tests/savegame/corpus/baselines/ui/menu_options_Anon1.png"
+
+[ -f "$LBA2_TEST_SAVE" ] || skip "fixture save missing: $LBA2_TEST_SAVE"
+
+# Same plasma-strip exclusion as test_ui_menu_options.sh, in the 640 golden's
+# coordinates: the centred crop has already put both images on one origin.
+ui_compare_wide "1920x1080" --exclude 46,71,549,49 "--black-bg menu-options" "$GOLDEN"


### PR DESCRIPTION
## What & why

The UI goldens stopped at 480 lines. `ui_compare_wide` already took a resolution
argument, but every caller passed a 480-tall one (`768x480`), so nothing in the
suite ever asserted anything about a framebuffer taller than the authored 640x480
canvas. The vertical float that centres the canvas in such a frame
(`UI_VCENTER_OFS`) had no test at any height, on any surface.

Adds the same cleanroom comparison at 1280x720 and 1920x1080. No new machinery
and no new golden files: both reuse `ui_compare_wide` and the existing 640
golden, which stays the single source of truth.

## Notes for reviewers

Both pass as things stand, so this is a net rather than a fix. The demonstration
that it is a net worth having: adding 3 lines to `UI_VCENTER_OFS` leaves
`test_ui_menu_options.sh` and `_wide` **green** and turns both new tests red.
That is the gap, exactly.

1080 gets its own rung rather than being folded into 720 because it is the
`ADELINE_MAX_Y_RES` boundary, the value that sizes `TabOffLine[]`. The float is
300 lines there against 120 at 720, so a rounding or clamp error with nowhere to
show itself at 720 has room to here.

`menu-main` is deliberately still uncovered above 640, at any height. I probed
it: it composites over the live sky rather than `--black-bg`, so a bigger frame
simply shows more scene and the centred crop differs by ~133k pixels at 768x480
before anything about the UI has moved. That is the reason the existing `_wide`
fixture covers only the options screen, and it holds at HD for the same reason.

Found while checking #558 across resolution tiers by hand. Independent of that
PR: no shared files, and this branch is cut from `main`.

## Checklist

- [x] Build passes on my platform (Linux)
- [ ] If LIB386 / 3DEXT touched: ASM equivalence tests pass (`./run_tests_docker.sh`)
- [x] If behavior changes: opt-in via flag/cvar/config (preserves default game feel)
- [x] Docs updated in the same PR if behavior or workflow changed
- [x] French comments and ASCII art preserved in any modified files
