### PR TITLE
fix(test): keep the distance property check inside the defined domain

### DIFF
--- a/tests/numeric_contract/test_numeric_contract.cpp
+++ b/tests/numeric_contract/test_numeric_contract.cpp
@@ -321,12 +321,22 @@ static void test_vector(void) {
  * the run above measures, and these still fail if the arithmetic is broken
  * rather than merely different. */
 
+/* Distance needs its own, smaller, coordinate set. kCoords runs out to 16777217
+   for the rotations, where the products go through long double and are fine, but
+   DISTANCE.CPP squares in `int` first, so feeding it those values is the
+   overflow described above rather than a test of anything. Every combination
+   below stays inside the domain: the largest sum of three squares here is
+   3 * 15000^2, well under the 2147483647 that would wrap. */
+static const S32 kDistCoords[] = {0, 1, -1, 511, -512, 4096, -4096, 15000, -15000};
+
+#define NDIST ((int)(sizeof kDistCoords / sizeof kDistCoords[0]))
+
 static void test_distance_properties(void) {
     int i;
     /* A point is no distance from itself, and distance does not care which way
        round its arguments are. */
-    for (i = 0; i < (int)(sizeof kCoords / sizeof kCoords[0]); i++) {
-        S32 x = kCoords[i], y = kCoords[(i + 3) % 10], z = kCoords[(i + 7) % 10];
+    for (i = 0; i < NDIST; i++) {
+        S32 x = kDistCoords[i], y = kDistCoords[(i + 3) % NDIST], z = kDistCoords[(i + 7) % NDIST];
         ASSERT_EQ_UINT(0u, Distance3D(x, y, z, x, y, z));
         ASSERT_EQ_UINT(0u, Distance2D(x, y, x, y));
         ASSERT_EQ_UINT(Distance3D(x, y, z, 0, 0, 0), Distance3D(0, 0, 0, x, y, z));


### PR DESCRIPTION
Fixes the `sanitize` job, which #597 took red on main.

## What broke

`test_distance_properties` looped over `kCoords`, the coordinate set the rotation cases use. That
set runs out to 16777217 on purpose: the rotations promote to `long double` before multiplying, so
large values are exactly where the precision is worth testing.

`DISTANCE.CPP` does not. It squares the deltas in `int` before promoting the sum, so handing it
those values is the overflow that same file documents, not a test of anything. UBSan aborted on
`1000000 * 1000000` and the job went red.

The irony is the point: #597 added a paragraph explaining that overflow and kept the *vector* cases
inside the domain, then walked straight into it two functions later.

## The fix

Distance gets its own coordinate set, bounded so the largest sum of three squares is
`3 * 15000^2`, comfortably under the `2147483647` that would wrap. The vector cases were already
inside the domain, so **the committed numbers do not move** and nothing is regenerated.

## What I got wrong about checking it

Not the reasoning, the verification. I ran the Release build, which cannot see this, and the
`sanitize` leg is the one that exists to. `tests/precision_paths` says as much in its own header:
it was written because the ASM-equivalence tests never reach these paths under the sanitizers.

Verified under the actual preset this time:

```
cmake -S . -B build-asan -DLBA2_BUILD_TESTS=ON -DLBA2_BUILD_ASM_EQUIV_TESTS=OFF --preset linux_sanitize
cmake --build build-asan --target host_tests
cd build-asan && UBSAN_OPTIONS=print_stacktrace=1 ctest -L host_quick
```

69 of 69, and the Release build still passes with the vector unchanged.

The underlying `DISTANCE.CPP` overflow is still there and still worth its own change: `Distance2D`
returns 0 past a separation of 46340, and `Distance3D(0,0,0,40000,40000,40000)` returns 22472
instead of 69282. What this PR fixes is only the test walking into it.
