### PR TITLE
docs(plan): a refactor roadmap ordered by what tests cover

### DIFF
--- a/docs/FEATURE_WORKFLOW.md
+++ b/docs/FEATURE_WORKFLOW.md
@@ -104,46 +104,67 @@ that is spelled inline at many call sites into one place, without changing behav
 
 **Reasoning:**
 
-1. **CODESTYLE.md first:** ["Where new code goes"](../CODESTYLE.md#where-new-code-goes) and
+1. **Count what CI can see of the code you are about to move, before anything else.** A
+   refactor promises the behaviour is unchanged, and that promise is only worth what the tests
+   backing it are worth. Find out which they are first:
+
+   ```bash
+   # is any of it linked into a host test (the only thing CI runs on every push)?
+   grep -rn "SOURCES/YOUR_FILE.CPP" tests/*/CMakeLists.txt
+   # is there a fixture that drives it? (local only: needs retail data and a display)
+   grep -rln "your-verb\|YourFunc" tests/automation/
+   ```
+
+   Expect the answer to be no. Roughly **5% of `SOURCES` is linked into a host test**, and every
+   file that is has no 1997 ancestor; the 59 fixtures in `tests/automation` are referenced by no
+   workflow, and `LBA2_BUILD_ASM_EQUIV_TESTS` is `OFF` in all of them. So for most of the tree
+   the honest starting position is that nothing would catch you.
+
+   **If nothing covers it, building that cover is the first commit of the refactor, not a later
+   one.** Not a full suite: one host test over the part that can be reached without engine
+   state, or one fixture pinning the surface as it behaves today. Everything below assumes it
+   exists, and none of it is safe without it. [docs/TESTING.md](TESTING.md) has what runs where.
+
+2. **CODESTYLE.md next:** ["Where new code goes"](../CODESTYLE.md#where-new-code-goes) and
    ["Features and surfaces"](../CODESTYLE.md#features-and-surfaces) say what the result has to look
    like: a new subsystem gets its own TU, a module owns its own state, and a surface must not name a
    feature's variables. What follows is the order to get there in, distilled from the two extractions
    that have been done this way (the Auto camera, PRs #533/#540/#542/#544, and the cfg reader, #541).
 
-2. **Cut along the testable line first.** The part that reads no engine globals comes out before
+3. **Cut along the testable line first.** The part that reads no engine globals comes out before
    anything moves, as a header with a host test. From then on the refactor has an oracle that runs on
    every platform with no retail data. [SOURCES/FOLLOWCAM_MATH.H](../SOURCES/FOLLOWCAM_MATH.H) is the
    worked example, tested by `tests/camera/test_followcam_math.cpp`, and it landed a full PR before
    the module itself moved. If you cannot name that part, you are not ready to start.
 
-3. **Make the extracted part correct on its own terms.** A helper lifted out of one call site leans
+4. **Make the extracted part correct on its own terms.** A helper lifted out of one call site leans
    on guarantees that caller happened to provide. Restore them inside the helper even where they are
    inert today, and say in the comment that they are inert and why:
    [`FollowCamRotStep`](../SOURCES/FOLLOWCAM_MATH.H) carries an overshoot clamp its two callers can
    never trigger, because a later change to either constant would otherwise walk the camera past its
    target.
 
-4. **Move before you change.** The commit that creates the file is a move: same lines, new home, no
+5. **Move before you change.** The commit that creates the file is a move: same lines, new home, no
    edits. `refactor(camera): give the Auto camera its own file` is 472 insertions against 420
    deletions across four files, and reviewing it is checking that nothing changed. What you want to
    fix on the way gets its own commit afterwards.
 
-5. **Then ownership.** The header declares exactly what the `.CPP` defines, and the module's globals
+6. **Then ownership.** The header declares exactly what the `.CPP` defines, and the module's globals
    come out of [SOURCES/C_EXTERN.H](../SOURCES/C_EXTERN.H) and
    [SOURCES/GLOBAL.CPP](../SOURCES/GLOBAL.CPP). The mechanical test is the include list: after the
    move, the files that genuinely use the module are the ones that had to add the include. For the
    camera that was seven, against the ninety-odd that could previously reach it by accident.
 
-6. **Then surfaces, one entry point each.** The cfg reader, the console, the CLI table and the
+7. **Then surfaces, one entry point each.** The cfg reader, the console, the CLI table and the
    options menu call into the module rather than naming its variables. Expect exactly one leak of
    private state and give it a named entry point instead of widening the header; both extractions so
    far found exactly one.
 
-7. **Bugs found on the way are not part of the refactor.** They get their own commit, test first and
+8. **Bugs found on the way are not part of the refactor.** They get their own commit, test first and
    allowed to fail, as in `test(camera): put the HD recompose rule under CI, and let two tests fail`
    followed by the fix. A behaviour change buried in a move commit is invisible to review.
 
-8. **Write the rule down as you find it.** Three `docs(style)` commits landed inside those PRs, each
+9. **Write the rule down as you find it.** Three `docs(style)` commits landed inside those PRs, each
    recording something the extraction had just taught. Later means never.
 
 **Docs to update:** the subsystem's own doc if the layout it describes moved, and
@@ -168,9 +189,11 @@ exactly what that check exists to catch.
 The list above is feature-shaped: it assumes new behaviour and asks what to document. A refactor
 promises the opposite, so its risks are different.
 
-1. **Get an oracle before touching anything.** A refactor with no way to say "same as before" is a
-   rewrite. Host tests are the cheapest (no retail data, every platform); the UI goldens in
-   `tests/automation` and the projection corpus cover what needs a booted engine.
+1. **Get an oracle before touching anything**, per step 1 of Example 5. A refactor with no way to
+   say "same as before" is a rewrite, and in this tree the default is that no such way exists.
+   Host tests are the cheapest (no retail data, every platform); the UI goldens in
+   `tests/automation` and the projection corpus cover what needs a booted engine, at the price
+   of not running in CI.
 2. **No behaviour change inside a refactor commit.** If a commit both moves code and fixes
    something, split it. This repo reviews per commit rather than splitting PRs, and that only works
    when each commit answers one question.

--- a/docs/README.md
+++ b/docs/README.md
@@ -111,6 +111,7 @@ doc is now history: where it disagrees with the code, the code wins.
 | [INPUT_REPLAY_RESEARCH.md](plan/INPUT_REPLAY_RESEARCH.md) | Research | Capturing input per tick and replaying a session as a gameplay-regression net, the counterpart to the draw-call [polyrec](POLYREC.md). No implementation. |
 | [LBA1_PORT_PLAN.md](plan/LBA1_PORT_PLAN.md) | Proposed | Awaiting go/no-go: how to bring LBA1 to this groundwork. Costs three paths, recommends hosting LBA1 content on the lba2cc engine behind a game-id, with a feasibility-spike ladder. Companion to [LBA1_PORTING_SURFACE.md](LBA1_PORTING_SURFACE.md). |
 | [PLATFORM_PAL_PLAN.md](plan/PLATFORM_PAL_PLAN.md) | Proposed | Awaiting go/no-go: in-place Platform Abstraction Layer decoupling the engine from direct SDL3. SDL-surface audit, RFC #120 reconciliation, PR-sequenced extraction with a headless backend. |
+| [REFACTOR_ROADMAP.md](plan/REFACTOR_ROADMAP.md) | Living | Which areas are worth restructuring and what each one buys, ordered by what tests cover them rather than by how untidy they are. Measures what CI can actually see: 5% of `SOURCES/`, and no 1997 game logic at all. Companion to [FEATURE_WORKFLOW.md](FEATURE_WORKFLOW.md) Example 5. |
 | [RENDER_INTERP_PLAN.md](plan/RENDER_INTERP_PLAN.md) | Proposed | Smooth motion above the sim rate (#412), building on the fixed-timestep sim in [MOVEMENT_FRAMERATE.md](MOVEMENT_FRAMERATE.md). Nothing landed. |
 
 ## External resources

--- a/docs/plan/REFACTOR_ROADMAP.md
+++ b/docs/plan/REFACTOR_ROADMAP.md
@@ -1,0 +1,241 @@
+# Refactor roadmap
+
+Which parts of the tree are worth restructuring, what each one actually buys, and the order
+that follows from it. A companion to [CODESTYLE.md](../../CODESTYLE.md), which says what the
+result should look like, and [FEATURE_WORKFLOW.md](../FEATURE_WORKFLOW.md) Example 5, which
+says what order to do one in.
+
+Measured against `main` on 2026-08-18. Numbers age; re-run the commands in each section rather
+than trusting them.
+
+## The rule that decides the order
+
+**Test coverage gates everything.** A refactor is a promise that behaviour did not change, and
+that promise is worth exactly what the tests behind it are worth. So an area's position here is
+set by what covers it today, not by how untidy it is.
+
+Where an area has no cover, that does not disqualify it. It means the first commit builds the
+cover, and the area costs more than its line count suggests.
+
+## What CI can see today
+
+| Scope | Lines | Linked into a host test | Runs in CI |
+|---|---|---|---|
+| `SOURCES/` | 73,499 | 4,171 (**5%**), 19 files | yes, every push, 3 platforms |
+| `LIB386/` | 43,222 | 7,238 (**16%**), 25 files | yes |
+| `tests/automation` (59 fixtures) | n/a | n/a | **no workflow references it** |
+| ASM equivalence tests | n/a | n/a | **no**, `LBA2_BUILD_ASM_EQUIV_TESTS` is OFF everywhere |
+
+Two things follow, and they shape every section below.
+
+**Every host-tested file in `SOURCES/` is a community TU.** Not one line of 1997 game logic is
+reachable from a test CI runs. The 5% is `CLI_ARGS`, `RES_*`, `SAVEGAME_WIRE`, `AUDIO_BALANCE`
+and their neighbours, all written in this fork.
+
+**The best coverage in the repo does not run anywhere automatic.** The 59 fixtures drive a real
+engine and catch real regressions, but they need retail data and a display, so they run when
+someone remembers. The ASM equivalence suite is stronger still and needs Docker and a 32-bit
+toolchain. Both are opt-in, which is why an area can be well covered on paper and unguarded in
+practice.
+
+Reproduce:
+
+```bash
+grep -rhoE "SOURCES/[A-Z_0-9]+\.CPP" tests/*/CMakeLists.txt | sort -u   # what a host test links
+grep -rn "LBA2_BUILD_ASM_EQUIV_TESTS" .github/workflows/                # OFF in all of them
+```
+
+## Growth since the 1997 import
+
+The import is `333929ab`. How far each original file has drifted says where new work has been
+landing, which is where the dialect rule stops being decidable:
+
+| File | 1997 | now | delta |
+|---|---|---|---|
+| [SOURCES/GAMEMENU.CPP](../../SOURCES/GAMEMENU.CPP) | 3,521 | 5,292 | **+1,771 (+50%)** |
+| [SOURCES/PERSO.CPP](../../SOURCES/PERSO.CPP) | 2,562 | 3,205 | +643 (+25%) |
+| [SOURCES/SAVEGAME.CPP](../../SOURCES/SAVEGAME.CPP) | 1,544 | 2,015 | +471 (+30%) |
+| [SOURCES/GRILLE.CPP](../../SOURCES/GRILLE.CPP) | 1,155 | 1,498 | +343 (+29%) |
+| [SOURCES/CONFIG.CPP](../../SOURCES/CONFIG.CPP) | 1,273 | 1,455 | +182 (+14%) |
+| [SOURCES/OBJECT.CPP](../../SOURCES/OBJECT.CPP) | 7,393 | 6,787 | -606 (-8%) |
+
+CODESTYLE names PERSO.CPP as the cautionary case because it holds `main()`. By volume the worse
+case is the game menu, which has taken nearly three times as many new lines.
+
+The other standing figure: [SOURCES/C_EXTERN.H](../../SOURCES/C_EXTERN.H) declares 266 externs
+and is included by 58 files, so most of these globals are reachable from most of the tree
+without any file saying it uses them.
+
+---
+
+## The areas
+
+### 1. Audio ownership
+
+**What.** Move the audio globals out of the god header into the module headers that already
+exist: `SampleVolume`, `VoiceVolume`, `MasterVolume`, `SamplesEnable`, `ReverseStereo`,
+`RestartMusic`, the three `ParmSample*`, `SampleAmbiance[]`, `CubeJingle`.
+
+**Coverage today.** Good, and unusually so: `tests/ambiance_balance` already links
+[SOURCES/AUDIO_BALANCE.CPP](../../SOURCES/AUDIO_BALANCE.CPP) straight into a host test, plus
+`tests/music`, `focus_audio`, `cdda`, `cdtracks`, `voc_header`.
+
+**What it buys.** The first domain out of the god header whole, and the cheapest proof that the
+camera pattern generalises to something that was not designed for it. Most of the recipe is
+already satisfied by accident: the module TUs exist ([SOURCES/AMBIANCE.CPP](../../SOURCES/AMBIANCE.CPP),
+[SOURCES/MUSIC.CPP](../../SOURCES/MUSIC.CPP)), the pure part is already under CI, and the cfg
+surface reaches these through the settings table rather than by hand. What is left is step 6,
+ownership, in isolation.
+
+**What it costs.** Small. Expect to land maybe 7 of the 11 and leave the rest: `SampleAmbiance[]`
+and `CubeJingle` are written per cube by gameplay, and CODESTYLE's "state that is genuinely
+shared stays shared" rule applies to them until an owner exists.
+
+**Verdict: do this first.** Best ratio in the list, and it ends with a documented statement about
+where the gameplay-to-audio coupling actually sits.
+
+### 2. Boot and fatal-error plumbing
+
+**What.** Lift the boot diagnostics out of PERSO.CPP into their own TU: `ErrorHQRGet`,
+`TheEndCheckFile`, `InitTheEnd`, `TheEnd`, `DebugHQR`, `ShowFatalErrorDialog`, `BootFatal`,
+`TheEndInfo`, both `Message` overloads. Roughly 275 contiguous lines.
+
+**Coverage today.** Indirect only: `tests/cli_args`, `version`, `distrib`, `discovery`, `picker`
+cover boot inputs, and the `cli_*` fixtures cover boot behaviour. The failure paths themselves
+are untested, because reaching them means failing a boot.
+
+**What it buys.** A boot failure path that can be asserted on. This is not hypothetical: bad or
+partial installs are what users actually hit, and the history is there (cfg corruption dropping
+resolution, incomplete VOX, missing HQRs, disc-image sources). Today the code that decides what
+the player is told when that happens cannot be exercised without breaking an install by hand.
+Also the item CODESTYLE explicitly still names as owed, now that config file IO has moved.
+
+**What it costs.** Small, and low risk: it is a surface, so nothing depends on its state and the
+dependency direction is trivial.
+
+**Verdict: do this second**, or first if a smaller blast radius matters more than the domain win.
+
+### 3. The game menu
+
+**What.** [SOURCES/GAMEMENU.CPP](../../SOURCES/GAMEMENU.CPP), 5,292 lines and +50% since import.
+The new material is resolution switching, mouse support, save-list handling, language selection
+and the display sub-pages, sitting in and around 1997 menu code.
+
+**Coverage today.** The best in the tree for a file this size: 14 `ui_*` fixtures, plus
+`tests/menu_keynav`, `menu_labels`, `plasma_steps`, `ui_layout` as host tests. The tiered
+comparison now runs to 1920x1080.
+
+**What it buys.** This is the finding worth acting on. The largest accumulation of new code in an
+original file is also the best covered surface, so it is far safer to restructure than its size
+suggests, and the coverage was built for other reasons and is sitting unused for this. Splitting
+the community additions into their own TUs would take the biggest single bite out of the
+original-versus-new ambiguity anywhere in the tree.
+
+**What it costs.** Medium to large, and it wants slicing: the sub-pages first, then mouse, then
+the save list. The fixtures are local-only, so whoever does it has to run them deliberately.
+
+**Verdict: the biggest prize, and only worth starting when someone has a run of time.** Not a
+first move, but the one that pays most.
+
+### 4. Remaining UI canvas surfaces
+
+**What.** The roughly 26 sites in CONFIG, MESSAGE, HOLOGLOB, PERSO, INVENT and COMPORTE that
+still spell the horizontal anchor inline, after the menu was converted.
+
+**Coverage today.** Good for the menu and inventory, thin for the config and dialogue surfaces.
+
+**What it buys.** Consistency, and little else. The rule already has one home and a host test;
+these sites are correct, just verbose. FEATURE_WORKFLOW's own guidance applies: an unconverted
+site is a known cost, not a regression.
+
+**Verdict: opportunistic.** Convert a surface when already editing it. Not worth a dedicated PR.
+
+### 5. Save
+
+**What.** [SOURCES/SAVEGAME.CPP](../../SOURCES/SAVEGAME.CPP), +30% since import.
+
+**Coverage today.** The strongest in the tree: `tests/save_wire` (including a fuzz test),
+`tests/savegame`, `tests/save_thumbnail`, all host tests, plus the wire format pinned
+bit-exactly.
+
+**What it buys.** Very little right now. The growth is real but the risky part, the on-disk
+format, was already extracted and pinned. This is what an area looks like after its refactor.
+
+**Verdict: leave it.** It is here because the +30% invites a second look, and the answer is no.
+
+### 6. World and cube transform
+
+**What.** [SOURCES/GRILLE.CPP](../../SOURCES/GRILLE.CPP), +29%, plus the cube and block index
+arithmetic around it.
+
+**Coverage today.** `tests/zone` as a host test, some cube fixtures. Thin for the index maths.
+
+**What it buys.** The open cube-change crash lives here, and so does the brick renumbering table
+that #555 is currently fixing. A pure index seam with a host test, on the model of the camera and
+UI ones, would make that class of bug expressible as a test instead of a repro script.
+
+**What it costs.** Medium. Some of it is ASM-adjacent, so the bit-exactness rule applies and the
+equivalence tests are the oracle, which means Docker.
+
+**Verdict: after #555 lands**, and only with the crash still open as the motivation.
+
+### 7. Rendering
+
+**What.** [SOURCES/OBJECT.CPP](../../SOURCES/OBJECT.CPP), 6,787 lines, the only big original file
+that has shrunk.
+
+**Coverage today.** On paper the best in the repo: ASM equivalence suites for OBJECT, SVGA, 3D,
+ANIM and pol_work, plus `tests/render`, `pol_work`, `texfilter`, `present_rect`. **In practice
+none of the equivalence tests run in CI.**
+
+**What it buys.** Nothing yet, and this is the important entry. The prerequisite is not a
+refactor: it is getting the equivalence tests to run automatically, or a documented subset of
+them. Until then any restructuring here is guarded by a suite someone has to remember to run in
+Docker.
+
+**Verdict: blocked, and the block is a CI question rather than a code one.** Raise it separately;
+the open work on gating compiler warnings in CI is the nearest neighbour.
+
+### 8. Gameplay and simulation
+
+**What.** GERELIFE, EXTRA, EXTFUNC, and the roughly 55 gameplay globals.
+
+**Coverage today.** The thinnest of any area: `tests/movement`, `tests/demo_rng_seed`, one
+walkthrough fixture. The behaviour is emergent, script-driven and RNG-coupled, and the RNG is a
+single shared libc stream, so reproducing a divergence is itself hard.
+
+**What it buys.** In principle the most, since this is where the engine-versus-game line would
+eventually be drawn. In practice nothing safely, today.
+
+**Verdict: do not.** Any work here should be adding cover, not moving code. If the goal is the
+engine and game split, the LBA1 plan is the cheaper route to it (see below).
+
+---
+
+## What none of this buys
+
+The obvious claim for restructuring on this scale is that it unblocks something bigger. It does not.
+
+**Hosting LBA1 does not need any of this.** [LBA1_PORT_PLAN.md](LBA1_PORT_PLAN.md) section 0 is
+explicit: the work is format transcoders, a script opcode remap and media integration, "not
+re-architecting", with the agnostic menu and shell extraction deferred until LBA1 content
+actually loads. Do not sell a refactor here as unblocking it.
+
+**None of this makes the game faster.** No area above is motivated by a measurement.
+
+**None of this fixes an open bug**, except indirectly in area 6. The bugs that are open have
+their own fixes in flight.
+
+The real buys are narrower: more of the tree reachable from a test CI runs, fewer files that mean
+two things at once, and a smaller god header.
+
+## Order
+
+1. **Audio ownership.** Small, well covered, proves the pattern generalises.
+2. **Boot and fatal-error plumbing.** Small, low risk, makes a failure path testable.
+3. **The game menu.** Largest payoff, wants a dedicated run at it.
+4. **World and cube**, once #555 lands and if the crash is still open.
+5. Everything else is opportunistic, blocked on CI, or better left alone.
+
+Running underneath all of it: every one of these should raise the 5% figure at the top. A proposed
+refactor that does not raise it needs a different justification.


### PR DESCRIPTION
## What & why

Two commits, read in order.

**The recipe now starts with a coverage check.** [FEATURE_WORKFLOW.md](docs/FEATURE_WORKFLOW.md)
Example 5 opened by pointing at CODESTYLE and then said to cut along the testable line. Both
assume a test exists to cut toward, and here that assumption is usually wrong. Step 1 is now to
find out what would catch you, with the two greps that answer it, and to treat building that
cover as the refactor's first commit rather than a later one.

**A roadmap ordered by that same question.** Restructuring proposals have been argued from size
or untidiness. Those are the wrong inputs: a refactor promises behaviour is unchanged, so its
cost is set by whether anything would catch a break. `docs/plan/REFACTOR_ROADMAP.md` measures
the coverage first, then walks eight areas against it, saying for each what it buys, what it
costs, and whether to start.

## Notes for reviewers

The baseline is the part worth checking, since everything else follows from it:

| Scope | Lines | Linked into a host test |
|---|---|---|
| `SOURCES/` | 73,499 | 4,171 (5%), 19 files, **all community TUs** |
| `LIB386/` | 43,222 | 7,238 (16%), 25 files |

Plus: the 59 fixtures in `tests/automation` are referenced by no workflow, and
`LBA2_BUILD_ASM_EQUIV_TESTS` is `OFF` in every one. So not one line of 1997 game logic in
`SOURCES/` is reachable from a test CI runs, and the strongest suites in the repo are opt-in.

Two findings reordered the areas:

- **The game menu, not the entry point, is the worst case.** GAMEMENU.CPP is +1,771 lines
  (+50%) since the import against PERSO.CPP's +643 (+25%), though CODESTYLE names PERSO as the
  cautionary case. It is *also* the best covered surface in the tree (14 `ui_*` fixtures plus
  four host tests), so it is far safer to restructure than its size suggests. Biggest prize.
- **Rendering is the reverse.** OBJECT.CPP has the strongest suites in the repo behind it and
  none of them run automatically, so its blocker is a CI question rather than a code one. Listed
  as blocked rather than as a candidate.

There is a section on what none of it buys, which I think matters more than the ordering.
Hosting LBA1 does not need any of this: [LBA1_PORT_PLAN.md](docs/plan/LBA1_PORT_PLAN.md) §0 says
the work is transcoders, an opcode remap and media integration, "not re-architecting", with the
shell extraction deferred until LBA1 content loads. Nothing here is motivated by a speed
measurement, and nothing here fixes an open bug except indirectly.

Recommended order that falls out: audio ownership, then boot and fatal-error plumbing, then the
game menu. Save is explicitly listed as done. Gameplay is explicitly listed as do-not, on
coverage grounds.

Numbers are dated in the doc and every one has the command to re-derive it.

## Checklist

- [x] Build passes on my platform (Linux) — docs only, no code touched
- [ ] If LIB386 / 3DEXT touched: ASM equivalence tests pass (`./run_tests_docker.sh`)
- [x] If behavior changes: opt-in via flag/cvar/config (preserves default game feel)
- [x] Docs updated in the same PR if behavior or workflow changed
- [x] French comments and ASCII art preserved in any modified files
