### PR TITLE
feat(res): keep the UI on screen below the authored canvas

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -1618,6 +1618,14 @@ static void res_do_switch(U32 newW, U32 newH) {
         Console_Close();
     }
     Console_Print("Resolution: %ux%u", newW, newH);
+
+    /* The UI is authored on a 640x480 canvas and centred rather than scaled, so
+       below that the menus, inventory and holomap lay out past the screen edge.
+       The world still renders correctly, which is what these modes are for, so
+       they stay selectable and we say what to expect instead. */
+    if (newW < UI_CANVAS_W || newH < UI_CANVAS_H)
+        Console_Print("  note: below %ux%u the UI is clipped; world render is unaffected.",
+                      (unsigned)UI_CANVAS_W, (unsigned)UI_CANVAS_H);
 }
 
 static void cmd_perftrace_print_sink(const char *line) {

--- a/SOURCES/INVENT.H
+++ b/SOURCES/INVENT.H
@@ -30,8 +30,15 @@
    moves as a unit; INV_DELTA_X stays fixed at the authored inner width (623).
    At 640 INV_LEFT_OFFSET is 0 and every macro resolves to the historical
    literal (10/8/0/...). The iso-relative INV_ZOOM box centres on
-   ModeDesiredX/2 - 3 (matches the historical 317 anchor at 640). */
-#define INV_LEFT_OFFSET (((S32)ModeDesiredX - 640) / 2)
+   ModeDesiredX/2 - 3 (matches the historical 317 anchor at 640).
+
+   Below 640 the offset clamps to 0 rather than going negative (UI_LAYOUT.H,
+   same rule as the vertical twin). The authored 623-wide block cannot fit, so
+   the choice is where to clip it: anchored at the left edge the first column
+   and the selection stay on screen, and the X coordinates stay inside the
+   framebuffer. A negative origin put the block's left edge off-screen and is
+   how the frame corner copies came to index outside Log. */
+#define INV_LEFT_OFFSET UI_HCANVAS_OFS
 #define INV_TOP_OFFSET UI_VCENTER_OFS // vertical twin of INV_LEFT_OFFSET; shared with the other UI surfaces (UI_LAYOUT.H, clamped >= 0)
 #define INV_START_X (INV_START_X_MARGIN + INV_LEFT_OFFSET)
 #define INV_START_Y (INV_START_Y_MARGIN + INV_TOP_OFFSET)

--- a/SOURCES/MESSAGE.CPP
+++ b/SOURCES/MESSAGE.CPP
@@ -132,7 +132,7 @@ S32 Dial_ForceFlag = 0;
 /* Horizontal inset to apply when Dial_Letterbox is set: half the gap between
    the framebuffer's width and the authored 640 px PCX width. Zero at 640. */
 static S32 DialLetterboxInset(void) {
-    return Dial_Letterbox ? (((S32)ModeDesiredX - 640) / 2) : 0;
+    return Dial_Letterbox ? UI_HCANVAS_OFS : 0;
 }
 
 /* Vertical twin of DialLetterboxInset (== UI_VCENTER_OFS when letterboxed):

--- a/SOURCES/UI_LAYOUT.H
+++ b/SOURCES/UI_LAYOUT.H
@@ -42,9 +42,13 @@
  * space the UI literals live in. They differ whenever the player is not at
  * 640x480, which is the whole reason this header exists.
  *
- * There is no width twin because nothing needs one: X centres on the framebuffer
- * at every size, so the authored 640 never enters the arithmetic. */
+ * Most X placement centres on the framebuffer at every size, so the authored
+ * width never enters that arithmetic. The surfaces that are laid out as a whole
+ * 4:3 block rather than centred per element (the inventory, the letterboxed
+ * dialogue box) do need it, which is what UI_CANVAS_W and UiCanvasOriginX are
+ * for. */
 #define UI_CANVAS_H 480
+#define UI_CANVAS_W 640
 
 /* Where the canvas starts inside a framebuffer `modeH` tall, and the same pinned
  * to the bottom edge for the surfaces authored against it (the dialogue box, the
@@ -55,6 +59,15 @@
  * bottom (origin 0) and indexing the row table out of bounds. */
 static inline S32 UiCanvasOriginY(S32 modeH) {
     return modeH > UI_CANVAS_H ? (modeH - UI_CANVAS_H) / 2 : 0;
+}
+
+/* X twin of UiCanvasOriginY, and clamped for the same reason. Below the canvas
+ * width the authored block does not fit, and a negative origin puts its left
+ * edge off-screen, which is how the frame corner copies in INVENT.CPP came to
+ * index outside Log at 320 wide. Clipping at the left edge instead keeps the
+ * visible part on screen and the arithmetic in bounds. */
+static inline S32 UiCanvasOriginX(S32 modeW) {
+    return modeW > UI_CANVAS_W ? (modeW - UI_CANVAS_W) / 2 : 0;
 }
 
 static inline S32 UiCanvasBottomOfsY(S32 modeH) {
@@ -81,5 +94,6 @@ static inline S32 UiCenterX(S32 modeW) {
 #define UI_VCENTER_OFS UiCanvasOriginY((S32)ModeDesiredY)
 #define UI_VBOTTOM_OFS UiCanvasBottomOfsY((S32)ModeDesiredY)
 #define UI_CENTER_X UiCenterX((S32)ModeDesiredX)
+#define UI_HCANVAS_OFS UiCanvasOriginX((S32)ModeDesiredX)
 
 #endif /* UI_LAYOUT_H */


### PR DESCRIPTION
Closes the question left open by #555: the sub-640x480 modes **stay**. They are console and CLI only, never offered by the in-game menu, and they are useful for render and performance testing. So the answer is to make them behave rather than remove them.

## What was wrong

`UI_LAYOUT.H` states there is no width twin to `UI_CANVAS_H` because "X centres on the framebuffer at every size, so the authored 640 never enters the arithmetic".

Two surfaces disagree. The inventory and the letterboxed dialogue box are laid out as a whole 4:3 block rather than centred per element, and both compute `(ModeDesiredX - 640) / 2` directly:

```
SOURCES/INVENT.H:34    #define INV_LEFT_OFFSET (((S32)ModeDesiredX - 640) / 2)
SOURCES/MESSAGE.CPP:135  return Dial_Letterbox ? (((S32)ModeDesiredX - 640) / 2) : 0;
```

Below 640 that goes negative. At 320 wide the inventory block starts at x = -152, which is how the frame corner copies in #555 came to index outside `Log`.

## The change

Add `UI_CANVAS_W` and `UiCanvasOriginX`, clamped to `>= 0` for exactly the reason the Y twin already documents ("below the canvas the authored UI does not fit, and the choice is between clipping it and indexing the row table out of bounds"), and route both surfaces through it.

The authored 623-wide block still runs past the right edge at 320 wide, which no offset can fix without scaling the art. What changes is which part you see.

**Before** (block starts at -152, first column off screen):

| | |
| --- | --- |
| selection sits at the very left edge, leftmost column invisible | |

**After** (block anchored at 0): the first column and the selection are on screen.

## Verification

Captures with `--fixed-dt 16` so the comparison means something, inventory and options at three sizes:

| capture | before vs after |
| --- | --- |
| `inv_640x480` | identical |
| `opt_640x480` | identical |
| `inv_1920x1080` | identical |
| `opt_1920x1080` | identical |
| `opt_320x240` | identical |
| `inv_320x240` | **changed, as intended** |

Only the one surface at the one size that was broken. The options screen never used the offset, so it is untouched everywhere. Full suite green at 153/153, including the `ui_layout` tests that landed in #559.

## Also

The console now says what to expect when switching below the canvas, in the same spirit as the tall modes flagged `experimental`: the player can still pick them, we just tell them.

```
Resolution: 320x240
  note: below 640x480 the UI is clipped; world render is unaffected.
```
