### PR TITLE
ci(android): build the native library on every push and pull request

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,44 @@
+name: Android
+
+# Validation tier: compile the Android native library on every push and PR.
+#
+# Android is the one target whose toolchain disagrees with the desktop three
+# about more than instruction set: a different libc (Bionic), a different STL,
+# 32-bit as well as 64-bit, and a clang the other legs do not use. Until this
+# workflow existed, none of that ran until a `v*` tag, so a change could pass
+# every check, merge, and break the release build with nobody looking.
+#
+# It calls the same reusable file the release workflows do, with bundle: false
+# so the SDK packaging and artifact upload stay on the release tier. The compile
+# is the part that gates.
+#
+# Both ABIs run. armv7a is the project's only 32-bit build anywhere in CI, which
+# makes it the one leg that can see a pointer-size or alignment assumption, and
+# this tree has a documented history of those.
+
+on:
+  push:
+    paths-ignore: &doc-paths
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.vscode/**'
+      - '.editorconfig'
+      - '.git-blame-ignore-revs'
+      - 'cliff.toml'
+  pull_request:
+    paths-ignore: *doc-paths
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  native:
+    name: Native library
+    uses: ./.github/workflows/reusable-build-android.yml
+    with:
+      bundle: false

--- a/.github/workflows/docs-gate.yml
+++ b/.github/workflows/docs-gate.yml
@@ -17,8 +17,11 @@ name: CI gate (docs-only)
 # still gates the merge.
 #
 # Keep the paths list below in sync with the paths-ignore list in
-# linux.yml (mirrored in macos.yml, windows.yml, test.yml, and the
-# push: branches:[main] trigger of release-latest.yml).
+# linux.yml (mirrored in macos.yml, windows.yml, android.yml, test.yml,
+# and the push: branches:[main] trigger of release-latest.yml).
+#
+# android.yml needs no stand-in here: its check is not a required context,
+# so a docs-only PR that never fires it is not left waiting on one.
 on:
   push:
     paths: &doc-paths

--- a/.github/workflows/reusable-build-android.yml
+++ b/.github/workflows/reusable-build-android.yml
@@ -1,9 +1,13 @@
 name: Build Android APK (reusable)
 
-# Reusable build steps for the Android APK target. Called by
-# release-android.yml (tag-triggered) and release-latest.yml (rolling
-# pre-release). Produces a `dist/` directory with the debug-signed APK
-# and uploads it as a workflow artifact named `<artifact-prefix>-<arch>`.
+# Reusable build steps for the Android target. Called by release-android.yml
+# (tag-triggered) and release-latest.yml (rolling pre-release), which package,
+# and by android.yml on every push and PR, which does not.
+#
+# With bundle: true (the default) it produces a `dist/` directory with the
+# debug-signed APK and uploads it as a workflow artifact named
+# `<artifact-prefix>-<arch>`. With bundle: false it stops after the native
+# library, which is the part a validation run needs.
 #
 # Requires the Android SDK + NDK on the runner. The job installs them
 # via the command-line tools if not already present.
@@ -19,9 +23,18 @@ on:
           Prefix for the upload-artifact name. Caller appends -<arch>.
           Tag releases pass "Android" (default); release-latest passes
           "latest-android" so its download-artifact pattern picks them up.
+          Unused when bundle is false.
         type: string
         required: false
         default: Android
+      bundle:
+        description: >-
+          Package the APK and upload it. Release callers leave this true.
+          The push/PR caller passes false: the native compile is what gates,
+          and packaging on every push would upload artifacts nobody reads.
+        type: boolean
+        required: false
+        default: true
 
 jobs:
   build:
@@ -177,6 +190,7 @@ jobs:
           cmake --build --preset ${{ matrix.preset }} -- -j"$(nproc)" 2>&1
 
       - name: Bundle APK
+        if: ${{ inputs.bundle }}
         run: |
           BUILD_DIR="out/build/${{ matrix.preset }}"
           VERSION=$(cat "$BUILD_DIR/VERSION.txt")
@@ -198,13 +212,18 @@ jobs:
             --cxx-shared-lib "$CXX_SHARED_LIB" \
             --output-dir dist
 
+      # Reads the packaged APK, so it goes with the packaging. The alignment it
+      # checks comes from linker flags in the android_common preset, which a
+      # validation run does exercise; what it cannot see there is whether the
+      # bundling step preserved them.
       - name: Verify 16 KB page alignment (arm64-v8a)
-        if: matrix.arch == 'arm64-v8a'
+        if: ${{ inputs.bundle && matrix.arch == 'arm64-v8a' }}
         run: |
           APK=$(find dist -maxdepth 1 -name '*-arm64-v8a.apk' | sort | head -1)
           bash scripts/dev/check-16k-align.sh "$APK"
 
       - name: Upload temporary artifact
+        if: ${{ inputs.bundle }}
         uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.artifact-prefix }}-${{ matrix.arch }}

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -22,6 +22,7 @@ ties both tiers together — path filtering, the docs-only gate, and the
 | `linux.yml` | Validation | push, PR, dispatch | `build`, `build-clang`, `build-demo`, `sanitize`, `warnings` | Configure (`linux` preset), build `lba2cc` + `host_tests`, run `ctest -L host_quick`; the same through clang and for the demo SKU; the host tests once more under Address + UndefinedBehavior sanitizers; and a `-Wall -Wextra` build compared against the warning baseline |
 | `macos.yml` | Validation | push, PR, dispatch | `build` | Same, on `macos-latest` (`macos_arm64` preset) |
 | `windows.yml` | Validation | push, PR, dispatch | `build` | Same, on Windows MSYS2 UCRT64 (`windows_ucrt64` preset) |
+| `android.yml` | Validation | push, PR, dispatch | `native` | Compiles the Android native library for both ABIs through `reusable-build-android.yml` with `bundle: false`. The only leg on a different libc (Bionic) and the only 32-bit build anywhere in CI |
 | `test.yml` | Validation | push, PR, dispatch | `test` | Docker: `./run_tests_docker.sh` — full ASM↔C++ equivalence suite (Linux only, slow) |
 | `format.yml` | Validation | push, PR, dispatch | `check-format`, `check-arch` | `scripts/ci/check-format.sh` (clang-format), and `scripts/ci/check-arch.py` for the architecture boundaries CODESTYLE.md and AGENTS.md state. Deliberately unfiltered: see the header comment there for why the architecture check is not in `lint.yml` |
 | `lint.yml` | Validation | push, PR (shell/Python/workflow/action paths), dispatch | `shellcheck`, `actionlint`, `ruff` | Lints the non-C++ surface. Settings live in `.shellcheckrc` and `ruff.toml`; tool versions are pinned in the workflow. The `shellcheck` job covers `*.sh` and, via `scripts/ci/check-action-shell.py`, the `run:` blocks of composite actions, which neither it nor actionlint would otherwise see. That checker hand-rolls a block-scalar parser to stay stdlib-only, so `check-action-shell-selftest.py` runs first on the same runner: a drifted parser reports clean rather than failing, and the suite is what pins that direction |
@@ -29,7 +30,7 @@ ties both tiers together — path filtering, the docs-only gate, and the
 | `docs-gate.yml` | Validation | push, PR | `build`, `test` | No-op stand-ins for the required `build`/`test` checks on docs-only changes — see [below](#docs-only-gate) |
 | `docs-links.yml` | Validation | push, PR, weekly | `links`, `external` | `scripts/ci/check-docs-links.sh` and `scripts/ci/check-docs-symbols.py`. Not path-filtered: a doc reference breaks from either side, since renaming a doc breaks source comments. `external` is weekly-only; see [below](#documentation-links) |
 | `release-*.yml` | Release | `v*` tags, dispatch | `build` → `release` | Per-platform tag releases |
-| `reusable-build-*.yml` | Release | `workflow_call` | `build` | Shared build+package steps, called by the release workflows |
+| `reusable-build-*.yml` | Release | `workflow_call` | `build` | Shared build+package steps, called by the release workflows. `reusable-build-android.yml` also serves the validation tier: `bundle: false` stops it after the compile |
 | `release-latest.yml` | Release | push to `main` | build legs → `release` | Rolling `latest` pre-release |
 
 Host build jobs (`linux`/`macos`/`windows`) need neither retail game
@@ -343,6 +344,33 @@ changes.
 ccache directory that churns on every run would compete with the image
 layers for the repository's 10 GB Actions cache budget. Revisit if the
 Windows build grows or the cache budget frees up.
+
+### Why Android is a validation leg
+
+Every other target CI builds is glibc on a desktop. Android is not: Bionic
+rather than glibc, `c++_shared` rather than libstdc++, an NDK clang the
+other legs do not use, and `armeabi-v7a` is the only 32-bit build anywhere
+in this repository. Those are four independent ways for a change to be
+correct on the desktop three and wrong here.
+
+It used to build on `v*` tags only, which meant a change could pass every
+check, merge, and break the release. That is not hypothetical: `MAX_INPUT`
+was a POSIX name that `<linux/limits.h>` gives the value 255, reachable on
+Bionic through `<limits.h>` and not on desktop glibc, so a header that
+defined it as 36 compiled everywhere except Android. The desktop legs, the
+sanitizers and review all passed it.
+
+The job compiles and does not package. `bundle: false` skips the APK
+assembly, the 16 KB alignment check that reads the packaged APK, and the
+artifact upload, because the compile is what gates and an artifact per push
+is one nobody reads.
+
+**What to measure on the first few runs, before tuning anything.** The SDK
+step installs `platforms`, `build-tools` and `platform-tools` alongside the
+NDK, and only the NDK compiles; whether splitting that is worth doing
+depends on numbers this workflow has never produced, since it ran on tags
+until now. SDL3 is cached per ABI, the NDK is not. Read the step timings
+first, as with everything else in this section.
 
 ### Where the time goes
 


### PR DESCRIPTION
Android built on `v*` tags only, so #588 could pass every check, merge, and break the release build with nobody looking. This closes that.

## Why Android specifically

Every other target CI covers is glibc on a desktop. Android is Bionic, `c++_shared` rather than libstdc++, an NDK clang no other leg uses, and **`armeabi-v7a` is the only 32-bit build anywhere in this repository**. Four independent ways to be right on the desktop three and wrong here.

The break that prompted this is a clean example: `MAX_INPUT` is a POSIX name `<linux/limits.h>` gives the value 255, reachable on Bionic through `<limits.h>` and not on desktop glibc, so a header defining it as 36 compiled everywhere except Android. Linux, clang, demo, macOS, Windows, ASan and UBSan all passed it, and so did review.

## What it does

`android.yml` — validation tier, push + PR + dispatch, sharing the same `paths-ignore` doc set as `linux.yml` — calls the same `reusable-build-android.yml` the release workflows use, with a new `bundle` input set to `false`.

That skips the APK assembly, the 16 KB alignment check (it reads the packaged APK), and the artifact upload. The compile is what gates, and an artifact per push is one nobody reads. Release callers pass nothing and keep today's behaviour exactly.

Both ABIs build, because armv7a is the leg that can see a pointer-size or alignment assumption.

## Deliberately not done

**No speed tuning.** The SDK step installs `platforms`, `build-tools` and `platform-tools` beside the NDK, and only the NDK compiles — but this workflow has never run on a push, so there are no step timings to reason from. `docs/CI.md` says read those before assuming a leg is slow, so this ships untuned and the doc records what to measure: that split, and whether the NDK wants caching the way SDL3 already is.

**No branch-protection change.** The new check is not a required context, so a docs-only PR that never fires it is not left waiting on one, and no `docs-gate.yml` stand-in is needed. Making it required is a repo settings change and belongs with whoever owns that.

## Verified

`actionlint` clean across all workflows. `check-arch` clean at 561 files, doc links clean. The build itself was reproduced locally first: `android_arm64` against NDK 28.2 (the version this workflow pins) builds `liblba2cc.so` with zero errors.

`docs/CI.md` gains the workflow-map row and a section on why Android is a validation leg rather than a release-only one.


## It caught something on its first run, by accident

This branch was first cut from `main` *before* #589 merged, so its own tip did not compile for Android. The two runs on that commit are an unintended A/B of the gate itself:

| run | event | tree it built | result |
|---|---|---|---|
| `32192322896` | `push` | branch tip, based on main without #589 | **failed** — the real `MAX_INPUT` redefinition |
| `32192327385` | `pull_request` | same branch merged into main with #589 | **passed** |

Same commit, same workflow, red on the broken tree and green on the fixed one. The branch has since been rebased onto current `main`, so both legs build a tree that has the fix.