### PR TITLE
docs(camera): correct what a camera zone switches off, and record four rules

### DIFF
--- a/docs/CAMERA.md
+++ b/docs/CAMERA.md
@@ -123,7 +123,12 @@ The latching shape is by far the more common in the shipped data. `CameraZone` i
 The angle is the visible part, but `CameraZone` gates three other behaviours, and anything that suppresses or bypasses zones inherits all four:
 
 - **The hidden-hero recovery.** When the hero is completely masked by geometry, the engine recentres the camera, unless `CameraZone` is set ([OBJECT.CPP](../SOURCES/OBJECT.CPP)). An authored shot is assumed deliberate, including when it hides him.
-- **HD recompose.** Skipped in zones ([FOLLOWCAM.CPP](../SOURCES/FOLLOWCAM.CPP)), so hand-composed framing is not adjusted at tall render heights.
+- **The follow update, for that one frame.** `UpdateFollowCameraExt` is called from inside `if (!CameraZone)`
+  ([PERSO.CPP](../SOURCES/PERSO.CPP)), so on the frame a zone claims the view the Auto camera does not run at
+  all and the zone's own writes reach the screen untouched. Note what this is *not*: an authored shot is not
+  exempt from the HD recompose. It escapes it for that single frame and is recomposed like anything else for
+  every frame it holds afterwards. A boom written raw there is the one frame in the sequence rendered without
+  the correction its neighbours have, which at 1080p is a third of the boom in and straight back out.
 - **The recentre input.** `I_RETURN` is a no-op inside a zone.
 
 `FlagCameraForcee` outlives the zone: the off-screen path clears it and restores `AlphaCam` / `GammaCam` / `VueDistance` to the `VueCamera` presets, which is how a forced shot's parameters are given back.
@@ -194,11 +199,24 @@ Pitch is the binding lever and saturates at the `AlphaCam` clamp (600 ≈ 53°),
 
 **Status: tuned for ~720p; 1080p is experimental.** The strength scales linearly with render height, which over-reaches at 1080p: the subject can feel too far and terrain near-clipping is more visible (the height-scaled near clip reduces it but does not fully solve it; a per-cell near-plane clip of the terrain grid is the real fix). The `cam_hd_*` cvars (and `cam_hd_cap`, which caps the strength so tall resolutions converge) let you tune it, and `cam_hd 0` disables it. Refining the 1080p framing and the terrain near-clip is left to a focused follow-up.
 
+**480 and 1080 are different regimes, so a camera change verified at one is not verified.** Every recompose
+term is an exact no-op at 480, which means a fix measured only there has not met the correction at all, and
+one measured only at 1080 has not met the original framing. A change to the boom that removed a 14% jump at
+480 introduced a 49% one at 1080, because the frame it corrected is the one frame the recompose never
+reaches. Capture both, and treat a result from one height as half an answer.
+
 ### Ground / occlusion clearance
 
 A smooth port of the classic `SearchCameraPos` terrain awareness onto the follow path (`cam_ground`, default on; clearance `cam_ground_clear`). After `CameraCenter(3)` positions the eye, a few points are sampled along the eye-to-hero line (`FollowCamHDExcess`-style, in `FOLLOWCAM.CPP`). Where terrain there would rise above the line of sight (a hill between the camera and the hero, or the eye sinking into rising ground), the eye is raised just enough to clear the worst occluder and re-aimed at the hero via the same `SetPosCamera` / `SetTargetCamera` calls the classic recenter uses.
 
 The difference from the classic path is that the lift **eases** toward its target every frame (`FollowCamEyeLift`, tuned by `FOLLOW_CAM_GROUND_*`) instead of snapping. An earlier always-on snap fought the orbit and was reverted; easing is what makes it safe to run every frame. A `FollowCamGroundSettling` flag keeps the dirty check live until the lift converges, so it finishes even while the hero stands still. Active at every resolution (world awareness, not HD-specific), skipped in camera zones and when the eye leaves the cube (where `CalculAltitudeObjet` is invalid). It clears terrain only; decor/scenery occlusion is not yet handled.
+
+**Eased state is self-correcting; latched state is not.** The distinction decides what a discontinuity
+(a scene change, a camera zone, a recentre) has to reset. `FollowCamEyeLift` and the spring arm converge on
+whatever the new situation asks for a frame at a time, so carrying a stale value across costs a short glide
+and zeroing it costs a jump of thousands of units. `FollowCamTargetBeta`, the re-engage and manual-hold
+counters and the orbit follow-through do not converge on their own: nothing retires them, so they discharge
+against a situation they were never measured in. Drop what latches, leave what eases.
 
 ### Manual-override fade
 

--- a/docs/FEATURE_WORKFLOW.md
+++ b/docs/FEATURE_WORKFLOW.md
@@ -120,6 +120,13 @@ that is spelled inline at many call sites into one place, without changing behav
    workflow, and `LBA2_BUILD_ASM_EQUIV_TESTS` is `OFF` in all of them. So for most of the tree
    the honest starting position is that nothing would catch you.
 
+   **A test you found is not yet an oracle: check it can fail.** A binary that calls `TEST_SUMMARY()` and
+   falls off the end of `main` exits 0 whatever failed, and ctest reads that as a pass; two in this tree
+   did until `test(camera): put the HD recompose rule under CI` fixed them, and the way that was
+   established was to break the formula on purpose and watch the run stay green. Do that once, to the
+   test you are about to lean on, before you lean on it. Coverage that cannot fail is worse than none,
+   because it is quoted in the PR.
+
    **If nothing covers it, building that cover is the first commit of the refactor, not a later
    one.** Not a full suite: one host test over the part that can be reached without engine
    state, or one fixture pinning the surface as it behaves today. Everything below assumes it
@@ -154,6 +161,13 @@ that is spelled inline at many call sites into one place, without changing behav
    [SOURCES/GLOBAL.CPP](../SOURCES/GLOBAL.CPP). The mechanical test is the include list: after the
    move, the files that genuinely use the module are the ones that had to add the include. For the
    camera that was seven, against the ninety-odd that could previously reach it by accident.
+
+   **A guard whose caller already decides it reads as intentional and moves with the code.** The include
+   list proves what compiles, not what is reachable. `FollowCamHDExcess` was called as
+   `CameraZone ? 0 : ...` inside a function whose only caller sits in `if (!CameraZone)`, so the test could
+   never be true; it survived a whole extraction and had its non-existent behaviour written up in a fresh
+   header on the way. When a conditional moves, check who calls it now, and delete the ones the caller
+   already answers rather than carrying them into the new file.
 
 7. **Then surfaces, one entry point each.** The cfg reader, the console, the CLI table and the
    options menu call into the module rather than naming its variables. Expect exactly one leak of


### PR DESCRIPTION
## The correction

`CAMERA.md` listed the HD recompose among the things a camera zone switches off:

> **HD recompose.** Skipped in zones, so hand-composed framing is not adjusted at tall render heights.

It is not skipped. `UpdateFollowCameraExt`'s only call site sits inside `if (!CameraZone)`, so what a zone actually switches off is the follow update for that one frame; an authored shot is recomposed like anything else for every frame it holds afterwards. #545 removed the same claim from `FOLLOWCAM_MATH.H` — this is the other place it was written down.

It matters beyond the wording: a boom written raw on that frame is the one frame in the sequence rendered without the correction its neighbours have, which at 1080p is a third of the boom out and straight back in.

## The rules

Four, each from a measurement in the camera-zone boom work rather than a preference. Two are camera behaviour and live in `CAMERA.md`; two are process and live in `FEATURE_WORKFLOW.md`'s extraction recipe.

- **Eased state is self-correcting; latched state is not.** Decides what a scene change has to reset. The ground lift and spring arm converge on their own, so zeroing them swaps a glide for a jump of thousands of units; the target angle, the countdowns and the orbit follow-through never retire and have to be dropped.
- **480 and 1080 are different regimes.** Every recompose term is an exact no-op at 480, so a camera change verified only there has not met the correction at all. A boom fix that removed a 14% jump at 480 introduced a 49% one at 1080.
- **A test you found is not yet an oracle: check it can fail.** Two binaries here exited 0 whatever failed until `test(camera): put the HD recompose rule under CI` fixed them, and that was established by breaking the formula on purpose. Coverage that cannot fail is worse than none, because it gets quoted in the PR.
- **A guard whose caller already decides it reads as intentional and moves with the code.** The include list proves what compiles, not what is reachable. The `CameraZone ? 0` test survived a whole extraction and had its non-existent behaviour written up in a fresh header on the way.

## Testing

Docs only. `check-docs-links.sh`, `check-docs-symbols.py` and `check-format.sh` all run clean locally.
