### PR TITLE
fix(grille): bound a cell's brick index before drawing it

### DIFF
--- a/SOURCES/GRILLE.CPP
+++ b/SOURCES/GRILLE.CPP
@@ -811,6 +811,44 @@ void DrawOverBrickCage(S32 xm, S32 ym, S32 zm) {
 
 /*--------------------------------------------------------------------------*/
 
+/*--------------------------------------------------------------------------*/
+/*	Un bloc contient dx*dy*dz entrees de 4 octets apres son entete. Rien ne
+    bornait l'index brick des cellules, et une cellule qui pointe au dela lit
+    l'entete du bloc suivant: le U16 recupere n'est pas un index de brique
+    remappe, donc AffGraph() calcule bankgraph + un offset arbitraire.
+
+    Les cellules de la carte tiennent toujours dans leur bloc. Celles qu'une GRM
+    incruste, non: sur le cube 38 pres de la moitie des cellules non vides
+    designent une brique au dela de son bloc, ce qui reste inexplique. En un
+    seul gros bloc memoire, comme sur DOS, l'offset arbitraire retombait dans de
+    la memoire allouee et dessinait n'importe quoi sans planter. Ici il sort. */
+/*	Le banc de briques du cube commence par sa table d'offsets, donc son premier
+    U32 vaut (nbbrick + 1) * 4: le compte se relit comme NbBlock se relit depuis
+    TabBlock. Une entree de bloc qui n'a pas ete renumerotee garde un identifiant
+    global (jusqu'a Max_Brk), qui depasse ce compte et envoie AffGraph lire une
+    table d'offsets hors du banc. */
+static S32 BrickInBank(S32 numbrick) {
+    S32 packed;
+
+    if (!BufferBrick)
+        return FALSE;
+
+    packed = (S32)((*(U32 *)BufferBrick) / 4) - 1;
+
+    return numbrick >= 1 && numbrick <= packed;
+}
+
+static S32 BrickInsideBlock(const U8 *blockadr, S32 brick) {
+    S32 extent;
+
+    if (brick < 0)
+        return FALSE;
+
+    extent = (S32)blockadr[DXBLOCK] * (S32)blockadr[DYBLOCK] * (S32)blockadr[DZBLOCK];
+
+    return brick < extent;
+}
+/*--------------------------------------------------------------------------*/
 void AffBrickBlock(S32 block, S32 brick, S16 x, S16 y, S16 z) {
     U8 *adr;
     S32 nb, col;
@@ -819,6 +857,10 @@ void AffBrickBlock(S32 block, S32 brick, S16 x, S16 y, S16 z) {
     U8 brickcol;
 
     adr = GetAdrBlock(block);
+
+    if (!BrickInsideBlock(adr, brick))
+        return; //	cellule hors de son bloc: rien de defini a dessiner
+
     adr += HEADER_BLOCK;
 
     adr += (brick << 2); /* 4 Bytes to Jump	*/
@@ -827,7 +869,7 @@ void AffBrickBlock(S32 block, S32 brick, S16 x, S16 y, S16 z) {
 
     numbrick = *(U16 *)adr; /* & 32767 */
 
-    if (numbrick AND numbrick != ForbidenBrick) {
+    if (numbrick AND numbrick != ForbidenBrick AND BrickInBank(numbrick)) {
         Map2Screen(x - StartXCube, y - StartYCube, z - StartZCube);
 
         // Left clip is -47 (one full brick width minus a pixel), not -24 (half-brick).
@@ -917,6 +959,10 @@ void AffBrickBlockColon(S32 block, S32 brick, S16 x, S16 y, S16 z) {
     U8 brickcol;
 
     adr = GetAdrBlock(block);
+
+    if (!BrickInsideBlock(adr, brick))
+        return; //	cellule hors de son bloc: rien de defini a dessiner
+
     adr += HEADER_BLOCK;
 
     adr += (brick << 2); /* 4 Bytes to Jump	*/
@@ -925,7 +971,7 @@ void AffBrickBlockColon(S32 block, S32 brick, S16 x, S16 y, S16 z) {
 
     numbrick = *(U16 *)adr; /* & 32767 */
 
-    if (numbrick AND numbrick != ForbidenBrick) {
+    if (numbrick AND numbrick != ForbidenBrick AND BrickInBank(numbrick)) {
         Map2Screen(x - StartXCube, y - StartYCube, z - StartZCube);
 
         if (XScreen >= -24 AND XScreen < (S32)ModeDesiredX AND YScreen >= -38 AND YScreen < (S32)ModeDesiredY) {
@@ -1000,6 +1046,10 @@ void AffBrickBlockOnly(S32 block, S32 brick, S16 x, S16 y, S16 z) {
     S32 numbrick;
 
     adr = GetAdrBlock(block);
+
+    if (!BrickInsideBlock(adr, brick))
+        return; //	cellule hors de son bloc: rien de defini a dessiner
+
     adr += HEADER_BLOCK;
 
     adr += (brick << 2); /* 4 Bytes to Jump	*/
@@ -1007,7 +1057,7 @@ void AffBrickBlockOnly(S32 block, S32 brick, S16 x, S16 y, S16 z) {
 
     numbrick = *(U16 *)adr; /* & 32767 */
 
-    if (numbrick AND numbrick != ForbidenBrick) {
+    if (numbrick AND numbrick != ForbidenBrick AND BrickInBank(numbrick)) {
         Map2Screen(x - StartXCube, y - StartYCube, z - StartZCube);
 
         if (XScreen >= -24 AND XScreen < (S32)ModeDesiredX AND YScreen >= -38 AND YScreen < (S32)ModeDesiredY) {

--- a/scripts/dev/probe_grm_frame.py
+++ b/scripts/dev/probe_grm_frame.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Walk cubes at gameplay pace, deterministically, then record the frame's draw calls.
+
+Two constraints shape this. `--exec` fires every command in one go, which is too
+fast for DoLife to run the zone triggers that incrust GRMs, and `--exec-at` caps
+at 16 entries, so neither can pace a long walk. The socket can.
+
+The pacing has to be counted, not waited for. Sleeping between commands lets a
+variable number of frames elapse, and the recording then differs run to run by a
+few hundred bytes, which is wide enough to swallow the difference you are trying
+to measure. The control server runs exactly one command per frame ("spending a
+frame per line ... makes each command's effect its own", CONTROL_SERVER.CPP), so
+sending N no-op commands advances exactly N frames. With `--fixed-dt` pinning the
+step size too, the whole walk is reproducible.
+
+Needs an ENABLE_POLY_RECORDING build.
+
+Usage: probe_grm_frame.py <out.lba2polyrec> [last-cube] [frames-per-cube] [attempts]
+"""
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from lba2ctl import Control, engine_binary, env_path, game_dir
+
+BIN = engine_binary()
+SAVE = env_path("LBA2_SAVE", "a save to boot into, as a full path")
+PORT = 4463
+OUT = sys.argv[1]
+LAST = int(sys.argv[2]) if len(sys.argv) > 2 else 40
+FRAMES = int(sys.argv[3]) if len(sys.argv) > 3 else 18
+ATTEMPTS = int(sys.argv[4]) if len(sys.argv) > 4 else 5
+
+
+def step(conn, frames):
+    """Advance exactly `frames` frames: one command consumed per frame."""
+    for _ in range(frames):
+        conn.send("status")
+
+
+def one_run(attempt):
+    user_dir = tempfile.mkdtemp(prefix=f"lba2-grmframe{attempt}-")
+    log_path = os.path.join(user_dir, "engine.log")
+    env = dict(os.environ, ASAN_OPTIONS="detect_leaks=0")
+    with open(log_path, "wb") as log:
+        p = subprocess.Popen(
+            [BIN, "--headless", "--no-audio", "--fixed-dt", "16",
+             "--game-dir", game_dir(), "--user-dir", user_dir,
+             "--no-autosave", "--load", SAVE, "--listen", str(PORT)],
+            stdout=log, stderr=log, env=env)
+
+    conn = None
+    for _ in range(240):
+        time.sleep(0.25)
+        if p.poll() is not None:
+            break
+        try:
+            conn = Control(PORT, timeout=60)
+            break
+        except OSError:
+            continue
+    if conn is None:
+        return None, log_path, "engine never came up"
+
+    try:
+        conn.send("skipmodals 1")
+        for n in range(0, LAST + 1):
+            conn.send(f"cube {n}")
+            step(conn, FRAMES)
+        conn.send(f"polyrec {OUT}")
+        step(conn, 8)  # the recorder captures the frame after the request
+    except Exception as exc:
+        return None, log_path, f"died during the walk: {exc}"
+    finally:
+        if p.poll() is None:
+            p.terminate()
+            p.wait(timeout=10)
+
+    return (OUT if os.path.exists(OUT) else None), log_path, None
+
+
+for attempt in range(ATTEMPTS):
+    out, log_path, err = one_run(attempt)
+    if out:
+        print(f"attempt {attempt}: recorded {out} ({os.path.getsize(out)} bytes)")
+        print(f"   log: {log_path}")
+        sys.exit(0)
+    print(f"attempt {attempt}: {err or 'no recording written'}  log: {log_path}")
+
+print("no frame recorded")
+sys.exit(1)


### PR DESCRIPTION
Walking cubes over the control socket segfaults intermittently, roughly **one sweep in three**, always the same way:

```
SEGV  GRAPH.CPP:61 in AffGraph
      <- AffBrickBlock <- AffGrille <- RefreshGrille <- AffScene <- MainLoop
```

`AffGraph` resolves `bankgraph + ((U32 *)bankgraph)[numgraph]` to a wild pointer. Two unbounded reads get it there, and guarding only the first moves the crash instead of fixing it, which is how the second turned up.

## 1. A cell's brick index is not bounded by its block

A block holds `dx*dy*dz` four-byte entries after its header. The cell readers did `adr += (brick << 2)` with no test against that.

At the fault: `cube=38 block=1 brick=30 usedbit=1 dxdydz=2x10x1 maxbrk=20`. Block 1 has **20** entries and the cell asks for **brick 30**, so the read lands ten entries past the end, inside the next block's header. The `U16` there is not a renumbered brick index at all (`numbrick=11521` against a 284-entry bank).

## 2. An in-range entry can still hold a raw global id

Some entries hold a global brick identifier rather than a packed one, which is past the end of the cube's bank. The bank's first `U32` is `(nbbrick + 1) * 4`, so the count reads back exactly the way `NbBlock` already reads back from `TabBlock`:

```c
packed = (S32)((*(U32 *)BufferBrick) / 4) - 1;
```

No new global, same idiom the file already uses.

## Where the bad cells come from, and what is still open

They are written by `IncrustGrm`, which memcpys a GRM's `(block, brick)` pairs straight into the cube map. That is why the map validates clean at load and goes bad later.

**Why a GRM names bricks its blocks do not have is not answered here.** For cube 38, ~1000 of ~2070 non-empty cells do. Narrowed but unresolved:

- No payload offset reads them as valid (swept 0..7 over the full payload).
- Not byte order (the swapped reading is worse: 775 valid / 1292 past).
- Not a neighbouring GRM (searched HQR indices 148..156; none fits, and 152 and 156 are byte-identical).
- Size is exactly consistent: `Load_HQR` returns 16723, header is 3 bytes, 20*19*22*2 = 16720.
- **Every block number it uses is legal** — zero cells reference a block above `NbBlock` across every reading, which would be near-impossible by chance and says the pair alignment is right.
- The map's own cells are 100% valid against the same extent formula.

In one big DOS allocation the arbitrary offset landed in memory that existed and drew nonsense without faulting. Here it escapes the allocation.

## Verification

**Crash**: eighteen sweeps of 120 cube changes with both guards, no fault. Before, roughly one in three died.

**Cost**: measured rather than assumed, and this took two attempts to get right. `scripts/dev/probe_grm_frame.py` walks the cubes at gameplay pace and records the frame's polygon calls with `polyrec`.

The pacing has to count frames rather than sleep. `--exec` fires everything at once, too fast for `DoLife` to run the zone triggers that incrust GRMs; `--exec-at` caps at 16 entries; and wall-clock sleeps let the frame count drift, which produced recordings varying by a few hundred bytes run to run — wide enough to swallow the signal. The control server runs one command per frame by design, so N no-op commands advance exactly N frames. With that, the same binary twice records **byte-identical** output.

Against that baseline:

| | |
| --- | --- |
| recording size, both builds | 520803 bytes |
| draw calls lost | 0 |
| bytes changed | **3** |

I had expected holes, since ~1000 cells are affected in that GRM. Almost none are ever in view. Caveat: one walk, one vantage, so not the last word on how those cells would look from elsewhere.

Full suite green at 153/153.
