### PR TITLE
chore(arch): refuse a macro name the standard headers already own

### DIFF
--- a/CODESTYLE.md
+++ b/CODESTYLE.md
@@ -102,6 +102,7 @@ That split is worth reaching for because it is the same line as the testable one
 - **Indentation:** 4 spaces in C/C++. Tabs are preserved in ASM. The original used tabs; there is an ongoing migration to 4 spaces, so new contributions use 4 spaces.
 - **Types:** use the fixed-width aliases `S32`/`U32`/`S16`/`U16`/`U8` from [`LIB386/H/SYSTEM/ADELINE_TYPES.H`](LIB386/H/SYSTEM/ADELINE_TYPES.H), not bare `int`/`unsigned`, in ported and engine code.
 - **Standard:** C++98 for engine and game code; tests may use C11/C++11.
+- **Macro names:** a macro this project defines must not take a name the C or POSIX standard headers own. `MAX_INPUT` was ours for the 36 bindable actions and is also POSIX's, where `<linux/limits.h>` gives it the value 255; Bionic reaches it through `<limits.h>` and desktop glibc does not, so the collision compiled on every host but Android and surfaced only when someone cut a release. Whether it bites at all depends on include order, which makes it a landmine rather than a build failure. Names are cheap: `MAX_INPUT_SLOTS` costs nothing and cannot be clobbered.
 
 ## Strings a player reads
 

--- a/SOURCES/CONFIG/AFFKEY.CPP
+++ b/SOURCES/CONFIG/AFFKEY.CPP
@@ -1,6 +1,6 @@
 #include "C_EXTERN.H"
 
-char ConfigTxt[MAX_INPUT][100] = {
+char ConfigTxt[MAX_INPUT_SLOTS][100] = {
     "Avancer",
     "Reculer",
     "Tourner à Gauche",

--- a/SOURCES/CONFIG/CONFIG.CPP
+++ b/SOURCES/CONFIG/CONFIG.CPP
@@ -1,7 +1,7 @@
 #include "C_EXTERN.H"
 
 //▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-char ConfigTxt[MAX_INPUT][100] = {
+char ConfigTxt[MAX_INPUT_SLOTS][100] = {
     "Avancer",
     "Reculer",
     "Tourner à Gauche",
@@ -156,7 +156,7 @@ S32 SelectKey = 0;
 #define CFG_X0 10
 #define CFG_Y0 10
 #define CFG_X1 630
-#define CFG_Y1 (CFG_Y0 + MAX_INPUT * 10 + 35)
+#define CFG_Y1 (CFG_Y0 + MAX_INPUT_SLOTS * 10 + 35)
 
 #define ACTION_X (CFG_X0 + 20)
 #define KEY1_X (CFG_X0 + 390)
@@ -269,7 +269,7 @@ void DrawScreenConfig(void) {
 
     DrawStatusConfig(STATUS_MENU);
 
-    for (n = 0; n < MAX_INPUT; n++) {
+    for (n = 0; n < MAX_INPUT_SLOTS; n++) {
         DrawOneConfig(n);
     }
 }
@@ -278,7 +278,7 @@ void DrawScreenConfig(void) {
 S32 CheckKeyConfig(S32 key) {
     S32 n;
 
-    for (n = 0; n < MAX_INPUT; n++) {
+    for (n = 0; n < MAX_INPUT_SLOTS; n++) {
         if (DefKeys[n].Key1 == key OR DefKeys[n].Key2 == key) {
             return n;
         }
@@ -310,7 +310,7 @@ void MenuConfig(void) {
         if (akey == A_UP) {
             SelectConfig--;
             if (SelectConfig < 0)
-                SelectConfig = MAX_INPUT - 1;
+                SelectConfig = MAX_INPUT_SLOTS - 1;
 
             DrawOneConfig(oldselect);
             DrawOneConfig(SelectConfig);
@@ -320,7 +320,7 @@ void MenuConfig(void) {
 
         if (akey == A_DOWN) {
             SelectConfig++;
-            if (SelectConfig >= MAX_INPUT)
+            if (SelectConfig >= MAX_INPUT_SLOTS)
                 SelectConfig = 0;
 
             DrawOneConfig(oldselect);
@@ -342,8 +342,8 @@ void MenuConfig(void) {
 
         if (akey == A_PGDN) {
             SelectConfig += 10;
-            if (SelectConfig >= MAX_INPUT)
-                SelectConfig = MAX_INPUT - 1;
+            if (SelectConfig >= MAX_INPUT_SLOTS)
+                SelectConfig = MAX_INPUT_SLOTS - 1;
 
             DrawOneConfig(oldselect);
             DrawOneConfig(SelectConfig);
@@ -361,7 +361,7 @@ void MenuConfig(void) {
         }
 
         if (akey == A_END) {
-            SelectConfig = MAX_INPUT - 1;
+            SelectConfig = MAX_INPUT_SLOTS - 1;
 
             DrawOneConfig(oldselect);
             DrawOneConfig(SelectConfig);

--- a/SOURCES/CONFIG/INPUT.CPP
+++ b/SOURCES/CONFIG/INPUT.CPP
@@ -10,9 +10,9 @@ U32 WaitNoClick = 0;
 #endif
 
 U32 LastInput = 0;
-U32 NbInput = MAX_INPUT;
+U32 NbInput = MAX_INPUT_SLOTS;
 
-T_DEF_KEY DefKeysDefault[MAX_INPUT + 1] =
+T_DEF_KEY DefKeysDefault[MAX_INPUT_SLOTS + 1] =
     {
         {K_UP, 0},           // I_UP
         {K_DOWN, 0},         // I_DOWN
@@ -52,10 +52,10 @@ T_DEF_KEY DefKeysDefault[MAX_INPUT + 1] =
         {K_F, 0},            // I_FOUDRE
 };
 
-T_DEF_KEY DefKeys[MAX_INPUT + 1];
+T_DEF_KEY DefKeys[MAX_INPUT_SLOTS + 1];
 
 // tableau de configuration des touches utilisé au cours du jeux
-U32 TabInputBit[MAX_INPUT + 1];
+U32 TabInputBit[MAX_INPUT_SLOTS + 1];
 
 /*══════════════════════════════════════════════════════════════════════════*
 			██████┐ ██┐ ██┐ ██████┐ ██████┐
@@ -72,7 +72,7 @@ void InitInput(void) {
     U32 shift = 0;
     U32 shiftbit = 0;
 
-    for (NbInput = 0; NbInput < MAX_INPUT;) {
+    for (NbInput = 0; NbInput < MAX_INPUT_SLOTS;) {
         key = DefKeys[NbInput].Key1;
 
         if (key == K_SHIFT_LEFT OR key == K_SHIFT_RIGHT) {
@@ -125,7 +125,7 @@ void ReadInputConfig(void) {
 
     if (!winmode) {
         // reinit des input par défaut
-        for (n = 0; n < MAX_INPUT; n++) {
+        for (n = 0; n < MAX_INPUT_SLOTS; n++) {
             DefKeys[n].Key1 = DefKeysDefault[n].Key1;
             DefKeys[n].Key2 = DefKeysDefault[n].Key2;
         }
@@ -133,7 +133,7 @@ void ReadInputConfig(void) {
         // On peut identifier chaque input avec un tableau de chaine,
         // mais bon, bof !!!
 
-        for (n = 0; n < MAX_INPUT; n++) {
+        for (n = 0; n < MAX_INPUT_SLOTS; n++) {
             snprintf(id, sizeof(id), "Input%d_1", n);
             DefKeys[n].Key1 = DefFileBufferReadValueDefault(id, DefKeysDefault[n].Key1);
             // Blindage si les Inputs sont configurés à 0
@@ -164,7 +164,7 @@ void WriteInputConfig(void) {
     // On peut identifier chaque input avec un tableau de chaine,
     // mais bon, bof !!!
 
-    for (n = 0; n < MAX_INPUT; n++) {
+    for (n = 0; n < MAX_INPUT_SLOTS; n++) {
         snprintf(id, sizeof(id), "Input%d_1", n);
         DefFileBufferWriteValue(id, DefKeys[n].Key1);
 

--- a/SOURCES/CONFIG/INPUT.H
+++ b/SOURCES/CONFIG/INPUT.H
@@ -49,7 +49,7 @@
 #define I_PROTECTION (1 << 2) // 'C'		Sort de Protection
 #define I_FOUDRE (1 << 3)     // 'F'		Sort de Foudre
 
-#define MAX_INPUT 36
+#define MAX_INPUT_SLOTS 36
 
 #define I_JOY (I_UP | I_DOWN | I_LEFT | I_RIGHT)
 #define I_FIRE (I_ACTION_M | I_INVENTORY | I_RETURN | I_THROW | I_COMPORTEMENT)
@@ -84,10 +84,10 @@ typedef struct {
     U32 Key2;
 } T_DEF_KEY;
 
-extern T_DEF_KEY DefKeys[MAX_INPUT + 1];
+extern T_DEF_KEY DefKeys[MAX_INPUT_SLOTS + 1];
 
 // tableau de configuration des touches utilisé au cours du jeu
-extern U32 TabInputBit[MAX_INPUT + 1];
+extern U32 TabInputBit[MAX_INPUT_SLOTS + 1];
 
 /*══════════════════════════════════════════════════════════════════════════*
 			██████┐ ██┐ ██┐ ██████┐ ██████┐

--- a/docs/plan/ARCH_RULES_PLAN.md
+++ b/docs/plan/ARCH_RULES_PLAN.md
@@ -223,9 +223,41 @@ The check reads string literals only, so a comment naming a doc stays legal, whi
 numbers need the pattern anchored tightly enough to leave
 [EXIT_SCREEN.CPP](../../SOURCES/EXIT_SCREEN.CPP)'s "RULE #1024-GH" joke alone.
 
+### 8. No macro takes a name the standard headers own
+
+CODESTYLE.md, "Layout and naming": "a macro this project defines must not take a name the C or
+POSIX standard headers own."
+
+One live case, fixed in #589 before the rule landed: `MAX_INPUT` named this project's 36 bindable
+actions and also names POSIX's terminal type-ahead buffer, which
+[`<linux/limits.h>`](https://man7.org/linux/man-pages/man0/limits.h.0p.html) gives the value 255.
+Bionic reaches it through `<limits.h>`; desktop glibc on the same path does not. The collision
+therefore compiled on Linux, macOS and Windows, under clang and gcc, and under both sanitizers,
+and broke only Android.
+
+**Why a rule and not a compiler warning.** Whether it bites depends on include order. The name was
+wrong for twenty-nine years and harmless for all of them, because `INPUT.H` happened to be included
+after the system headers everywhere it mattered. The first translation unit to include its own
+header first turned it into six errors. A gate that only fires when the ordering is unlucky is not
+a gate, which is why this one reads the name rather than the outcome.
+
+**The list is embedded, not read from the host.** `RESERVED_MACRO_NAMES` holds what the `<limits.h>`
+family defines on glibc, with the regeneration command beside it. Asking the local libc at check
+time would give a macOS laptop a different answer from the CI runner, and a gate that moves with
+the host is not one. A name arriving in a future libc is something to add deliberately, in a diff
+someone reads.
+
+**The portability idiom is allowed.** A define whose own `#ifndef` guards it is supplying a name
+the host omitted, which is the opposite of taking one. Nothing in the tree does that today; a rule
+that fired on it would be telling people not to write correct code.
+
+`SOURCES/CONFIG/` is renamed along with the rest even though nothing builds it. An exception for
+one directory would be a hole in the rule worth more than the dead tree's likeness to its 1997
+self, and the same argument the `VENDORED` comment makes about convenient exemptions applies here.
+
 ## What is deliberately not a rule
 
-Four candidates that failed one of the three tests. Recording them matters as much as the list
+Five candidates that failed one of the three tests. Recording them matters as much as the list
 above, because each will look attractive again later.
 
 **A surface must not name a feature's variables.** Load-bearing, and the reason
@@ -249,6 +281,15 @@ version: GAMEMENU.CPP is +1,771 lines since the import and PERSO.CPP +643. As a 
 every bug fix in those files to discourage new subsystems, which is not the behaviour the
 roadmap asks for. The ownership ratchets in rules 4 and 5 catch the same drift at the place it
 actually causes harm.
+
+**Reserved name *patterns*, as opposed to names.** POSIX reserves whole shapes, not just the
+entries in `<limits.h>`: `E[0-9A-Z]*` for errno, `SIG[A-Z]*`, `LC_[A-Z]*`, `str[a-z]*`, `mem[a-z]*`,
+and a leading underscore for the implementation. Checking those would be the more complete rule and
+it fails the third test: the tree defines 50 macros starting with `E` (`EOP`, `END_READ`,
+`ERROR_FILE_NOT_CREATED`) and 8 with a leading underscore, all of them resource-script leftovers.
+Every one is a false positive, so the rule would land red and teach people to skip it. The other
+four shapes are at zero today and could be added if a real collision ever appears; that would be
+enforcement earned by an incident, which is how rule 8 arrived.
 
 ## Where the check runs
 

--- a/scripts/ci/check-arch.py
+++ b/scripts/ci/check-arch.py
@@ -48,6 +48,44 @@ VENDORED = (
     "LIB386/FILEIO/stb_image_write.h",
 )
 
+# --- rule 8: macro names the standard headers already own -------------------
+
+# Names the C and POSIX standard headers define, taken from the <limits.h> family
+# on a glibc host:
+#
+#   for h in /usr/include/limits.h /usr/include/linux/limits.h \
+#            /usr/include/*/bits/posix1_lim.h /usr/include/*/bits/posix2_lim.h \
+#            /usr/include/*/bits/local_lim.h; do
+#       sed -n 's/^[[:space:]]*#[[:space:]]*define[[:space:]]\+\([A-Z][A-Z0-9_]*\).*/\1/p' "$h"
+#   done | sort -u
+#
+# Embedded rather than read at check time on purpose: a rule that asks the local
+# libc what it defines gives a different answer on a macOS laptop than on the CI
+# runner, and a gate that moves with the host is not a gate. Regenerating it is
+# the command above; a name arriving in a future libc is a thing to add here
+# deliberately, in a diff someone reads.
+#
+# Underscore-prefixed names are left out. Those belong to the implementation
+# rather than to a caller, nothing here defines one, and the four resource-script
+# leftovers that do (_APS_NEXT_*) would be noise rather than a finding.
+RESERVED_MACRO_NAMES = frozenset(
+    """
+    AIO_PRIO_DELTA_MAX ARG_MAX BC_BASE_MAX BC_DIM_MAX BC_SCALE_MAX BC_STRING_MAX
+    BOOL_MAX BOOL_WIDTH CHARCLASS_NAME_MAX CHAR_BIT CHAR_MAX CHAR_MIN CHAR_WIDTH
+    COLL_WEIGHTS_MAX DELAYTIMER_MAX EXPR_NEST_MAX HOST_NAME_MAX INT_MAX INT_MIN
+    INT_WIDTH LINE_MAX LINK_MAX LLONG_MAX LLONG_MIN LLONG_WIDTH LOGIN_NAME_MAX
+    LONG_MAX LONG_MIN LONG_WIDTH MAX_CANON MAX_INPUT MB_LEN_MAX MQ_PRIO_MAX
+    NAME_MAX NGROUPS_MAX NR_OPEN PATH_MAX PIPE_BUF PTHREAD_DESTRUCTOR_ITERATIONS
+    PTHREAD_KEYS_MAX RE_DUP_MAX RTSIG_MAX SCHAR_MAX SCHAR_MIN SCHAR_WIDTH
+    SEM_VALUE_MAX SHRT_MAX SHRT_MIN SHRT_WIDTH SSIZE_MAX TTY_NAME_MAX UCHAR_MAX
+    UCHAR_WIDTH UINT_MAX UINT_WIDTH ULLONG_MAX ULLONG_WIDTH ULONG_MAX ULONG_WIDTH
+    USHRT_MAX USHRT_WIDTH XATTR_LIST_MAX XATTR_NAME_MAX XATTR_SIZE_MAX
+    """.split()
+)
+
+DEFINE_RE = re.compile(r"^\s*#\s*define\s+([A-Za-z_][A-Za-z0-9_]*)")
+IFNDEF_RE = re.compile(r"^\s*#\s*ifndef\s+([A-Za-z_][A-Za-z0-9_]*)")
+
 # --- rule 3: where a platform conditional may live --------------------------
 
 PLATFORM_MACROS = (
@@ -474,6 +512,39 @@ def rule_console_library_names_no_game(sources: list[Source]) -> list[Violation]
     return found
 
 
+def rule_no_reserved_macro_names(sources: list[Source]) -> list[Violation]:
+    """Flag a #define that takes a name the standard headers own.
+
+    The portability idiom is allowed: a define whose own #ifndef guards it is
+    supplying the name where the host did not, which is the opposite of taking it.
+    Nothing in the tree does that today, and a rule that fired on it would be
+    telling people not to write correct code.
+    """
+    found = []
+    for source in sources:
+        guarded = None
+        for line, text in source.lines():
+            ifndef = IFNDEF_RE.match(text)
+            if ifndef:
+                guarded = ifndef.group(1)
+                continue
+            match = DEFINE_RE.match(text)
+            if not match:
+                continue
+            name = match.group(1)
+            if name in RESERVED_MACRO_NAMES and name != guarded:
+                found.append(
+                    Violation(
+                        source.path,
+                        line,
+                        f"{name} is defined by the standard headers "
+                        f"(<limits.h> and friends); pick a name of this project's own",
+                    )
+                )
+            guarded = None
+    return found
+
+
 def rule_no_repo_reference_in_strings(sources: list[Source]) -> list[Violation]:
     found = []
     for source in sources:
@@ -549,6 +620,19 @@ RULES = (
         'CODESTYLE.md: "its core builds as a library that touches no game state, while '
         'CONSOLE_CMD.CPP [...] is deliberately left out of that library."',
         rule_console_library_names_no_game,
+    ),
+    Rule(
+        8,
+        "no macro takes a name the standard headers own",
+        'CODESTYLE.md "Layout and naming": "a macro this project defines must not take '
+        'a name the C or POSIX standard headers own."',
+        rule_no_reserved_macro_names,
+        remedy=(
+            "rename the macro. Whether a collision breaks the build depends on include "
+            "order and on which libc the host uses, so a tree that compiles today is no "
+            "evidence. If instead you are supplying a name the host omitted, guard the "
+            "define with its own #ifndef and this rule steps aside."
+        ),
     ),
     Rule(
         7,


### PR DESCRIPTION
The cheap half of the guard against what broke Android in #589. Complements #591 rather than replacing it: this catches the name at edit time with no toolchain, while the Android job catches everything a name check cannot see.

## The rule

`CODESTYLE.md`, "Layout and naming": *a macro this project defines must not take a name the C or POSIX standard headers own.* `check-arch.py` enforces it as rule 8 and quotes that sentence back on failure, exactly as the other seven do.

## Why a name check rather than trusting the compiler

`MAX_INPUT` was ours for the 36 bindable actions and is also POSIX's, where `<linux/limits.h>` gives it the value 255. Bionic reaches it through `<limits.h>`; desktop glibc on the same path does not. So it compiled on Linux, macOS and Windows, under gcc and clang, under ASan and UBSan — and broke only Android.

It survived twenty-nine years because whether it bites depends on include order: `INPUT.H` was included after the system headers everywhere it mattered, so 36 won. The first translation unit to include its own header first turned it into six errors. A defect that only appears when the ordering is unlucky is precisely what a name check is for.

## Design decisions worth reviewing

**The list is embedded, not read from the host.** `RESERVED_MACRO_NAMES` holds what the `<limits.h>` family defines on glibc, with the regeneration command beside it. Reading the local libc at check time would give a macOS laptop a different answer from the CI runner, and a gate that moves with the host is not a gate.

**The portability idiom is allowed.** A define guarded by its own `#ifndef` is supplying a name the host omitted rather than taking one. Nothing in the tree does that today; a rule that fired on it would be telling people not to write correct code.

**`SOURCES/CONFIG/` is renamed too**, though nothing builds it. An exception for one directory would be a hole in the rule worth more than the dead tree's likeness to its 1997 self — the same argument the `VENDORED` comment in that file already makes about convenient exemptions.

## Validated three ways

- reintroduce `#define MAX_INPUT 36` → check fails, exit 1, with the CODESTYLE sentence and the remedy
- add an `#ifndef PATH_MAX` / `#define PATH_MAX 260` shim → check passes
- run the rule against `SOURCES/INPUT.H` **as it stood before #589** → flags `MAX_INPUT` at line 52

8 rules over 561 files, all clean. 64 host tests, format and doc links green.

## Left out deliberately, with the measurement

POSIX reserves whole *shapes*, not just the `<limits.h>` entries: `E[0-9A-Z]*`, `SIG[A-Z]*`, `LC_[A-Z]*`, `str[a-z]*`, `mem[a-z]*`, leading underscore. Checking those fails `ARCH_RULES_PLAN.md`'s third test — the tree defines 50 macros starting with `E` (`EOP`, `END_READ`, `ERROR_FILE_NOT_CREATED`) and 8 with a leading underscore. Every one is a false positive, so the rule would land red and teach people to skip it. Recorded in the plan's "deliberately not a rule" section with those numbers, and could be revisited if a real collision ever appears — enforcement earned by an incident, which is how rule 8 arrived.
