### PR TITLE
docs(input): research the input system, and plan the work area 8 asks for

### DIFF
--- a/docs/ENGINE_FILE_FORMATS.md
+++ b/docs/ENGINE_FILE_FORMATS.md
@@ -39,7 +39,8 @@ decompressing an entry.
 | Scene / grid / island | `SYSTEM`+`3DEXT` | HQR / `.ILE`/`.OBL` | all | compatible model, repackaged |
 
 Tooling for all of the below lives in `scripts/dev/`: `hqr_inspect.py` (HQR + LZ),
-`acf_inspect.py` / `acf_decode.py` (XCF), `iso_bin.py` (read a raw CD-image / `.gog`/`.bin`).
+`text_dump.py` (TEXT.HQR banks), `acf_inspect.py` / `acf_decode.py` (XCF), `iso_bin.py` (read a
+raw CD-image / `.gog`/`.bin`).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@ The engine mapped as a whole: layers, the engine/game membrane, and the on-disk 
 | Doc | Description |
 |-----|-------------|
 | [FRENCH_COMMENTS.md](FRENCH_COMMENTS.md) | Curated French comments from the codebase with English translations. |
+| [SPEEDRUN_MECHANICS.md](SPEEDRUN_MECHANICS.md) | Why the movement techniques used in runs work, read from the engine: the behaviour-switch animation rewind, the take-off foot chosen by animation keyframe events, hold versus re-press, simultaneous-opposite resolution, and what preserving the original behaviour alongside fixes would take. |
 | [ASCII_ART.md](ASCII_ART.md) | Catalog of ASCII art banners in the original source files. |
 
 ## Porting & technical
@@ -109,6 +110,9 @@ doc is now history: where it disagrees with the code, the code wins.
 | [BOOT_LOG_PLAN.md](plan/BOOT_LOG_PLAN.md) | Implemented, partly superseded | Boot log and exit screen. Its per-sink severity model was reworked into the single global log level described in [LOGGING_UNIFICATION.md](LOGGING_UNIFICATION.md). |
 | [INIT_RESEARCH.md](plan/INIT_RESEARCH.md) | Research | Initialisation path from `main` to a running scene: boot phases, new-game vs load-save, timing/speed model, cleanup candidates, verbatim TODO inventory. |
 | [INPUT_REPLAY_RESEARCH.md](plan/INPUT_REPLAY_RESEARCH.md) | Research | Capturing input per tick and replaying a session as a gameplay-regression net, the counterpart to the draw-call [polyrec](POLYREC.md). No implementation. |
+| [INPUT_RESEARCH.md](plan/INPUT_RESEARCH.md) | Research | The input system as a whole: the two funnels and which devices depend on the unbindable one, what each device can and cannot express, the open issues clustered, and nine gaps no issue records. |
+| [INPUT_DOOM3_RESEARCH.md](plan/INPUT_DOOM3_RESEARCH.md) | Research | Doom 3's input path read from the GPL release, and which of its decisions apply here: fixed sample rate, impulses off level bits, per-subsystem inhibit, and command demos with a consistency hash. |
+| [INPUT_PLAN.md](plan/INPUT_PLAN.md) | Proposed | Awaiting go/no-go: seven increments making input a subsystem, ordered so each de-risks the next. Scope excludes a new control scheme, with the reason measured rather than preferred. Companion to [SPEEDRUN_MECHANICS.md](SPEEDRUN_MECHANICS.md). |
 | [LBA1_PORT_PLAN.md](plan/LBA1_PORT_PLAN.md) | Proposed | Awaiting go/no-go: how to bring LBA1 to this groundwork. Costs three paths, recommends hosting LBA1 content on the lba2cc engine behind a game-id, with a feasibility-spike ladder. Companion to [LBA1_PORTING_SURFACE.md](LBA1_PORTING_SURFACE.md). |
 | [PLATFORM_PAL_PLAN.md](plan/PLATFORM_PAL_PLAN.md) | Proposed | Awaiting go/no-go: in-place Platform Abstraction Layer decoupling the engine from direct SDL3. SDL-surface audit, RFC #120 reconciliation, PR-sequenced extraction with a headless backend. |
 | [REFACTOR_ROADMAP.md](plan/REFACTOR_ROADMAP.md) | Living | Which areas are worth restructuring and what each one buys, ordered by what tests cover them rather than by how untidy they are. Measures what CI can actually see: 5% of `SOURCES/`, and no 1997 game logic at all. Companion to [FEATURE_WORKFLOW.md](FEATURE_WORKFLOW.md) Example 5. |

--- a/docs/SPEEDRUN_MECHANICS.md
+++ b/docs/SPEEDRUN_MECHANICS.md
@@ -1,0 +1,305 @@
+# Speedrunning mechanics
+
+Why the movement techniques used in LBA2 runs work, read from the engine rather than inferred
+from play. Written for the speedrunning community, which is still active, and for anyone changing
+input or animation code in this port.
+
+Truth hierarchy: code > this document > external sources. Line numbers were verified against the
+working tree; re-grep before relying on an exact one.
+
+**This doubles as a specification.** Every behaviour below is depended on by people, so it is
+regression surface. Several are original bugs, and the comments prove the 1997 team knew. They
+stay bugs: [BIT_EXACTNESS.md](BIT_EXACTNESS.md) decides what may change in this port, and for
+anything here the answer is nothing.
+
+**Attribution.** The French comments quoted below are from the original Adeline codebase and
+reflect the 1990s team, not this community, following the practice in
+[FRENCH_COMMENTS.md](FRENCH_COMMENTS.md). Techniques credited to runners come from
+[speedrun.com/lba2](https://www.speedrun.com/lba2); the mechanisms and everything marked as
+undocumented are read from the source here.
+
+---
+
+## 1. Behaviour switching cancels the current animation
+
+**What runners do.** Tap a behaviour key on landing, or just after a blow lands, to skip the
+recovery and act immediately. Runners describe it as resetting the animation to the beginning.
+
+**Why it works.** `SetComportement` ([SOURCES/OBJECT.CPP:790](../SOURCES/OBJECT.CPP)) does three
+things on its way out:
+
+```c
+ptrobj->FlagAnim = 0;
+InitAnim(GEN_ANIM_RIEN, ANIM_REPEAT, NUM_PERSO);
+ObjectSetFrame(&(ptrobj->Obj), 0);
+```
+
+It clears the animation flags, forces the idle animation, and rewinds to frame 0. The third line
+is the one that matters and is the part usually left out of descriptions: it is not that the new
+behaviour interrupts the old animation, it is that the animation is *rewound*, so whatever
+recovery frames remained are discarded outright.
+
+That is decisive here because hero displacement is not velocity. It is baked into the animation's
+keyframe translations and applied by `ObjectSetInterDep` (see
+[MOVEMENT_FRAMERATE.md](MOVEMENT_FRAMERATE.md)). A recovery animation is therefore not a timer
+being waited out, it is a sequence of frames each carrying a displacement, and rewinding to idle
+frame 0 removes all of them at once.
+
+**Not widely documented:** the same call also swaps the body model and carries a warning from the
+original team about doing so.
+
+**`SOURCES/OBJECT.CPP:883`**
+```
+// ATTENTION: répare un bug lorsqu'on change de cube en NO_BODY
+// mais cela peut avoir des effets secondaires, donc méfie Garçon !
+```
+> "WARNING: fixes a bug when you change cube while in NO_BODY, but this can have side effects, so
+> watch yourself, sunshine!"
+
+## 2. The running jump picks a foot, and the animation decides which
+
+**What runners know.** Sporty running jumps are the movement backbone, and some of them are
+described as extremely picky.
+
+**Why they are picky, which does not appear to be documented anywhere.** The jump has three
+variants and the engine chooses between them by asking which foot is currently planted:
+
+```c
+if (ptrobj->WorkFlags & LEFT_JUMP)       Jumping = DO_LEFT_JUMP;
+else if (ptrobj->WorkFlags & RIGHT_JUMP) Jumping = DO_RIGHT_JUMP;
+else                                     Jumping = DO_NORMAL_JUMP;
+```
+
+The comment above it is `// determine pied d'appel`, "work out the take-off foot".
+
+Those two flags are `WorkFlags` bits, and the original names them plainly
+([SOURCES/COMMON.H:548](../SOURCES/COMMON.H)):
+
+```
+#define	LEFT_JUMP		(1<<15)	// prêt à sauter du pied gauche
+#define	RIGHT_JUMP		(1<<16)	// prêt à sauter du pied droit
+```
+> "ready to jump off the left foot" / "ready to jump off the right foot"
+
+**And nothing in the input code sets them. The animation does.** They are driven by per-frame
+animation events, `F_LEFT_JUMP` (37) and `F_RIGHT_JUMP` (38), in the object's data sheet
+([SOURCES/FICHE.CPP:858](../SOURCES/FICHE.CPP)):
+
+```c
+case F_LEFT_JUMP:
+    if (testframe == *ptrc++) {
+        ptrobj->WorkFlags &= ~(RIGHT_JUMP);
+        ptrobj->WorkFlags |= LEFT_JUMP;
+    }
+    break;
+```
+
+So the walk cycle announces which foot is planted, at a named frame, and the jump reads whatever
+the last announcement was. **The timing window for a given jump variant is a frame of the walk
+animation, not a window in time.**
+
+Two consequences follow, and the second is the useful one:
+
+- The variant is deterministic given the walk-cycle frame, so it is learnable rather than random.
+- **Animation advance is per rendered frame, not per unit of time** (again
+  [MOVEMENT_FRAMERATE.md](MOVEMENT_FRAMERATE.md)), so the walk cycle runs at a rate that depends
+  on frame rate. The window therefore moves relative to wall-clock as frame rate changes. This is
+  the most likely explanation for jumps being picky on some setups and not others, and it means a
+  run's movement tech is not portable across frame rates. See section 6.
+
+There is also a wind-up state. `Jumping = 1024` is set when a jump is being primed from a walk,
+and the low bits carry the variant:
+
+**`SOURCES/OBJECT.CPP:4408`**
+```
+// Seulement si on n'est pas en amorce
+// de saut en course
+```
+> "Only if we are not in the wind-up for a running jump"
+
+## 3. Holding a button and re-pressing it are different inputs
+
+Two paths read input *history* rather than input state, so a hold and a re-press of the same
+button produce different results. Neither is documented outside the source.
+
+### Up or Down across a jump
+
+**`SOURCES/OBJECT.CPP:4396`**
+```
+// skip pour ne pas interrompre un saut
+// si le joueur n'a pas relacher Up et Down
+// avant de reappuyer dessus
+```
+> "skip, so as not to interrupt a jump, if the player has not released Up and Down before pressing
+> them again"
+
+The test is `Jumping & 1023 AND LastMyJoy & (I_UP | I_DOWN) AND !FlagClimbing`. If the direction
+was *already* held on the previous frame the whole block is skipped and the jump survives. Release
+and press again mid-jump and `LastMyJoy` no longer carries the bit, so the jump prep is cleared
+instead. Keeping the key down is not the same as pressing it again, and only one of the two
+preserves the jump.
+
+### Attacking in Aggressive
+
+Holding attack gives the same animation every time. The 1997 team documented it as a bug and
+shipped it:
+
+**`SOURCES/OBJECT.CPP:4111`**
+```
+//	Ici, il y a un bug, le IF qui suit empeche de retirer au hasard une
+//	nouvelle anim. Resultat, Twinsen combat toujours avec le meme coup...
+```
+> "There is a bug here: the IF below stops a new animation being drawn at random. Result: Twinsen
+> always fights with the same blow..."
+
+The guard is `if ((LastInput & I_ACTION_M) AND (ptrobj->GenAnim != GEN_ANIM_RIEN)) break;`, sitting
+directly in front of a `MyRnd(3)` that would otherwise pick one of three attack animations. So
+**releasing and re-pressing attack draws a new animation; holding it does not.** This is the
+mechanism underneath the community's habit of re-pressing rather than holding during a fight.
+
+The line above the guard is a note to self from the same session:
+
+**`SOURCES/OBJECT.CPP:4108`**
+```
+/* essai control direction pendant combat */
+```
+> "trying out directional control during combat"
+
+It is not a trial any more: `Obj.Beta` is advanced from the turn accumulator on that path, so the
+hero can be steered while attacking.
+
+## 4. Simultaneous opposite directions resolve first-listed-wins
+
+Not documented anywhere, and easy to depend on without noticing.
+
+| Pressed together | Result | Where |
+|---|---|---|
+| Up and Down | Up wins; `if (Input & I_UP) ... else test_down = TRUE` gates Down behind it | [OBJECT.CPP:4440](../SOURCES/OBJECT.CPP) |
+| Left and Right | Left wins, both in the turn block and in `ManualRealAngle` | [OBJECT.CPP:3864](../SOURCES/OBJECT.CPP) |
+
+There is no dedicated handling and no neutral result. Whichever branch the `if` reaches first wins,
+consistently. This matters on a gamepad, where a stick near a diagonal boundary can set two
+opposing bits through the quantiser, and on keyboards where both arrows and keypad are bound to
+the same actions.
+
+## 5. Two behaviour keys in the same frame resolve by list order, not by press
+
+Also undocumented. The four behaviour keys are an if/else-if chain
+([SOURCES/PERSO.CPP:1441](../SOURCES/PERSO.CPP)):
+
+```c
+if (Input & I_NORMAL)        SetComportement(C_NORMAL);
+else if (Input & I_SPORTIF)  SetComportement(C_SPORTIF);
+else if (Input & I_AGRESSIF) SetComportement(C_AGRESSIF);
+else if (Input & I_DISCRET)  SetComportement(C_DISCRET);
+```
+
+So Normal beats Sporty beats Aggressive beats Discreet, regardless of which key was pressed first
+or which was pressed most recently. A rolled input across two behaviour keys lands on whichever is
+earlier in that list.
+
+## 6. Frame rate changes movement tech, not just movement speed
+
+The one section here that is a **claim rather than a measurement**, flagged as such because it is
+the most consequential for runs.
+
+Two facts that are measured, in [MOVEMENT_FRAMERATE.md](MOVEMENT_FRAMERATE.md):
+
+- Walking, running and jump length are animation-driven and applied once per rendered frame, so
+  distance covered per unit of game time varies with frame rate, with a sweet spot near 60 fps and
+  losses both above and below it. At very high frame rates the slowest movers stop entirely.
+- Turning is different. It goes through the `MOVE` accumulator, which is velocity times elapsed
+  time with a carried remainder, so it is frame-rate independent.
+
+Three things follow that have not been tested and would be worth a runner's attention:
+
+1. **Arc radius should change with frame rate.** Holding a direction and a turn together walks an
+   arc whose turn rate is correct and whose forward distance is not, so the same input carves a
+   tighter circle at high frame rates.
+2. **Running-jump foot windows move**, per section 2, because the walk cycle advances per frame.
+3. **Any strategy tuned at one frame rate may not transfer to another**, which is a different
+   claim from the usual "the game runs faster or slower".
+
+If the community has frame-rate rules already, they are likely to be empirical versions of these,
+and comparing notes would settle whether the mechanism above matches what runs actually show.
+
+## What is here that is not on the internet
+
+For anyone checking this against community knowledge rather than reading it fresh:
+
+| Known outside | Added here |
+|---|---|
+| behaviour switch cancels animations | it *rewinds* to frame 0, and displacement lives in the frames, which is why recovery vanishes rather than being skipped |
+| Sporty is the movement mode; some jumps are picky | the take-off foot comes from animation keyframe events, so the window is a walk-cycle frame and moves with frame rate |
+| re-press rather than hold when attacking | the mechanism is a guard in front of `MyRnd(3)`, documented as a bug in 1997 |
+| nothing | holding versus re-pressing a direction changes whether a jump survives |
+| nothing | simultaneous opposite directions resolve first-listed-wins |
+| nothing | two behaviour keys in one frame resolve by list order |
+| the game behaves oddly at unusual frame rates | which parts are animation-driven and which are time-driven, and that the split predicts arcs and jump windows changing shape |
+
+## Could the original behaviour be preserved alongside fixes?
+
+Possible, and cheaper than it looks, because the record is structural rather than a habit somebody
+has to keep.
+
+**The delta is always computable.** [2point21/lba2-classic](https://github.com/2point21/lba2-classic)
+is frozen: twelve commits, last touched 2021-12-22. This fork's import commit `333929ab` *is* that
+tree, so `git diff 333929ab..main` is the complete list of everything this port changed, derivable
+at any time by anyone, with no per-commit discipline required. The surface is bounded too: of the
+files that existed at the import, **52 original `SOURCES/*.CPP` files have been edited**. That is
+the whole territory a compatibility mode would have to reason about.
+
+**But the frozen source is not the retail oracle, and this is the part that catches people.**
+The 1997 build used assembly: 280 `.ASM` files are present at the import. The Code Reborn release
+translated those to C++, and some translations were wrong. The clearest is #357, where the ASM's
+`neg eax` became `radius = ~radius`, two's complement mistaken for bitwise-not:
+
+```c
+-        radius = ~radius;
++        radius = -radius; // ASM `neg eax`: two's-complement, not bitwise ~ (#357)
+```
+
+So `lba2-classic` faithfully records **what 2point21 released**, not **what retail did**. Where the
+two disagree, this fork has the better oracle: 81 of the original `.ASM` files are still in the
+tree and the equivalence suite runs them in CI on every push.
+
+**That makes the delta two-directional, which is the useful finding.** Changes since the import
+fall into three buckets, not two:
+
+| Bucket | Example | A vanilla mode would want it |
+|---|---|---|
+| Restores retail, fixing a port regression | the sphere radius above, and the other ASM mistranslations | **on**, because it moves toward retail |
+| Diverges from retail deliberately | time-scaling the holomap globe so it stops spinning with frame rate | **off**, this is the compat surface |
+| No behavioural effect | reformatting, refactors, new translation units | irrelevant |
+
+A naive "revert to lba2-classic" would therefore be wrong: it would reintroduce bugs retail never
+had. The classification is the work, and it is a bounded pass over 52 files against a fixed
+reference rather than archaeology across hundreds of commits.
+
+**What stays genuinely hard** is section 6. A Doom-style compatibility level fully determines
+behaviour because Doom's simulation is a fixed 35 Hz tic. This game's is not, so vanilla code paths
+alone would not reproduce retail outcomes; a faithful mode needs a pinned cadence as well, which is
+what `--fixed-dt` already provides for testing. Preserving "the original" here means choosing
+between original *code paths*, which is reproducible, and original *outcomes*, which were never a
+property of the game alone.
+
+**And one limit no compatibility mode removes:** the RNG is a single shared libc `rand()` stream
+whose sequence differs by platform (#530), so a recording is not guaranteed to replay on a
+different operating system regardless of how faithful the game logic is.
+
+None of this argues for building the switch now. It argues that the switch can be built whenever
+someone wants it, that the fixtures in [plan/INPUT_PLAN.md](plan/INPUT_PLAN.md) are already the
+executable half of the record, and that the classification above is what a future maintainer would
+actually be asking for.
+
+## For anyone changing this code
+
+Everything above is behaviour somebody relies on. The input work planned in
+[plan/INPUT_PLAN.md](plan/INPUT_PLAN.md) records these as fixtures precisely so that they are
+pinned before anything moves. Two of them need care beyond that:
+
+- The Aggressive-attack guard is an original bug. Removing it would look like a fix and would
+  change combat for every existing run.
+- Anything that presses attack draws from `MyRnd`, which is one shared stream, so a test that
+  exercises combat perturbs the RNG for everything after it. Fix the seed and assert on the reset
+  counters rather than on which animation was drawn.

--- a/docs/TEXT.md
+++ b/docs/TEXT.md
@@ -140,7 +140,8 @@ authored with it.
 
 ### Verified against the retail asset
 
-Decoding `Common/TEXT.HQR` (442,979 bytes) with the format above:
+Decoding `Common/TEXT.HQR` (442,979 bytes) with the format above, which
+`scripts/dev/text_dump.py` implements (`text_dump.py <TEXT.HQR> --lang N --bank sys --range LO:HI`):
 
 | Check | Result |
 |---|---|

--- a/docs/plan/INPUT_DOOM3_RESEARCH.md
+++ b/docs/plan/INPUT_DOOM3_RESEARCH.md
@@ -1,0 +1,554 @@
+# Doom 3 input: research
+
+What id's input path does, read from the GPL source, and which of its design choices are worth
+having in this engine. Written as an input to the wider input research rather than as a
+proposal: it commits nothing and plans nothing.
+
+Doom 3's input system is Quake 3's, five years on. That makes the *differences* the most useful
+part of it, because they are id revising their own design under pressures this engine also has:
+a sample rate that must not follow the frame rate, one-shot actions that must not be lost, and a
+replay that has to be trustworthy. Where a delta is instructive, the Quake 3 version is named.
+
+Every claim about Doom 3 was read out of the source. Every figure about this tree was grepped
+against the working tree. Re-run the commands at the end rather than trusting a number that has
+aged.
+
+## What was read
+
+Doom 3, `id-Software/DOOM-3` at `a9c49da`, the source as released under the GPL on 22 November
+2011, `ENGINE_VERSION "DOOM 1.3.1"`. Read from a local clone of that repository.
+
+`neo/framework/UsercmdGen.{h,cpp}` (170 and 1,112 lines), `neo/framework/KeyInput.{h,cpp}` (221
+and 785), `neo/framework/EventLoop.cpp` (274), `neo/framework/Session.cpp` and
+`Session_local.h`, `neo/sys/sys_public.h`, `neo/game/Game.h`, `neo/game/Player.cpp`.
+
+Quake 3 Arena, `id-Software/Quake-III-Arena`, for the deltas: `code/client/cl_input.c`,
+`code/client/cl_keys.c`, `code/qcommon/common.c`, `code/game/q_shared.h`.
+
+This tree: [SOURCES/INPUT.CPP](../../SOURCES/INPUT.CPP) (446),
+[SOURCES/INPUT.H](../../SOURCES/INPUT.H),
+[LIB386/SYSTEM/INPUT.CPP](../../LIB386/SYSTEM/INPUT.CPP) (59),
+[LIB386/SYSTEM/KEYBOARD.CPP](../../LIB386/SYSTEM/KEYBOARD.CPP) (138),
+[LIB386/SYSTEM/EVENTS.CPP](../../LIB386/SYSTEM/EVENTS.CPP),
+[SOURCES/JOYSTICK.CPP](../../SOURCES/JOYSTICK.CPP) (470), and the input sections of
+[SOURCES/PERSO.CPP](../../SOURCES/PERSO.CPP).
+
+## The path, end to end
+
+| Stage | Doom 3 | This engine |
+|---|---|---|
+| OS to engine | `Sys_GetEvent` returns one `sysEvent_t` | `SDL_PollEvent` loop in `ManageEvents`, fanned out to weak per-subsystem handlers |
+| What is kept | the event, queued, and optionally journalled to disk | nothing; the keyboard handler discards key events except to set `LastInputWasKeyboard` |
+| Device state | `idKeyInput::PreliminaryKeyEvent` maintains `keys[].down` from the stream | re-sampled whole each poll: `memset(TabKeys, 0, 256)` then `SDL_GetKeyboardState` |
+| Who owns input | `idSessionLocal::ProcessEvent`, one chain, each link consuming or passing | whoever is spinning a `MyGetInput()` loop; 81 call sites in 16 files |
+| Key to action | `keys[k].usercmdAction` if it is a movement action, else `keys[k].binding` as text | `DefKeys[]` plus `GamepadKeys[]` folded into one flat (key, mask) table, scanned to rebuild `Input` |
+| The frame's intent | `usercmd_t`, built by `idUsercmdGen` on a fixed 60 Hz clock, buffered 64 deep | `Input`, `LastInput`, `Key`, `MyKey`, `TabKeys[]`, all global, all live |
+| Consumed by | `game->RunFrame( &cmd )`, once per game tic | the object loop, on whichever frames the sim throttle allows |
+| Replay | event journal, and `.cdemo` usercmd demos with a per-tic consistency hash | none |
+
+## The design choices
+
+### 1. One fixed sample rate, and frame time removed from the input maths
+
+```c
+const int USERCMD_HZ   = 60;
+const int USERCMD_MSEC = 1000 / USERCMD_HZ;
+```
+
+Quake 3 generated one command per rendered frame and scaled keyboard turning by
+`cls.frametime`, the measured length of the last frame. Doom 3 generates one command per fixed
+tic and scales by the constant:
+
+```c
+speed = idMath::M_MS2SEC * USERCMD_MSEC * in_angleSpeedKey.GetFloat();
+```
+
+Measured frame time does not appear in `idUsercmdGenLocal::AdjustAngles` or `JoystickMove` at
+all. Fixing the rate did not merely stabilise the input; it deleted a whole class of
+frame-rate-dependent arithmetic from the file. Quake 3's `CL_KeyState`, which returned the
+fraction of a frame a key was held so that turning stayed frame-rate independent, has no
+counterpart in Doom 3 because there is nothing left for it to correct.
+
+**Asynchronous sampling is a cvar, not the architecture.** `UsercmdInterrupt` (async, called on
+the timer) and `GetDirectUsercmd` (synchronous, called inline) run the identical five-step
+pipeline: `InitCurrent`, `Mouse`, `Keyboard`, `Joystick`, `MakeCurrent`. `RunGameTic` picks
+between them on `com_asyncInput`:
+
+```c
+if ( com_asyncInput.GetBool() ) {
+    cmd = usercmdGen->TicCmd( lastGameTic );
+} else {
+    cmd = usercmdGen->GetDirectUsercmd();
+}
+```
+
+The generator does not know or care. That separation is the reusable part: the pipeline is one
+function, and which clock drives it is a setting.
+
+### 2. `usercmd_t` is the whole contract, and it is buffered by tic number
+
+Doom 3's grew from Quake 3's six fields to thirteen, but the shape is unchanged: one small
+struct, built at exactly one place, that says everything the player asked for this tic.
+
+```c
+class usercmd_t {
+    int   gameFrame, gameTime, duplicateCount;
+    byte  buttons;
+    signed char forwardmove, rightmove, upmove;
+    short angles[3], mx, my;
+    signed char impulse;
+    byte  flags;
+    int   sequence;
+};
+```
+
+`UsercmdInterrupt` files each finished command into a ring indexed by tic:
+
+```c
+buffered[(com_ticNumber+1) & (MAX_BUFFERED_USERCMD-1)] = cmd;
+```
+
+`MAX_BUFFERED_USERCMD` is 64. The consumer asks for a command *by tic number*
+(`TicCmd(lastGameTic)`), so falling behind means reading the ones it missed, not skipping them.
+Nothing about "which frame is it now" enters the question.
+
+That single struct is why record, replay, injection and networking are one mechanism rather than
+four. Anything that can produce a `usercmd_t` can drive the game, and `game->RunFrame` cannot
+tell where one came from. `RunGameTic` proves it in eight lines: if a `.cdemo` is open the
+command is read from the file, otherwise it is generated, and the call below is the same either
+way.
+
+### 3. One-shot actions do not travel as level bits
+
+The impulse mechanism, and the sharpest single idea in the file. An action that happens once
+carries a value plus a flag bit that is *toggled* rather than set:
+
+```c
+// idUsercmdGenLocal::Key
+if ( action >= UB_IMPULSE0 && action <= UB_IMPULSE61 ) {
+    cmd.impulse = action - UB_IMPULSE0;
+    cmd.flags ^= UCF_IMPULSE_SEQUENCE;
+}
+```
+
+The consumer fires when the flag *differs* from the one it last saw, then records what it saw:
+
+```c
+// idPlayer::Think
+if ( ( usercmd.flags & UCF_IMPULSE_SEQUENCE ) != ( oldFlags & UCF_IMPULSE_SEQUENCE ) ) {
+    PerformImpulse( usercmd.impulse );
+}
+oldFlags = usercmd.flags;
+```
+
+A pending action survives any number of unobserved tics, and observing it consumes it exactly
+once. There is no list of which actions get this treatment; being an impulse *is* the treatment.
+
+Its limit, because it bounds the recommendation below: `impulse` is one value and the flag is
+one bit, so two impulses between two observations coalesce, and two that toggle the flag twice
+are both lost. It is a one-deep slot, not a queue. Doom 3 gets away with that because the
+observer runs every tic and the commands are buffered, so an observation is never skipped in the
+first place. Take both halves or neither.
+
+`idUsercmdGenLocal::Key` also opens with `if ( keyState[keyNum] == down ) return;`, commented
+"sometimes we get double message". The edge is filtered once, at the source, rather than at each
+consumer.
+
+### 4. Bindings are split by kind, and only one kind is text
+
+This is the correction Doom 3 makes to Quake 3, and it matters here.
+
+In Quake 3 every binding went through the command buffer, movement included: pressing a key
+bound to `+forward` formatted a string and queued it as console text. Doom 3 keeps that path for
+console commands and takes movement off it entirely. `SetBinding` resolves the binding once, at
+bind time, into an action id:
+
+```c
+keys[keynum].binding = binding;
+keys[keynum].usercmdAction = usercmdGen->CommandStringUsercmdData( binding );
+```
+
+and `ExecKeyBinding` then refuses to buffer text for it:
+
+```c
+// commands that are used by the async thread don't add text
+if ( keys[keynum].usercmdAction ) {
+    return false;
+}
+```
+
+`userCmdStrings[]` is the table doing the resolving: `{"_forward", UB_FORWARD}`,
+`{"_attack", UB_ATTACK}`, `{"_impulse13", UB_IMPULSE13}`. A name in a config file, an enum in
+the engine, resolved once.
+
+So the mature id design is: **a table mapping a key to an action id, plus a text escape hatch
+for things that are genuinely commands.** That is the half this engine already has. Its
+`DefKeys`-to-`Input` table *is* `usercmdAction`, arrived at independently.
+
+`SetBinding` also opens with `usercmdGen->Clear()`, so rebinding a key cannot leave the old
+action stuck down, and closes with `cvarSystem->SetModifiedFlags( CVAR_ARCHIVE )`, so a rebind
+marks the config dirty through the same mechanism an archived cvar does. No separate "did the
+bindings change" bookkeeping to get wrong.
+
+### 5. Key names have three columns, and the lookups go both ways
+
+```c
+keyname_t keynames[] = {
+    {"TAB",      K_TAB,      "#str_07018"},
+    {"ENTER",    K_ENTER,    "#str_07019"},
+    ...
+```
+
+A stable name for the config file, the key code, and a **localised display string** for the UI.
+`KeyNumToString( keyNum, bool localized )` picks a column. The config gets a name that never
+changes with language; the options screen gets one that does.
+
+The reverse lookups exist as first-class API, because a controls screen needs them:
+`KeysFromBinding`, `BindingFromKey`, `NumBinds`, `KeyIsBoundTo`, plus
+`ArgCompletion_KeyName` so the console can complete key names. `WriteBindings` emits
+`unbindall` and then one `bind "SPACE" "_attack"` line per bound key, into a file that is itself
+a script the engine can execute, with the backslash case handled explicitly.
+
+### 6. Input is inhibited per subsystem, not by a flag
+
+```c
+void idUsercmdGenLocal::InhibitUsercmd( inhibit_t subsystem, bool inhibit ) {
+    if ( inhibit ) {
+        inhibitCommands |= 1 << subsystem;
+    } else {
+        inhibitCommands &= ( 0xffffffff ^ ( 1 << subsystem ) );
+    }
+}
+bool idUsercmdGenLocal::Inhibited( void ) { return ( inhibitCommands != 0 ); }
+```
+
+Two subsystems use it, `INHIBIT_SESSION` (menu or console) and `INHIBIT_ASYNC`. Each owns one
+bit and can only set or clear its own. Nothing has to know whether anyone else is also
+suppressing input, and nobody can turn input back on underneath a subsystem that still wants it
+off.
+
+`MakeCurrent` respects it by skipping the whole movement pipeline and, importantly, zeroing the
+accumulated mouse deltas rather than banking them:
+
+```c
+} else {
+    mouseDx = 0;
+    mouseDy = 0;
+}
+```
+
+Suppressed input is discarded, not saved up to arrive at once when the menu closes.
+
+### 7. Ownership is a chain, and each link consumes or passes
+
+`idSessionLocal::ProcessEvent` is the whole router. Quake 3 used a `keyCatchers` bitmask;
+Doom 3 uses an ordered chain where each link returns true if it took the event:
+
+1. Escape, if no GUI is up, asks the game with `game->HandleESC` and then opens the menu.
+2. `console->ProcessEvent`.
+3. `guiTest`, if one is being tested.
+4. `guiActive`, the menus.
+5. If no map is running, the console takes it unconditionally.
+6. Otherwise, on a key *down*, `idKeyInput::ExecKeyBinding`.
+
+One function, six links, in one file. A screen does not spin an input loop; it exists in the
+chain.
+
+### 8. Two record and replay systems, at two different layers
+
+**The event journal**, inherited from Quake 3 almost unchanged but promoted into a class of its
+own (`idEventLoop`, `EventLoop.cpp`). `idEventLoop::GetRealEvent` is the entire mechanism: with
+`com_journal 1` it calls `Sys_GetEvent` and writes the struct to disk; with `com_journal 2` it
+never calls the system and reads the struct back instead. Nothing else in the engine knows.
+Its cost when off is one `if`.
+
+**Command demos**, which are new. `writeCmdDemo` and `playCmdDemo` record and replay at the
+`usercmd_t` layer into a `.cdemo` file. These are not video and not a network stream; they are
+the input, one command per tic, replayed through the same `RunGameTic` that live play uses.
+
+The two layers answer different questions. The journal replays a *process*, including everything
+that arrived through the system boundary. A command demo replays a *session of play*, and is
+portable across anything that consumes commands.
+
+### 9. The recording carries its own oracle
+
+This is the best idea in the file for anything that wants gameplay regression testing.
+
+Each recorded command is stored with a hash of the state it produced:
+
+```c
+typedef struct {
+    usercmd_t cmd;
+    int       consistencyHash;
+} logCmd_t;
+```
+
+`game->RunFrame` returns a `gameReturn_t` whose `consistencyHash` is documented as "used to
+check for network game divergence". `RunGameTic` reuses it for playback:
+
+```c
+if ( cmdDemoFile ) {
+    if ( ret.consistencyHash != logCmd.consistencyHash ) {
+        common->Printf( "Consistency failure on logIndex %i\n", logIndex );
+        Stop();
+        return;
+    }
+}
+```
+
+So a recording is simultaneously the fixture and the assertion, and a failure names the exact
+tic at which the replay stopped matching. One number, computed for the network, paying for the
+regression suite as a side effect.
+
+The consequence worth extracting: **a replay does not have to be provably faithful to be
+useful, if it can tell you when it stopped being faithful.** That is a much weaker precondition
+than "enumerate every non-deterministic input first", and it is reached with a hash and a
+comparison.
+
+### 10. Fixing the rate let something be deleted
+
+Quake 3's `sysEvent_t` carried `evTime`, and its whole button layer existed to use it:
+`kbutton_t` recorded `downtime`, `IN_KeyUp` credited elapsed milliseconds, `CL_KeyState`
+returned a sub-frame fraction, and `+attack 12 34567` appended the key and the timestamp to
+every button command so that releases could be matched and sub-frame-corrected.
+
+Doom 3's `sysEvent_t` has no `evTime`. None of that layer survives. Once the sample clock is
+fixed, per-event timestamps stop earning their place, because "how much of this tic was the key
+held" has one answer.
+
+The tempting reading of Quake 3 is that precise timestamps are the fix for
+lost and mistimed input. id's own later answer was that a fixed sample rate is the fix, and
+timestamps were the workaround for not having one.
+
+## What this engine does today
+
+Measured against the working tree.
+
+**Sampling is level-triggered, unstamped, and tied to the render loop.**
+`UpdateKeyboardState` ([KEYBOARD.CPP](../../LIB386/SYSTEM/KEYBOARD.CPP)) clears
+`TabKeys[0..255]` and re-reads `SDL_GetKeyboardState` on every call. A press and release between
+two polls is not merely mistimed, it never existed. `Key` is the lowest set scancode, so which
+key "the" key is among simultaneous presses is an artifact of scancode ordering.
+
+**The event pump already exists and is already fanned out.** `ManageEvents`
+([EVENTS.CPP](../../LIB386/SYSTEM/EVENTS.CPP)) runs the `SDL_PollEvent` loop and hands each event
+to `HandleEventsTimer`, `HandleEventsMouse`, `HandleEventsKeyboard`, `HandleEventsJoystick`,
+`HandleEventsTouch`, `HandleEventsVideo` and `HandleEventsWindow`, several of them weak symbols.
+`HandleEventsKeyboard` receives every key event and, by an explicit comment, keeps none of them
+beyond setting `LastInputWasKeyboard`. The hard part of an event queue, one pump with a clean
+fan-out, is built. What is missing is anything that remembers.
+
+**The key-to-action table is the right shape already.** `InitInput` folds `DefKeys[]` and
+`GamepadKeys[]`, `Key1` and `Key2` each, into a flat 128-entry (key, mask) table that `GetInput`
+scans to rebuild `Input`. That is Doom 3's `usercmdAction`, and the pad being folded into the
+same table rather than OR-ed in afterwards is the same instinct as Doom 3 running keyboard,
+mouse and joystick through one `MakeCurrent`.
+
+**What is missing around that table is the naming.** Bindings are positional indices onto raw
+scancodes, written to the cfg as `Input7_1=57` and `Gamepad13=1030`. There is no name table, no
+round trip, and no localised display column; the key-config screen reads SDL's English scancode
+name through `GetKeyScancodeName`. Slots 32 to 35, the four spells, do not reach `Input` at all
+and are read by direct `CheckKey(DefKeys[..])` in PERSO.CPP, so the table has a hole in it that
+only a comment marks.
+
+**Suppression is a static latch with no owner.** `NoRepeatInput`
+([LIB386/SYSTEM/INPUT.CPP](../../LIB386/SYSTEM/INPUT.CPP), 59 lines in total) masks bits already
+held, and `ClearNoRepeatInput` resets it wholesale. The wait and clear macros around it are used
+at 109 sites. Any of them can clear a suppression another put there.
+
+**Ownership is per-screen, with one hardcoded exception.** 81 `MyGetInput()` call sites across 16
+files, concentrated in GAMEMENU (19), PERSO (15), EXTFUNC (10) and INVENT (8). Each modal screen
+spins its own loop and clears its own globals. The console is the exception: handled inline
+inside `MyGetInput` with a `memset(TabKeys, ...)`, an `Input = 0` and a one-frame suppress flag.
+That is a chain link, written once, for one client, by hand.
+
+**Ninety-three sites compare a raw scancode.** `MyKey == K_...` or `Key == K_...` outside INPUT.CPP.
+Each is unbindable by definition and blind to the keypad twin its action has in `DefKeys`.
+
+**The throttle is patched with a whitelist.** `Timer_ForceStepIfPending` forces a sim step only
+when a named signal is pending, with `I_ACTION_EDGE` the hand-maintained set of qualifying bits.
+The set is currently complete, as [INPUT_SIM_PLAN.md](INPUT_SIM_PLAN.md) verified. It is complete
+by audit, and stays complete only until the next post-gate edge consumer.
+
+**Injection is two weak symbols.** `ApplyVirtualKeys` and `ApplyHarnessKeys`, called inside
+`UpdateKeyboardState` before the scan, so the touch overlay and the control harness both reach
+every modal loop. This is the one place the design already matches the id principle: one funnel
+that consumers cannot distinguish from a real device.
+
+## The mapping
+
+Ranked by value per cost, against problems that are already open.
+
+### A. Per-subsystem inhibit, replacing the unowned latch
+
+**Take. Cheapest real win here.** `InhibitUsercmd( subsystem, bool )` over a bitmask is about
+eight lines, and it converts "115 sites poke a static that nobody owns" into "each subsystem owns
+one bit". Doom 3 needed only two subsystems; this engine would want a handful (console, menu,
+dialogue, holomap, cutscene).
+
+**Buys.** The class where one screen's input suppression is cleared by another's exit. It also
+gives the console's hand-written suppression a general mechanism to be the first user of, instead
+of remaining a special case.
+
+**Costs.** Small for the mechanism. Converting call sites is incremental and can stop at any
+point, because the old latch and the new mask can coexist.
+
+Take the discard rule with it: Doom 3 zeroes accumulated mouse delta while inhibited rather than
+banking it. Suppressed input should be dropped, not delivered late.
+
+### B. The impulse pattern for one-shot actions, and the buffer that makes it safe
+
+**Take, both halves or neither.** One-shot actions stop travelling as level bits, so no consumer
+can miss one by sampling at the wrong moment, and `I_ACTION_EDGE` stops being a list that has to
+be maintained.
+
+**Buys.** The open half of the throttle-drop class, structurally rather than by audit. Weapon
+select, behaviour select, holomap, pause and item use stop depending on where in `MainLoop` they
+are read.
+
+**Costs.** Small in code, larger in review: each converted action's consumer changes from "is the
+bit set" to "has the sequence changed". Convert one and measure before converting a second.
+
+The warning from section 3 is the whole recommendation: the one-deep slot is only safe because
+commands are buffered and every tic is observed. This engine's sub-step loop can skip several
+frames at once, so importing the toggle without something that guarantees observation would
+substitute a subtler bug for a visible one. If only one half is affordable, take a counter rather
+than a toggle bit.
+
+### C. Named bindings, with a localised display column and reverse lookups
+
+**Take.** A `keynames[]`-equivalent with three columns and working `StringToKeyNum` /
+`KeyNumToString( n, localized )`, plus `KeysFromBinding` and `BindingFromKey`.
+
+**Buys.** Four things at once, which is why it ranks high despite being the least exciting item.
+The cfg becomes readable and diffable, which matters more here than it did for id given this
+game's history of silent cfg misbehaviour. The key-config screen gets localised key names instead
+of SDL's English ones, in an engine that already localises its menu labels. The reverse lookups
+are exactly what a controls screen and a profile system need, and are currently done by indexing
+`DefKeys` positionally. And a named binding is the unit an input profile would be expressed in.
+
+**Costs.** Medium, and it needs a migration path: existing cfgs hold numbers. `unbindall` as a
+written header is id's pattern for making a config self-sufficient rather than a patch on
+defaults. The 90 raw scancode comparisons do not have to move for this to be worth doing, but
+they cap its value until they do.
+
+### D. A chain of responsibility for input ownership, diagnostic first
+
+**Take the idea, not the refactor.** Replacing 81 `MyGetInput()` loops is not a proportionate
+move and should not be proposed as one.
+
+What is proportionate: a single "who owns input" value that screens set on entry and clear on
+exit, observed only at first, with nothing routed through it. It turns the modal-bypass survey
+and the missing-consume survey from findings that need re-deriving into a table that can be
+asserted on.
+
+Doom 3's escape rule is worth importing early and cheaply on its own: escape is handled at the
+top of the chain, and the *game* is asked first (`game->HandleESC`) before the menu opens. One
+rule, and it is the shape of fix that a whole class of modal-escape bug wants.
+
+### E. Command demos with a consistency hash
+
+**Take this as the replay design.** It is the answer
+[INPUT_REPLAY_RESEARCH.md](INPUT_REPLAY_RESEARCH.md) went looking for and did not find in the
+retail data, and it is better than the journal for this engine's purposes.
+
+**Buys.** A gameplay regression net whose fixtures are recorded play, and which reports the exact
+tic where behaviour changed rather than a pass or fail at the end. The hash also does double duty
+as a determinism probe for the work already underway there.
+
+**Why it outranks the journal here.** A journal is only worth what its boundary is complete, and
+this boundary is wider than id's: dt and the direct clock reads documented in
+[TIMING.md](../TIMING.md) sit outside any event queue, and dt is the dominant determinism lever.
+Journalling keys alone would produce recordings that do not replay, which is worse than none
+because it looks like it works. The consistency hash sidesteps that precondition rather than
+satisfying it: it does not make replay faithful, it makes unfaithfulness *visible and located*.
+That is a far cheaper thing to build and a far more useful thing to have first.
+
+**Costs.** Needs a stable per-tic hash of gameplay state, which does not exist yet and is the
+real work in this item. It also needs the command struct in F, or something standing in for it.
+`--fixed-dt` and the control harness already supply the rest.
+
+### F. One frame-intent struct
+
+**The destination, not a task.** A, B and E all push toward the same shape: one small struct
+saying what the player asked for this tic, built at one place, consumed by gameplay that cannot
+tell whether it came from a keyboard, a pad, the touch overlay, the harness or a file. That one
+decision is why record, replay, injection and networking are one mechanism in Doom 3.
+
+Worth writing down as where the items above are heading, so they land in a compatible direction.
+Not worth proposing as a change on its own, and not a justification for one.
+
+## What not to take
+
+**The asynchronous input thread, as a thread.** But note the finding in section 1: it is a cvar.
+`GetDirectUsercmd` runs the same pipeline synchronously, and `RunGameTic` chooses. Take the
+pipeline as one function called from the main loop; the async option stays available and costs
+nothing to leave unbuilt. A real async sampler would fight `--fixed-dt` and every fixture built
+on it.
+
+**Prediction, reconciliation, snapshots, `delta_angles`.** All of it exists to survive a network.
+There is no server here. Nothing to buy.
+
+**Absolute view angles in the command.** In Doom 3 the player's angles are the aim, and
+`usercmd_t.angles` is authoritative. Here the hero turns and the camera follows, and the camera's
+rules are established by measurement in [CAMERA.md](../CAMERA.md). Adopting the id angle model
+would rewrite that contract for no gain.
+
+**Bindings dispatched as text for movement.** Quake 3 did this; Doom 3 explicitly stopped, and
+`ExecKeyBinding` returning false for a `usercmdAction` is the code that stopped it. This engine
+already has the table. Do not regress toward the text path in the name of matching id.
+
+**Mouse acceleration and filtering.** The mouse camera already has its own smoothing and
+sensitivity tunables in the cfg, documented in [CONTROLLER.md](../CONTROLLER.md). Nothing to
+import.
+
+## Open questions
+
+1. **How deep does the sub-step skip actually go?** Item B's choice between a toggle bit and a
+   counter depends on the maximum number of consecutive frames the sub-step loop can skip in
+   practice. Measurable from the existing harness, not yet measured.
+
+2. **What would a consistency hash of this game's state cover?** Item E is blocked on this and
+   little else. Hero position and animation are the obvious core; whether actors, RNG draw count
+   and scene state belong in it decides whether the hash catches the regressions worth catching
+   or trips on noise.
+
+3. **Is the spell-slot hole in the binding table deliberate?** Slots 32 to 35 bypass `Input` and
+   are read through `CheckKey` directly. Whether that was a 1997 constraint or a port-era
+   shortcut decides whether item C can close it or has to preserve it.
+
+4. **Does the level-sampled path lose anything a player can feel today?** The whitelist audit says
+   current exposure is narrow, so item B is justified by fragility rather than by a measured drop.
+   If a measured drop is wanted instead, it would need a fast-press fixture at several throttle
+   settings, and it does not exist.
+
+## Reproduce
+
+```bash
+# This tree, all figures quoted above. Patterns are CPP-only and spacing-tolerant;
+# widening them to SOURCES/ as a whole also matches the macro and extern declarations.
+grep -rn 'MyGetInput()' --include=*.CPP SOURCES | wc -l                          # 81
+grep -rn 'MyGetInput()' --include=*.CPP SOURCES | cut -d: -f1 | sort | uniq -c   # per file
+grep -rnE '(MyKey|Key) *== *K_' --include=*.CPP SOURCES | grep -v INPUT.CPP | wc -l   # 93
+grep -rn 'ClearNoRepeatInput\|ClearWaitNoInput\|InitWaitNoInput\|InitWaitNoKey' \
+     --include=*.CPP SOURCES | wc -l                                             # 109
+grep -rn 'Input *& *I_' --include=*.CPP --include=*.H SOURCES LIB386 | wc -l     # 154
+grep -rn 'CheckKey(' --include=*.CPP SOURCES | wc -l                             # 21
+
+# Doom 3, from a clone of id-Software/DOOM-3 at a9c49da; paths below are relative to it
+neo/framework/UsercmdGen.h        # USERCMD_HZ, usercmd_t, UCF_IMPULSE_SEQUENCE
+neo/framework/UsercmdGen.cpp      # MakeCurrent, UsercmdInterrupt, GetDirectUsercmd,
+                                  # InhibitUsercmd, userCmdStrings[], Key()
+neo/framework/KeyInput.cpp        # keynames[], SetBinding, ExecKeyBinding, WriteBindings
+neo/framework/EventLoop.cpp       # GetRealEvent (the journal), ProcessEvent, RunEventLoop
+neo/framework/Session.cpp         # ProcessEvent (the chain), RunGameTic, WriteCmdDemo
+neo/framework/Session_local.h     # logCmd_t
+neo/game/Game.h                   # gameReturn_t.consistencyHash
+neo/game/Player.cpp               # the UCF_IMPULSE_SEQUENCE consumer
+
+# Quake 3, for the deltas quoted in sections 4 and 10
+B=https://raw.githubusercontent.com/id-Software/Quake-III-Arena/master
+curl -sfL $B/code/client/cl_input.c   # kbutton_t, CL_KeyState, CL_CreateCmd
+curl -sfL $B/code/client/cl_keys.c    # keyCatchers, the +cmd key time protocol
+curl -sfL $B/code/game/q_shared.h     # the six-field usercmd_t
+```

--- a/docs/plan/INPUT_PLAN.md
+++ b/docs/plan/INPUT_PLAN.md
@@ -1,0 +1,513 @@
+# Input: plan
+
+An order for making input a subsystem: owned, tested, complete across its devices, and
+expressible as data. Each increment ships on its own, and each one makes the next cheaper or
+less risky.
+
+Follows [INPUT_RESEARCH.md](INPUT_RESEARCH.md), which describes what is there now, with
+[INPUT_DOOM3_RESEARCH.md](INPUT_DOOM3_RESEARCH.md) as the outside comparison and
+[REFACTOR_ROADMAP.md](REFACTOR_ROADMAP.md) area 8 as the case for doing it at all. The recipe
+each increment follows is [FEATURE_WORKFLOW.md](../FEATURE_WORKFLOW.md) Example 5.
+
+## What this plan is not
+
+**It does not deliver a new control scheme.** #372's omnidirectional proposal and #4's
+Enhanced-Edition-style controls are out of scope, and the research is why rather than a
+preference: both are blocked on things that are not input.
+
+Hero locomotion is animation-driven. `Input & I_UP` calls
+`InitAnim(GEN_ANIM_MARCHE, ANIM_REPEAT, numobj)` and the displacement comes from the animation's
+keyframes, so there is no speed scalar for a stick to fill and no `forwardmove` field to put one
+in. Camera-relative movement then needs the exterior camera, where `BetaCam` is variable and is
+taken away by camera zones and cutscenes. Neither of those is fixed by anything below.
+
+That is a scope line, not a refusal. Everything below makes the scheme question **cheaper to
+experiment with**, because a binding set that can be swapped whole is how an alternative scheme
+would ship anyway, and a tested binding layer is what makes trying one reversible.
+
+## Where input already is
+
+Better placed than area 8 implies, in one specific way. The prerequisite most refactor areas
+share, de-aggregating a module header out of `DEFINES.H`, does not apply:
+`//#include "INPUT.H"` is already commented out there, 18 files include
+[SOURCES/INPUT.H](../../SOURCES/INPUT.H) explicitly, and none of its state
+(`DefKeys`, `GamepadKeys`, `LastInput`, `NbInput`) is declared in
+[C_EXTERN.H](../../SOURCES/C_EXTERN.H). Input has already had its ownership move.
+
+So this plan is not about untangling a god header. What is actually missing is narrower and more
+tractable: no test on the binding table, suppression that nobody owns, three devices on a path
+that cannot be bound, and a localised key-name table shipping unread since 1997.
+
+## The rule about parity
+
+The keyboard layer has a parity obligation to retail, and increment 0 is where that stops being a
+claim. The rule this plan follows:
+
+**Freeze observable behaviour. List the exceptions. Every exception arrives with the test that
+says why it changed.**
+
+Frozen: `DefKeysDefault95`'s action-to-key mapping, and the bits `GetInput` produces for a given
+key state including `NoRepeatInput`'s masking. Free: everything behind those, including how the
+combined table is built and where the code lives.
+
+Two exceptions are already known and expected to be taken, each in the increment that owns it:
+
+| Exception | Where | Why |
+|---|---|---|
+| `K_NUMPAD_POINT` offered but unpressable (#508) | increment 3 | the alias names `SDL_SCANCODE_KP_DECIMAL`; hardware sends `KP_PERIOD` |
+| A rebind drops the action's keypad twin (#507) | increment 4 | the twin is a layout fact sharing a slot with a preference |
+
+## The refactor, named
+
+[REFACTOR_ROADMAP.md](REFACTOR_ROADMAP.md) area 8 does not ask for correctness work. It asks for an
+extraction, on the pattern the camera used: *"Which physical keys carry which intent, and which
+action a profile puts where, are both pure lookups over a table, so they can come out as a header
+with a host test in the way the camera's angle arithmetic did."* The increments below do that work
+but never said what comes out, so this section says it.
+
+**Step 1 of [FEATURE_WORKFLOW.md](../FEATURE_WORKFLOW.md) Example 5 is to count what CI can see of
+the code about to move, before anything else.** Measured on
+[SOURCES/INPUT.CPP](../../SOURCES/INPUT.CPP), 447 lines, of which none is under any test:
+
+| Part | Lines | Reads engine globals or IO |
+|---|---|---|
+| `DefKeysDefault95`, the retail layout | 41 | no |
+| `GamepadKeysDefault` and the live tables | 55 | no |
+| `InitInput`, the fold of two tables into the combined one | 24 | no |
+| `RestoreInput` | 9 | no |
+| **pure total** | **150** | |
+| `ReadInputConfig` / `WriteInputConfig` / the two gamepad halves | 179 | `DefFileBuffer` IO |
+| `MyGetInput` | 75 | console, joystick, `TabKeys`, `Key` |
+| `WaitNoInput` / `WaitInput` | 24 | polls |
+
+**The testable line is therefore clean**, and the extraction is 150 lines: the tables and the fold
+come out, the config IO and the polling stay. Proposed name `INPUT_BINDINGS.{H,CPP}`, on the naming
+pattern of `AUDIO_BALANCE`, `SAVEGAME_WIRE` and `RES_DISCOVERY`. The layout half of increment 4
+grows out of [MENU_KEYNAV.CPP](../../SOURCES/MENU_KEYNAV.CPP), which area 8 already calls the first
+piece of it.
+
+**The justification is better than the coverage arithmetic suggests.** 150 lines moves
+`SOURCES/` from 6% covered to about 6.6%, which satisfies the roadmap's standing rule and is not
+in itself interesting. What is interesting is *which* 150 lines. `DefKeysDefault95`, `InitInput`
+and `RestoreInput` are all present in the 1997 import, and the roadmap's own headline finding is
+that **not one line of 1997 game logic is currently reachable from a host test**. Testing the
+retail key table and the fold that builds `Input` from it would be the first. That is the
+different justification the roadmap asks for from any refactor that does not move the percentage
+much, and it is a stronger claim than the percentage.
+
+A detail worth keeping while the table is being moved: the 1997 file carried **two** default
+layouts, `DefKeysDefault` and `DefKeysDefault95`, a DOS set and a Windows 95 set. This port kept
+only the second. An extracted table is the natural place to record that, and a binding set
+(increment 6) is the natural place for the first one to come back if anyone wants it.
+
+### Which increment does which step of the recipe
+
+| Recipe step | Where it happens |
+|---|---|
+| 1. Count what CI can see before moving | the table above, and increment 0 |
+| 2. CODESTYLE "where new code goes" | increment 0, when the new TU is created |
+| 3. Cut along the testable line first | the 150 pure lines, leaving IO and polling behind |
+| 4. Make the extracted part correct on its own terms | increment 0's round-trip and fold tests |
+| 5. **Move before you change** | increment 0, second commit: same lines, new home, no behaviour change |
+| 6. Then ownership | already true. `INPUT.H` is out of the `DEFINES.H` aggregation with 18 explicit includers |
+| 7. Then surfaces, one entry point each | increment 3 (the key names the config screen shows), increment 6 (cfg reader and writer) |
+| 8. Bugs found on the way get their own commit | the two parity exceptions above, each with its own test |
+| 9. Write the rule down as you find it | this plan and [SPEEDRUN_MECHANICS.md](../SPEEDRUN_MECHANICS.md) |
+| 10. Re-read every doc that describes what moved | [CONFIG.md](../CONFIG.md), [CONTROLLER.md](../CONTROLLER.md), [MENU.md](../MENU.md) |
+
+Step 5 is the one nothing in this plan previously carried, and it is the one that makes the rest
+safe: the commit that creates `INPUT_BINDINGS.{H,CPP}` must be a pure move with the tests from
+increment 0 moving alongside it, so that increments 3 and 4 change a module that is already under
+test in its own translation unit rather than editing 1997 code in place.
+
+## Two decisions this plan defers
+
+Both are real forks, and neither should be settled by preference when an increment can settle it
+by measurement. They are listed here so that the increment which answers each says so.
+
+**Do the two funnels converge?** 154 sites read the action bits, 93 compare raw scancodes, and
+three devices depend on the raw path by design. Converging means routing the raw sites; not
+converging means formalising the second path so a screen inherits the legend instead of restating
+it. **Increment 4 answers it**, because once layout is a real layer the 93 sites can be counted by
+which of them wanted a binding and which only wanted the legend.
+
+**How much test machinery gets built?** Consumption is what host tests cannot reach, and Doom 3's
+answer (record commands, replay, compare a per-tic state hash) is genuinely enabling and also the
+most plausible candidate for overengineering here. **Increments 0 and 1 answer it**, by covering the pure layers and then measuring whether the
+fixtures plus the flow counters catch what the later increments could break.
+
+## Injection: the harness is not a device
+
+Four things put input into this engine and only three of them are injection paths, which is worth
+settling before increment 7 treats them alike.
+
+| Path | Enters as | Where | Metered in |
+|---|---|---|---|
+| `ApplyVirtualKeys` (touch overlay) | scancodes in `TabKeys` | inside `UpdateKeyboardState`, before the scan | held while the finger is down |
+| `ApplyHarnessKeys` (`key` verb) | scancodes in `TabKeys` | same hook site, immediately after | **input polls**, one per `ManageKeyboard` |
+| `DbgInjectInput` (`input` verb) | action bits in `Input` | `MainLoop`, after `MyGetInput` | **sim ticks** |
+| `--listen` socket | nothing | `Control_ServiceListen`, in front of the console bus | **presents** |
+
+**The socket is a transport, not a fourth path.** It delivers the same `key` and `input` verbs a
+`--exec` line would. What it adds is a third clock: a command *arrives* on a present, and then
+meters itself in polls or ticks depending on which verb it was. So one driver on one socket runs on
+two different time bases, and the present-versus-tick trap already documented in
+[CONTROL.md](../CONTROL.md) is the first of three rather than a standalone caveat. The set should
+be written down there.
+
+**The rule that makes the rest coherent is the inverse of the device rule.**
+
+A *device* should name an **action** and let the binding layer resolve it. The touch overlay naming
+a scancode is exactly G1: rebind the keyboard and the on-screen D-pad stops working. The pad
+synthesising `K_UP` for menus is G2.
+
+The *harness* should name a **layer**, deliberately. `key` proves the binding layer itself works
+(rebind an action, press the new key, watch the hero); `input` proves consumption works
+independently of whatever is bound. Neither is redundant and neither is a workaround: they are
+probes at two different boundaries, and a harness with only one of them could not test half of
+this subsystem. That they inject at different levels is the feature.
+
+So increment 7 moves the devices onto the binding layer and leaves the harness spanning it.
+
+**Two things this leaves open.**
+
+*No action-level injection reaches a modal.* `input` ORs into `Input` from `MainLoop`, which a
+screen spinning its own `MyGetInput` loop never reaches;
+[INPUT_SIM_PLAN.md](INPUT_SIM_PLAN.md) resolves that by reaching for `key` instead. That is fine
+today and stops being fine at increment 4, because `key` deliberately bypasses the binding layer
+and a menu is where you would most want to assert that a *binding* resolved. A third verb naming a
+resolved action belongs with that increment, as test machinery rather than as a feature.
+
+*The two hooks cannot see each other.* `ApplyVirtualKeys` runs first and `ApplyHarnessKeys`
+second, and on expiry the harness lifts its key explicitly with `control_key_poke(sc, 0)` rather
+than waiting for the next clear. If touch is holding the same scancode, that lift clears it. It
+needs the harness and the overlay live together on the same key, so it is narrow, but the comment
+at the hook site saying the two "do not have to know about each other" is precisely why it is
+possible.
+
+**A naming collision, on the pattern of "profile".** `ApplyVirtualKeys` is the touch overlay's
+synthetic scancode state, an implementation detail of one device. The *virtual keyboard* a
+non-keyboard player needs in order to type a save name (G4, the `TODO(input)` at
+[GAMEMENU.CPP:1175](../../SOURCES/GAMEMENU.CPP)) does not exist and is unrelated. Two different
+things under one word, and the second one has no owner in this plan.
+
+## Three fixes that should not wait for any of this
+
+Not increments. Independent bug fixes, each small, none blocked on the plan:
+
+- **#509**, the disc prompt cannot be answered with a gamepad. `ConfirmMenu` reads only `MyKey`
+  and matches no pad scancode, so a pad-only player sits in `while (flag == -1)` with no way out
+  and `CDROM` is unconditional in the default build. This is a lock, and it should go first of
+  everything on this page.
+- **#508**, the Key2 column is unreachable from the keyboard on the gamepad screen, because the
+  screen's key filter swallows Left and Right before the line that would toggle the column. A
+  player is on that screen precisely when the pad is not working.
+- **#514**, orbit follow-through applies to the mouse, which does not spring back to centre.
+
+## The increments
+
+### 0. Put the binding table under test
+
+**What.** [SOURCES/INPUT.CPP](../../SOURCES/INPUT.CPP) into a host test, which nothing links
+today. Three assertions: `DefKeysDefault95` as data; `InitInput`'s folding of two tables into the
+combined 128-entry one, including that slots 32 to 35 do not reach `Input`; and
+`ReadInputConfig`/`WriteInputConfig` as a round trip, including the all-zero-bindings guard and
+the first-exit case the code carries comments about.
+
+**What it de-risks.** Everything after it. The binding table is the one layer with no test sitting
+between two that have one (`tests/input_device` below it, `tests/menu_keynav` above it), and every
+increment here edits it. It is also where the parity rule becomes an artifact instead of a
+sentence.
+
+**How it is proven.** It is the proof. No playtest needed.
+
+**What it costs.** Small, and no behaviour change. The module header is already owned, so there is
+no de-aggregation to do first.
+
+**Two commits, in this order.** First the tests against `SOURCES/INPUT.CPP` where it stands. Then
+the pure move of the 150 lines into `INPUT_BINDINGS.{H,CPP}`, same lines and same behaviour, tests
+travelling with them. That second commit is step 5 of the recipe and it is what lets every
+increment after this one edit a tested module rather than 1997 code in place.
+
+**What it decides.** The deferred test-investment question. If covering the pure layers leaves the
+fixtures as the obvious bottleneck for the increments below, replay earns a second look; if not,
+it does not.
+
+### 1. Watch the signal flow, and record the combos before anything moves
+
+**What.** Two halves, both read-only, both before any behaviour changes.
+
+*A per-boundary flow counter.* Input crosses three boundaries and each can lose a signal for a
+different reason. Count transitions on both sides of each and report the mismatch:
+
+| Boundary | Loses a signal when | Counted against |
+|---|---|---|
+| SDL event to polled state | a press and release both land between two polls, so the level sample never saw it | `SDL_EVENT_KEY_DOWN`/`UP` in `HandleEventsKeyboard` against rising edges in `TabKeys` |
+| polled state to action bits | a key is held that no binding names, including the spell slots that never reach `Input` | `TabKeys` rising edges against `Input` rising bits, with `NoRepeatInput`'s deliberate masking excluded |
+| action bits to the sim | the throttle skips the frame the edge fell on | `Input ^ LastInput` per rendered frame against what a stepped frame consumed |
+
+The first of those is nearly free: `HandleEventsKeyboard`
+([KEYBOARD.CPP:120](../../LIB386/SYSTEM/KEYBOARD.CPP)) already receives every key event and, by an
+explicit comment, keeps none of them. It is the only measurement that can answer whether level
+sampling loses anything in practice, which the research left open.
+
+`input trace` is not this. It logs the *injected* mask and hero state per sim tick, which serves
+the simulator; this counts the *real* signal at each layer and reports disagreement.
+
+*Combo fixtures, recorded as a baseline.* The `fseq` verb from
+[INPUT_SIM_PLAN.md](INPUT_SIM_PLAN.md) Phase 1 already places an edge on a chosen frame, which is
+what these need. The speedrunning community supplied the first group; the rest came from reading
+every branch in `MOVE_MANUAL` that tests an input combination or tests input against animation
+state, and three of them the community does not appear to have named.
+
+Why each one works, with the original comments, is
+[SPEEDRUN_MECHANICS.md](../SPEEDRUN_MECHANICS.md). That doc is written for the runners rather
+than for this plan, and it is the reason these are a specification and not a wish list: people
+depend on every row below.
+
+**Behaviour-coupled.** The family speedrunners actually use.
+
+| Combo | Why it probes input | Where |
+|---|---|---|
+| Running jump | Sporty plus `I_ACTION_M` on `GEN_ANIM_MARCHE` at `LastFrame == 0` picks `DO_LEFT_JUMP`, `DO_RIGHT_JUMP` or `DO_NORMAL_JUMP` by which foot is down, so the outcome is frame-exact | OBJECT.CPP `C_SPORTIF` |
+| Behaviour press cancels a landing | the community's core trick. `SetComportement` sets `GenAnim = NO_ANIM` and `FlagAnim = 0`, so a press on the landing frame clears the recovery | OBJECT.CPP:889-899 |
+| Sporty and Aggressive alternated between hits | keeps Twinsen close as enemies recoil; a late edge changes the exchange visibly | same |
+| Two behaviour keys in one frame | `I_NORMAL`, `I_SPORTIF`, `I_AGRESSIF`, `I_DISCRET` are an if/else-if chain, so the *first listed* wins rather than the one pressed. Nobody has written that down | PERSO.CPP:1441-1447 |
+
+**Hold against re-press.** The richest group, and the one most exposed to a lost edge, because
+these paths read input *history* rather than input state.
+
+| Combo | Why it probes input | Where |
+|---|---|---|
+| Up or Down held across a jump | if the bit was already in `LastMyJoy` the frame is skipped and the jump survives; release and re-press and it is not, so the jump prep cancels. The original comment says exactly this: *"si le joueur n'a pas relacher Up et Down avant de reappuyer dessus"* | OBJECT.CPP:4392-4413 |
+| Aggressive attack held against re-pressed | held gives the same blow every time, because `(LastInput & I_ACTION_M) AND GenAnim != GEN_ANIM_RIEN` skips the `MyRnd(3)` draw. The 1997 comment calls it a bug: *"Twinsen combat toujours avec le meme coup"* | OBJECT.CPP:4113 |
+| Direction changed while climbing | a change against `LastMyJoy` resets the animation on a ladder | OBJECT.CPP:4424 |
+| Any movement or fire change after an action | `((Input & I_JOY) != LastMyJoy) OR ((Input & I_FIRE) != LastMyFire)` resets to idle, and already increments `DbgHeroActionResets` | OBJECT.CPP:4415 |
+
+**Simultaneous opposites.** Undocumented anywhere, and the group a stick quantiser or a binding
+change could flip without anyone noticing.
+
+| Combo | Resolution today | Where |
+|---|---|---|
+| Up and Down together | Up wins: `if (Input & I_UP) ... else test_down = TRUE` | OBJECT.CPP:4440,4464 |
+| Left and Right together | Left wins, in both the turn block and `ManualRealAngle` | OBJECT.CPP:3864, 4481 |
+
+**Modifier and cross-layer.**
+
+| Combo | Why it probes input | Where |
+|---|---|---|
+| Direction plus `I_ESQUIVE` | selects the four `GEN_ANIM_ESQUIVE_*` variants, with a separate branch for sidestep plus a turn | OBJECT.CPP:4383 |
+| Direction held plus a spell | the spell keys bypass `Input` entirely through `SpellKeyDown`, so this probes the hole in the binding table | PERSO.CPP:1361-1407 |
+| Walk and turn together | the arc: turning is velocity times dt and frame-rate independent, walking is animation-driven and is not, so the radius may change with frame rate | INPUT_RESEARCH open question 6 |
+| Any of the above in the buggy | `BUGGY.CPP:277` carries its own copy of the re-press test, so vehicle input is a second path with the same shape | BUGGY.CPP:277 |
+
+**Two constraints these carry.**
+
+The Aggressive-attack case is an **original bug**, and its comment says so in 1997 French. A
+fixture pins the buggy behaviour; it does not fix it. [BIT_EXACTNESS.md](../BIT_EXACTNESS.md)
+decides what may change here and the answer is nothing.
+
+Anything pressing attack draws from `MyRnd(3)`, and the RNG is one shared stream, so an attack
+fixture perturbs it for everything downstream. Those fixtures need a fixed seed and should assert
+on the reset counters rather than on which of the three animations was drawn.
+
+**The counter precedent already exists.** `DbgHeroActionResets` counts one of these paths and is
+already reported by `--dump-state` as `action_resets`, added for #456. The flow counters above are
+the same idea applied at the layer boundaries rather than at one consumer.
+
+**What it de-risks.** Everything after it, in the way the plan cares about: it is the baseline that
+says what the engine did *before* increments 2 to 7 touched it, at the exact places where a
+regression would otherwise be invisible. Behaviour cancels and foot-dependent jumps are precisely
+what an input change breaks without anyone noticing until a player complains.
+
+**How it is proven.** It is instrumentation, so the proof is that it agrees with itself: the
+counters must show zero mismatch on the paths the existing throttle tests already cover, and the
+combo fixtures must pass on today's engine before they are worth anything.
+
+**What it costs.** Small to medium, and none of it changes engine behaviour. The counters are three
+pairs of integers and a report; the fixtures are `fseq` scripts plus the traces the harness
+already has.
+
+**What it decides.** More than its size suggests. It measures the second boundary, which is the
+two-funnel question stated as a number rather than a count of grep hits. It measures the third,
+which tells increment 5 whether a static guard is still needed or whether the counter is the
+guard. And it is the concrete form of the deferred test-investment question: if the fixtures plus
+these counters catch what the increments below could break, replay is not needed.
+
+### 2. Give suppression an owner
+
+**What.** Replace the single file-static `NoRepeatInput` with a per-subsystem mask on Doom 3's
+`InhibitUsercmd( subsystem, bool )` shape: each of console, menu, dialogue, holomap and cutscene
+owns one bit and can only set or clear its own. The old latch and the new mask coexist, so call
+sites convert a few at a time and the increment can stop anywhere.
+
+Take the discard rule with it: while inhibited, accumulated input is dropped rather than banked,
+so closing a menu cannot deliver a backlog.
+
+**What it de-risks.** The class where one screen's suppression is cleared by another's exit, over
+109 macro call sites that nobody owns. It also gives the console's hand-written suppression inside
+`MyGetInput` (a `memset`, an `Input = 0`, a one-frame flag) a general mechanism to be the first
+user of rather than a special case to be worked around by every later screen.
+
+**How it is proven.** Extends `tests/input_funnel`, which already builds a synthetic binding table
+and pins the mid-frame-rebuild regression. Playtest: menu and dialogue entry and exit, on keyboard
+and pad.
+
+**What it costs.** Small for the mechanism, incremental for the conversion.
+
+### 3. Name the keys
+
+**What.** Wire the localised key-name table the game already ships. Ids 200 to 268 in the `sys`
+bank are 69 key names in all six languages, and the engine reads four of them, for the legacy
+joystick axis path. This increment adds the scancode-to-text-id map and uses it for keyboard
+bindings, falling back to `GetKeyScancodeName` for what the table does not cover (letters and
+Escape).
+
+**What it de-risks.** It is the first half of #61 at a fraction of its estimate, because the
+strings exist and are already translated. It also puts a name on a binding, which is what
+increments 4 and 6 need in order to express one as data rather than as a slot index.
+
+**How it is proven.** The map is a pure bidirectional lookup, which is the shape
+`tests/menu_keynav` already demonstrates: 40 host-test cases over 33 lines of source. Playtest: the
+key config screen in more than one language.
+
+**What it costs.** Small. A 69-entry table and a fallback.
+
+**Exception taken here.** #508's keypad-period alias, which is a key identity question rather than
+a screen question.
+
+**Not included.** #61's other half, names in the cfg file. These ids are LBA's own, not a text form
+of a scancode, so a written config wants its own vocabulary. That is a later step and it belongs
+with increment 6.
+
+### 4. Split layout from preference
+
+**What.** #507. The `{Key1, Key2}` pair does two unrelated jobs: `{K_GRAY_UP, K_NUMPAD_8}` is a
+layout fact and `{K_W, K_GRAY_END}` is a preference. Separate them, so a rebind cannot drop a
+layout twin, and grow [MENU_KEYNAV.CPP](../../SOURCES/MENU_KEYNAV.CPP) from the keypad-only helper
+it is into the layout layer that holds the rest (modifier pairs, and the keypad legend it already
+covers).
+
+**What it de-risks.** The defect class behind #497, #506 and #508, where a screen restates part of
+the legend and silently loses what it left out. And it is the prerequisite for increment 6: a
+binding set that could not hold layout facts separately would either duplicate them into every set
+or lose them.
+
+**How it is proven.** The layout layer is a pure lookup and joins `tests/menu_keynav`. The split
+itself is proven by increment 0's round-trip test plus a new case per exception. Playtest: rebinding
+with a keypad, both config screens.
+
+**What it costs.** Medium, and it is the first increment where the cfg format changes, so it needs
+a migration that reads the old shape.
+
+**What it decides.** The deferred funnel question. With a layout layer in place, each of the 93
+raw-scancode sites can be sorted into wanted-a-binding, wanted-only-the-legend, or genuinely
+physical (a console toggle, a debug key). That count is the answer, and it is not knowable before
+this lands.
+
+### 5. Guard the throttle whitelist
+
+**What.** A baseline of the post-gate `Input` edge-read sites, checked in CI, on the pattern
+`scripts/ci/warnings-baseline.txt` already established. A new post-gate edge consumer fails the
+check until its bits are in `I_ACTION_EDGE` or the baseline is updated deliberately.
+
+**Possibly already done by increment 1.** That increment's third boundary counts the same loss at
+runtime, and a runtime count is the more truthful of the two: a grep baseline can only see sites
+it recognises. The static check earns its place only if it catches something the counter cannot,
+which is a consumer no fixture exercises. Decide once the counters have run, and skip this
+increment if they cover it.
+
+**Why only a guard.** [INPUT_SIM_PLAN.md](INPUT_SIM_PLAN.md) Phase 2 measured this and chose not
+to build the latch: the whitelist is complete, so the latch would be a pure refactor carrying
+byte-exact risk for zero live bugs, and `test_melee_throttle.sh`,
+`test_blowgun_release_throttle.sh` and `test_item_use_throttle.sh` were built instead. That
+decision stands. Its stated trigger was "the day a future post-gate edge consumer lands outside the
+whitelist", and nothing detects that day arriving. This increment is that detector and nothing
+more.
+
+**It also closes an open question in that plan.** The spell edges (`I_PINGOUIN`, `I_JETPACK`,
+`I_PROTECTION`, `I_FOUDRE`) were listed as outside both the whitelist and the latch, with their
+scope unconfirmed. They are read through `SpellKeyDown` at
+[PERSO.CPP:1361-1407](../../SOURCES/PERSO.CPP#L1361), before the throttle gate at line 1618, so
+they run every rendered frame and cannot be dropped. Genuinely out of scope, and the record should
+say so.
+
+**What it costs.** Small. No engine change.
+
+### 6. Binding sets
+
+**What.** A named set of bindings covering keyboard and pad together, swappable whole, with the
+layout facts from increment 4 held outside it so no set has to carry them. The existing cfg keys
+become the default set.
+
+**Naming, to settle when this starts.** "Profile" is taken: `--profile <name>` already means a
+user-directory profile, and `ChoosePlayerName` calls a save a profile too. A third meaning would be
+one too many.
+
+**What it de-risks.** It is the shape #4 and #372 would ship into, whenever their direction call is
+made, which is what keeps the scope line above from being a dead end. It is also where #61's cfg
+half belongs, because a set written to disk wants readable names by then.
+
+**How it is proven.** Set selection and serialisation are pure and host-testable. Playtest: real,
+and the first increment where a community tester adds something a host test cannot.
+
+**What it costs.** Medium to large: cfg format, a UI, and defaults.
+
+### 7. Sources onto the binding layer
+
+**What.** The two *devices* still on hardcoded scancodes (the harness stays spanning the layer, per the section above). The touch overlay presses default
+scancodes from a static table, so a keyboard rebind silently stops the on-screen D-pad working
+(G1). The pad synthesises `K_UP` and `K_ENTER` for menu navigation, which is a second, hardcoded
+binding table that no config screen mentions (G2). Both should read the layer that increments 3
+and 4 build. #359's 8-way virtual stick lands here too, and is cheap: the pad's own quantiser
+already produces exactly the eight directions the hero can hear.
+
+**Why last.** Both need somewhere to read a binding *from*, which is increment 4.
+
+**How it is proven, and this constrains the increment.** There is no Android device on the
+maintainer's desk, so the touch half has to be self-provable: the mapping becomes a pure lookup
+with a host test, and the device pass is confirmation rather than the proof. #359 was filed from a
+CMF Phone 1 on Android 15, so its reporter is the route for that confirmation. Until someone runs
+it,
+**G1 stays a reasoned finding rather than a confirmed bug**, and the plan should not claim
+otherwise.
+
+**What it costs.** Medium, and the touch half is gated on a tester rather than on effort.
+
+## Play-testing
+
+What each increment needs, given the answer that a pad on the desktop and community testers are
+available and an Android device is not:
+
+| Increment | Needs |
+|---|---|
+| 0, 1, 5 | nothing, they are checks and instruments |
+| 2 | pad and keyboard, menu and dialogue transitions |
+| 3 | a language other than English on the key config screen |
+| 4 | a keyboard with a keypad, both config screens |
+| 6 | real play, and the first place a community tester sees something a test cannot |
+| 7 | an Android device, so a community tester, for the touch half only |
+
+The three independent fixes each need a pad, and #509 needs a build with no keyboard reachable to
+confirm the lock is gone.
+
+## What this plan does not buy
+
+**It does not make the game feel different.** Nothing above changes how the hero moves. The one
+user-visible change in the whole plan is #509 unblocking a player who cannot currently proceed,
+and that is listed as an independent fix rather than an increment.
+
+**It does not settle the scheme question**, and increment 6 is the most it does toward it: a place
+for an answer to live once the direction call is made.
+
+**It does not raise the coverage percentage much.** The extraction is 150 lines against
+`SOURCES/`'s 73,664, so roughly 6% becomes 6.6%. The roadmap's rule is satisfied on the letter and
+the real argument is the one above: those 150 lines would be the first 1997 game logic any host
+test has reached.
+
+## How this doc changes
+
+Edited as increments land, not rewritten at the end. The two deferred decisions above are the
+places where it is expected to change most: increments 0, 1 and 4 each exist partly to
+produce an answer, and if either answer contradicts the ordering here then the ordering is what
+gives way.

--- a/docs/plan/INPUT_RESEARCH.md
+++ b/docs/plan/INPUT_RESEARCH.md
@@ -1,0 +1,644 @@
+# Input system: research
+
+The input system as it stands, across every device that reaches it, with the open issues mapped
+onto it and the gaps that no issue records yet.
+
+This is findings only. It proposes nothing, orders nothing and commits nothing; the planning doc
+comes after review. It exists because [REFACTOR_ROADMAP.md](REFACTOR_ROADMAP.md) area 8 names
+input as the area the issue tracker is asking for, and because an area that is going to be pinned
+with tests has to be described first.
+
+Companions: [INPUT_SIM_PLAN.md](INPUT_SIM_PLAN.md) for the simulator and the throttle-drop class,
+[INPUT_REPLAY_RESEARCH.md](INPUT_REPLAY_RESEARCH.md) for why no recorded-input subsystem was
+inherited, and [INPUT_DOOM3_RESEARCH.md](INPUT_DOOM3_RESEARCH.md) for what a mature version of
+this system looks like elsewhere.
+
+Measured against `main` at `97e9f303`. Numbers age; re-run the commands at the end.
+
+## The finding that organises everything else
+
+**There are two funnels, not one, and only one of them is bindable.**
+
+The engine has a proper binding layer: `DefKeys[]` and `GamepadKeys[]` are folded by `InitInput`
+into one flat (key, mask) table, and `GetInput` scans it to rebuild the `Input` action bitfield.
+Anything reading `Input` inherits every binding and every alternate key for free. 154 sites do.
+
+Alongside it, and reaching the same consumers, is a raw scancode path. `TabKeys[]` and `MyKey`
+carry physical keys, and 93 sites compare them directly. That path is not bindable, does not know
+about alternates, and is where every input bug of the last few months has been found.
+
+The important part is not that the second path exists for legacy reasons. It is that **new code
+keeps being written into it, and three devices depend on it by design**:
+
+- the touch overlay presses hardcoded scancodes into `TabKeys`
+- the gamepad synthesises hardcoded scancodes for menu navigation
+- text entry reads `GetAscii` and never touches either funnel
+
+So "route the raw-key sites through the binding layer" is not a cleanup of old code. It is a
+question about how three current devices work.
+
+## The path, layer by layer
+
+| Layer | File | What it does | Covered by a test |
+|---|---|---|---|
+| Event pump | [LIB386/SYSTEM/EVENTS.CPP](../../LIB386/SYSTEM/EVENTS.CPP) | `SDL_PollEvent` loop, fans out to seven per-subsystem `HandleEventsXxx` handlers, two of them weak | no |
+| Keyboard sample | [LIB386/SYSTEM/KEYBOARD.CPP](../../LIB386/SYSTEM/KEYBOARD.CPP) (138) | clears `TabKeys[0..255]`, re-reads `SDL_GetKeyboardState`, sets `Key` to the lowest scancode down | `tests/input_device` |
+| Mouse | [LIB386/SYSTEM/MOUSE.CPP](../../LIB386/SYSTEM/MOUSE.CPP) (229) | event-driven deltas, wheel, box clamp | `tests/input_device` |
+| Gamepad | [SOURCES/JOYSTICK.CPP](../../SOURCES/JOYSTICK.CPP) (470) | writes virtual scancodes >= 1024 into `TabKeys`; raw axes for the camera | no |
+| Touch | [SOURCES/TOUCH_INPUT.CPP](../../SOURCES/TOUCH_INPUT.CPP) (507) | on-screen buttons write scancodes into `TabKeys` via `ApplyVirtualKeys` | no |
+| Funnel | [LIB386/SYSTEM/INPUT.CPP](../../LIB386/SYSTEM/INPUT.CPP) (59) | rebuilds `Input` from the combined table; `NoRepeatInput` latch | `tests/input_funnel` |
+| Binding table | [SOURCES/INPUT.CPP](../../SOURCES/INPUT.CPP) (446) | `DefKeys`, `GamepadKeys`, `InitInput`, cfg read and write, `MyGetInput` | **none** |
+| Layout helper | [SOURCES/MENU_KEYNAV.CPP](../../SOURCES/MENU_KEYNAV.CPP) (33) | keypad legend to navigation keys | `tests/menu_keynav`, 40 cases |
+| Consumption | everywhere | 154 `Input &`, 93 raw scancode compares, 21 `CheckKey`, 81 `MyGetInput()` loops | two automation fixtures |
+
+The shape of the coverage is the thing to notice. The layer below the binding table is tested, the
+layer above it is tested, and **no test links `SOURCES/INPUT.CPP`**. `tests/input_funnel` gets
+close, but it builds its own fake binding table with a local `setBinding` helper precisely so it
+can test the funnel without the real one.
+
+## Per device
+
+### Keyboard
+
+The reference device, and the one with a parity obligation. `DefKeysDefault95` is the retail
+layout, 36 slots of `{Key1, Key2}`. It is the only place the 1997 control scheme is written down,
+which makes it an asset as well as a table.
+
+Sampling is level-triggered: `UpdateKeyboardState` clears and re-reads the whole keyboard each
+call, so a press and release between two polls never existed. `Key` is the lowest set scancode, so
+which key "the" key is among simultaneous presses is an artifact of scancode ordering rather than
+a decision.
+
+### Mouse
+
+Event-driven, unlike everything else, and entirely outside the binding layer. It drives the menu
+pointer, the camera orbit and the wheel zoom, with its own cfg tunables (`MouseCamera`,
+`MouseSensitivityX/Y`, `MouseCameraDivisor`, `MouseCameraSmoothing`, documented in
+[CONTROLLER.md](../CONTROLLER.md)). No mouse control is rebindable and none appears in either
+config screen.
+
+### Gamepad
+
+Two separate paths, and neither one makes the other visible.
+
+**Gameplay** goes through the binding layer properly. `GamepadKeys[]` sits beside `DefKeys[]` in
+the combined table, so a pad button is a first-class binding that honours `NoRepeatInput` exactly
+like a key. This was deliberate and is commented as such in `InitInput`.
+
+**Menus** do not. `JoystickMenuNavOnly` and `JoystickMenuAction` return hardcoded `K_UP`,
+`K_DOWN`, `K_LEFT`, `K_RIGHT` and `K_ENTER`, which screens then compare as raw scancodes. Menu
+navigation on a pad is therefore unbindable, and a screen has to handle both paths to be fully
+pad-driveable. #509 is exactly a screen that handles neither.
+
+**Analog is destroyed at the funnel, as it was in 1997.** `ApplyStickDirection` quantises a stick
+into 8 sectors with hysteresis and emits digital virtual scancodes; magnitude is discarded. The
+imported 1997 `JoyMakeBitfield` did the same with a fixed third-of-range threshold (see G3).
+
+The one exception is the right stick when
+`GamepadCameraAnalog && FollowCamera && CubeMode == CUBE_EXTERIEUR`, where raw axes go to
+`ApplyManualCameraNudge` instead, bypassing the funnel entirely. So the engine has exactly one
+analog consumer, it is the camera, and it got there by not using the input system.
+
+### Touch
+
+An on-screen overlay of 14 buttons, each with a hardcoded scancode in a static table:
+`{BTN_DPAD_UP, "U", ..., K_UP}`, `{BTN_SPACE, "ACT", ..., K_SPACE}`. `ApplyVirtualKeys` re-applies
+them into `TabKeys` after the keyboard poll clears it, through the weak-symbol hook.
+
+The hook design is good and is the same one the control harness uses. The table is not: the
+buttons press *default* scancodes, and nothing rebuilds them when bindings change.
+
+### Text entry
+
+`GetAscii`, read directly, bypassing both funnels. Three call sites in the game build: the
+save-name field twice and the cheat code reader. There is no virtual keyboard, and
+[GAMEMENU.CPP:1175](../../SOURCES/GAMEMENU.CPP) says so in a `TODO(input)`: non-keyboard users
+cannot enter save or profile names, and are routed around the field entirely by the
+`!LastInputWasKeyboard` branch in `ChoosePlayerName`, which gives a new slot a datetime stem and
+overwrites an existing one.
+
+## The two world modes ask different questions of input
+
+Not visible from the input code at all, which is the point. `CubeMode` never appears in
+`MOVE_MANUAL`: the hero is driven by identical tank-control code in isometric interiors and
+perspective exteriors. What differs is the camera, and it differs in a way that decides whether a
+camera-relative control scheme is even well-defined.
+
+| | Interior (isometric) | Exterior (perspective) |
+|---|---|---|
+| Projection call | `SetIsoProjection(xcentre, ycentre)` | `SetFollowCamera(..., AlphaCam, BetaCam, GammaCam, VueDistance)` |
+| Camera orientation | **no angle parameter exists**; `TypeProj = TYPE_ISO` and that is all | `BetaCam`, computed from hero `Beta`, orbitable by the player |
+| Camera motion | pans on the tile grid, half-step interpolation toward the hero's brick | orbits, follows, and is overridden by camera zones and cutscenes |
+| Screen "up" in world terms | one constant, for the whole game | changes continuously |
+| Auto camera (`FollowCamera`) | never runs | exterior only, and suppressed by `CameraZone` and `CinemaMode` |
+
+**Tank controls are camera-invariant, which is why one code path serves both.** "Left" means
+"rotate the hero left" regardless of where the camera is, so a fixed iso camera and a free orbiting
+one can share `MOVE_MANUAL` without either knowing about the other. That is not an accident of the
+port; it is the property that let a 1997 game ship both modes with one control scheme.
+
+**The consequence for #372 runs opposite to the intuition.** Its keystone, camera-relative
+movement, is explicitly built on "the new free dynamic camera", which in code is
+`FollowCamera && CubeMode == CUBE_EXTERIEUR`. But that is the *harder* of the two modes to make
+camera-relative:
+
+- **Interiors are the easy case.** The iso camera has no orientation parameter, so screen space
+  maps to world space through one constant rotation, forever. Camera-relative movement there is a
+  fixed basis change and nothing else, which is exactly how modern isometric games use an analog
+  stick.
+- **Exteriors are the hard case.** `BetaCam` is continuously variable and is not owned by the
+  player: camera zones and cutscenes take it away. Camera-relative movement has to survive the
+  moment the camera is yanked, which is the classic bug where a camera cut reverses the player's
+  direction mid-stride.
+- **And exteriors have a feedback loop interiors do not.** `BetaCam` is derived from hero `Beta`
+  by the auto-follow. Make the hero's direction derive from `BetaCam` as well and the two chase
+  each other: the hero turns, the camera follows, the stick's meaning rotates, the hero turns
+  further. Real implementations break the loop by latching the reference frame when the stick is
+  pushed, or by suspending auto-follow while it is held. The Auto camera already has the machinery
+  for the second (`FollowCamForgetManualGesture`, the re-engage grace period), which is worth
+  knowing before anyone estimates this.
+
+So the shape of the question is: does a control-scheme change apply to both modes, giving the
+player one scheme and needing the harder exterior case solved, or to exteriors only, giving the
+player an invisible scheme change at every door? Neither is free, and #372 does not currently say
+which it means.
+
+## What retail parity means here, concretely
+
+Worth pinning down because "keyboard must have parity with retail" is the constraint that decides
+what the binding work may and may not touch.
+
+Parity is `DefKeysDefault95` plus the funnel's behaviour, not the whole system. The table is data
+and is directly checkable. The funnel's semantics are the subtler half: `NoRepeatInput` masks a
+bit that was already held so a held key does not repeat, and `ClearNoRepeatInput` releases it.
+That is the mechanism the whole 1997 menu and dialogue layer is built on, and it is what a
+rewrite would most easily get wrong in a way no screenshot catches.
+
+`tests/input_funnel` already pins some of it, including the regression where a mid-frame
+`GetInput` rebuild dropped held movement. It does so against a synthetic table, so it pins the
+funnel's rules without pinning the retail layout. Those are two different assertions and only one
+of them exists.
+
+## The open issues, clustered
+
+Thirteen open issues touch input. They are not thirteen problems.
+
+**Cluster 1: screens that bypass the binding layer.** #509 (the disc prompt cannot be answered
+with a gamepad, and `while (flag == -1)` has no other exit), #508 (the pad config screen's Key2
+column is unreachable from the keyboard, and the keypad period is offered but unbindable), #507
+(the umbrella: layout against preference). Closed siblings #497 and #506 are the same shape. This
+cluster is the 93 raw scancode sites, and it is the only cluster producing user-visible defects
+today.
+
+**Cluster 2: the config file's vocabulary.** #61, human-readable key names alongside raw
+scancodes, with acceptance criteria already written. It is the smallest issue here and it is a
+prerequisite for anything that wants to express a binding set as data.
+
+**Cluster 3: control-scheme features.** #4 (LBA1 Enhanced Edition style controls), #372 (the
+omnidirectional proposal from field testing, explicitly a direction decision before it is a task), #365
+(hold-to-lock Z-targeting), #369 (weapon wheel), #370 (inventory items on the D-pad). All five
+are profile features: they are alternative mappings of actions to controls, and #372 says in its
+own text that the retail scheme must remain the default.
+
+**Cluster 4: devices that cannot express what they need to.** #359 (the Android on-screen pad is
+4-way, wants 8-way).
+
+**Cluster 5: timing and harness.** #412 (fixed-step sim plus interpolated render plus input
+latching, the structural fix for the throttle-drop class), #433 (harness ergonomics). #514 is
+adjacent: the camera orbit follow-through is right for a stick that springs back and wrong for a
+mouse that does not, which is a device-difference problem wearing a camera hat.
+
+The cluster ordering that falls out: 1 is defects, 2 is a prerequisite, 3 is blocked on a
+direction call and on 1, 4 is blocked on an architectural property described below, 5 is a
+separate campaign already under way.
+
+## Prior art for cluster 3, and what "LBA1 Enhanced Edition controls" actually means
+
+#4 asks for "similar controls to LBA1 Enhanced Edition" and its body is one sentence. The phrase
+names a specific build, and it is worth pinning down before anyone builds against it.
+
+Read from the installed files rather than from the web, because the web accounts of this game
+describe the mobile release and are wrong about the desktop one. The Steam install of
+*Little Big Adventure* ships **three** things side by side, which is the first thing to get
+straight:
+
+| Path | What it is |
+|---|---|
+| `TLBA1C.exe` plus `SDL2.dll` / `SDL3.dll` | *Twinsen's Little Big Adventure Classic*, the 2022 official re-release, the sibling of this project |
+| `DotEmu/LBA.exe` | the **Enhanced Edition**, a separate cocos2d-x build (`libcocos2d.dll`, `libEGL.dll`, `libGLESv2.dll`), a mobile engine brought to desktop |
+| `original/`, `Speedrun/` | the DOS data and a DOSBox-wrapped build |
+
+So "Enhanced Edition" is not the Steam retitle, and the two are not the same executable.
+
+### What the Enhanced Edition actually does
+
+From `DotEmu/resources/lba_strings_en.xml` and the asset names.
+
+**Two selectable control modes**, `controlMode`: `controlTouch` ("Touch") and `controlVPad`
+("Virtual Pad"). The entire options screen is four rows: Control mode, Volume, Hotspots, Language.
+
+**It has keyboard support and rebinding on desktop.** The web sources say it does not, and that is
+true of the mobile release only. The strings carry a `key_configuration` screen titled "Controls"
+with `keyboard_control_label` "Keyboard" and `gamepad_control_label` "Gamepad", plus
+`press_a_key_label` and `press_a_button_label` prompts and a `key_confirmation` step.
+
+**The bindable action set is about three, against this engine's 36.** The rebind rows named in the
+strings are `Action`, `Jump` and `Attack/Ball`. Everything else is a fixed HUD control
+(`btn_hide`, `btn_inventory`, `btn_pause`) or a pad glyph. The Virtual Pad overlay is three
+buttons: `btn_virtual_action`, `btn_virtual_attack`, `btn_virtual_jump`. Pad glyphs shipped are
+A, B, X, Y, L1, R1, L3, R3, Back and Start, of which A, B, X, Y and R1 appear as in-HUD prompts.
+
+**The behaviour wheel is gone, replaced by dedicated buttons and contextual gestures**, and the
+tutorial strings state each scheme twice, once per input:
+
+| Action | Mouse and touch | Gamepad |
+|---|---|---|
+| Run | double-click | press and hold the action button |
+| Jump | click Twinsen, hold, drag away to aim | jump button, **default distance** |
+| Magic ball | same drag, past jump range, release to throw | press and hold the attack button |
+| Attack | double-click the NPC | attack button |
+| Hide (Discreet) | footsteps button in the HUD | hide button |
+| Camera | mouse wheel to zoom | zoom in and out buttons |
+
+**Hotspots are an affordance layer with an on/off toggle.** `spot_attack`, `spot_look`,
+`spot_cube`, `spot_inventory_get`, `spot_inventory_use`, `spot_scenaric` mark interactable things
+on screen. That is how the Enhanced Edition replaced "select the right behaviour and walk into
+it": it tells the player what is interactable instead of making the behaviour the question.
+
+**The camera zooms and does not rotate**, which is consistent with LBA1 being isometric throughout.
+
+### Three things this says for cluster 3
+
+**The Enhanced Edition's own pad scheme is deliberately less expressive than its pointer scheme.**
+The mouse gets direction and distance out of one drag for both jump and magic ball. The pad gets
+"Pressing the jump button will use the default distance." DotEmu hit exactly the problem G3
+describes, an analog gesture with no button equivalent, and answered it by dropping to a
+constant rather than by finding a stick idiom. Worth knowing before this project assumes the pad
+is the richer input.
+
+**It could do this because LBA1 is isometric throughout, which LBA2 is not.** Checked against
+`../lba1-classic`: gameplay uses `SetIsoProjection( 320-8-1, 240, SIZE_BRICK_XZ )`, and every
+perspective `SetProjection` call in that tree is in `GAMEMENU.C` (the behaviour-menu model spin),
+`HOLOMAP.C` (the globe) or one scripted case in `GERELIFE.C`. There is no `CubeMode` and no
+exterior world mode. A screen point therefore maps to a world direction through one constant
+rotation, everywhere, always, which is what makes tap-to-move well defined at all. LBA2 has the
+second mode, so the same scheme lands cleanly in interiors and meets the variable `BetaCam`
+problem in exteriors. That is the seam described above, reached from the other end.
+
+**There are three shipped answers to "what replaces the behaviour wheel", not two.** Retail keeps
+it explicit. The Enhanced Edition removed it and split the job: dedicated buttons for Jump and
+Attack, contextual inference for Run, a HUD toggle for Discreet, and a hotspot layer so the player
+no longer has to guess what a behaviour is for. *Twinsen's Quest* (Microids, 2024, a remake rather
+than a port) kept it explicit with dedicated run and dodge buttons, WASD and pad, rebindable.
+#372 proposes a fourth arrangement and cites none of them.
+
+Sources: the installed files at `E:\Steam\steamapps\common\Little Big Adventure` for everything
+above the Twinsen's Quest line; [Microids announcement](https://www.microids.com/microids-announces-little-big-adventure-twinsens-quest/)
+and [Steam](https://store.steampowered.com/app/2318070/Little_Big_Adventure__Twinsens_Quest/) for
+that one. The [Magicball Network mobile review](https://magicball.net/lba1/articles/lba1-mobile-review/)
+describes the touch scheme on mobile and matches the Touch-mode strings here.
+
+## What the official LBA2 binaries say
+
+Read from `E:\Steam\steamapps\common\Little Big Adventure 2`. That install ships two official
+builds side by side, both stamped by 2.21, and neither is the 1997 executable:
+
+| File | Build stamp |
+|---|---|
+| `TLBA2C.exe` | `tlba2-classic-Steam` |
+| `TLBA2.exe` | `tlba2-retro-Steam v3.2.3 / 2point21 (Sep  6 2022)` |
+
+This matters because these are the direct ancestor of this fork, so what they do is the baseline
+that "parity" is measured against, not a third-party opinion.
+
+**The cfg key scheme is inherited, not invented here.** Both carry the format strings `%s%d_1` and
+`%s%d_2`, one parameterised helper taking the prefix, where this tree has two literals
+(`Input%d_1`, `Gamepad%d`). `TLBA2C.exe` also carries `WinMode` and `AutoCameraCenter`, the legacy
+key [CONFIG.md](../CONFIG.md) records this engine as still reading.
+
+**They already have a gamepad key-name table, and this fork inherited it.** 25 entries in both
+binaries:
+
+```
+Action Down, Action Right, Action Left, Action Up, Back, Select, Start,
+Left Stick, Right Stick, Left Shoulder, Right Shoulder,
+D-Pad Up/Down/Left/Right, L-Axis Left/Right/Up/Down, R-Axis Left/Right/Up/Down,
+Left Trigger, Right Trigger
+```
+
+`CONFIG.CPP:253` holds the same list, same positional face-button naming, abbreviated in five
+places (`LB`/`RB` for Left and Right Shoulder, `LT`/`RT` for the triggers, `D-Up` for D-Pad Up,
+`L-Axis Btn` for Left Stick) and with `Guide` added. The abbreviations do not appear to be forced:
+"Right Shoulder" is 14 characters and `string[14] = 0` leaves room for it. Matching the official
+spelling is a cosmetic change with a real argument behind it, which is more than most cosmetic
+changes have.
+
+**Naming face buttons by position rather than letter is theirs and is worth keeping.** "Action
+Down" rather than "A" sidesteps the Xbox and Nintendo layout swap. The internal enum here is
+`K_GAMEPAD_A`/`B`/`X`/`Y` with comments mapping to `SDL_GAMEPAD_BUTTON_SOUTH` and friends, so the
+positional truth is one layer down from the names. Worth knowing before anyone "fixes" the labels.
+
+**The official builds have no keyboard key-name table at all.** Keyboard bindings are displayed
+through the format `Key %02X`, a raw hex scancode, with `Joy %d` and `Btn %d` as the other
+fallbacks. No `Space`, `Enter` or `Escape` strings exist in either binary. Two things follow:
+
+- **#61's complaint is inherited.** A numeric, unreadable representation of a keyboard binding is
+  what the official release does, so this is not a regression introduced by the fork.
+- **The pattern #61 wants already exists in-tree, for the other device.** The gamepad has a name
+  table; the keyboard does not. This fork already improved the *display* half by routing keyboard
+  names through `GetKeyScancodeName`, which is SDL's name and English-only. What neither build has
+  is the *file* half: the cfg is still integers on both sides, which is exactly what #61 asks for
+  and what Doom 3's three-column `keynames[]` supplies.
+
+**Stick quantisation is now confirmed across three generations.** `L-Axis Left/Right/Up/Down` and
+`R-Axis ...` appear in the official table as bindable keys, so the 2022 port also presents a stick
+as eight digital directions. With `JoyMakeBitfield` in the 1997 import and `ApplyStickDirection`
+here, every version of this game has thrown the magnitude away at the same place. G3 is a property
+of the lineage, not a port decision.
+
+**Not found:** the bindable action labels are not in either binary. They come
+from the localised text data, as they do here, so comparing this engine's 36 action names against
+the official set needs an HQR extraction rather than a strings pass.
+
+## What the retail text data carries
+
+Extracted from `Common/TEXT.HQR` (442,979 bytes, the Steam LBA2 install) with
+`scripts/dev/text_dump.py`, written for this and following the format in [TEXT.md](../TEXT.md).
+The `sys` bank holds 164 slots, ids 6 to 268, in each of six languages.
+
+**The 36 action labels are ids 100 to 135, in this engine's `I_*` bit order**, reached through
+`GetMultiText(START_ACTION_TXT + n, ...)` at [CONFIG.CPP:384](../../SOURCES/CONFIG.CPP):
+
+```
+100 Forwards            108 Talk/Search             118 Inventory help/Keyboard configuration
+101 Backwards           109 Center camera/Select    119 Save        125..131 Weapon 1..7
+102 Turn left           110 Menus                   120 Load        132 Meca-Pinguin
+103 Turn right          111 Holomap                 121 Options Menu  133 Jetpack On/Off
+104 Use weapon          112 Pause                   122 Turn camera   134 Protection spell
+105 Behavior menu       113 Sidestep                123 Next cameral level   135 Lightning spell
+106 Inventory           114..117 Normal / Sporty /  124 Previous camera level
+107 Behavior action              Aggressive / Discreet Behavior
+```
+
+Two things fall out. The retail vocabulary names 109 "Center camera/Select", which is the exact
+pairing #365 proposes to split, so that issue is arguing with a shipped label. And id 123 reads
+"Next cameral level" in the retail English data. [TEXT.md](../TEXT.md) records TEXT.HQR as a frozen
+asset that cannot be regenerated, so that typo is not ours to fix.
+
+### A localised key-name table already ships, and the engine uses four entries of it
+
+**Ids 200 to 268 are 69 keyboard key names, present in all six languages.** Verified by dumping
+each: id 226 reads `Left shift`, `Maj Gauche`, `Linke Umschalttaste`, `Mayús Izquierda`,
+`Shift Sinistra`, `SHIFT Esquerda`. The table covers the numeric keypad including `Num Pad .` and
+`Num Pad Enter`, the navigation cluster, the left and right variants of shift, ctrl and alt, the
+function keys, the digit row, Space, Enter, Backspace, Tab, the lock keys, Print Screen, Pause,
+and both Windows keys. It does not cover the letter keys or Escape.
+
+**The engine reads four of them.** `GetKeyText` ([CONFIG.CPP:336](../../SOURCES/CONFIG.CPP)) calls
+`GetMultiText(START_KEYS_TXT + 16 + button, ...)` with `button` reduced to 0..3, which lands on ids
+216 to 219, `Up`/`Down`/`Left`/`Right`, and only on the legacy multi-axis joystick path (the Z, R,
+U, V and H axes). Every keyboard binding instead goes to `GetKeyScancodeName`, which is SDL's name
+and English only.
+
+This changes what #61 is. It asks for human-readable key names; the readable, localised names are
+already in the shipped data and have been since 1997, unused for their own purpose. The work is
+wiring plus a scancode-to-id map, not authoring, and it would give the key config screen the same
+six languages the rest of the menu has. What #61 also asks for, names in the **cfg file**, is a
+separate half that this table does not supply, since the ids are LBA's own and not a text
+representation of a scancode.
+
+It also completes the comparison in the Doom 3 section: that engine's `keynames[]` carries a
+localised display string as its third column. This engine has that column too. It is in TEXT.HQR
+and nothing reads it.
+
+### The two config screens draw their vocabulary from different systems
+
+The keyboard config screen is retail throughout: ids 160 to 165 give it `Action`, `Key 1`, `Key 2`,
+`Default Configuration`, `Restore Previous Configuration`, `Accept Configuration`, and its rows are
+the action labels above. The gamepad config screen is community strings by way of
+`GetLocalizedMenuLabel` and the hardcoded English `kNames[]` table at
+[CONFIG.CPP:253](../../SOURCES/CONFIG.CPP).
+
+That split is not a defect but it is the reason the two screens have drifted, which is what #508
+reports and what #507 records as a pattern.
+
+### The game menu is now mostly community strings
+
+`GAMEMENU.CPP` has 9 `GetMultiText` sites against 15 `GetLocalizedMenuLabel` ones, with 24 labels
+defined in [MENU_LABELS.H](../../SOURCES/MENU_LABELS.H). The retail main menu is ids 70 to 75,
+`Resume Game` / `New Game` / `Load Game` / `Save Game` / `Options Menu` / `Quit`; the behaviour
+names are 80 onward; the options strings are 11 to 50. Everything the fork has added since,
+resolution, vsync, display mode, Auto camera, the controller screen, the language pickers and the
+movie fit modes, has no TEXT.HQR id and cannot be given one.
+
+So the menu's vocabulary is already two systems, and any input work that adds a surface adds to
+the community half. [TEXT.md](../TEXT.md) states the rule this follows from: TEXT.HQR is a frozen
+asset, so a new string has to come from the in-source table. A binding set expressed as data would
+need its own name source for the same reason.
+
+## Gaps this research found that no issue records
+
+The reason for looking at the whole system rather than the issue list.
+
+**G1. Rebinding the keyboard silently breaks the touch overlay.** The overlay presses default
+scancodes. `K_UP` and `K_GRAY_UP` are the same scancode, so the D-pad works by default; rebind
+`I_UP` to something else and the on-screen D-pad stops moving the hero, with no error and no way
+for the player to connect the two. The overlay is also not re-layoutable for the same reason.
+Nothing reads `DefKeys` in `TOUCH_INPUT.CPP`.
+
+**G2. Menu navigation on a pad is a second, hardcoded binding table.** `GamepadKeys` governs
+gameplay; `JoystickMenuNavOnly` governs menus and is not data. A screen must handle both to be
+pad-complete, and neither config screen mentions the second one exists.
+
+**G3. #372's walk-versus-run by stick actuation is architecturally blocked, and the block is
+deeper than the funnel.** Two separate facts, and the second is the one that matters.
+
+The funnel discards magnitude: `ApplyStickDirection` quantises a stick into 8 sectors and emits
+digital scancodes. But **the 1997 code did the same thing**, so this is not something the port
+lost. `JoyMakeBitfield` in the imported `SOURCES/JOYSTICK.CPP` (`333929ab`) read `joyGetPosEx`,
+compared each of six axes against a threshold of a third of its range, and set one of two bits per
+axis plus four POV-hat bits. `GetJoys(U32 *bitfield)` returned that bitfield, and the modern
+function keeps the signature with `(void)bitfield;` as a fossil. If anything the current
+quantiser is the more careful one, with 8 sectors, hysteresis and a configurable
+`GamepadDeadzone` where 1997 had a fixed third.
+
+The real block is that **nothing downstream could consume a magnitude if it survived.** Hero
+locomotion is animation-driven, not velocity-driven. In `MOVE_MANUAL`
+([OBJECT.CPP:4048](../../SOURCES/OBJECT.CPP)) a direction bit selects an animation and nothing
+else: `Input & I_UP` calls `InitAnim(GEN_ANIM_MARCHE, ANIM_REPEAT, numobj)`, `I_DOWN` selects
+`GEN_ANIM_RECULE`, and `I_LEFT` selects the turn-in-place animation `GEN_ANIM_GAUCHE` when the
+hero is idle or advances `Obj.Beta` by `GetDeltaMove(&ptrobj->BoundAngle.Move)` when already
+moving, an interpolator step that likewise takes no input scalar. The displacement itself is baked
+into the animation keyframes and applied by `ObjectSetInterDep`, which is the mechanism
+[MOVEMENT_FRAMERATE.md](../MOVEMENT_FRAMERATE.md) documents for #358.
+
+So the hero's speed is a property of which animation is playing, and which animation plays is
+chosen by `Comportement`. Speed is a mode, not an axis. There is no `forwardmove` scalar anywhere
+for a stick to fill, which is the field Doom 3's `usercmd_t` spends a `signed char` on.
+
+That makes #372's actuation-based walk/run the same underlying change as #412 and #358:
+decoupling locomotion from animation selection. That belongs on the issue, because it moves the
+request from "add an analog path" to "change how the hero moves".
+
+The same property caps #359 differently: an 8-way virtual stick is reachable by copying the pad's
+own quantiser into the touch overlay, because 8-way is all the hero can hear anyway. Anything
+finer has nowhere to go.
+
+**G4. There is no text entry for non-keyboard users, and the workaround is silent.** The
+`TODO(input)` at GAMEMENU.CPP:1175 is accurate and the routing around it means a pad or touch
+player never sees a name field, gets a datetime stem, and is not told why. This is the "virtual
+keyboard" item as it actually exists today: not missing UI, but a silently different code path.
+
+**G5. Dead input state is exported on the god-header bus.** `TabInputBit` and `NbInput` are
+defined in `SOURCES/INPUT.CPP`, declared in `SOURCES/INPUT.H`, and read by nothing: `InitInput`
+assigns `NbInput` and then uses its own static arrays, and `TabInputBit` is never read at all.
+The only code that genuinely uses them is `SOURCES/CONFIG/INPUT.CPP`, and that directory is
+referenced by no CMakeLists in the tree. It is the standalone DOS-era config utility, carrying its
+own `MAIN.CPP`, `C_EXTERN.H`, `LBA2.CFG` and palette, and nothing builds it. Its header also
+declares `TabInputBit` at a different size from the game's (`MAX_INPUT + 1` against
+`MAX_INPUT * 2 + 1`). So two exported globals sit on the shared bus for the benefit of a tool that
+is not built, which is exactly what an ownership move has to resolve rather than carry.
+
+**G6. The binding table is the one layer with no test, and it sits between two that have one.**
+Stated in the roadmap; confirmed here. `tests/input_funnel` deliberately fakes the table, so
+`DefKeysDefault95`, `InitInput`'s folding, and the cfg read and write round trip are all
+unasserted. The cfg round trip is the one with a history: `ReadInputConfig` carries a guard for
+an all-zero binding table, and `WriteInputConfig` carries a comment about a first-session rebind
+that used to vanish.
+
+**G7. Suppression has no owner.** `NoRepeatInput` is a single file-static in a 59-line
+translation unit, and the macros over it are used at 109 sites. Any of them can clear a
+suppression another one set, and nothing records who set it.
+
+**G8. Four bindable actions do not reach `Input` at all.** Slots 32 to 35, the spells, are read
+by direct `CheckKey(DefKeys[..])` in PERSO.CPP because only the low 32 slots fit the bitfield.
+They are in the config screen and in the cfg like every other binding, so from the player's side
+they are ordinary, and from the engine's side they are a hole in the table.
+
+**G9. "Profile" is already taken.** `--profile <name>` keeps a run's saves and settings under a
+name ([CLI_ARGS.CPP](../../SOURCES/CLI_ARGS.CPP)), and `ChoosePlayerName` calls a save a profile
+too. An input profile is a third meaning. Worth settling the vocabulary before anything is named.
+
+## What a test could see
+
+The question roadmap area 8 turns on, so recording what was found rather than what it would cost.
+
+**Already pure and testable, untested.** `DefKeysDefault95` as data. `InitInput`'s folding of two
+tables into one. `ReadInputConfig` and `WriteInputConfig` as a round trip, including the all-zero
+guard. A key-name mapping, if #61 lands, is a pure bidirectional lookup, which is the shape
+`tests/menu_keynav` already demonstrates with 40 cases over 33 lines of source.
+
+**Pure but not yet extracted.** The layout legend beyond the keypad: modifier pairs, and the
+alternates in `DefKeysDefault95` that are layout facts rather than preferences. `MENU_KEYNAV.CPP`
+is the first piece and its header argues carefully for where the boundary is.
+
+**Not reachable by a host test.** Consumption. 93 raw scancode sites and 81 `MyGetInput` loops
+mean anything a screen does with a key. The existing net is the automation fixtures:
+`test_input_injection.sh` and `test_input_hold_throttle.sh` drive input directly, and
+`test_askchoice_menus_consume.sh`, `test_demo_behaviour_menu.sh` and the six `test_ui_menu_*.sh`
+fixtures exercise screens that read input. They need retail data and a display, so they run when
+someone remembers.
+
+## What the Doom 3 reading contributes
+
+Four of its findings land on gaps above rather than on general principle, which is why that
+research is a companion rather than an appendix.
+
+- Its `InhibitUsercmd( subsystem, bool )` bitmask is G7's shape: each subsystem owns one bit and
+  cannot clear another's.
+- Its `keynames[]` has three columns, name, code, and a **localised** display string, with
+  `KeyNumToString( n, localized )` choosing. #61 asks for two of those three; the third matters
+  here because the game already localises its menu labels but shows SDL's English scancode names
+  on the key config screen.
+- Its `KeysFromBinding` / `BindingFromKey` / `NumBinds` reverse lookups are what a config screen
+  and a profile system need, and are what `CONFIG.CPP` currently does by indexing `DefKeys`
+  positionally.
+- Its split between a binding that resolves to an action id and a binding that is a text command
+  is the design this engine already half has. The action table here *is* that, which is worth
+  knowing before anyone proposes replacing it.
+
+Its `usercmd_t` plus consistency-hash replay is the answer to a different question, the one
+[INPUT_REPLAY_RESEARCH.md](INPUT_REPLAY_RESEARCH.md) asked, and it is recorded there rather than
+counted as an input-system finding.
+
+## Open questions
+
+1. **Does the touch overlay's default-scancode coupling (G1) reproduce?** It follows from the
+   code, but it has not been run. A rebind of `I_UP` and an Android or touch-emulation run would
+   settle it, and decides whether G1 is a filed bug or a design note.
+
+2. **Is menu pad navigation meant to be bindable (G2)?** If not, then the hardcoded path is
+   correct and only needs to be documented and made complete. If so, it is a second table to fold
+   in. That is a product call, not a code question.
+
+3. **What does retail parity cover?** The default table is checkable. Whether `NoRepeatInput`'s
+   exact semantics are part of the parity promise, or an implementation detail free to change
+   behind the fixtures, decides how much of the funnel is frozen.
+
+4. **Which of the 93 raw scancode sites actually want the binding layer?** Some are screens that
+   should honour bindings. Some are genuinely physical, like a console toggle or a debug key. The
+   split has not been made, and the size of cluster 1 depends entirely on it.
+
+5. **What would an analog action look like here (G3)?** Not whether to build it. Whether the
+   bitfield gains a parallel array of magnitudes, or whether analog stays a camera-style bypass,
+   is the question #372 and #359 both wait on.
+
+6. **Does the radius of a walking turn change with frame rate?** A hypothesis that falls out of
+   G3, not a measurement. Holding a direction and a rotation together is supported and always was:
+   the left/right block in `MOVE_MANUAL` is a separate `if`, and its rotate branch is taken
+   precisely *because* a walk animation is playing (`GenAnim != GEN_ANIM_RIEN`), so the hero walks
+   an arc. But the two halves of that arc are driven differently. Turning is
+   `ChangeSpeedMove(&ptrobj->BoundAngle.Move, +/-1024)` read back through `GetDeltaMove`, which is
+   `Acc += elapsed * Speed` against `TimerRefHR` with a carried remainder, so it is velocity times
+   dt and frame-rate independent. Walking is animation keyframe translation applied once per
+   rendered frame, which is #358 and is not. If both hold, then at high frame rates the hero turns
+   correctly while covering less ground, and the same held input carves a tighter circle than it
+   does at 60 fps. Measurable with `--fixed-dt` and a held `input up left`, against the sweep
+   already in [MOVEMENT_FRAMERATE.md](../MOVEMENT_FRAMERATE.md). Worth knowing because it would
+   mean #358 changes the shape of a path and not only its length.
+
+## Reproduce
+
+```bash
+# Structure
+wc -l SOURCES/INPUT.CPP SOURCES/JOYSTICK.CPP SOURCES/TOUCH_INPUT.CPP SOURCES/MENU_KEYNAV.CPP \
+      LIB386/SYSTEM/INPUT.CPP LIB386/SYSTEM/KEYBOARD.CPP LIB386/SYSTEM/MOUSE.CPP
+
+# The two funnels
+grep -rn 'Input *& *I_' --include=*.CPP --include=*.H SOURCES LIB386 | wc -l          # 154
+grep -rnE '(MyKey|Key) *== *K_' --include=*.CPP SOURCES | grep -v INPUT.CPP | wc -l   # 93
+grep -rnE '(MyKey|Key) *== *K_' --include=*.CPP SOURCES | grep -v INPUT.CPP \
+    | cut -d: -f1 | sort | uniq -c | sort -rn                                         # GAMEMENU 38, PERSO 19, CONFIG 14
+grep -rn 'MyGetInput()' --include=*.CPP SOURCES | wc -l                               # 81
+grep -rn 'ClearNoRepeatInput\|ClearWaitNoInput\|InitWaitNoInput\|InitWaitNoKey' \
+     --include=*.CPP SOURCES | wc -l                                                  # 109
+
+# Coverage
+grep -rn 'SOURCES/INPUT.CPP' tests/*/CMakeLists.txt      # nothing
+grep -rhoE '(SOURCES|LIB386)/[A-Za-z_0-9/]+\.CPP' tests/input_device/CMakeLists.txt \
+     tests/input_funnel/CMakeLists.txt tests/menu_keynav/CMakeLists.txt
+ls tests/automation/ | grep -iE 'input|menu'
+
+# Gaps
+grep -n 'K_' SOURCES/TOUCH_INPUT.CPP | head -20          # G1: hardcoded scancodes
+grep -n 'return K_' SOURCES/JOYSTICK.CPP                 # G2: synthesised menu keys
+sed -n '/ApplyStickDirection/,/^}/p' SOURCES/JOYSTICK.CPP | grep -n 'SetVirtualKeyDown'  # G3
+grep -n 'TODO(input)' SOURCES/GAMEMENU.CPP               # G4
+grep -rn 'TabInputBit\|NbInput' --include=*.CPP --include=*.H SOURCES LIB386  # G5
+grep -rn 'CheckKey(DefKeys' SOURCES/PERSO.CPP            # G8
+grep -n '"--profile"' SOURCES/CLI_ARGS.CPP               # G9
+
+# Issues
+gh issue list --state open --limit 400 --json number,title --jq '.[] | "\(.number)\t\(.title)"' \
+  | grep -iE 'input|key|control|gamepad|joystick|pad|mouse|touch|bind|profile'
+
+# Retail text data (paths are the Steam LBA2 install)
+T='.../Little Big Adventure 2/Common/TEXT.HQR'
+scripts/dev/text_dump.py "$T" --bank sys --range 100:135   # the 36 action labels
+scripts/dev/text_dump.py "$T" --bank sys --range 200:268   # 69 key names
+scripts/dev/text_dump.py "$T" --bank sys --range 160:165   # key config screen columns
+scripts/dev/text_dump.py "$T" --bank sys --range 70:75     # retail main menu
+for L in 0 1 2 3 4 5; do scripts/dev/text_dump.py "$T" --lang $L --bank sys --range 226:226; done
+grep -c GetMultiText SOURCES/GAMEMENU.CPP                  # 9 retail sites
+grep -c GetLocalizedMenuLabel SOURCES/GAMEMENU.CPP         # 15 community sites
+```

--- a/scripts/dev/text_dump.py
+++ b/scripts/dev/text_dump.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Dump a TEXT.HQR bank as (id, attribute, string) rows.
+
+TEXT.HQR layout (see docs/TEXT.md, SOURCES/MESSAGE.CPP InitDial):
+  - 6 languages x 15 banks x 2 entries = 180 HQR entries.
+      entry (Language * 30) + (file * 2) + 0  ->  order bank, U16 id[MaxText]
+      entry (Language * 30) + (file * 2) + 1  ->  text  bank, U16 offset[MaxText + 1] then blobs
+  - The two banks are parallel arrays keyed by slot: slot n of the order bank names
+    the id, slot n of the offset table locates the string.
+  - Each blob is [U8 attribute][CP850 bytes][NUL]. Ids are in authoring order, not sorted.
+
+Usage:
+  text_dump.py <TEXT.HQR> [--lang N] [--bank sys|cre|gam|000..011] [--range LO:HI]
+"""
+import os, sys, struct, argparse
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from hqr_inspect import entries, decompress_entry
+
+LANGUAGES = ["English", "Francais", "Deutsch", "Espanol", "Italiano", "Portugues"]
+BANKS = ["sys", "cre", "gam"] + ["%03d" % i for i in range(12)]
+MAX_TEXT_LANG = 15
+
+
+def _entry(path, index):
+    ents, data = entries(path)
+    if index >= len(ents):
+        return b""
+    _, off, size, csize, method = ents[index]
+    if size is None:
+        return b""
+    return decompress_entry(data, off, size, csize, method)
+
+
+def bank_rows(path, lang, file_index):
+    """Return [(id, attribute, text)] for one language's copy of one bank."""
+    base = lang * MAX_TEXT_LANG * 2 + file_index * 2
+    order = _entry(path, base + 0)
+    text = _entry(path, base + 1)
+    count = len(order) // 2
+    if not count or not text:
+        return []
+    ids = struct.unpack_from("<%dH" % count, order, 0)
+    offsets = struct.unpack_from("<%dH" % (count + 1), text, 0)
+    rows = []
+    for slot in range(count):
+        start, end = offsets[slot], offsets[slot + 1]
+        if start >= len(text) or end > len(text) or end <= start:
+            continue
+        blob = text[start:end]
+        rows.append((ids[slot], blob[0], blob[1:].split(b"\x00")[0].decode("cp850", "replace")))
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("path")
+    ap.add_argument("--lang", type=int, default=0, help="0..5, order per TabLanguage[]")
+    ap.add_argument("--bank", default="sys")
+    ap.add_argument("--range", default=None, metavar="LO:HI", help="filter by text id")
+    args = ap.parse_args()
+
+    rows = bank_rows(args.path, args.lang, BANKS.index(args.bank))
+    lo, hi = (-1, 1 << 30)
+    if args.range:
+        lo, hi = (int(v) for v in args.range.split(":"))
+
+    print("# %s / %s: %d slots" % (LANGUAGES[args.lang], args.bank, len(rows)))
+    for slot, (text_id, attr, body) in enumerate(rows):
+        if lo <= text_id <= hi:
+            print("%5d  slot=%4d attr=%3d  %r" % (text_id, slot, attr, body))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Research and a plan for the input system, plus one tool and a reference doc that came out of it. **No engine code changes**, so nothing here alters behaviour.

Roadmap area 8 says input is the area the issue tracker, rather than the roadmap, is asking for. This describes it before anything moves.

## What is here

| Commit | Artifact |
|---|---|
| `tools(text)` | `scripts/dev/text_dump.py`, so TEXT.md's decoded figures can be reproduced |
| `docs(plan)` | `INPUT_DOOM3_RESEARCH.md`, the outside comparison |
| `docs(plan)` | `INPUT_RESEARCH.md`, the system as it stands |
| `docs(speedrun)` | `SPEEDRUN_MECHANICS.md`, why the movement techniques work |
| `docs(plan)` | `INPUT_PLAN.md`, eight increments |
| `docs` | the index rows |

One commit per artifact, each in final form, so they read as finished documents rather than as edits.

## The findings that shaped the plan

**There are two funnels and only one is bindable.** 154 sites read the action bits; 93 compare raw scancodes, and three devices depend on that path by design. So routing them is a question about how touch, pad menus and text entry work, not a cleanup.

**A localised key-name table already ships and has never been read.** Ids 200 to 268 in the `sys` bank are 69 key names in all six languages. The engine reads four of them, for the legacy joystick axis path, and sends every keyboard binding to SDL's English-only name. #61 asks for readable key names; half of what it asks for is in the retail data.

**The control-scheme issues are not blocked on input.** Hero locomotion is animation-driven, so `Input & I_UP` selects an animation and there is no speed scalar for a stick to fill. #372 and #4 need locomotion and camera work, which is why this plan's scope excludes them and says so with the measurement rather than as a preference.

**The extraction is 150 lines.** Of `SOURCES/INPUT.CPP`'s 447, the two default tables and the fold are pure; the other 297 are config IO and polling. Those 150 are 1997 code, and the roadmap's own finding is that no 1997 game logic is currently reachable from a host test, so they would be the first.

Nine gaps no issue records are listed in the research doc, including a keyboard rebind silently breaking the touch overlay.

## What is decided and what is not

`INPUT_PLAN.md` is **Proposed, awaiting go/no-go**. Two decisions are deliberately deferred to the increment that can settle them by measurement: whether the two funnels converge, and how much test machinery to build.

## Reviewing it

Every figure has a command in each doc's reproduce block, and the tool makes the TEXT.HQR ones runnable. Two things are marked as claims rather than measurements and should be read as such: the touch-overlay coupling follows from the code but has not been run on a device, and the frame-rate section of the speedrun doc predicts arc radius and jump windows changing without having tested either.

`SPEEDRUN_MECHANICS.md` has an audience beyond this work and could be merged on its own if the plan needs longer.
