### PR TITLE
fix(audio): match the fade locals to the volumes they compare against

### DIFF
--- a/SOURCES/BOOT_EXIT.CPP
+++ b/SOURCES/BOOT_EXIT.CPP
@@ -163,8 +163,6 @@ LBA_NORETURN void BootFatal(const char *fmt, ...) {
 
 /*══════════════════════════════════════════════════════════════════════════*/
 void TheEndInfo() {
-    S32 err = FALSE;
-
 #ifdef CDROM
     ClearVoiceFile();
 #endif

--- a/SOURCES/MUSIC.CPP
+++ b/SOURCES/MUSIC.CPP
@@ -411,9 +411,13 @@ void ResumeMusic(S32 fade) {
 
 void FadeOutVolumeMusic(void) {
     S32 timer;
-    U32 startjvol, jvolume, oldjvol;
+    /* Signed to match JingleVolume and CDVolume, which these are compared and
+       assigned against. They were unsigned while those globals were, and the two
+       have to agree or the comparison converts one side behind the reader's
+       back. */
+    S32 startjvol, jvolume, oldjvol;
 #ifdef CDROM
-    U32 startcdvol, cdvolume, oldcdvol;
+    S32 startcdvol, cdvolume, oldcdvol;
 #endif
 
     ManageTime();
@@ -464,9 +468,13 @@ void FadeOutVolumeMusic(void) {
 
 void FadeInVolumeMusic(void) {
     S32 timer;
-    U32 startjvol, jvolume, oldjvol;
+    /* Signed to match JingleVolume and CDVolume, which these are compared and
+       assigned against. They were unsigned while those globals were, and the two
+       have to agree or the comparison converts one side behind the reader's
+       back. */
+    S32 startjvol, jvolume, oldjvol;
 #ifdef CDROM
-    U32 startcdvol, cdvolume, oldcdvol;
+    S32 startcdvol, cdvolume, oldcdvol;
 #endif
 
     ManageTime();


### PR DESCRIPTION
Two of the three warnings that #523's baseline reports against current `main`. The third is not mine and is identified below.

## Why this is separate from #523

#523's baseline should be a picture of *inherited* debt, so "clear one entry" stays a legible unit of work. Folding last week's regressions into it muddles the number and turns the baseline file into a diff nobody reads. Fixing them here means #523 lands against a tree where its baseline holds.

## What was wrong

**`MUSIC.CPP`, two `-Wsign-compare`.** Aligning `JingleVolume` and `CDVolume` with their three signed siblings (#570) left the locals in `FadeOutVolumeMusic` and `FadeInVolumeMusic` unsigned, so `cdvolume < CDVolume` and `jvolume < JingleVolume` now convert one side silently.

Worth being plain about this one: those are the exact two lines I inspected while making that type change, and I concluded they were safe because the values are clamped to 0..127. That was true, and the job was half done. Nothing else would have caught it. Not the host tests, not the automation suite, not the ASM suite, not the code review.

**`BOOT_EXIT.CPP`, one `-Wunused-variable`.** A dead `err` in `TheEndInfo`, already unused before the exit path moved out of `PERSO.CPP`. So it is not fallout from that move, but the move is what surfaced it: with a per-file baseline, relocating code shows up as `NEW` in one file and `improved` in another. Worth knowing when reading a report, since a pure move and a real regression look the same by count.

## The one that is not mine

`SOURCES/MEM.CPP:227` `-Wsign-compare`, which took that file from 6 to 7. Blame points at `4f7adabe`, the arena isolation flag from #560. Left for its author rather than swept in here.

## Verification

- `MUSIC.CPP` back to its inherited count of 1 (the `volatile U32` timer compare at line 548, untouched); `BOOT_EXIT.CPP` clean.
- Ran #523's own `warning-baseline.sh` against this branch: the only remaining entry above baseline is the MEM.CPP one above.
- `ctest -L host_quick` 59/59, full automation suite 60 passed / 2 skipped / 0 failed, format and arch checks clean.

## Checklist

- [x] Build passes on my platform (Linux)
- [ ] If LIB386 / 3DEXT touched: ASM equivalence tests pass
- [x] If behavior changes: opt-in via flag/cvar/config (preserves default game feel)
- [x] Docs updated in the same PR if behavior or workflow changed
- [x] French comments and ASCII art preserved in any modified files
