### PR TITLE
ci: retry and bound every tool download

### DIFF
--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -34,7 +34,8 @@ jobs:
 
       - name: Install lychee
         run: |
-          curl -fsSL -o lychee.tar.gz \
+          curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --retry-max-time 120 --connect-timeout 10 --max-time 60 \
+            -o lychee.tar.gz \
             "https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz"
           tar xzf lychee.tar.gz
           sudo install -m755 lychee-x86_64-unknown-linux-gnu/lychee /usr/local/bin/lychee
@@ -63,7 +64,8 @@ jobs:
 
       - name: Install lychee
         run: |
-          curl -fsSL -o lychee.tar.gz \
+          curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --retry-max-time 120 --connect-timeout 10 --max-time 60 \
+            -o lychee.tar.gz \
             "https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz"
           tar xzf lychee.tar.gz
           sudo install -m755 lychee-x86_64-unknown-linux-gnu/lychee /usr/local/bin/lychee

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -27,10 +27,30 @@ jobs:
       - name: Install clang-format
         # Keep this major version in sync with CLANG_FORMAT_MAJOR in
         # scripts/ci/clang-format-select.sh (the single source of truth).
-        # Acquire::Retries so a mirror hiccup costs a retry, not the run.
         run: |
-          sudo apt-get -o Acquire::Retries=5 update
-          sudo apt-get -o Acquire::Retries=5 install -y clang-format-18
+          # Retries alone do not cover the failure that matters here: a mirror
+          # that accepts the connection and then stalls returns no error to
+          # retry on, and apt has no wall clock of its own. See docs/CI.md.
+          apt_opts=(
+            -o Acquire::Retries=5
+            -o Acquire::http::Timeout=15
+            -o Acquire::https::Timeout=15
+          )
+          for attempt in 1 2 3; do
+            # A killed apt leaves dpkg interrupted, and the next attempt would
+            # abort on that before fetching anything.
+            sudo dpkg --configure -a || true
+            if timeout -k 30 90 sudo apt-get "${apt_opts[@]}" update \
+              && timeout -k 30 240 sudo apt-get "${apt_opts[@]}" install -y clang-format-18; then
+              exit 0
+            fi
+            if [ "${attempt}" = 3 ]; then
+              echo "apt failed after 3 attempts" >&2
+              exit 1
+            fi
+            echo "apt attempt ${attempt} failed or timed out; retrying in 10s"
+            sleep 10
+          done
 
       - name: Check formatting
         run: bash ./scripts/ci/check-format.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,8 @@ jobs:
       - name: Install shellcheck
         run: |
           mkdir -p "$HOME/.local/bin"
-          curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+          curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --retry-max-time 120 --connect-timeout 10 --max-time 60 \
+            "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
             | tar -xJ -C "$HOME/.local/bin" --strip-components=1 "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/shellcheck" --version
@@ -87,9 +88,11 @@ jobs:
       - name: Install shellcheck and actionlint
         run: |
           mkdir -p "$HOME/.local/bin"
-          curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+          curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --retry-max-time 120 --connect-timeout 10 --max-time 60 \
+            "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
             | tar -xJ -C "$HOME/.local/bin" --strip-components=1 "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
-          curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+          curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --retry-max-time 120 --connect-timeout 10 --max-time 60 \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
             | tar -xz -C "$HOME/.local/bin" actionlint
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/actionlint" --version

--- a/.github/workflows/reusable-build-android.yml
+++ b/.github/workflows/reusable-build-android.yml
@@ -62,6 +62,7 @@ jobs:
           if [ ! -f "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" ]; then
             CLI_ZIP="${RUNNER_TEMP}/cmdline-tools.zip"
             curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
+              --retry-max-time 300 --connect-timeout 15 --max-time 300 \
               -o "$CLI_ZIP" \
               "https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip"
             unzip -qo "$CLI_ZIP" -d "${RUNNER_TEMP}/cmdline-tools-unzip"

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -73,6 +73,7 @@ RUN : "${SDL3_VERSION:?build-arg SDL3_VERSION is required (see .github/sdl3-vers
 ARG UASM_VERSION=2.57r
 ARG UASM_ARCHIVE=uasm257_linux64.zip
 RUN curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
+        --retry-max-time 300 --connect-timeout 15 --max-time 300 \
         -o /tmp/uasm.zip \
         "https://github.com/Terraspace/UASM/releases/download/v${UASM_VERSION}/${UASM_ARCHIVE}" \
     && unzip -oq /tmp/uasm.zip -d /usr/local/bin \

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -281,14 +281,23 @@ Four rules follow from that, and the workflows apply them:
    first shape above, so a fetch that can stall also wants a `timeout`
    and per-connection limits to fail in bounded time with a named cause.
    See [apt is bounded, not just
-   retried](#apt-is-bounded-not-just-retried). This is applied to the apt
-   phases in `linux.yml`, `reusable-build-linux-tarball.yml` and
-   `.github/actions/setup-sdl3`, and to the SDL3 clones. It is *not* yet
-   applied to `pacman -Syu` and the appimagetool download in
-   `scripts/packaging/make-appimage.sh` (three attempts, no wall clock),
-   the apt in `docker/Dockerfile.test` (neither), or the UASM `curl`
-   there (`--retry` but no `--max-time`). Those keep the exposure this
-   section describes; add the bound when you next touch one.
+   retried](#apt-is-bounded-not-just-retried). Applied to the apt phases
+   in `linux.yml`, `reusable-build-linux-tarball.yml` and
+   `.github/actions/setup-sdl3`, to the SDL3 clones, and to every tool
+   download (`curl --retry --retry-all-errors --retry-max-time
+   --connect-timeout --max-time`). `--retry-max-time` is the one that
+   bounds the total: `--max-time` applies per attempt, so retries can
+   outlive it. Sizes are set against the job's own `timeout-minutes`, not
+   picked in the abstract; the tightest is the docs link job at 5.
+   What is still unbounded: `pacman -Syu` and the appimagetool download
+   in `scripts/packaging/make-appimage.sh` (three attempts around the
+   whole script, no wall clock), and the apt in `docker/Dockerfile.test`
+   (neither). Both are inside an image or a script with its own retry
+   wrapper, which is why they are lower priority, not why they are safe.
+
+   The list above has been wrong three times by omission. Before trusting it,
+   run `grep -rn 'curl \|wget \|apt-get\|pacman\|pipx install' \
+   .github/ docker/ scripts/packaging/` and check the result against it.
 4. **Bound every job.** All jobs carry `timeout-minutes`, so nothing can
    burn the six-hour default. Treat this as the backstop, not the bound:
    when it is what stops a job, the log ends mid-step with no diagnosis,


### PR DESCRIPTION
A lychee install took out the `Docs links` check on `main`:

```
curl: (35) Recv failure: Connection reset by peer
##[error]Process completed with exit code 35
```

That `curl` had no `--retry` at all, so a transient reset 140ms in failed a
required check. A re-run passed, confirming it was nothing but a blip.

Five of the six download sites in the validation tier were in the same state:

| Site | Retry | Wall clock |
|---|---|---|
| `docs-links.yml` lychee (local job) | none | none |
| `docs-links.yml` lychee (external job) | none | none |
| `lint.yml` shellcheck (shellcheck job) | none | none |
| `lint.yml` shellcheck (actionlint job) | none | none |
| `lint.yml` actionlint | none | none |
| `reusable-build-android.yml` SDK tools | `--retry 5` | none |

## The flag that matters

All six now carry `--retry --retry-delay --retry-all-errors
--retry-max-time --connect-timeout --max-time`.

`--retry-max-time` is the one worth calling out, and the easiest to leave out:
`--max-time` applies *per attempt*, so retries can outlive it. Only
`--retry-max-time` bounds the total.

Budgets are sized against each job's own `timeout-minutes` rather than picked
in the abstract. The docs link job is `timeout-minutes: 5`, so its tools get a
120s total retry window, leaving room for the check itself; the 60-minute
Android job gets 300s.

## format.yml, found by grep rather than by eye

`format.yml`'s apt was retried but unbounded — the exact pair that let
`apt-get update` stall for 29 minutes on a `linux.yml` leg, and it gates the
required `check-format`. It now uses the same bounded loop, dpkg recovery
included, that `linux.yml` and `.github/actions/setup-sdl3` already use.

It was missed by two passes over the file list. What found it was running the
grep, which is why the unbounded-sites list in `docs/CI.md` now carries the
command that regenerates it:

```
grep -rn 'curl \|wget \|apt-get\|pacman\|pipx install' .github/ docker/ scripts/packaging/
```

That list has now been wrong three times by omission. A command beats a
conclusion.

## Deliberately not done

**Caching the tool binaries.** Measured first: `Install shellcheck` 0s,
`Install shellcheck and actionlint` 1s, `Install ruff` 2s, `Install lychee`
~4s. An `actions/cache` restore costs about the same, so it nets ~0. And
shellcheck, actionlint and lychee all download from `github.com` release URLs
while the Actions cache is also GitHub, so it swaps one GitHub endpoint for
another rather than buying independence. The same reasoning `docs/CI.md`
already uses to reject ccache.

The downloads exist because the versions are pinned, which that doc defends on
its own terms: a linter that changes its mind on someone else's release
schedule turns a branch red for reasons nobody here touched.

**Still unbounded, and now accurately named in the doc:** `pacman -Syu` and
the appimagetool download in `scripts/packaging/make-appimage.sh`, and the apt
in `docker/Dockerfile.test`. Both sit inside a wrapper with its own retries,
which is why they are lower priority, not why they are safe.

## Verification

`actionlint`, the composite-action shell checker and its self-test (9/9), and
the docs link gate all pass locally. `curl`'s flag semantics were read off
`curl --help all` rather than assumed, which is what surfaced
`--retry-max-time` as distinct from `--max-time`.
