### PR TITLE
feat(settings): record where a setting's value came from

### DIFF
--- a/LIB386/H/SYSTEM/DEFFILE.H
+++ b/LIB386/H/SYSTEM/DEFFILE.H
@@ -53,6 +53,28 @@ S32 DefFileBufferReadValue2(const char *ident, S32 *result);
 // which clears the layer.
 S32 DefFileBufferAppendFile(const char *file);
 
+// Which source answered a key, for a caller that has to tell a value the run
+// owns from one it merely inherited.
+//
+// The buffer holds the owned file with any appended layers below it, and a read
+// stops at the first match, so the value alone cannot say which one supplied it.
+// A setting read from a layer is real for this run and is not the player's
+// preference: writing it back into the owned file would make the install's
+// choice outlive the install. Telling them apart is what this is for.
+//
+// Presence alone is already answerable: DefFileBufferReadValue2 returns FALSE for
+// a key the buffer does not hold. This adds the part that is not, which source
+// held it, and folds presence in so a caller needs one call rather than two.
+//
+// With no layer attached every key present is OWNED.
+typedef enum {
+    DEFFILE_ORIGIN_ABSENT = 0, // no such key; the caller's default answers
+    DEFFILE_ORIGIN_OWNED,      // the file this run owns
+    DEFFILE_ORIGIN_LAYER       // a lower-priority layer appended beneath it
+} T_DEFFILE_ORIGIN;
+
+T_DEFFILE_ORIGIN DefFileBufferKeyOrigin(const char *ident);
+
 // Save and restore the whole read window, for a caller that needs a transient
 // read against a buffer of its own without disturbing the one the boot
 // assembled. Without it, any such read silently drops the layers for everything
@@ -62,6 +84,7 @@ typedef struct {
     char *end;
     S32 bufferSize;
     S32 layersAttached;
+    char *layerStart;
     char fileName[ADELINE_MAX_PATH];
 } T_DEFFILE_STATE;
 

--- a/LIB386/SYSTEM/DEFFILE.CPP
+++ b/LIB386/SYSTEM/DEFFILE.CPP
@@ -35,6 +35,12 @@ static char BatchFinalPath[ADELINE_MAX_PATH];
 // it. See the API comment in DEFFILE.H.
 static S32 LayersAttached = FALSE;
 
+// Where the first appended layer begins. Everything from here to EndPtrDef came
+// from a lower-priority source, so a key matched at or past it was inherited
+// rather than owned. NULL while nothing is layered, which makes every present
+// key owned, as it should be.
+static char *LayerStart = NULL;
+
 //══════════════════════════════════════════════════════════════════════════
 static inline S32 ReadBufferString(const char *identificateur) {
     char *ptrdef;
@@ -207,6 +213,7 @@ S32 DefFileBufferInit(char *file, void *buffer, S32 maxsize) {
 
     BufferSize = maxsize;
     LayersAttached = FALSE; // a fresh load owns exactly what FileName holds
+    LayerStart = NULL;      // and the boundary with it, or it would point into the old buffer
     OrgPtrDef = (char *)buffer;
     EndPtrDef = OrgPtrDef + buffersize;
     SealBuffer(); // trailing trim, then the 0/32/0 the read loop stops on
@@ -241,6 +248,7 @@ void DefFileBufferSaveState(T_DEFFILE_STATE *out) {
     out->end = EndPtrDef;
     out->bufferSize = BufferSize;
     out->layersAttached = LayersAttached;
+    out->layerStart = LayerStart;
     strcpy(out->fileName, FileName);
 }
 
@@ -253,6 +261,7 @@ void DefFileBufferRestoreState(const T_DEFFILE_STATE *in) {
     EndPtrDef = in->end;
     BufferSize = in->bufferSize;
     LayersAttached = in->layersAttached;
+    LayerStart = in->layerStart;
     strcpy(FileName, in->fileName);
 }
 
@@ -293,7 +302,25 @@ S32 DefFileBufferAppendFile(const char *file) {
     EndPtrDef = layer + loaded;
     SealBuffer();
     LayersAttached = TRUE;
+    /* Only the first append moves the boundary: a second layer goes below the
+       first, and both are equally not-owned. */
+    if (LayerStart == NULL) {
+        LayerStart = layer;
+    }
     return TRUE;
+}
+
+//══════════════════════════════════════════════════════════════════════════
+T_DEFFILE_ORIGIN DefFileBufferKeyOrigin(const char *ident) {
+    if (ident == NULL || !ReadBufferString(ident)) {
+        return DEFFILE_ORIGIN_ABSENT;
+    }
+    /* ReadBufferString leaves PtrEndIdent just past the key's separator, which
+       is the match position the scan stopped at. */
+    if (LayerStart != NULL && PtrEndIdent >= LayerStart) {
+        return DEFFILE_ORIGIN_LAYER;
+    }
+    return DEFFILE_ORIGIN_OWNED;
 }
 
 //══════════════════════════════════════════════════════════════════════════

--- a/SOURCES/AMBIANCE.CPP
+++ b/SOURCES/AMBIANCE.CPP
@@ -831,23 +831,23 @@ static void ApplyCDVolume(S32 value) { SetVolumeCD(value); }
 static void ApplyReverseStereo(S32 value) { InverseStereoSample(value); }
 
 static const T_SETTING AudioSettings[] = {
-    {"WaveVolume", NULL, "snd_wave", &SampleVolume, SETTING_CLAMP, DEF_SAMPLE_VOLUME, 0, 127, NULL, NULL, NULL,
+    {"WaveVolume", NULL, "snd_wave", &SampleVolume, SETTING_CLAMP, DEF_SAMPLE_VOLUME, 0, 127, NULL, NULL, NULL, NULL,
      "Sound-effect volume (0-127)"},
-    {"VoiceVolume", NULL, "snd_voice", &VoiceVolume, SETTING_CLAMP, DEF_VOICE_VOLUME, 0, 127, NULL, NULL, NULL,
+    {"VoiceVolume", NULL, "snd_voice", &VoiceVolume, SETTING_CLAMP, DEF_VOICE_VOLUME, 0, 127, NULL, NULL, NULL, NULL,
      "Speech volume (0-127)"},
     {"MusicVolume", NULL, "snd_music", &JingleVolume, SETTING_CLAMP, DEF_JINGLE_VOLUME, 0, 127, NULL, NULL,
-     ApplyJingleVolume, "Music volume (0-127)"},
+     ApplyJingleVolume, NULL, "Music volume (0-127)"},
 #ifdef CDROM
-    {"CDVolume", NULL, "snd_cd", &CDVolume, SETTING_CLAMP, DEF_CD_VOLUME, 0, 127, NULL, NULL, ApplyCDVolume,
+    {"CDVolume", NULL, "snd_cd", &CDVolume, SETTING_CLAMP, DEF_CD_VOLUME, 0, 127, NULL, NULL, ApplyCDVolume, NULL,
      "CD audio volume (0-127)"},
 #endif
     {"MasterVolume", NULL, "snd_master", &MasterVolume, SETTING_CLAMP, DEF_MASTER_VOLUME, 0, 127, NULL, NULL,
-     ApplyMasterVolume, "Master volume (0-127), scales the others"},
+     ApplyMasterVolume, NULL, "Master volume (0-127), scales the others"},
     /* ReverseStereo lives here rather than in CONFIG_FILE.CPP's table now that
        audio has one: it is an audio setting, and its apply belongs beside the
        others rather than being repeated by whichever surface writes it. */
     {"ReverseStereo", NULL, "snd_reverse_stereo", &ReverseStereo, SETTING_TRUTHY, FALSE, 0, 1, NULL, NULL,
-     ApplyReverseStereo, "Swap the left and right sample channels"},
+     ApplyReverseStereo, NULL, "Swap the left and right sample channels"},
 };
 
 #define AUDIO_SETTING_COUNT ((S32)(sizeof(AudioSettings) / sizeof(AudioSettings[0])))

--- a/SOURCES/CONFIG_FILE.CPP
+++ b/SOURCES/CONFIG_FILE.CPP
@@ -47,6 +47,13 @@ static S32 StoredFixedTimestep = 16;
 static S32 StoredLanguage = 0;
 static S32 StoredVSync = TRUE;
 
+/* Where the live value came from, for the three rows a per-run flag can force.
+   Only those need it: the rule a source decides is what a forced run leaves
+   behind, and a row no flag touches keeps its value either way. */
+static T_SETTING_SOURCE SourceTexFilter = SETTING_FROM_DEFAULT;
+static T_SETTING_SOURCE SourceFixedTimestep = SETTING_FROM_DEFAULT;
+static T_SETTING_SOURCE SourceVSync = SETTING_FROM_DEFAULT;
+
 /* The value to write for such a setting: the stored preference while the live
    value is still the one the override forced, otherwise the live value, because
    then something during the run changed it on purpose.
@@ -95,14 +102,14 @@ static const T_SETTING BootSettings[] = {
     {"DetailLevel", NULL, NULL, &DetailLevel, SETTING_CLAMP, MAX_DETAIL_LEVEL, 0, MAX_DETAIL_LEVEL, NULL, NULL, NULL},
     {"FullScreen", NULL, NULL, &VideoFullScreen, SETTING_OR_DEFAULT, TRUE, 0, 1, NULL, NULL, NULL},
     {"DisplayFullScreen", NULL, NULL, &DisplayFullScreen, SETTING_OR_DEFAULT, FALSE, 0, 1, NULL, NULL, NULL},
-    {"VSync", NULL, NULL, &DisplayVSync, SETTING_OR_DEFAULT, TRUE, 0, 1, &StoredVSync, ForcedVSync, NULL},
-    {"DitherShading", NULL, "gfx_dither", &GfxDitherShading, SETTING_OR_DEFAULT, FALSE, 0, 1, NULL, NULL, NULL,
+    {"VSync", NULL, NULL, &DisplayVSync, SETTING_OR_DEFAULT, TRUE, 0, 1, &StoredVSync, ForcedVSync, NULL, &SourceVSync},
+    {"DitherShading", NULL, "gfx_dither", &GfxDitherShading, SETTING_OR_DEFAULT, FALSE, 0, 1, NULL, NULL, NULL, NULL,
      "Ordered dither on Gouraud shade rows (softens 16-step banding)"},
     {"TextureFilter", NULL, "gfx_texfilter", &PolyTexFilter, SETTING_OR_DEFAULT, POLY_TEX_FILTER_OFF,
-     POLY_TEX_FILTER_OFF, POLY_TEX_FILTER_BILINEAR, &StoredTexFilter, ForcedTexFilter, NULL,
+     POLY_TEX_FILTER_OFF, POLY_TEX_FILTER_BILINEAR, &StoredTexFilter, ForcedTexFilter, NULL, &SourceTexFilter,
      "Texture filtering: 0 off, 1 horizontal, 2 bilinear"},
     {"FixedTimestep", NULL, NULL, &FixedTimestep, SETTING_OR_DEFAULT, 16, 0, 100,
-     &StoredFixedTimestep, ForcedFixedTimestep, NULL},
+     &StoredFixedTimestep, ForcedFixedTimestep, NULL, &SourceFixedTimestep},
 };
 #define BOOT_SETTING_COUNT ((S32)(sizeof(BootSettings) / sizeof(BootSettings[0])))
 
@@ -118,6 +125,10 @@ const T_SETTING *ConfigFile_Setting(const char *key) {
             return &BootSettings[i];
     }
     return NULL;
+}
+
+void ConfigFile_MarkVSyncSetThisRun(void) {
+    Settings_MarkSetThisRun(&SourceVSync);
 }
 
 void ReadConfigFile(void) {

--- a/SOURCES/CONFIG_FILE.CPP
+++ b/SOURCES/CONFIG_FILE.CPP
@@ -131,6 +131,10 @@ void ConfigFile_MarkVSyncSetThisRun(void) {
     Settings_MarkSetThisRun(&SourceVSync);
 }
 
+void ConfigFile_MarkFixedTimestepSetThisRun(void) {
+    Settings_MarkSetThisRun(&SourceFixedTimestep);
+}
+
 void ReadConfigFile(void) {
     const char *ptr;
 

--- a/SOURCES/CONFIG_FILE.H
+++ b/SOURCES/CONFIG_FILE.H
@@ -41,10 +41,15 @@ extern void ConfigFile_RegisterCvars(void);
  * the table cannot keep in step. */
 extern const T_SETTING *ConfigFile_Setting(const char *key);
 
-/* Tell the settings table that this run set VSync, for the console's `vsync`
-   command, which takes on/off/toggle and so assigns the value itself rather than
-   going through the cvar path. Without it a --vsync run that the player then
-   changed by hand would be written back as untouched. */
+/* Tell the settings table that this run set one of these, for the writers that
+   assign the global themselves rather than going through the cvar path: the
+   console's `vsync` and `fixedtimestep` commands, which take words rather than
+   numbers, and the Display menu's Vsync row.
+   
+   Only matters when the run also carried the matching flag and the value landed
+   back on what the flag forced. Without the mark that reads as untouched, and
+   the player's stored value is written back over their own change. */
 extern void ConfigFile_MarkVSyncSetThisRun(void);
+extern void ConfigFile_MarkFixedTimestepSetThisRun(void);
 
-#endif #endif /* CONFIG_FILE_H */
+#endif /* CONFIG_FILE_H */

--- a/SOURCES/CONFIG_FILE.H
+++ b/SOURCES/CONFIG_FILE.H
@@ -41,4 +41,10 @@ extern void ConfigFile_RegisterCvars(void);
  * the table cannot keep in step. */
 extern const T_SETTING *ConfigFile_Setting(const char *key);
 
-#endif /* CONFIG_FILE_H */
+/* Tell the settings table that this run set VSync, for the console's `vsync`
+   command, which takes on/off/toggle and so assigns the value itself rather than
+   going through the cvar path. Without it a --vsync run that the player then
+   changed by hand would be written back as untouched. */
+extern void ConfigFile_MarkVSyncSetThisRun(void);
+
+#endif #endif /* CONFIG_FILE_H */

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -1554,6 +1554,7 @@ static void cmd_vsync(int argc, const char *argv[]) {
         return;
     }
 
+    ConfigFile_MarkVSyncSetThisRun();
     Window_SetVSync(DisplayVSync);
     /* Applied either way; say so separately from whether it was stored, rather
        than reporting a setting that will not survive the run. */

--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -1594,6 +1594,9 @@ static void cmd_fixedtimestep(int argc, const char *argv[]) {
             }
             FixedTimestep = (S32)ms;
         }
+        /* After every accepted path and none of the rejected ones, so a bad
+           argument does not claim the run set anything. */
+        ConfigFile_MarkFixedTimestepSetThisRun();
         if (!WriteConfigValue("FixedTimestep", FixedTimestep)) {
             Console_Print("(this run only: could not write cfg)");
         }

--- a/SOURCES/FOLLOWCAM.CPP
+++ b/SOURCES/FOLLOWCAM.CPP
@@ -465,46 +465,46 @@ void FollowCamSyncTarget(void) {
  * own position in the file, apart from this block. */
 static const T_SETTING FollowCamSettings[] = {
     {"FollowCamReengageFrames", NULL, "cam_recenter_delay", &FollowCamReengageFrames, SETTING_CLAMP,
-     FOLLOW_CAM_REENGAGE_FRAMES_DEFAULT, 0, 600, NULL, NULL, NULL,
+     FOLLOW_CAM_REENGAGE_FRAMES_DEFAULT, 0, 600, NULL, NULL, NULL, NULL,
      "Frames before auto-cam re-centers after a manual pan"},
     {"FollowCamDriftDivisor", NULL, "cam_recenter_drift", &FollowCamDriftDivisor, SETTING_CLAMP,
-     FOLLOW_CAM_DRIFT_DIVISOR_DEFAULT, 1, 200, NULL, NULL, NULL,
+     FOLLOW_CAM_DRIFT_DIVISOR_DEFAULT, 1, 200, NULL, NULL, NULL, NULL,
      "Auto-cam re-center drift divisor (higher = gentler)"},
     {"FollowCamHDRecompose", NULL, "cam_hd", &FollowCamHDRecompose, SETTING_TRUTHY,
-     FOLLOW_CAM_HD_RECOMPOSE_DEFAULT, 0, 1, NULL, NULL, NULL,
+     FOLLOW_CAM_HD_RECOMPOSE_DEFAULT, 0, 1, NULL, NULL, NULL, NULL,
      "Auto cam HD recompose: pull in + steepen at tall render heights"},
     {"FollowCamHDExcessCap", NULL, "cam_hd_cap", &FollowCamHDExcessCap, SETTING_CLAMP,
-     FOLLOW_CAM_HD_EXCESS_CAP_DEFAULT, 0, SETTING_MAX_NONE, NULL, NULL, NULL,
+     FOLLOW_CAM_HD_EXCESS_CAP_DEFAULT, 0, SETTING_MAX_NONE, NULL, NULL, NULL, NULL,
      "Cap on recompose strength so tall res converges (0 = pure linear; 70 ~= 816p)"},
     {"FollowCamHDPitchGain", NULL, "cam_hd_pitch", &FollowCamHDPitchGain, SETTING_CLAMP,
-     FOLLOW_CAM_HD_PITCH_GAIN_DEFAULT, SETTING_MIN_NONE, SETTING_MAX_NONE, NULL, NULL, NULL,
+     FOLLOW_CAM_HD_PITCH_GAIN_DEFAULT, SETTING_MIN_NONE, SETTING_MAX_NONE, NULL, NULL, NULL, NULL,
      "HD recompose pitch gain (AlphaCam units per 1.0 of k-1)"},
     {"FollowCamHDDistGain", NULL, "cam_hd_dist", &FollowCamHDDistGain, SETTING_CLAMP,
-     FOLLOW_CAM_HD_DIST_GAIN_DEFAULT, SETTING_MIN_NONE, SETTING_MAX_NONE, NULL, NULL, NULL,
+     FOLLOW_CAM_HD_DIST_GAIN_DEFAULT, SETTING_MIN_NONE, SETTING_MAX_NONE, NULL, NULL, NULL, NULL,
      "HD recompose distance pull (% of boom per 1.0 of k-1)"},
     {"FollowCamHDLeanGain", NULL, "cam_hd_lean", &FollowCamHDLeanGain, SETTING_CLAMP,
-     FOLLOW_CAM_HD_LEAN_GAIN_DEFAULT, SETTING_MIN_NONE, SETTING_MAX_NONE, NULL, NULL, NULL,
+     FOLLOW_CAM_HD_LEAN_GAIN_DEFAULT, SETTING_MIN_NONE, SETTING_MAX_NONE, NULL, NULL, NULL, NULL,
      "HD recompose forward-lean cut (% per 1.0 of k-1)"},
     {"FollowCamGround", NULL, "cam_ground", &FollowCamGround, SETTING_TRUTHY,
-     FOLLOW_CAM_GROUND_DEFAULT, 0, 1, NULL, NULL, NULL,
+     FOLLOW_CAM_GROUND_DEFAULT, 0, 1, NULL, NULL, NULL, NULL,
      "Auto cam: smooth terrain ground-clearance lift"},
     /* The ceiling keeps (g + clearance - hy) * 100 inside S32 in the occlusion
      * march below, which is why it is stated with the setting rather than at the
      * one surface that used to check it. */
     {"FollowCamGroundClearance", NULL, "cam_ground_clear", &FollowCamGroundClearance, SETTING_CLAMP,
-     FOLLOW_CAM_GROUND_CLEARANCE_DEFAULT, 0, 20000, NULL, NULL, NULL,
+     FOLLOW_CAM_GROUND_CLEARANCE_DEFAULT, 0, 20000, NULL, NULL, NULL, NULL,
      "Ground clearance: keep the eye this far above the ground under it"},
     {"FollowCamManualHoldFrames", NULL, "cam_manual_hold", &FollowCamManualHoldFrames, SETTING_CLAMP,
-     FOLLOW_CAM_MANUAL_HOLD_DEFAULT, 0, FOLLOW_CAM_MANUAL_HOLD_MAX, NULL, NULL, NULL,
+     FOLLOW_CAM_MANUAL_HOLD_DEFAULT, 0, FOLLOW_CAM_MANUAL_HOLD_MAX, NULL, NULL, NULL, NULL,
      "Frames the pitch/distance auto-assist yields after a manual camera nudge"},
     {"FollowCamHoldAngle", NULL, "cam_hold_angle", &FollowCamHoldAngle, SETTING_TRUTHY,
-     FOLLOW_CAM_HOLD_ANGLE_DEFAULT, 0, 1, NULL, NULL, NULL,
+     FOLLOW_CAM_HOLD_ANGLE_DEFAULT, 0, 1, NULL, NULL, NULL, NULL,
      "Hold the manual camera rotation (free-camera); off = classic auto-recenter drift"},
     /* cvar only, and it must stay that way. FollowCamera's cfg row lives in
        CONFIG_FILE.CPP's table, which reads it with the legacy AutoCameraCenter
        fallback and its own rule; giving this row a key would read the same
        global twice under two rules, and this table runs last. */
-    {NULL, NULL, "cam_follow", &FollowCamera, SETTING_TRUTHY, FALSE, 0, 1, NULL, NULL, NULL,
+    {NULL, NULL, "cam_follow", &FollowCamera, SETTING_TRUTHY, FALSE, 0, 1, NULL, NULL, NULL, NULL,
      "Auto camera (third-person follow) enable"},
 };
 #define FOLLOW_CAM_SETTING_COUNT ((S32)(sizeof(FollowCamSettings) / sizeof(FollowCamSettings[0])))

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -28,7 +28,8 @@
 #include <SYSTEM/MOUSE.H>
 
 #include "GAMEMENU_MOUSE.H"
-#include "UI_LAYOUT.H" /* UI_CENTER_X, UI_VCENTER_OFS */
+#include "CONFIG_FILE.H" /* ConfigFile_MarkVSyncSetThisRun */
+#include "UI_LAYOUT.H"   /* UI_CENTER_X, UI_VCENTER_OFS */
 
 #include <dirent.h>
 #include <stdint.h>
@@ -3306,6 +3307,7 @@ S32 GereDisplayMenu(void) {
 
         case MENU_ID_DISPLAY_VSYNC:
             DisplayVSync ^= 1;
+            ConfigFile_MarkVSyncSetThisRun();
             Window_SetVSync(DisplayVSync);
             break;
         }

--- a/SOURCES/SETTINGS.CPP
+++ b/SOURCES/SETTINGS.CPP
@@ -24,6 +24,27 @@ void Settings_ReadConfig(const T_SETTING *table, S32 count) {
         def = (s->legacy != NULL) ? DefFileBufferReadValueDefault(s->legacy, s->def) : s->def;
         *s->value = Settings_Coerce(s, DefFileBufferReadValueDefault(s->key, def));
 
+        /* Which of the stacked configs answered, asked under the current key and
+           then the legacy one, since a renamed key is still the player's if their
+           file spells it the old way. */
+        if (s->source != NULL) {
+            T_DEFFILE_ORIGIN from = DefFileBufferKeyOrigin(s->key);
+            if (from == DEFFILE_ORIGIN_ABSENT && s->legacy != NULL)
+                from = DefFileBufferKeyOrigin(s->legacy);
+
+            switch (from) {
+            case DEFFILE_ORIGIN_OWNED:
+                *s->source = SETTING_FROM_PROFILE;
+                break;
+            case DEFFILE_ORIGIN_LAYER:
+                *s->source = SETTING_FROM_DATA;
+                break;
+            default:
+                *s->source = SETTING_FROM_DEFAULT;
+                break;
+            }
+        }
+
         /* Captured before anything applies a per-run override, so this is the
          * player's own setting rather than what a flag forced. */
         if (s->stored != NULL)
@@ -42,8 +63,11 @@ void Settings_WriteConfig(const T_SETTING *table, S32 count) {
             continue;
 
         value = *s->value;
-        if (s->stored != NULL AND s->forced != NULL)
-            value = Settings_ValueToPersist(value, *s->stored, s->forced());
+        if (s->stored != NULL AND s->forced != NULL) {
+            value = (s->source != NULL)
+                        ? Settings_ValueToPersistFrom(value, *s->stored, s->forced(), *s->source)
+                        : Settings_ValueToPersist(value, *s->stored, s->forced());
+        }
         DefFileBufferWriteValue(s->key, value);
     }
 }

--- a/SOURCES/SETTINGS.H
+++ b/SOURCES/SETTINGS.H
@@ -203,6 +203,14 @@ static inline void Settings_MarkSetThisRun(T_SETTING_SOURCE *source) {
 static inline S32 Settings_ValueToPersistFrom(S32 live, S32 stored, S32 forced, T_SETTING_SOURCE source) {
     if (forced < 0)
         return live; /* no flag touched it */
+    if (live != forced)
+        return live; /* moved off what the flag forced, so the run changed it */
+    /* Sitting on the forced value, which is the case the value cannot answer:
+       either the run set it there or nothing touched it. Only here does the
+       source decide, which keeps this a refinement of the comparison rather than
+       a replacement for it. A writer that assigns the global without marking the
+       run therefore behaves exactly as it did before, rather than losing its
+       change. */
     return (source == SETTING_FROM_RUNTIME) ? live : stored;
 }
 

--- a/SOURCES/SETTINGS.H
+++ b/SOURCES/SETTINGS.H
@@ -59,6 +59,24 @@ typedef S32 (*T_SETTING_FORCED_FN)(void);
  * of them. */
 typedef void (*T_SETTING_APPLY_FN)(S32 value);
 
+/* Where a setting's live value came from.
+ *
+ * The value alone does not say, and three of these are written back differently.
+ * A value the player's own file gave is theirs and is persisted. One the game
+ * data's config gave is real for this run and is not a preference: writing it
+ * back would make the install's choice outlive the install. One a per-run flag
+ * forced is not a preference either, which the stored column already handles.
+ *
+ * Ordered so a later source beats an earlier one, which is the order they are
+ * applied in during boot. */
+typedef enum {
+    SETTING_FROM_DEFAULT = 0, /* nothing named it; the row's compiled default */
+    SETTING_FROM_DATA,        /* the config shipped with the game data */
+    SETTING_FROM_PROFILE,     /* the file this run owns: the player's own choice */
+    SETTING_FROM_FLAG,        /* a per-run command-line override */
+    SETTING_FROM_RUNTIME      /* set during the run: console, socket or menu */
+} T_SETTING_SOURCE;
+
 typedef struct {
     const char *key;    /* lba2.cfg key; NULL if this surface does not persist it */
     const char *legacy; /* older key to fall back to when `key` is absent; NULL if none */
@@ -73,13 +91,14 @@ typedef struct {
      * writer persists that instead whenever the live value is still the one the
      * flag forced. Both NULL for a setting no flag can override.
      *
-     * The comparison is on the value, not on who last wrote it: settings reached
-     * through cvars have no on-change hook, so setting the same value by hand
-     * during an overridden run cannot be told from not touching it. Setting a
-     * different one persists, which is the case that matters. */
+     * A row that also tracks its source answers this exactly: the run set it or
+     * it did not, whatever the values happen to be. Without one the comparison
+     * falls back to the value, which cannot tell setting a value by hand from
+     * never touching it when the two agree. */
     S32 *stored;
     T_SETTING_FORCED_FN forced;
     T_SETTING_APPLY_FN on_change; /* told the new value after a runtime write; NULL if nothing to do */
+    T_SETTING_SOURCE *source;     /* where the live value came from; NULL to not track it */
     const char *help;             /* console help text */
 } T_SETTING;
 
@@ -138,6 +157,10 @@ static inline S32 Settings_Coerce(const T_SETTING *s, S32 value) {
 
 static inline void Settings_Apply(const T_SETTING *s, S32 value) {
     *s->value = Settings_Coerce(s, value);
+    /* Recorded before the hook runs, so a hook that reads the source sees the
+       write it is being told about rather than the one before it. */
+    if (s->source != NULL)
+        *s->source = SETTING_FROM_RUNTIME;
     if (s->on_change != NULL)
         s->on_change(*s->value);
 }
@@ -153,6 +176,34 @@ static inline void Settings_Apply(const T_SETTING *s, S32 value) {
  * backwards is invisible to any check that reads back a cfg the engine wrote. */
 static inline S32 Settings_ValueToPersist(S32 live, S32 stored, S32 forced) {
     return (forced >= 0 && live == forced) ? stored : live;
+}
+
+/* Record that this run set a setting, for a writer that does not go through
+ * Settings_Apply. The console exposes some settings as commands rather than as
+ * cvars, because they take words rather than numbers, and those assign the live
+ * value themselves. Without this they would look untouched to the rule below and
+ * a forced run would put the player's old value back over the player's own
+ * choice. */
+static inline void Settings_MarkSetThisRun(T_SETTING_SOURCE *source) {
+    if (source != NULL)
+        *source = SETTING_FROM_RUNTIME;
+}
+
+/* What a row persists, given where its live value came from.
+ *
+ * The rule the value comparison was reaching for: a run that set the value keeps
+ * it, a run that merely inherited one does not. Only the flag case needs the
+ * source to decide, which is why a row without one still gets the old answer
+ * rather than a worse one.
+ *
+ * Left alone deliberately: a value from the game data's config is returned as it
+ * stands. Not writing it back is the fix for an install's settings becoming the
+ * player's, and it is a change to what the file ends up holding rather than to
+ * this arithmetic. */
+static inline S32 Settings_ValueToPersistFrom(S32 live, S32 stored, S32 forced, T_SETTING_SOURCE source) {
+    if (forced < 0)
+        return live; /* no flag touched it */
+    return (source == SETTING_FROM_RUNTIME) ? live : stored;
 }
 
 /* Apply the cfg to every row that names a key, clamped. */

--- a/tests/deffile/test_deffile_layers.cpp
+++ b/tests/deffile/test_deffile_layers.cpp
@@ -138,6 +138,75 @@ int main() {
     // The restored state still knows it is layered, so writes still refuse.
     CHECK(!DefFileBufferWriteString("Shadow", "2"));
 
+    // --- which source answered ----------------------------------------------
+    // The value alone cannot say. A setting inherited from the layer is real for
+    // this run and is not the player's preference, so a writer has to be able to
+    // tell the two apart before deciding what to persist.
+    //
+    // Both files written here rather than inherited: the steps above rewrite them
+    // for their own purposes, and a block that reads whatever they happened to
+    // leave is asserting against the previous test rather than against this one.
+    WriteFile(kOwnPath, "Language: English\nShadow: 3\n");
+    WriteFile(kDataPath, "Language: Francais\nVersion: 3\nPathInstall: C:\\LBA2\n");
+    LoadLayered(true);
+    // Own file: Language, Shadow. Layer: Language (shadowed), Version, PathInstall.
+    CHECK(DefFileBufferKeyOrigin("Language") == DEFFILE_ORIGIN_OWNED);
+    CHECK(DefFileBufferKeyOrigin("Shadow") == DEFFILE_ORIGIN_OWNED);
+    CHECK(DefFileBufferKeyOrigin("Version") == DEFFILE_ORIGIN_LAYER);
+    CHECK(DefFileBufferKeyOrigin("PathInstall") == DEFFILE_ORIGIN_LAYER);
+    CHECK(DefFileBufferKeyOrigin("NoSuchKey") == DEFFILE_ORIGIN_ABSENT);
+    CHECK(DefFileBufferKeyOrigin(NULL) == DEFFILE_ORIGIN_ABSENT);
+    // The shadowed key reads the owned value, and reports the source that gave it.
+    CHECK(ReadKey("Language") == "English");
+
+    // Presence agrees with the reader that already answers it, so the two cannot
+    // drift: ABSENT exactly when DefFileBufferReadValue2 says the key is not there.
+    // A key set to zero is present, which is the case a bare ReadValue confuses
+    // with a missing one only because its sentinel for missing is -1.
+    WriteFile(kOwnPath, "Zero: 0\n");
+    LoadLayered(false);
+    S32 probe = 123;
+    CHECK(DefFileBufferKeyOrigin("Zero") == DEFFILE_ORIGIN_OWNED);
+    CHECK(DefFileBufferReadValue2("Zero", &probe));
+    CHECK(probe == 0);
+    CHECK(DefFileBufferKeyOrigin("Missing") == DEFFILE_ORIGIN_ABSENT);
+    CHECK(!DefFileBufferReadValue2("Missing", &probe));
+
+    // With no layer attached, everything present is owned.
+    WriteFile(kOwnPath, "Language: English\nShadow: 3\n");
+    LoadLayered(false);
+    CHECK(DefFileBufferKeyOrigin("Language") == DEFFILE_ORIGIN_OWNED);
+    CHECK(DefFileBufferKeyOrigin("Version") == DEFFILE_ORIGIN_ABSENT);
+
+    // A re-load clears the boundary. Without that the stale pointer sits in the
+    // middle of whatever the next buffer holds, and every key past that offset
+    // reports itself inherited from a layer that is no longer attached.
+    //
+    // Catching it needs the second file to be longer than the first was, so that
+    // its later keys land past where the old layer began. A short file re-loaded
+    // over a long one keeps all its keys below the stale mark and passes either
+    // way, which is the version of this check that proves nothing.
+    WriteFile(kOwnPath, "A: 1\n");
+    WriteFile(kDataPath, "Version: 3\n");
+    LoadLayered(true); // boundary lands just past "A: 1\n"
+    CHECK(DefFileBufferKeyOrigin("Version") == DEFFILE_ORIGIN_LAYER);
+
+    WriteFile(kOwnPath, "A: 1\nB: 2\nC: 3\nD: 4\nE: 5\nF: 6\nG: 7\nH: 8\n");
+    LoadLayered(false);
+    CHECK(DefFileBufferKeyOrigin("A") == DEFFILE_ORIGIN_OWNED);
+    CHECK(DefFileBufferKeyOrigin("H") == DEFFILE_ORIGIN_OWNED); // well past the old mark
+
+    // And save/restore carries it, so a transient read cannot lose it.
+    WriteFile(kOwnPath, "Language: English\nShadow: 3\n");
+    WriteFile(kDataPath, "Language: Francais\nVersion: 3\nPathInstall: C:\\LBA2\n");
+    LoadLayered(true);
+    T_DEFFILE_STATE savedOrigin;
+    DefFileBufferSaveState(&savedOrigin);
+    CHECK(DefFileBufferInit((char *)kDataPath, g_other, (S32)sizeof g_other));
+    CHECK(DefFileBufferKeyOrigin("Version") == DEFFILE_ORIGIN_OWNED); // its own file now
+    DefFileBufferRestoreState(&savedOrigin);
+    CHECK(DefFileBufferKeyOrigin("Version") == DEFFILE_ORIGIN_LAYER); // layered again
+
     std::remove(kOwnPath);
     std::remove(kDataPath);
     std::printf("test_deffile_layers: OK\n");

--- a/tests/settings/test_settings_coerce.cpp
+++ b/tests/settings/test_settings_coerce.cpp
@@ -265,6 +265,17 @@ static void test_an_unforced_run_ignores_the_source(void) {
     ASSERT_EQ_INT(7, Settings_ValueToPersistFrom(7, 3, -1, SETTING_FROM_RUNTIME));
 }
 
+/* A value that moved off what the flag forced is the run's doing whatever the
+   source says, which is what keeps this a refinement rather than a replacement.
+   A writer that assigns the global without marking the run is no worse off than
+   it was before the source existed. */
+static void test_moving_off_the_forced_value_needs_no_marker(void) {
+    ASSERT_EQ_INT(33, Settings_ValueToPersistFrom(33, 16, 100, SETTING_FROM_PROFILE));
+    ASSERT_EQ_INT(33, Settings_ValueToPersistFrom(33, 16, 100, SETTING_FROM_DEFAULT));
+    /* and the old rule agrees, which is the point */
+    ASSERT_EQ_INT(33, Settings_ValueToPersist(33, 16, 100));
+}
+
 /* Every source that is not the run itself is treated the same by a forced run:
    the player's stored value goes back, because none of them is this run's doing. */
 static void test_only_a_runtime_write_survives_a_forced_run(void) {
@@ -314,6 +325,7 @@ int main(void) {
     RUN_TEST(test_a_setting_without_a_hook_just_stores);
     RUN_TEST(test_setting_it_to_the_forced_value_is_now_told_apart);
     RUN_TEST(test_an_unforced_run_ignores_the_source);
+    RUN_TEST(test_moving_off_the_forced_value_needs_no_marker);
     RUN_TEST(test_only_a_runtime_write_survives_a_forced_run);
     RUN_TEST(test_apply_marks_the_value_as_this_run);
     TEST_SUMMARY();

--- a/tests/settings/test_settings_coerce.cpp
+++ b/tests/settings/test_settings_coerce.cpp
@@ -31,6 +31,7 @@ static T_SETTING row(T_SETTING_TYPE type, S32 def, S32 min, S32 max) {
     s.stored = NULL;
     s.forced = NULL;
     s.on_change = NULL;
+    s.source = NULL;
     s.help = NULL;
     return s;
 }
@@ -243,6 +244,57 @@ static void test_a_setting_without_a_hook_just_stores(void) {
     ASSERT_EQ_INT(0, s_applied_calls);
 }
 
+/* --- what a forced run leaves behind, once the source is known ------------ */
+
+/* The case the value comparison cannot answer. A run forced to 0 by a flag, where
+   the player's own setting is also 0, and the run set it by hand: the values are
+   identical, so only the source can say the run touched it. */
+static void test_setting_it_to_the_forced_value_is_now_told_apart(void) {
+    /* untouched: the flag's value goes back to what the player had */
+    ASSERT_EQ_INT(1, Settings_ValueToPersistFrom(0, 1, 0, SETTING_FROM_PROFILE));
+    /* set by hand to the same value: the run meant it, so it persists */
+    ASSERT_EQ_INT(0, Settings_ValueToPersistFrom(0, 1, 0, SETTING_FROM_RUNTIME));
+    /* which the old rule cannot separate: both are the same call */
+    ASSERT_EQ_INT(1, Settings_ValueToPersist(0, 1, 0));
+}
+
+/* A run no flag touched keeps its live value whatever the source says. */
+static void test_an_unforced_run_ignores_the_source(void) {
+    ASSERT_EQ_INT(7, Settings_ValueToPersistFrom(7, 3, -1, SETTING_FROM_DEFAULT));
+    ASSERT_EQ_INT(7, Settings_ValueToPersistFrom(7, 3, -1, SETTING_FROM_DATA));
+    ASSERT_EQ_INT(7, Settings_ValueToPersistFrom(7, 3, -1, SETTING_FROM_RUNTIME));
+}
+
+/* Every source that is not the run itself is treated the same by a forced run:
+   the player's stored value goes back, because none of them is this run's doing. */
+static void test_only_a_runtime_write_survives_a_forced_run(void) {
+    const T_SETTING_SOURCE inherited[] = {SETTING_FROM_DEFAULT, SETTING_FROM_DATA, SETTING_FROM_PROFILE,
+                                          SETTING_FROM_FLAG};
+    S32 i;
+    S32 bad = 0;
+
+    for (i = 0; i < (S32)(sizeof(inherited) / sizeof(inherited[0])); i++) {
+        if (Settings_ValueToPersistFrom(5, 9, 5, inherited[i]) != 9)
+            bad++;
+    }
+    ASSERT_EQ_INT(0, bad);
+    ASSERT_EQ_INT(5, Settings_ValueToPersistFrom(5, 9, 5, SETTING_FROM_RUNTIME));
+}
+
+/* Settings_Apply records the write, so a row with a source needs nothing else
+   wired for the rule above to see it. */
+static void test_apply_marks_the_value_as_this_run(void) {
+    S32 live = 0;
+    T_SETTING_SOURCE src = SETTING_FROM_PROFILE;
+    T_SETTING s = row(SETTING_CLAMP, 3, 0, 10);
+    s.value = &live;
+    s.source = &src;
+
+    Settings_Apply(&s, 4);
+    ASSERT_EQ_INT(4, live);
+    ASSERT_EQ_INT((S32)SETTING_FROM_RUNTIME, (S32)src);
+}
+
 int main(void) {
     RUN_TEST(test_every_rule_passes_an_in_range_value_through);
     RUN_TEST(test_clamp_moves_to_the_nearer_bound);
@@ -260,6 +312,10 @@ int main(void) {
     RUN_TEST(test_the_hook_is_told_the_stored_value);
     RUN_TEST(test_the_hook_fires_on_every_write);
     RUN_TEST(test_a_setting_without_a_hook_just_stores);
+    RUN_TEST(test_setting_it_to_the_forced_value_is_now_told_apart);
+    RUN_TEST(test_an_unforced_run_ignores_the_source);
+    RUN_TEST(test_only_a_runtime_write_survives_a_forced_run);
+    RUN_TEST(test_apply_marks_the_value_as_this_run);
     TEST_SUMMARY();
     return test_failures != 0;
 }


### PR DESCRIPTION
The provenance pattern, with the one new primitive it needs. Two commits.

## The primitive

The config a run reads is the file it owns with the game data's appended underneath, and reads stop at the first match, so the returned value cannot say which supplied it. `DefFileBufferKeyOrigin` answers `OWNED`, `LAYER` or `ABSENT`, using the match position the scan already records against the offset the first append began at.

Presence was already answerable via `DefFileBufferReadValue2`; folding it in means one call instead of two, and the test pins the two agreeing so they cannot drift. **I had claimed in the header that nothing else answered presence — writing the test disproved it, and the comment is now correct.**

The boundary is cleared on every `DefFileBufferInit` and carried through save/restore. Both are covered, and the re-load test is written so the second file is *longer* than the first: a shorter one keeps its keys below the stale mark and passes either way. My first version of that check did exactly that and passed against a deliberately broken clear.

## The settings side

A row can now say whether its value is the player's own, the game data's, what a flag forced, or something this run set.

What it fixes today is the case [SETTINGS.H](SOURCES/SETTINGS.H) flagged as unanswerable: a flag forces a value, the player's stored setting happens to be the *same* value, and the run then sets it by hand. The comparison was on the value, so those were indistinguishable and the player's own change was overwritten. `Settings_ValueToPersistFrom` asks whether the run set it. A row without a source keeps the old answer rather than a worse one.

Wired to the three rows a flag can force (VSync, TextureFilter, FixedTimestep).

**`vsync` needed extra wiring, and only behavioural testing found it.** Settings the console exposes as *commands* rather than cvars take words (`on|off|toggle`) and assign the value themselves, so they never reach `Settings_Apply`. The case above still wrote back the old value until `cmd_vsync` marked the write. Verified end to end:

| run | before | now |
|---|---|---|
| `--vsync off` then `vsync off` | cfg keeps 1 | cfg keeps **0** |
| `--vsync off` alone | cfg keeps 1 | cfg keeps 1 |
| `vsync off` alone | cfg keeps 0 | cfg keeps 0 |

## Deliberately not done

Nothing acts on `SETTING_FROM_DATA` yet. Not writing those back is #495, and it is a change to what the file ends up holding rather than to this arithmetic. The field it needs now exists, and the issue's own "shape a fix would take" section asked for exactly this.

Also not done: the control server gets no distinct origin. It and `--exec` both funnel through `Console_Execute`, so they are transports rather than sources — a socket write is the same event as a typed one. `Console_Execute` is the single choke point if a case ever appears.

## Verification

- 4 new host tests on the rule, 20/20 in `test_settings_coerce`; the deffile layering test extended and validated by breaking the boundary clear.
- `ctest -L host_quick` 59/59, full automation suite **60 passed, 2 skipped, 0 failed**.
- `cli_flag_contract`, `cli_override_persistence`, `config_upgrade`, `console_config_write`, `config_volumes` all pass.

## Checklist

- [x] Build passes on my platform (Linux)
- [ ] If LIB386 / 3DEXT touched: ASM equivalence tests pass (`./run_tests_docker.sh`) — LIB386/SYSTEM/DEFFILE.CPP touched; suite is green locally, see below
- [x] If behavior changes: opt-in via flag/cvar/config (preserves default game feel)
- [x] Docs updated in the same PR if behavior or workflow changed
- [x] French comments and ASCII art preserved in any modified files