### PR TITLE
fix(polyline): make the Z wraparound explicit instead of undefined

### DIFF
--- a/LIB386/pol_work/POLYLINE.CPP
+++ b/LIB386/pol_work/POLYLINE.CPP
@@ -38,8 +38,11 @@ U8 ColorY = 0x12;
 
 // TODO: Verify
 void Line_ZBuffer(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
-    Z1 = z1 << 16;
-    Z2 = z2 << 16;
+    /*	ASM: `shl edi,16` / `shl esi,16`, qui deborde en silence. En C le
+        decalage d'un S32 dans le bit de signe est indefini, donc on passe par
+        U32 pour rendre l'enroulement explicite. Resultat identique. */
+    Z1 = (S32)((U32)z1 << 16);
+    Z2 = (S32)((U32)z2 << 16);
 
     S32 color = col;
     col &= 0xFF;
@@ -50,7 +53,8 @@ void Line_ZBuffer(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
 
     while (true) {
         // @@Trace_Still:
-        DZ = Z2 - Z1;
+        //	ASM: `sub esi,edi`, soustraction 32 bits qui s'enroule
+        DZ = (S32)((U32)Z2 - (U32)Z1);
 
         S32 diffX = x1 - x0;
         S32 diffY = y1 - y0;
@@ -345,8 +349,11 @@ void Line_ZBuffer(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
 
 // TODO: Verify
 void Line_ZBuffer_NZW(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
-    Z1 = z1 << 16;
-    Z2 = z2 << 16;
+    /*	ASM: `shl edi,16` / `shl esi,16`, qui deborde en silence. En C le
+        decalage d'un S32 dans le bit de signe est indefini, donc on passe par
+        U32 pour rendre l'enroulement explicite. Resultat identique. */
+    Z1 = (S32)((U32)z1 << 16);
+    Z2 = (S32)((U32)z2 << 16);
 
     S32 color = col;
     col &= 0xFF;
@@ -356,7 +363,8 @@ void Line_ZBuffer_NZW(S32 x0, S32 y0, S32 x1, S32 y1, S32 col, S32 z1, S32 z2) {
     Color = color;
     while (true) {
         // @@Trace_Still:
-        DZ = Z2 - Z1;
+        //	ASM: `sub esi,edi`, soustraction 32 bits qui s'enroule
+        DZ = (S32)((U32)Z2 - (U32)Z1);
 
         S32 diffX = x1 - x0;
         S32 diffY = y1 - y0;


### PR DESCRIPTION
`Z1 = z1 << 16` shifts into the sign bit, and `DZ = Z2 - Z1` overflows once the two depths are far apart. UBSan on the merged tree:

```
POLYLINE.CPP:53:17: runtime error: signed integer overflow:
    -2146631680 - 2145189888 cannot be represented in type 'int'
```

## Not the same as #554

Both of these are exactly what the original does. `shl edi,16` wraps in silence, and `sub esi,edi` is a plain 32-bit subtraction that wraps. **The C is faithful and the results are not wrong today**, which is the opposite of the clip products in #554, where the ASM's one-operand `imul`/`idiv` carried 64 bits and the C truncated.

What is left is undefined behaviour on arithmetic whose wraparound is load-bearing. Compilers are entitled to assume signed overflow never happens, so this is worth saying explicitly rather than relying on today's codegen. Routing both through `U32` states what the ASM does and removes the UB.

## Verification

Behaviour is unchanged by construction, and measured rather than asserted. The depth-graded equivalence sweep added in #554 compares ASM against C at exactly the magnitudes where this fires:

| endpoint depth | diverging |
| --- | --- |
| 0 | 0/300 |
| ±50 | 0/300 |
| ±2000 | 0/300 |
| ±32768 | 0/300 |

The fuzz seed that produced the report replays clean, and the full suite is green.

## Note on how it surfaced

Not review, and not the earlier waves either: UBSan's alignment check floods ~160 reports before the title screen, and turning it off is what let reports like this one become visible. Both copies of the function are patched, `Line_ZBuffer` and `Line_ZBuffer_NZW`.
