### PR TITLE
chore(dev): the fuzz hunt driver and the arena isolation flag

### DIFF
--- a/SOURCES/MEM.CPP
+++ b/SOURCES/MEM.CPP
@@ -197,6 +197,36 @@ void InitMainBuffer(void) {
         SizeOfMemAllocated += ptrm->Size;
     }
 
+    /* LBA2_DBG_ISOLATE: hand every region its own allocation instead of slicing
+       them out of one block.
+
+       The single-allocation layout below is what ships, and it hides a whole
+       class of bug: a write that runs off the end of one region lands in its
+       neighbour without leaving the allocation, so no sanitizer ever reports
+       it, and the damage surfaces later as garbage data somewhere unrelated.
+       Under this flag the gaps between regions become real redzones and ASan
+       names the code that wrote past.
+
+       Off unless the environment variable is set, so shipping behaviour and
+       memory layout are unchanged. The deliberate aliases are preserved
+       (BufCube and BufferBrick live inside PtrZBuffer), and each region gets a
+       little slack because the original ASM touches one element past a box
+       edge on purpose, which would otherwise mask the spill being hunted.
+       See docs/BUG_HUNTING.md. */
+    if (getenv("LBA2_DBG_ISOLATE")) {
+        ptrm = ListMem;
+        for (t = 0; t < NB_MEM_ELTS; t++, ptrm++) {
+            *ptrm->AdrPtr = (U8 *)Malloc(ptrm->Size + 256);
+            if (!*ptrm->AdrPtr)
+                TheEnd(NOT_ENOUGH_MEM, "MainBuffer");
+        }
+        MainBuffer = (U8 *)*ListMem[0].AdrPtr;
+        BufCube = (U8 *)*ListMem[MEM_PTR_ZBUFFER].AdrPtr;
+        BufferBrick = BufCube + (SIZE_CUBE_X * SIZE_CUBE_Y * SIZE_CUBE_Z * 2L);
+        fprintf(stderr, "[dbg] regions isolated for ASan\n");
+        return;
+    }
+
     // Alloue gros buffer
 
     MainBuffer = (U8 *)Malloc(SizeOfMemAllocated);

--- a/docs/BUG_HUNTING.md
+++ b/docs/BUG_HUNTING.md
@@ -26,11 +26,11 @@ Three parts, and the third is the one people miss.
 
 3. **Un-merge the arena.** `InitMainBuffer()` in SOURCES/MEM.CPP hands eleven buffers out of a
    single `Malloc`. A spill from one region into its neighbour never leaves that allocation, so
-   **no sanitizer will ever report it**. Give each region its own allocation behind a debug env
-   var and the redzones become real. Keep the deliberate aliases intact (`BufCube` and
-   `BufferBrick` live inside `PtrZBuffer`; `tabflag` is `Screen + OFFSET_BUFFER_FLAG`) or the
-   isolation invents faults that do not exist. Add a little slack per region: the original ASM
-   deliberately touches one element past a box edge, and that known quirk otherwise masks the
+   **no sanitizer will ever report it**. Set `LBA2_DBG_ISOLATE=1` and each region gets its own
+   allocation, which turns the gaps into real redzones and names the writer. Off by default, so
+   shipping layout is unchanged. It preserves the deliberate aliases (`BufCube` and `BufferBrick`
+   live inside `PtrZBuffer`) and leaves a little slack per region, because the original ASM
+   touches one element past a box edge on purpose and that known quirk would otherwise mask the
    spill you are hunting.
 
 Neighbour order matters when reading a symptom. `TabBlock` sits immediately after `BufMap`, so a
@@ -58,6 +58,35 @@ handles the dialogue and found-object paths; if you add a new modal, extend it.
 **Match the configuration to what people run.** Resolutions below 640x480 are catalogued but
 essentially unused, and a driver that spends a third of its budget there produces real bugs nobody
 will ever hit. Classic, widescreen and HD are where the risk is.
+
+## The driver
+
+`scripts/dev/probe_fuzzy_hunt.py` is the harness the above describes. One engine per run over
+`--listen`, a randomised sequence of player-shaped actions, and the log of any run that dies or
+reports:
+
+```
+export LBA2_BIN=./build-san/SOURCES/lba2cc
+export LBA2_GAME_DIR=/path/to/retail
+export LBA2_SAVE=/path/to/save/Spaceship.LBA
+python3 scripts/dev/probe_fuzzy_hunt.py 8 45 700     # runs, actions per run, first seed
+```
+
+Build the binary with both sanitizers and run with `LBA2_DBG_ISOLATE=1`, or the arena hides the
+interesting half of what it finds.
+
+Everything is seeded from the run index, so a finding replays exactly:
+
+```
+python3 scripts/dev/probe_fuzzy_hunt.py 1 45 704     # just seed 704, same actions
+```
+
+That replay is the A/B. Point `LBA2_BIN` at a pre-fix binary and it reproduces; point it at the
+fixed one and it goes quiet. Keep a copy of the binary you were hunting with, since rebuilding
+under a running sweep will break it.
+
+Two knobs worth changing per campaign: `RESOLUTIONS`, which should hold the modes people actually
+run, and the weights in `actions_for()`, which decide where the budget goes.
 
 ## Oracle discipline
 

--- a/scripts/dev/probe_fuzzy_hunt.py
+++ b/scripts/dev/probe_fuzzy_hunt.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Drive the engine through messy, player-shaped sequences and keep whatever breaks.
+
+The deterministic sweeps walk one axis at a time, which is what makes them good at
+pinning a known fault down and bad at finding new ones. A player does not do that:
+they open the holomap mid-scene, change resolution from the options menu, watch a
+video, load a save, and wander into another cube, all against whatever state the
+last thing left behind. This drives those combinations over the control socket
+under ASan and UBSan, one engine per run, and keeps the log of any run that dies
+or reports.
+
+Usage: probe_fuzzy_hunt.py [runs] [actions-per-run] [seed-base]
+"""
+import os
+import random
+import subprocess
+import sys
+import tempfile
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from lba2ctl import Control, engine_binary, env_path, game_dir
+
+BIN = engine_binary()
+SAVE = env_path("LBA2_SAVE", "a save to boot into, as a full path")
+PORT = 4461
+RUNS = int(sys.argv[1]) if len(sys.argv) > 1 else 6
+ACTIONS = int(sys.argv[2]) if len(sys.argv) > 2 else 40
+SEED_BASE = int(sys.argv[3]) if len(sys.argv) > 3 else 0
+
+# Cubes that load cleanly; 222+ are absent from the data and exit 1 by design.
+CUBES = [0, 1, 2, 4, 5, 7, 8, 10, 11, 13, 14, 16, 17, 19, 20, 22, 23, 25, 26, 27,
+         29, 31, 32, 34, 35, 37, 38, 40, 41, 50, 60, 70, 80, 90, 100, 120, 150, 180]
+RESOLUTIONS = ["640x480", "768x480", "1024x480", "1280x720", "1920x1080", "1024x768", "1152x648", "960x540"]
+ITEMS = ["magicball", "sabre", "holomap", "tunic", "protopack", "ferryticket"]
+BEHAVIOURS = ["0", "1", "2", "3"]
+INPUTS = ["up 6", "down 6", "left 6", "right 6", "action 4", "search 4", "throw 4"]
+
+
+def actions_for(rng, shots):
+    """One player-shaped action, weighted toward the transitions that mix state."""
+    pick = rng.random()
+    if pick < 0.30:
+        return f"cube {rng.choice(CUBES)}"
+    if pick < 0.45:
+        # UI modals composite over the live scene and some memset shared buffers.
+        modal = rng.choice(["inventory", "holomap", "menu-options", "menu-main", "config"])
+        return f"ui {modal} {shots}/ui_{modal}_{rng.randrange(1 << 20)}.png"
+    if pick < 0.58:
+        # Runtime resolution reallocates the framebuffers under everything.
+        return f"resolution {rng.choice(RESOLUTIONS)}"
+    if pick < 0.68:
+        return f"input {rng.choice(INPUTS)}"
+    if pick < 0.76:
+        return f"give {rng.choice(ITEMS)}"
+    if pick < 0.82:
+        return f"behaviour {rng.choice(BEHAVIOURS)}"
+    if pick < 0.87:
+        return f"teleport {rng.randrange(0, 60000)} {rng.choice([256, 1536, 3584])} {rng.randrange(0, 60000)}"
+    if pick < 0.91:
+        return f"playjingle {rng.randrange(1, 27)}"
+    if pick < 0.95:
+        return f"screenshot {shots}/shot_{rng.randrange(1 << 20)}.png"
+    if pick < 0.965:
+        return f"weapon {rng.randrange(0, 4)}"
+    if pick < 0.975:
+        # Scripts read these, so poking them exercises life/track code paths.
+        return f"vargame {rng.randrange(0, 40)} {rng.randrange(0, 4)}"
+    if pick < 0.985:
+        return f"varcube {rng.randrange(0, 40)} {rng.randrange(0, 4)}"
+    if pick < 0.995:
+        return f"useitem {rng.randrange(0, 8)}"
+    return "status"
+
+
+def run(seed):
+    rng = random.Random(seed)
+    user_dir = tempfile.mkdtemp(prefix=f"lba2-hunt{seed}-")
+    shots = os.path.join(user_dir, "shots")
+    os.makedirs(shots, exist_ok=True)
+    log_path = os.path.join(user_dir, "engine.log")
+    env = dict(os.environ,
+               ASAN_OPTIONS="detect_leaks=0",
+               UBSAN_OPTIONS="print_stacktrace=1",
+               LBA2_DBG_ISOLATE="1")
+
+    with open(log_path, "wb") as log:
+        p = subprocess.Popen(
+            [BIN, "--headless", "--no-audio", "--game-dir", game_dir(),
+             "--user-dir", user_dir, "--no-autosave", "--load", SAVE,
+             "--listen", str(PORT)],
+            stdout=log, stderr=log, env=env)
+
+    conn = None
+    for _ in range(240):
+        time.sleep(0.25)
+        if p.poll() is not None:
+            break
+        try:
+            conn = Control(PORT, timeout=30)
+            break
+        except OSError:
+            continue
+    if conn is None:
+        return seed, None, "engine never came up", log_path
+
+    history = []
+    died_on = None
+    try:
+        # Without this, the first `give` opens a found-object dialog that waits
+        # for a keypress no headless run will ever send, the socket times out,
+        # and the run reports a death a handful of actions in. Every wave before
+        # this was exploring a fraction of its intended depth.
+        conn.send("skipmodals 1")
+        for _ in range(ACTIONS):
+            cmd = actions_for(rng, shots)
+            history.append(cmd)
+            try:
+                conn.send(cmd)
+                # Let the engine actually run frames; a command per PRESENT is the trap.
+                time.sleep(rng.choice([0.15, 0.3, 0.6]))
+                conn.send("status")
+            except Exception:
+                died_on = cmd
+                break
+    finally:
+        if p.poll() is None:
+            try:
+                p.terminate()
+                p.wait(timeout=10)
+            except Exception:
+                p.kill()
+
+    return seed, died_on, history, log_path
+
+
+def main():
+    findings = 0
+    for i in range(RUNS):
+        seed = SEED_BASE + i
+        seed, died_on, history, log_path = run(seed)
+
+        reports = []
+        try:
+            with open(log_path, "r", errors="replace") as fh:
+                for line in fh:
+                    if "ERROR: AddressSanitizer" in line or "runtime error:" in line:
+                        reports.append(line.strip())
+        except OSError:
+            pass
+
+        if died_on or reports:
+            findings += 1
+            print(f"seed {seed}: died_on={died_on!r} reports={len(reports)}")
+            for r in reports[:4]:
+                print(f"   {r[:160]}")
+            print(f"   log: {log_path}")
+            if isinstance(history, list):
+                print(f"   last actions: {history[-6:]}")
+        else:
+            print(f"seed {seed}: clean")
+
+    print(f"{findings}/{RUNS} runs produced something")
+
+
+main()


### PR DESCRIPTION
**Stacked on #557** (the runbook), since the doc section describing this tool lives there. Review that one first; this branch contains its commit as a base.

Two halves of the same tool, and neither is much use alone.

## `scripts/dev/probe_fuzzy_hunt.py`

One engine per run over the control socket, driven through a randomised sequence of player-shaped actions: scene changes, UI modals, runtime resolution, input, pickups, behaviour, teleports, jingles, screenshots. Keeps the log of any run that dies or reports.

```
export LBA2_BIN=./build-san/SOURCES/lba2cc
export LBA2_GAME_DIR=/path/to/retail
export LBA2_SAVE=/path/to/save/Spaceship.LBA
python3 scripts/dev/probe_fuzzy_hunt.py 8 45 700     # runs, actions per run, first seed
```

Everything is seeded from the run index, so a finding replays exactly:

```
python3 scripts/dev/probe_fuzzy_hunt.py 1 45 704     # just seed 704
```

**That replay is the A/B.** Point `LBA2_BIN` at a pre-fix binary and it reproduces; point it at the fixed one and it goes quiet. It beats deriving a repro by hand, which failed twice during this campaign for findings a seed replayed on demand.

## `LBA2_DBG_ISOLATE`

Hands each `MainBuffer` region its own allocation instead of slicing eleven out of one block.

The shipping layout hides an entire class of bug: a write that runs off one region lands in its neighbour without ever leaving the allocation, so no sanitizer reports it and the damage surfaces later as garbage somewhere unrelated. Under the flag those gaps become real redzones and ASan names the writer.

Off unless the variable is set, so shipping behaviour and memory layout are unchanged. It preserves the deliberate aliases (`BufCube` and `BufferBrick` inside `PtrZBuffer`) and leaves a little slack per region, because the original ASM touches one element past a box edge on purpose and that quirk would otherwise mask the spill being hunted.

## Why both

Between them these produced the defects in #553, #554 and #555, including the options-screen stack smash and the Z-clip divergence from the original ASM. Without the isolation flag roughly half of those are invisible; without the driver nothing reaches the code paths in the first place.

## Notes for review

- The driver needs retail data and a save, so it is a dev tool rather than a CI job. It is not wired into ctest.
- Two knobs are meant to be edited per campaign: `RESOLUTIONS` should hold the modes people actually run, and the weights in `actions_for()` decide where the budget goes.
- Known limitation: it counts a socket timeout as a death, so any modal that waits for input reads as a finding and truncates the run. #556 fixes the one that mattered (`give`); if you add a new blocking modal, extend `skipmodals` or the runs will quietly get shallower.
