### PR TITLE
fix(input): rename MAX_INPUT, which POSIX already owns

### DIFF
--- a/SOURCES/CONFIG.CPP
+++ b/SOURCES/CONFIG.CPP
@@ -70,7 +70,7 @@ S32 SelectKey = 0;
 #define CFG_X0 ((S32)ModeDesiredX / 2 - 310)
 #define CFG_Y0 10
 #define CFG_X1 ((S32)ModeDesiredX / 2 + 310)
-#define CFG_Y1 (CFG_Y0 + MAX_INPUT * 10 + 35)
+#define CFG_Y1 (CFG_Y0 + MAX_INPUT_SLOTS * 10 + 35)
 
 #define ACTION_X (CFG_X0 + 20)
 #define KEY1_X (CFG_X0 + 371)
@@ -110,7 +110,7 @@ static S32 s_ConfigGamepadTripleFooter = 0;
 #define COUL_MENU (10 * 16 + 14)
 
 //▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-char KeyStrings[MAX_INPUT * 2][KEY_STRING_LEN]; // 14 char max
+char KeyStrings[MAX_INPUT_SLOTS * 2][KEY_STRING_LEN]; // 14 char max
 
 //▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
 U8 ScanKnown[] =
@@ -345,7 +345,7 @@ void GetKeyText(char *string, U32 scan) {
 void InitKeyStrings(void) {
     S32 n;
 
-    for (n = 0; n < MAX_INPUT; n++) {
+    for (n = 0; n < MAX_INPUT_SLOTS; n++) {
         GetKeyText(KeyStrings[n * 2], DefKeys[n].Key1);
         GetKeyText(KeyStrings[n * 2 + 1], DefKeys[n].Key2);
     }
@@ -457,12 +457,12 @@ void DrawOneConfigMenu(S32 n) {
     S32 x0, y0, x1, y1;
     S32 y;
 
-    if (n < MAX_INPUT) {
+    if (n < MAX_INPUT_SLOTS) {
         DrawOneConfig(n);
         return;
     }
 
-    n -= MAX_INPUT;
+    n -= MAX_INPUT_SLOTS;
     y = CFG_MENU_Y0 + 7 + n * 10;
 
     GetMultiText(START_MENUS_TXT + CFG_TXT_DEFAUT + n, txt);
@@ -479,7 +479,7 @@ void DrawOneConfigMenu(S32 n) {
         ShadeBoxBlk(x0, y0, x1, y1, CONFIG_SHADE_LVL);
     }
 
-    if ((SelectConfig - MAX_INPUT) == n) {
+    if ((SelectConfig - MAX_INPUT_SLOTS) == n) {
         CoulText(COUL_KEY, -1);
         BackupAngles(x0, y0, x1, y1);
         DrawConfigFire(x0, y0, x1, y1, FIRE_SELECT_MENU);
@@ -607,11 +607,11 @@ void DrawScreenConfig(S32 gamepadTripleFooter) {
 
     DrawStatusConfig(STATUS_MENU);
 
-    for (n = 0; n < MAX_INPUT; n++) {
+    for (n = 0; n < MAX_INPUT_SLOTS; n++) {
         DrawOneConfig(n);
     }
 
-    for (n = MAX_INPUT; n < MAX_INPUT + 3; n++) {
+    for (n = MAX_INPUT_SLOTS; n < MAX_INPUT_SLOTS + 3; n++) {
         DrawOneConfigMenu(n);
     }
 
@@ -622,7 +622,7 @@ void DrawScreenConfig(S32 gamepadTripleFooter) {
 S32 CheckKeyConfig(S32 key) {
     S32 n;
 
-    for (n = 0; n < MAX_INPUT; n++) {
+    for (n = 0; n < MAX_INPUT_SLOTS; n++) {
         if (DefKeys[n].Key1 == key OR DefKeys[n].Key2 == key) {
             return n;
         }
@@ -700,7 +700,7 @@ void MenuConfig(void) {
 
     oldselect = SelectConfig;
 
-    memcpy(MemoDefKeys, DefKeys, sizeof(T_DEF_KEY) * MAX_INPUT);
+    memcpy(MemoDefKeys, DefKeys, sizeof(T_DEF_KEY) * MAX_INPUT_SLOTS);
 
     MyKey = 0;
     ManageTime();
@@ -805,13 +805,13 @@ void MenuConfig(void) {
         if (MyKey == K_UP) {
             SelectConfig--;
             if (SelectConfig < 0)
-                SelectConfig = MAX_INPUT - 1 + 3;
+                SelectConfig = MAX_INPUT_SLOTS - 1 + 3;
         } else if (MyKey == K_DOWN) {
             SelectConfig++;
-            if (SelectConfig >= (MAX_INPUT + 3))
+            if (SelectConfig >= (MAX_INPUT_SLOTS + 3))
                 SelectConfig = 0;
         } else if (MyKey == K_ENTER) {
-            if (SelectConfig < MAX_INPUT) {
+            if (SelectConfig < MAX_INPUT_SLOTS) {
                 S32 memokey;
                 U32 *ptr;
 
@@ -871,16 +871,16 @@ void MenuConfig(void) {
 
                 WaitNoInput();
             } else {
-                switch ((SelectConfig - MAX_INPUT)) {
+                switch ((SelectConfig - MAX_INPUT_SLOTS)) {
                 case 0: // Configuration par Défaut
-                    memcpy(MemoDefKeys, DefKeys, sizeof(T_DEF_KEY) * MAX_INPUT);
+                    memcpy(MemoDefKeys, DefKeys, sizeof(T_DEF_KEY) * MAX_INPUT_SLOTS);
                     RestoreInput();
                     InitKeyStrings();
                     DrawScreenConfig(0);
                     break;
 
                 case 1: // Restaurer Configuration Précédente
-                    memcpy(DefKeys, MemoDefKeys, sizeof(T_DEF_KEY) * MAX_INPUT);
+                    memcpy(DefKeys, MemoDefKeys, sizeof(T_DEF_KEY) * MAX_INPUT_SLOTS);
                     InitKeyStrings();
                     DrawScreenConfig(0);
                     break;
@@ -902,8 +902,8 @@ void MenuConfig(void) {
 
         case K_PAGE_DOWN:
             SelectConfig += 10;
-            if (SelectConfig >= (MAX_INPUT + 3))
-                SelectConfig = MAX_INPUT - 1 + 3;
+            if (SelectConfig >= (MAX_INPUT_SLOTS + 3))
+                SelectConfig = MAX_INPUT_SLOTS - 1 + 3;
             break;
 
         case K_HOME:
@@ -911,12 +911,12 @@ void MenuConfig(void) {
             break;
 
         case K_END:
-            SelectConfig = MAX_INPUT - 1 + 3;
+            SelectConfig = MAX_INPUT_SLOTS - 1 + 3;
             break;
 
         case K_ESC:
-            if (SelectConfig != MAX_INPUT + 2) {
-                SelectConfig = MAX_INPUT + 2; // Menu Accepter Configuration
+            if (SelectConfig != MAX_INPUT_SLOTS + 2) {
+                SelectConfig = MAX_INPUT_SLOTS + 2; // Menu Accepter Configuration
             } else {
                 goto endloop;
             }
@@ -928,7 +928,7 @@ void MenuConfig(void) {
             oldselect = SelectConfig;
         }
 
-        if (SelectConfig < MAX_INPUT) {
+        if (SelectConfig < MAX_INPUT_SLOTS) {
             if (MyKey == K_LEFT OR MyKey == K_RIGHT) {
                 SelectKey ^= 1;
             }
@@ -947,7 +947,7 @@ endloop:
     if (!ok) // Sortie par <ESC>
     {
         // restaure config
-        memcpy(DefKeys, MemoDefKeys, sizeof(T_DEF_KEY) * MAX_INPUT);
+        memcpy(DefKeys, MemoDefKeys, sizeof(T_DEF_KEY) * MAX_INPUT_SLOTS);
         InitKeyStrings();
     }
 
@@ -988,14 +988,14 @@ static S32 GamepadRebindAllowed(S32 scan) {
 }
 
 static void InitGamepadKeyStrings(void) {
-    for (S32 n = 0; n < MAX_INPUT; n++) {
+    for (S32 n = 0; n < MAX_INPUT_SLOTS; n++) {
         GetKeyText(KeyStrings[n * 2], GamepadKeys[n].Key1);
         GetKeyText(KeyStrings[n * 2 + 1], GamepadKeys[n].Key2);
     }
 }
 
 static S32 CheckGamepadKeyConfig(S32 key) {
-    for (S32 n = 0; n < MAX_INPUT; n++) {
+    for (S32 n = 0; n < MAX_INPUT_SLOTS; n++) {
         if ((S32)GamepadKeys[n].Key1 == key OR(S32) GamepadKeys[n].Key2 == key) {
             return n;
         }
@@ -1009,7 +1009,7 @@ void MenuGamepadConfig(void) {
     U32 repeattime;
     S32 ok = FALSE;
     S32 memoclipwindow = FALSE;
-    T_DEF_KEY MemoGamepadKeys[MAX_INPUT];
+    T_DEF_KEY MemoGamepadKeys[MAX_INPUT_SLOTS];
     S32 padMenuPrev7 = 0;
     S32 padMenuPrev8 = 0;
     S32 padMenuPrev9 = 0;
@@ -1137,13 +1137,13 @@ void MenuGamepadConfig(void) {
         if (MyKey == K_UP) {
             SelectConfig--;
             if (SelectConfig < 0)
-                SelectConfig = MAX_INPUT - 1 + 3;
+                SelectConfig = MAX_INPUT_SLOTS - 1 + 3;
         } else if (MyKey == K_DOWN) {
             SelectConfig++;
-            if (SelectConfig >= (MAX_INPUT + 3))
+            if (SelectConfig >= (MAX_INPUT_SLOTS + 3))
                 SelectConfig = 0;
         } else if (MyKey == K_ENTER) {
-            if (SelectConfig < MAX_INPUT) {
+            if (SelectConfig < MAX_INPUT_SLOTS) {
                 S32 memokey;
                 U32 *ptr =
                     (SelectKey == 0) ? &GamepadKeys[SelectConfig].Key1 : &GamepadKeys[SelectConfig].Key2;
@@ -1189,7 +1189,7 @@ void MenuGamepadConfig(void) {
                 GetKeyText(KeyStrings[SelectConfig * 2 + SelectKey], (U32)MyKey);
                 WaitNoInput();
             } else {
-                switch ((SelectConfig - MAX_INPUT)) {
+                switch ((SelectConfig - MAX_INPUT_SLOTS)) {
                 case 0: // restore defaults
                     memcpy(MemoGamepadKeys, GamepadKeys, sizeof(MemoGamepadKeys));
                     memcpy(GamepadKeys, GamepadKeysDefault, sizeof(GamepadKeys));
@@ -1218,18 +1218,18 @@ void MenuGamepadConfig(void) {
             break;
         case K_PAGE_DOWN:
             SelectConfig += 10;
-            if (SelectConfig >= (MAX_INPUT + 3))
-                SelectConfig = MAX_INPUT - 1 + 3;
+            if (SelectConfig >= (MAX_INPUT_SLOTS + 3))
+                SelectConfig = MAX_INPUT_SLOTS - 1 + 3;
             break;
         case K_HOME:
             SelectConfig = 0;
             break;
         case K_END:
-            SelectConfig = MAX_INPUT - 1 + 3;
+            SelectConfig = MAX_INPUT_SLOTS - 1 + 3;
             break;
         case K_ESC:
-            if (SelectConfig != MAX_INPUT + 2) {
-                SelectConfig = MAX_INPUT + 2;
+            if (SelectConfig != MAX_INPUT_SLOTS + 2) {
+                SelectConfig = MAX_INPUT_SLOTS + 2;
             } else {
                 goto endloop_pad;
             }
@@ -1241,7 +1241,7 @@ void MenuGamepadConfig(void) {
             oldselect = SelectConfig;
         }
 
-        if (SelectConfig < MAX_INPUT && MyKey == K_SUPPR) {
+        if (SelectConfig < MAX_INPUT_SLOTS && MyKey == K_SUPPR) {
             if (SelectKey == 0)
                 GamepadKeys[SelectConfig].Key1 = 0;
             else
@@ -1250,7 +1250,7 @@ void MenuGamepadConfig(void) {
             DrawStatusConfig(STATUS_MENU);
         }
 
-        if (SelectConfig < MAX_INPUT && (MyKey == K_LEFT OR MyKey == K_RIGHT)) {
+        if (SelectConfig < MAX_INPUT_SLOTS && (MyKey == K_LEFT OR MyKey == K_RIGHT)) {
             SelectKey ^= 1;
         }
     }

--- a/SOURCES/INPUT.CPP
+++ b/SOURCES/INPUT.CPP
@@ -51,7 +51,7 @@ void ReadInputConfig(void) {
         // On peut identifier chaque input avec un tableau de chaine,
         // mais bon, bof !!!
 
-        for (n = 0; n < MAX_INPUT; n++) {
+        for (n = 0; n < MAX_INPUT_SLOTS; n++) {
             snprintf(id, sizeof(id), "Input%d_1", n);
             DefKeys[n].Key1 = DefFileBufferReadValueDefault(id, DEFKEYSDEFAULT[n].Key1);
 
@@ -74,7 +74,7 @@ void ReadInputConfig(void) {
            than from GamepadKeys: ReadGamepadConfig runs after this function, so
            the live table still holds whatever preceded it. */
         if (!initkeys) {
-            for (n = 0; n < MAX_INPUT; n++) {
+            for (n = 0; n < MAX_INPUT_SLOTS; n++) {
                 /* Defaulted exactly as ReadGamepadConfig will default them, so
                    the probe asks what the pad bindings are going to BE, not
                    what the file happens to spell out. A cfg predating gamepad
@@ -121,7 +121,7 @@ void WriteInputConfig(void) {
     // On peut identifier chaque input avec un tableau de chaine,
     // mais bon, bof !!!
 
-    for (n = 0; n < MAX_INPUT; n++) {
+    for (n = 0; n < MAX_INPUT_SLOTS; n++) {
         snprintf(id, sizeof(id), "Input%d_1", n);
         DefFileBufferWriteValue(id, DefKeys[n].Key1);
 
@@ -175,7 +175,7 @@ void ReadGamepadConfig(void) {
         GamepadCamMaxAlpha = 100;
 
     char id[32];
-    for (S32 n = 0; n < MAX_INPUT; n++) {
+    for (S32 n = 0; n < MAX_INPUT_SLOTS; n++) {
         snprintf(id, sizeof(id), "Gamepad%d", n);
         GamepadKeys[n].Key1 =
             DefFileBufferReadValueDefault(id, GamepadKeysDefault[n].Key1);
@@ -204,7 +204,7 @@ void WriteGamepadConfig(void) {
     DefFileBufferWriteValue("GamepadCamMaxAlpha", GamepadCamMaxAlpha);
 
     char id[32];
-    for (S32 n = 0; n < MAX_INPUT; n++) {
+    for (S32 n = 0; n < MAX_INPUT_SLOTS; n++) {
         snprintf(id, sizeof(id), "Gamepad%d", n);
         DefFileBufferWriteValue(id, GamepadKeys[n].Key1);
         snprintf(id, sizeof(id), "Gamepad%d_2", n);

--- a/SOURCES/INPUT_BINDINGS.CPP
+++ b/SOURCES/INPUT_BINDINGS.CPP
@@ -8,7 +8,7 @@
 // The 1997 source carried two default layouts, DefKeysDefault for DOS and this
 // one for Windows 95. Only the second was ported. A binding set is where the
 // first would come back if anyone wants it.
-const T_DEF_KEY DefKeysDefault95[MAX_INPUT + 1] =
+const T_DEF_KEY DefKeysDefault95[MAX_INPUT_SLOTS + 1] =
     {
         {K_GRAY_UP, K_NUMPAD_8},    // I_UP
         {K_GRAY_DOWN, K_NUMPAD_2},  // I_DOWN
@@ -49,11 +49,11 @@ const T_DEF_KEY DefKeysDefault95[MAX_INPUT + 1] =
         {K_F, 0},                           // I_FOUDRE
 };
 
-T_DEF_KEY MemoDefKeys[MAX_INPUT + 1];
-T_DEF_KEY DefKeys[MAX_INPUT + 1];
+T_DEF_KEY MemoDefKeys[MAX_INPUT_SLOTS + 1];
+T_DEF_KEY DefKeys[MAX_INPUT_SLOTS + 1];
 
 // tableau de configuration des touches utilisé au cours du jeux
-U32 TabInputBit[MAX_INPUT * 2 + 1];
+U32 TabInputBit[MAX_INPUT_SLOTS * 2 + 1];
 
 // Combined keyboard+gamepad key/mask table handed to GetInput(). Folding the
 // gamepad in here (instead of OR-ing it into Input afterward) makes it a
@@ -65,9 +65,9 @@ U32 TabInputBit[MAX_INPUT * 2 + 1];
 static U32 CombinedInputKeys[INPUT_TABLE_SLOTS * 4];
 static U32 CombinedInputMasks[INPUT_TABLE_SLOTS * 4];
 
-T_DEF_KEY GamepadKeys[MAX_INPUT];
+T_DEF_KEY GamepadKeys[MAX_INPUT_SLOTS];
 
-const T_DEF_KEY GamepadKeysDefault[MAX_INPUT] = {
+const T_DEF_KEY GamepadKeysDefault[MAX_INPUT_SLOTS] = {
     {K_GAMEPAD_RTRIGGER, 0},                         // 0  I_UP
     {K_GAMEPAD_LTRIGGER, 0},                         // 1  I_DOWN
     {K_GAMEPAD_LSTICK_LEFT, 0},                      // 2  I_LEFT
@@ -106,7 +106,7 @@ const T_DEF_KEY GamepadKeysDefault[MAX_INPUT] = {
     {K_GAMEPAD_DPAD_LEFT, 0},                        // 35 I_FOUDRE
 };
 
-U32 NbInput = MAX_INPUT;
+U32 NbInput = MAX_INPUT_SLOTS;
 
 //-------------------------------------------------------------------------
 void InitInput(void) {
@@ -137,6 +137,6 @@ void RestoreInput() {
     const T_DEF_KEY *DEFKEYSDEFAULT;
     DEFKEYSDEFAULT = DefKeysDefault95;
 
-    memcpy(DefKeys, DEFKEYSDEFAULT, sizeof(T_DEF_KEY) * MAX_INPUT);
+    memcpy(DefKeys, DEFKEYSDEFAULT, sizeof(T_DEF_KEY) * MAX_INPUT_SLOTS);
     memcpy(GamepadKeys, GamepadKeysDefault, sizeof(GamepadKeys));
 }

--- a/SOURCES/INPUT_BINDINGS.H
+++ b/SOURCES/INPUT_BINDINGS.H
@@ -22,7 +22,15 @@
 // I_* bits, one per slot); the last four are the spell bits of a second word,
 // which is why they cannot share the folded table -- I_PINGOUIN is (1 << 0),
 // the same bit as I_UP. PERSO.CPP reads those four with a direct CheckKey.
-#define MAX_INPUT 36
+//
+// Not spelled MAX_INPUT: that name belongs to POSIX. <linux/limits.h> gives it
+// the value 255, the size of the terminal type-ahead buffer, and Bionic reaches
+// it through <limits.h> where desktop glibc does not. A translation unit that
+// includes this header ahead of a system header would then declare these tables
+// at one size and define them at another, which the compiler reports as a
+// redefinition with a different type. A name this module owns cannot be
+// clobbered by include order, and that, rather than the number, is the point.
+#define MAX_INPUT_SLOTS 36
 
 typedef struct {
     U32 Key1;
@@ -32,23 +40,23 @@ typedef struct {
 // The Windows 95 default layout: what RestoreInput installs, and the value a
 // binding the config file leaves unset falls back to. Const like the pad table
 // below it, since a default nothing may edit is the point of having one.
-extern const T_DEF_KEY DefKeysDefault95[MAX_INPUT + 1];
+extern const T_DEF_KEY DefKeysDefault95[MAX_INPUT_SLOTS + 1];
 
-extern T_DEF_KEY DefKeys[MAX_INPUT + 1];
-extern T_DEF_KEY MemoDefKeys[MAX_INPUT + 1];
+extern T_DEF_KEY DefKeys[MAX_INPUT_SLOTS + 1];
+extern T_DEF_KEY MemoDefKeys[MAX_INPUT_SLOTS + 1];
 
 // tableau de configuration des touches utilisé au cours du jeu
 // Read by nothing in this build: the combined table InitInput hands to
 // DefineInputKeys replaced it. Moved with the tables it belongs to rather than
 // dropped, so the move stays a move.
-extern U32 TabInputBit[MAX_INPUT * 2 + 1];
+extern U32 TabInputBit[MAX_INPUT_SLOTS * 2 + 1];
 
 // Parallel gamepad binding table: Key1 / Key2 are alternate bindings (OR),
 // same semantics as DefKeys (see KEYBOARD_KEYS.H for K_GAMEPAD_*). 0 =
 // unbound. Folded into the combined input table by InitInput() alongside
 // DefKeys, so the pad flows through GetInput()'s NoRepeatInput edge-filter.
-extern T_DEF_KEY GamepadKeys[MAX_INPUT];
-extern const T_DEF_KEY GamepadKeysDefault[MAX_INPUT];
+extern T_DEF_KEY GamepadKeys[MAX_INPUT_SLOTS];
+extern const T_DEF_KEY GamepadKeysDefault[MAX_INPUT_SLOTS];
 
 // How many entries InitInput() handed to DefineInputKeys.
 extern U32 NbInput;

--- a/SOURCES/RES_SWITCH.CPP
+++ b/SOURCES/RES_SWITCH.CPP
@@ -117,7 +117,7 @@ static void Res_SceneTarget(U32 baseW, U32 baseH, U32 *outW, U32 *outH) {
 
 /* Scratch-buffer size for the transient, heap-free boot reads of lba2.cfg
    (Res_LoadBootDimensions / Res_LoadBootFullscreen). A fully-populated valid
-   cfg is already ~6 KB (72 keyboard + 72 gamepad bindings from MAX_INPUT, plus
+   cfg is already ~6 KB (72 keyboard + 72 gamepad bindings from MAX_INPUT_SLOTS, plus
    ~70 settings/camera/audio keys), so the old 8 KB left almost no headroom and
    any bloat -- a corrupt over-long line, future keys -- tips DefFileBufferInit
    into its "buffer too small" reject, dropping the cfg's ResolutionX/Y and

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -60,7 +60,7 @@ lba2.cfg stores user preferences and last-save info. Read at startup, written at
 | MusicVolume | int | 0–127 | 127 | Music/jingle volume (stored as JingleVolume in code) |
 | CDVolume | int | 0–127 | 66 | CD audio volume (no-op when no CD); still supported in config but no longer shown in the in-game volume submenu |
 | MasterVolume | int | 0–127 | 127 | Master volume, scales samples and music |
-| Input0_1..Input35_2 | int | Key scancodes | DefKeysDefault95 | 36 inputs × 2 keys each (`MAX_INPUT` in INPUT_BINDINGS.H). Only read when WinMode=1 |
+| Input0_1..Input35_2 | int | Key scancodes | DefKeysDefault95 | 36 inputs × 2 keys each (`MAX_INPUT_SLOTS` in INPUT_BINDINGS.H). Only read when WinMode=1 |
 | WinMode | int | 0, 1 | 0 | 0=ignore Input* keys, use defaults; 1=read Input* keys. WriteInputConfig always writes WinMode=1 |
 | CompressSave | int | 0, 1 | 1 | 0=uncompressed saves, 1=compressed |
 | Version | int | 0–5, distributor ID | 0 (UNKNOWN_VERSION) | Which publisher's edition this is (`DistribVersion`): Activision, EA, Virgin, regional variants. Installer-written; set via the `distrib` console command. See [VERSIONS.md](VERSIONS.md) |

--- a/tests/input_bindings/test_input_bindings.cpp
+++ b/tests/input_bindings/test_input_bindings.cpp
@@ -34,7 +34,7 @@
 #include <SYSTEM/INPUT.H>         // Input, GetInput, ClearNoRepeatInput
 #include <SYSTEM/KEYBOARD_KEYS.H> // K_*
 
-#include "INPUT.H" // SOURCES/INPUT.H: T_DEF_KEY, MAX_INPUT, InitInput, RestoreInput
+#include "INPUT.H" // SOURCES/INPUT.H: T_DEF_KEY, MAX_INPUT_SLOTS, InitInput, RestoreInput
 
 #include "held_keys.h"
 
@@ -115,9 +115,9 @@ const int kFoldedSlots = 32;
 
 // --- 1. The layout, as data -------------------------------------------------
 void CheckRetailLayout(void) {
-    CHECK(kRetailCount == MAX_INPUT,
-          "expected list covers %d slots, MAX_INPUT is %d", kRetailCount,
-          (int)MAX_INPUT);
+    CHECK(kRetailCount == MAX_INPUT_SLOTS,
+          "expected list covers %d slots, MAX_INPUT_SLOTS is %d", kRetailCount,
+          (int)MAX_INPUT_SLOTS);
 
     RestoreInput();
 
@@ -135,7 +135,7 @@ void CheckRetailLayout(void) {
 
     // RestoreInput restores the pad in the same breath, so a restore-defaults
     // from the options screen cannot leave the two tables from different eras.
-    for (int i = 0; i < MAX_INPUT; i++) {
+    for (int i = 0; i < MAX_INPUT_SLOTS; i++) {
         CHECK(GamepadKeys[i].Key1 == GamepadKeysDefault[i].Key1 &&
                   GamepadKeys[i].Key2 == GamepadKeysDefault[i].Key2,
               "slot %d: RestoreInput left the pad binding unrestored", i);
@@ -148,21 +148,21 @@ void CheckRetailLayout(void) {
 void CheckNoSharedKeys(void) {
     RestoreInput();
 
-    for (int a = 0; a < MAX_INPUT; a++) {
+    for (int a = 0; a < MAX_INPUT_SLOTS; a++) {
         const U32 mine[2] = {DefKeys[a].Key1, DefKeys[a].Key2};
         for (int m = 0; m < 2; m++) {
             if (!mine[m])
                 continue;
             CHECK(!(m == 1 && mine[0] == mine[1]),
                   "slot %d binds the same key twice (%u)", a, mine[0]);
-            for (int b = a + 1; b < MAX_INPUT; b++) {
+            for (int b = a + 1; b < MAX_INPUT_SLOTS; b++) {
                 CHECK(DefKeys[b].Key1 != mine[m] && DefKeys[b].Key2 != mine[m],
                       "key %u binds both slot %d (%s) and slot %d", mine[m], a,
                       kRetail[a].action, b);
             }
             // The pad shares the one table with the keyboard, so a collision
             // across the two would be the same bug.
-            for (int b = 0; b < MAX_INPUT; b++) {
+            for (int b = 0; b < MAX_INPUT_SLOTS; b++) {
                 CHECK(GamepadKeys[b].Key1 != mine[m] &&
                           GamepadKeys[b].Key2 != mine[m],
                       "key %u binds keyboard slot %d and pad slot %d", mine[m],
@@ -217,7 +217,7 @@ void CheckSpellSlotsStayOut(void) {
     InitInput();
 
     // With the defaults: N, J, C and F reach Input as nothing at all.
-    for (int slot = kFoldedSlots; slot < MAX_INPUT; slot++) {
+    for (int slot = kFoldedSlots; slot < MAX_INPUT_SLOTS; slot++) {
         const U32 keys[2] = {DefKeys[slot].Key1, DefKeys[slot].Key2};
         for (int k = 0; k < 2; k++) {
             if (!keys[k])

--- a/tests/input_bindings/test_input_config.cpp
+++ b/tests/input_bindings/test_input_config.cpp
@@ -103,28 +103,28 @@ std::string Line(const char *fmt, ...) {
 // A layout that is nobody's default, so a value that survives the trip can only
 // have come from the file. Every slot gets a distinct pair.
 void SetProbeLayout(void) {
-    for (int n = 0; n < MAX_INPUT; n++) {
+    for (int n = 0; n < MAX_INPUT_SLOTS; n++) {
         DefKeys[n].Key1 = (U32)(100 + n);
         DefKeys[n].Key2 = (U32)(200 + n);
     }
 }
 
 void ScribbleBindings(void) {
-    for (int n = 0; n < MAX_INPUT; n++) {
+    for (int n = 0; n < MAX_INPUT_SLOTS; n++) {
         DefKeys[n].Key1 = 0xDEAD;
         DefKeys[n].Key2 = 0xBEEF;
     }
 }
 
 void ScribblePad(void) {
-    for (int n = 0; n < MAX_INPUT; n++) {
+    for (int n = 0; n < MAX_INPUT_SLOTS; n++) {
         GamepadKeys[n].Key1 = 0xDEAD;
         GamepadKeys[n].Key2 = 0xBEEF;
     }
 }
 
 bool PadIsDefault(void) {
-    for (int n = 0; n < MAX_INPUT; n++) {
+    for (int n = 0; n < MAX_INPUT_SLOTS; n++) {
         if (GamepadKeys[n].Key1 != GamepadKeysDefault[n].Key1 ||
             GamepadKeys[n].Key2 != GamepadKeysDefault[n].Key2)
             return false;
@@ -133,7 +133,7 @@ bool PadIsDefault(void) {
 }
 
 bool BindingsAreProbeLayout(void) {
-    for (int n = 0; n < MAX_INPUT; n++) {
+    for (int n = 0; n < MAX_INPUT_SLOTS; n++) {
         if (DefKeys[n].Key1 != (U32)(100 + n) || DefKeys[n].Key2 != (U32)(200 + n))
             return false;
     }
@@ -143,8 +143,8 @@ bool BindingsAreProbeLayout(void) {
 // Compares against the defaults without leaving either live table disturbed:
 // RestoreInput writes both, and later checks in the same case still read them.
 bool BindingsAreDefaults(void) {
-    T_DEF_KEY savedKeys[MAX_INPUT];
-    T_DEF_KEY savedPad[MAX_INPUT];
+    T_DEF_KEY savedKeys[MAX_INPUT_SLOTS];
+    T_DEF_KEY savedPad[MAX_INPUT_SLOTS];
     std::memcpy(savedKeys, DefKeys, sizeof savedKeys);
     std::memcpy(savedPad, GamepadKeys, sizeof savedPad);
 
@@ -217,7 +217,7 @@ void CheckFirstExitCreatesFile(void) {
 // ReadGamepadConfig would install.
 std::string ClearedPad(int boundSlot) {
     std::string cfg;
-    for (int n = 0; n < MAX_INPUT; n++) {
+    for (int n = 0; n < MAX_INPUT_SLOTS; n++) {
         if (n == boundSlot) {
             cfg += Line("Gamepad%d: %u\nGamepad%d_2: 0\n", n,
                         (U32)K_GAMEPAD_A, n);
@@ -233,7 +233,7 @@ std::string ClearedPad(int boundSlot) {
 // the same way.
 void CheckAllZeroGuard(void) {
     std::string clearedKeyboard = "WinMode: 1\n";
-    for (int n = 0; n < MAX_INPUT; n++)
+    for (int n = 0; n < MAX_INPUT_SLOTS; n++)
         clearedKeyboard += Line("Input%d_1: 0\nInput%d_2: 0\n", n, n);
 
     // (a) Nothing bound anywhere. No key moves the hero, and the remap screen
@@ -249,7 +249,7 @@ void CheckAllZeroGuard(void) {
     LoadCfg(clearedKeyboard + ClearedPad(8));
     CHECK(!BindingsAreDefaults(),
           "a pad-only layout must not be mistaken for a corrupt cfg");
-    for (int n = 0; n < MAX_INPUT; n++) {
+    for (int n = 0; n < MAX_INPUT_SLOTS; n++) {
         CHECK(DefKeys[n].Key1 == 0 && DefKeys[n].Key2 == 0,
               "slot %d: the cleared keyboard binding must stay cleared", n);
     }
@@ -261,7 +261,7 @@ void CheckAllZeroGuard(void) {
     LoadCfg(clearedKeyboard);
     CHECK(!BindingsAreDefaults(),
           "a pre-gamepad cfg must not be mistaken for a corrupt cfg");
-    for (int n = 0; n < MAX_INPUT; n++) {
+    for (int n = 0; n < MAX_INPUT_SLOTS; n++) {
         CHECK(DefKeys[n].Key1 == 0 && DefKeys[n].Key2 == 0,
               "slot %d: a pre-gamepad cfg's cleared keyboard must stay cleared",
               n);
@@ -280,7 +280,7 @@ void CheckAllZeroGuard(void) {
 
     // (d) One keyboard binding left is enough on its own, pad or no pad.
     std::string oneKey = "WinMode: 1\n";
-    for (int n = 0; n < MAX_INPUT; n++)
+    for (int n = 0; n < MAX_INPUT_SLOTS; n++)
         oneKey += Line("Input%d_1: %u\nInput%d_2: 0\n", n,
                        n == 7 ? (U32)K_SPACE : 0u, n);
     LoadCfg(oneKey + ClearedPad(-1));
@@ -291,7 +291,7 @@ void CheckAllZeroGuard(void) {
 // --- 4. No WinMode ----------------------------------------------------------
 void CheckWinModeAbsentTakesDefaults(void) {
     std::string noWinMode;
-    for (int n = 0; n < MAX_INPUT; n++)
+    for (int n = 0; n < MAX_INPUT_SLOTS; n++)
         noWinMode += Line("Input%d_1: %d\nInput%d_2: 0\n", n, 100 + n, n);
 
     LoadCfg(noWinMode);
@@ -315,7 +315,7 @@ void CheckGamepadRoundTrip(void) {
     RemoveCfg();
     OpenCfg();
 
-    for (int n = 0; n < MAX_INPUT; n++) {
+    for (int n = 0; n < MAX_INPUT_SLOTS; n++) {
         GamepadKeys[n].Key1 = (U32)(300 + n);
         GamepadKeys[n].Key2 = (U32)(400 + n);
     }
@@ -324,7 +324,7 @@ void CheckGamepadRoundTrip(void) {
     ScribblePad();
     ReadGamepadConfig();
 
-    for (int n = 0; n < MAX_INPUT; n++) {
+    for (int n = 0; n < MAX_INPUT_SLOTS; n++) {
         CHECK(GamepadKeys[n].Key1 == (U32)(300 + n) &&
                   GamepadKeys[n].Key2 == (U32)(400 + n),
               "slot %d: pad binding did not survive the round trip", n);

--- a/tests/input_funnel/test_input_funnel.cpp
+++ b/tests/input_funnel/test_input_funnel.cpp
@@ -31,7 +31,7 @@
 #include <SYSTEM/KEYBOARD_KEYS.H> // K_GAMEPAD_*, K_ENTER, K_F10
 #include <SYSTEM/INPUT.H>         // Input, GetInput, DefineInputKeys, ClearNoRepeatInput
 
-#include "INPUT.H" // SOURCES/INPUT.H: I_* masks, T_DEF_KEY, MAX_INPUT, InitWaitNoInput
+#include "INPUT.H" // SOURCES/INPUT.H: I_* masks, T_DEF_KEY, MAX_INPUT_SLOTS, InitWaitNoInput
 
 #include <cstdio>
 #include <set>
@@ -61,11 +61,11 @@ static void hold2(U32 a, U32 b) {
 
 // --- Minimal binding tables for the inputs under test. Indexed by input slot,
 // mirroring SOURCES/INPUT.CPP's DefKeys / GamepadKeys layout. ---
-static T_DEF_KEY kbd[MAX_INPUT];
-static T_DEF_KEY pad[MAX_INPUT];
+static T_DEF_KEY kbd[MAX_INPUT_SLOTS];
+static T_DEF_KEY pad[MAX_INPUT_SLOTS];
 
-static U32 combinedKeys[MAX_INPUT * 4];
-static U32 combinedMasks[MAX_INPUT * 4];
+static U32 combinedKeys[MAX_INPUT_SLOTS * 4];
+static U32 combinedMasks[MAX_INPUT_SLOTS * 4];
 
 static void setBinding(int slot, U32 kbd1, U32 kbd2, U32 pad1, U32 pad2) {
     kbd[slot].Key1 = kbd1;


### PR DESCRIPTION
The Android release build stopped compiling on #588. This unbreaks it and removes the landmine that caused it.

## What happened

`MAX_INPUT` is a POSIX name. `/usr/include/linux/limits.h:11` defines it as 255 — the size of the terminal type-ahead buffer — and Bionic reaches it through `<limits.h>` where desktop glibc does not. This tree has used the same spelling for its 36 bindable actions since 1997.

It only ever worked by accident of include order: `INPUT.H` was included *after* every system header, so 36 won. #588 gave the tables a translation unit that includes its own header first, which is the convention, and that put the define ahead of `<string.h>`:

```
INPUT_BINDINGS.H  -> #define MAX_INPUT 36  -> arrays declared [37]
<string.h>        -> limits.h redefines it to 255
definitions below -> compile as [256]

error: redefinition of 'DefKeysDefault95' with a different type:
       'const T_DEF_KEY[256]' vs 'const T_DEF_KEY[37]'
```

Six globals, all binding tables.

## The fix

Rename to `MAX_INPUT_SLOTS` — 87 sites across six sources and three tests. Reordering the includes would also compile, but a name this module owns cannot be clobbered by include order at all, and the next translation unit to follow the convention would have hit the same thing. `SOURCES/CONFIG/` keeps the old spelling: it is 1997 code nothing builds.

The header says why the name is what it is, so it does not get "tidied" back.

## The warning is older than #588

Compiling `BUGGY.CPP` from `dbe07a5b` — the commit before #588 merged — with the NDK reports the same `-Wmacro-redefined`. Every Android build has carried it; #588 only turned it into an error. It is gone now: zero redefinition warnings across the whole native library.

## Verification

`android_arm64` builds clean against NDK 28.2, the version CI uses: 0 errors, 0 redefinition warnings, `liblba2cc.so` produced. `armv7a` could not be configured locally because the SDL3 install here is arm64-only; the change is architecture-independent and CI builds both.

Linux, 64 host tests, `check-arch` at 561 files, format and doc links all green.

## Why CI could not have caught this

Android builds only on `v*` tags and `workflow_dispatch` — no PR-triggered workflow builds it. Any PR can break the Android release and CI stays green. Worth a follow-up: either add the Android job to PR runs (the workflow is already reusable and caches SDL3), or a cheaper source-level guard against defining POSIX-reserved macro names. Raised separately rather than bundled here, since this PR should merge fast.
