### PR TITLE
refactor(camera): put the recompose shrink on the testable line, with its test

### DIFF
--- a/SOURCES/FOLLOWCAM.CPP
+++ b/SOURCES/FOLLOWCAM.CPP
@@ -242,10 +242,8 @@ void UpdateFollowCameraExt(void) {
         if (hdExcess) {
             /* Shorten the forward lean so the hero is not pushed
                              * toward the bottom edge of the taller frame. */
-            S32 cut = hdExcess * FollowCamHDLeanGain / 100;
-            if (cut > FOLLOW_CAM_HD_LEAN_MAX_CUT)
-                cut = FOLLOW_CAM_HD_LEAN_MAX_CUT;
-            leanDist = DISTANCE_VISEE * (100 - cut) / 100;
+            leanDist = FollowCamHDShrink(DISTANCE_VISEE, hdExcess,
+                                         FollowCamHDLeanGain, FOLLOW_CAM_HD_LEAN_MAX_CUT);
         }
         Rotate(0, leanDist, leanBeta);
 
@@ -319,10 +317,8 @@ void UpdateFollowCameraExt(void) {
             S32 renderDist = FollowCamEffectiveDist;
             S32 saveAlphaCam = AlphaCam;
             if (hdExcess) {
-                S32 pull = hdExcess * FollowCamHDDistGain / 100;
-                if (pull > FOLLOW_CAM_HD_DIST_MAX_PULL)
-                    pull = FOLLOW_CAM_HD_DIST_MAX_PULL;
-                renderDist = FollowCamEffectiveDist * (100 - pull) / 100;
+                renderDist = FollowCamHDShrink(FollowCamEffectiveDist, hdExcess,
+                                               FollowCamHDDistGain, FOLLOW_CAM_HD_DIST_MAX_PULL);
 
                 /* Only the pitch steepen fades under manual control
                                  * (autoFactor): it is what fights the player's tilt.

--- a/SOURCES/FOLLOWCAM_MATH.H
+++ b/SOURCES/FOLLOWCAM_MATH.H
@@ -127,4 +127,34 @@ static inline S32 FollowCamHDExcessFor(S32 recompose, S32 modeY, S32 cap) {
     return e;
 }
 
+/* One recompose length, shrunk. The boom pull-in and the forward-lean cut are the same rule with
+ * different tuning: reduce a length in proportion to how much taller the frame is than the 480 the
+ * game was composed for, and stop reducing at `maxPercent` so a very tall frame converges instead
+ * of collapsing the length to nothing. `gain` is percent of the length per 1.00 of excess;
+ * `maxPercent` is the ceiling on the reduction, not on the excess.
+ *
+ * An exact identity at `hdExcess` 0, which is what makes the whole recompose a no-op at 480: the
+ * pull is 0 and `length * 100 / 100` is `length` for every value it is given. The early return is
+ * therefore inert for 0 and earns its place on negatives, which FollowCamHDExcessFor cannot
+ * currently produce; without it a negative excess would lengthen the boom instead of shortening
+ * it, which is the one direction this rule must never move.
+ *
+ * The order of operations is load-bearing and not interchangeable with subtracting the reduction.
+ * Scaling first and dividing once truncates a single time; taking `length * pull / 100` away
+ * truncates the part being removed instead, which rounds the other way and lands a unit out on
+ * boom lengths the camera actually uses. Whichever this is, both callers have to agree, or the
+ * frame a camera zone owns disagrees with the frames either side of it by that unit. */
+static inline S32 FollowCamHDShrink(S32 length, S32 hdExcess, S32 gain, S32 maxPercent) {
+    S32 pull;
+
+    if (hdExcess <= 0)
+        return length;
+
+    pull = hdExcess * gain / 100;
+    if (pull > maxPercent)
+        pull = maxPercent;
+
+    return length * (100 - pull) / 100;
+}
+
 #endif /* FOLLOWCAM_MATH_H */

--- a/tests/camera/test_followcam_math.cpp
+++ b/tests/camera/test_followcam_math.cpp
@@ -237,6 +237,75 @@ static void test_hd_recompose_cap_bounds_tall_heights(void) {
     ASSERT_EQ_INT(0, bad);
 }
 
+/* The recompose is defined to be an exact no-op at the height the game was composed for, and the
+ * boom is where that matters most: a length that came back one unit short at 480 would move the
+ * camera on the one resolution that must look as it shipped. Checked over a wide spread of lengths
+ * and tunings rather than at the two the engine currently runs with. */
+static void test_hd_shrink_is_an_exact_identity_at_no_excess(void) {
+    S32 len, gain, bad = 0;
+
+    for (len = 0; len <= 50000; len += 137)
+        for (gain = 0; gain <= 100; gain += 25)
+            if (FollowCamHDShrink(len, 0, gain, 50) != len)
+                bad++;
+
+    ASSERT_EQ_INT(0, bad);
+}
+
+/* A negative excess is not reachable through FollowCamHDExcessFor, which floors at 0, but the rule
+ * has to hold on its own terms: the recompose only ever shortens, and arithmetic on a negative
+ * would lengthen the boom. Pinned so a later change to how the excess is derived cannot quietly
+ * invert the correction. */
+static void test_hd_shrink_never_lengthens_on_a_negative_excess(void) {
+    ASSERT_EQ_INT(13750, FollowCamHDShrink(13750, -1, 27, 50));
+    ASSERT_EQ_INT(13750, FollowCamHDShrink(13750, -125, 27, 50));
+}
+
+/* The documented working point: at 1080 the excess is 125, which at the shipped distance gain is a
+ * 33% pull, taking the resting boom to 9212. The lean uses the same rule with its own tuning. */
+static void test_hd_shrink_matches_the_documented_working_point(void) {
+    S32 excess = FollowCamHDExcessFor(TRUE, 1080, FOLLOW_CAM_HD_EXCESS_CAP_DEFAULT);
+
+    ASSERT_EQ_INT(125, excess);
+    ASSERT_EQ_INT(9212, FollowCamHDShrink(13750, excess,
+                                          FOLLOW_CAM_HD_DIST_GAIN_DEFAULT,
+                                          FOLLOW_CAM_HD_DIST_MAX_PULL));
+    ASSERT_EQ_INT(7035, FollowCamHDShrink(10500, excess,
+                                          FOLLOW_CAM_HD_DIST_GAIN_DEFAULT,
+                                          FOLLOW_CAM_HD_DIST_MAX_PULL));
+}
+
+/* Scaling then dividing once is not the same as subtracting the reduction: at the working point
+ * above the two disagree by a unit. Both call sites have to round the same way, or the frame a
+ * camera zone owns is a unit off the frames either side of it. This pins which one it is. */
+static void test_hd_shrink_truncates_once_rather_than_subtracting(void) {
+    S32 len = 13750, pull = 33;
+
+    ASSERT_EQ_INT(len * (100 - pull) / 100, FollowCamHDShrink(len, 125, 27, 50));
+    /* the other order, spelled out, is a different number */
+    ASSERT_EQ_INT(9213, len - len * pull / 100);
+    ASSERT_EQ_INT(9212, FollowCamHDShrink(len, 125, 27, 50));
+}
+
+/* The ceiling bounds the reduction, not the excess, so past it a taller frame converges on one
+ * length instead of shrinking without bound. It must also never grow a length. */
+static void test_hd_shrink_is_bounded_and_never_grows(void) {
+    S32 excess, bad = 0, grew = 0;
+
+    ASSERT_EQ_INT(6875, FollowCamHDShrink(13750, 100000, 27, 50)); /* pinned at the 50% ceiling */
+
+    for (excess = 0; excess <= 4000; excess += 7) {
+        S32 got = FollowCamHDShrink(13750, excess, 27, FOLLOW_CAM_HD_DIST_MAX_PULL);
+        if (got < 13750 * (100 - FOLLOW_CAM_HD_DIST_MAX_PULL) / 100)
+            bad++;
+        if (got > 13750)
+            grew++;
+    }
+
+    ASSERT_EQ_INT(0, bad);
+    ASSERT_EQ_INT(0, grew);
+}
+
 int main(void) {
     RUN_TEST(test_pan_round_trips_for_every_angle);
     RUN_TEST(test_angles_stay_within_the_turn);
@@ -251,6 +320,11 @@ int main(void) {
     RUN_TEST(test_hd_recompose_disabled_is_always_zero);
     RUN_TEST(test_hd_recompose_matches_the_documented_scale);
     RUN_TEST(test_hd_recompose_cap_bounds_tall_heights);
+    RUN_TEST(test_hd_shrink_is_an_exact_identity_at_no_excess);
+    RUN_TEST(test_hd_shrink_never_lengthens_on_a_negative_excess);
+    RUN_TEST(test_hd_shrink_matches_the_documented_working_point);
+    RUN_TEST(test_hd_shrink_truncates_once_rather_than_subtracting);
+    RUN_TEST(test_hd_shrink_is_bounded_and_never_grows);
     TEST_SUMMARY();
     return test_failures != 0;
 }


### PR DESCRIPTION
Step 3 of the extraction recipe, applied to the part of the camera that was still out of reach: cut along the testable line before anything else moves.

## What moved

The HD recompose shrinks two lengths — the boom and the forward lean. Both were written inline in the apply path as copies of one expression, reading their tuning from globals, so neither could be reached from a host test. The arithmetic CI could see stopped at `FollowCamHDExcessFor`, the excess the two of them scale by.

`FollowCamHDShrink(length, excess, gain, maxPercent)` takes its inputs as arguments and the module supplies its settings at the call site — the shape `FollowCamHDExcessFor` already set. One function covers both sites because they are one rule with two tunings, not two rules that happen to spell the same arithmetic.

## The tests

Over the domain rather than at the points a scripted run happens to visit:

- **The exact identity at zero excess**, across a spread of lengths and gains. This is what makes the whole recompose a no-op at the 480 the game was composed for; a length coming back a unit short there would move the camera on the one resolution that must look as it shipped.
- **The documented working point** — 125 excess at the shipped gain takes the resting boom to 9212.
- **That it scales and divides once**, rather than subtracting the reduction. The two disagree by a unit at that working point, and both call sites have to round the same way.
- **That the ceiling bounds the reduction** and the result never grows.

## Verification

Behaviour is unchanged, so this is a move. A camtrace A/B at 1920x1080 with `cam_hd` on, where the recompose is live rather than the no-op it is at 480, is identical for all 115 frames.

The tests were confirmed to fail before being relied on, per the rule added in #564. Swapping the rounding order fails the run. Disabling the negative-excess guard did *not* fail it at first, which was the useful result: at zero excess the identity already holds, so that guard is inert there and only does work on negatives `FollowCamHDExcessFor` cannot currently produce. It now has a test of its own, and disabling it fails.

`check-format.sh`, `check-docs-links.sh` and `check-docs-symbols.py` all run clean locally.
