### PR TITLE
fix(mem): give the isolation loop its own unsigned counter

### DIFF
--- a/SOURCES/MEM.CPP
+++ b/SOURCES/MEM.CPP
@@ -223,8 +223,14 @@ void InitMainBuffer(void) {
        edge on purpose, which would otherwise mask the spill being hunted.
        See docs/BUG_HUNTING.md. */
     if (getenv("LBA2_DBG_ISOLATE")) {
+        /*	NB_MEM_ELTS is sizeof/sizeof, so it is unsigned; a S32 counter here
+            compares signed against unsigned. Its own counter, rather than
+            retyping the shared t, so the loops that came before keep the shape
+            they have. */
+        size_t i;
+
         ptrm = ListMem;
-        for (t = 0; t < NB_MEM_ELTS; t++, ptrm++) {
+        for (i = 0; i < NB_MEM_ELTS; i++, ptrm++) {
             *ptrm->AdrPtr = (U8 *)Malloc(ptrm->Size + 256);
             if (!*ptrm->AdrPtr)
                 TheEnd(NOT_ENOUGH_MEM, "MainBuffer");


### PR DESCRIPTION
Picked up from #523, which flagged `MEM.CPP:227` as blamed to 4f7adabe and left it for its author rather than sweeping it in. That is the `LBA2_DBG_ISOLATE` block from #560, so it is mine.

## What it is

`NB_MEM_ELTS` is `NbTabIndex(ListMem)`, which expands to `sizeof/sizeof` and is therefore unsigned. Driving the loop with the function's `S32 t` compares signed against unsigned:

```
SOURCES/MEM.CPP:227:23: warning: comparison of integer expressions of different
signedness: 'S32' {aka 'int'} and 'long unsigned int' [-Wsign-compare]
```

The isolation block gets its own `size_t` counter.

## Why not fix the others while here

`MEM.CPP` has four loops with this exact shape — at 203, 227, 250 and 270 before this change. **Only 227 is mine**; the other three are inherited and sit in the 222 that #523 baselines.

Retyping the shared `t` would have cleared all four in one line, but it would also move three baseline entries underneath a PR that is actively being worked. Clearing those is the unit of cleanup #523 describes, and it belongs to that flow rather than to this fix. So this removes exactly the one it introduced: the file's `-Wsign-compare` count goes 7 to 6, and the remaining three are untouched (they renumber to 203, 256, 276 only because this adds lines above them).

## Check

Warning gone, confirmed by compiling `MEM.CPP` with `-Wall -Wextra` before and after.

Behaviour untouched: with `LBA2_DBG_ISOLATE=1` the flag still hands each region its own allocation ("regions isolated for ASan"), and a cube-change walk under it reports nothing.
