### PR TITLE
test(3d): put the long double rotation path under the sanitizers

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ add_subdirectory(movement)
 add_subdirectory(zone)
 add_subdirectory(plasma_steps)
 add_subdirectory(camera)
+add_subdirectory(precision_paths)
 add_subdirectory(ui_layout)
 add_subdirectory(settings)
 

--- a/tests/precision_paths/CMakeLists.txt
+++ b/tests/precision_paths/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Host coverage for the long double / lrintl rotation path.
+#
+# The ASM-equivalence tests that own this code (tests/3D, tests/OBJECT,
+# tests/ANIM) need the 32-bit UASM toolchain and only run in the Docker leg, so
+# the sanitize job in linux.yml never reaches it. This compiles the same sources
+# without an ASM twin, which puts them under ASan and UBSan in CI.
+add_executable(test_precision_paths
+    test_precision_paths.cpp
+    ${CMAKE_SOURCE_DIR}/LIB386/3D/LROT2DF.CPP
+    ${CMAKE_SOURCE_DIR}/LIB386/3D/SINTABF.CPP
+)
+
+# CAMERA.CPP is not linked: it owns the X0/Y0/Z0 the rotation writes to, but
+# also pulls in the matrix and projection stack, which would drag most of the 3D
+# library into a test that only needs three globals. The test defines them.
+
+target_include_directories(test_precision_paths PRIVATE
+    ${CMAKE_SOURCE_DIR}/LIB386/H
+    ${CMAKE_SOURCE_DIR}/tests
+)
+
+target_compile_definitions(test_precision_paths PRIVATE
+    "TEST_SOURCE_ROOT=\"${CMAKE_SOURCE_DIR}/\""
+)
+
+set_target_properties(test_precision_paths PROPERTIES CXX_STANDARD 11)
+
+add_test(NAME test_precision_paths COMMAND test_precision_paths)
+
+register_host_test(test_precision_paths)

--- a/tests/precision_paths/test_precision_paths.cpp
+++ b/tests/precision_paths/test_precision_paths.cpp
@@ -1,0 +1,102 @@
+/*
+ * Drives the long double / lrintl rotation paths so the sanitizers can watch
+ * them.
+ *
+ * Issue #138 asked whether the x87 precision code conflicts with UBSan and left
+ * it as an open sanity check, because the only tests that touch these functions
+ * are ASM-equivalence tests (tests/3D, tests/OBJECT, tests/ANIM). Those need the
+ * 32-bit UASM toolchain and run in the Docker leg, so the `sanitize` job in
+ * linux.yml, which builds `host_tests` and runs `ctest -L host_quick`, never
+ * reaches this code at all.
+ *
+ * What this is for: coverage under the sanitizers, not correctness. The
+ * ASM-equivalence tests already own correctness, and they compare against the
+ * original to a far higher standard than anything asserted here. This drives the
+ * same entry points over a spread of inputs, including the ones most likely to
+ * upset a conversion (the angle wrap, the quadrant boundaries, and coordinates
+ * near the S32 edges where `long double` -> `lrintl` has to land somewhere
+ * defined). Under `linux_sanitize` a signed overflow, a bad shift or an invalid
+ * float-to-int conversion in that path fails the run.
+ *
+ * The assertions are deliberately weak but true: the same input gives the same
+ * output, and the identity angle leaves a point alone. Anything stronger would
+ * either restate the ASM comparison or invent a precision contract this file has
+ * no standing to define.
+ */
+
+#include "test_harness.h"
+
+#include <3D/CAMERA.H>
+#include <3D/ROT2D.H>
+
+#include <stdlib.h>
+
+/* LongRotate writes its result to these. CAMERA.CPP defines them for the engine
+   but brings the whole matrix and projection stack with it, so the test owns
+   them here instead. */
+S32 X0 = 0;
+S32 Y0 = 0;
+S32 Z0 = 0;
+
+/* Angles are 12-bit (0..4095). These are the wrap and quadrant boundaries plus a
+   few interior values; `LongRotate` special-cases angle 0. */
+static const S32 kAngles[] = {0, 1, 1023, 1024, 1025, 2047, 2048,
+                              2049, 3071, 3072, 3073, 4094, 4095, 4096, 8191};
+
+/* Coordinates spanning small, scene-sized and extreme magnitudes. The large ones
+   matter: the products feed a long double before `lrintl`, and that is where a
+   conversion would go undefined if the arithmetic were done narrower. */
+static const S32 kCoords[] = {0, 1, -1, 512, -512,
+                              32767, -32768, 1000000, -1000000, 16777216,
+                              -16777216};
+
+static void test_rotate_is_deterministic(void) {
+    for (unsigned a = 0; a < sizeof(kAngles) / sizeof(kAngles[0]); a++) {
+        for (unsigned i = 0; i < sizeof(kCoords) / sizeof(kCoords[0]); i++) {
+            for (unsigned j = 0; j < sizeof(kCoords) / sizeof(kCoords[0]); j++) {
+                LongRotate(kCoords[i], kCoords[j], kAngles[a]);
+                const S32 x1 = X0;
+                const S32 z1 = Z0;
+
+                LongRotate(kCoords[i], kCoords[j], kAngles[a]);
+
+                ASSERT_EQ_INT(x1, X0);
+                ASSERT_EQ_INT(z1, Z0);
+            }
+        }
+    }
+}
+
+static void test_identity_angle_is_a_no_op(void) {
+    for (unsigned i = 0; i < sizeof(kCoords) / sizeof(kCoords[0]); i++) {
+        for (unsigned j = 0; j < sizeof(kCoords) / sizeof(kCoords[0]); j++) {
+            LongRotate(kCoords[i], kCoords[j], 0);
+
+            ASSERT_EQ_INT(kCoords[i], X0);
+            ASSERT_EQ_INT(kCoords[j], Z0);
+        }
+    }
+}
+
+/* Rotate() is the shipping entry point and forwards to LongRotate(); drive it so
+   the wrapper is covered too rather than only its target. */
+static void test_rotate_wrapper_matches(void) {
+    for (unsigned a = 0; a < sizeof(kAngles) / sizeof(kAngles[0]); a++) {
+        LongRotate(12345, -6789, kAngles[a]);
+        const S32 x1 = X0;
+        const S32 z1 = Z0;
+
+        Rotate(12345, -6789, kAngles[a]);
+
+        ASSERT_EQ_INT(x1, X0);
+        ASSERT_EQ_INT(z1, Z0);
+    }
+}
+
+int main(void) {
+    RUN_TEST(test_rotate_is_deterministic);
+    RUN_TEST(test_identity_angle_is_a_no_op);
+    RUN_TEST(test_rotate_wrapper_matches);
+    TEST_SUMMARY();
+    return test_failures != 0;
+}


### PR DESCRIPTION
Follow-up to #138, closing the one scope note that landed unanswered: *"The `long double` / x87 precision code (`LPROJ3DF`, `LROT3DF`) shouldn't conflict with UBSan, but worth a sanity check."*

## Why a label change could not do it

My first thought was to add `test_fpu_precision` and `test_lirot3df` to `host_quick`. That does not work, and it is worth writing down so nobody tries again:

**Every test that touches this code is an `add_asm_cpp_test` with an ASM source** — `tests/3D`, `tests/OBJECT`, `tests/ANIM`, `tests/fpu_precision`. They need the 32-bit UASM toolchain and only run in the Docker leg. The `sanitize` job builds `host_tests` and runs `ctest -L host_quick`, so it never reached the precision code at all.

## What this does

Compiles `LROT2DF.CPP` and `SINTABF.CPP` into a host test with no ASM twin, so they land under ASan and UBSan in CI. Inputs span the angle wrap and quadrant boundaries (0, 1, 1023/1024/1025, ... 4095, 4096, 8191) and coordinates out to ±16777216 — the large ones being the point, since the products feed a `long double` before `lrintl` and a narrower intermediate would show up there.

**Answer to the scope note: clean.** 3902 assertions, no findings.

## What it does not do

The assertions are deliberately weak and true — same input gives same output, and angle 0 leaves the point alone. Correctness belongs to the ASM-equivalence tests, which compare against the original to a far higher standard. Restating that here would be a worse copy of it, and inventing a precision contract this file has no standing to define would be worse still. This exists so the sanitizers have something to watch.

## Verification

- Host lane: 60/60 under `linux_sanitize` (was 59), full suite 154/154.
- **The gate can fail**: a temporary signed overflow inside the test aborts it and takes `ctest` red. That is `-fno-sanitize-recover=undefined` doing its job, and worth confirming rather than trusting, since a UBSan finding that only prints would scroll past inside a green run.

`CAMERA.CPP` is not linked. It owns the `X0`/`Y0`/`Z0` the rotation writes to, but brings the matrix and projection stack with it, which would drag most of the 3D library into a test that needs three globals. The test defines them.
