### PR TITLE
ci(macos): print the ARM numeric measurement, and stop a zero reading as a conclusion

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,6 +58,18 @@ jobs:
       - name: Host tests
         run: cd build && ctest -L host_quick --output-on-failure
 
+      # tests/numeric_contract measures rather than asserts where long double is
+      # not 80-bit, which is every Apple target. That measurement is the reason
+      # it runs here at all: it says how far this host's projection, rotation and
+      # distance rounding sits from the x86-64 numbers a recording is replayed
+      # against, and nobody needs a Mac to read it.
+      #
+      # A second, verbose run because `--output-on-failure` shows nothing for a
+      # test that passes, and this one passes on purpose. Costs a hundredth of a
+      # second and is the only place the ARM figures appear.
+      - name: Report the ARM numeric measurement
+        run: cd build && ctest -R test_numeric_contract -V
+
       - name: Verify Binary
         # CMake's MACOSX_BUNDLE wiring (in SOURCES/CMakeLists.txt) puts the
         # binary inside an .app bundle. The bundle dir is named after

--- a/tests/numeric_contract/test_numeric_contract.cpp
+++ b/tests/numeric_contract/test_numeric_contract.cpp
@@ -307,11 +307,23 @@ static void test_vector(void) {
     ASSERT_EQ_INT(NEXPECTED, g_idx);
 
 #if !HAS_X87_LONG_DOUBLE
-    printf("# long double is %d mantissa bits here, not 64: the vector above is\n",
+    printf("# long double is %d mantissa bits here, not 64, so the vector is reported\n",
            (int)LDBL_MANT_DIG);
-    printf("# reported, not asserted. Largest difference %ld, at %s.\n", g_maxDelta,
-           g_worstLabel);
-    printf("# A recording made on x86-64 does not replay here until that is 0.\n");
+    printf("# rather than asserted. Largest difference %ld, at %s.\n", g_maxDelta, g_worstLabel);
+    if (g_maxDelta == 0) {
+        /* Do not let a zero here be read as "ARM replay works". It is one
+           necessary condition out of several, and these cases are not evenly
+           discriminating: a 25-bit coordinate times a 24-bit float mantissa is
+           exact in a 53-bit double, so most of the rotation products cannot
+           differ whatever the host, and the rotation matrix is a Z-rotation
+           whose third row copies its input. The eight projections are the cases
+           that carry a real division, and so the ones with something to say. */
+        printf("# Zero is necessary for an x86-64 recording to replay here, and a long\n");
+        printf("# way from sufficient: five functions of LIB386/3D, and most of these\n");
+        printf("# products are exact in a double whatever the host.\n");
+    } else {
+        printf("# A recording made on x86-64 does not replay here while that is not 0.\n");
+    }
 #endif
 }
 


### PR DESCRIPTION
One line of CI plus a wording fix, closing a hole in #597.

`tests/numeric_contract` measures rather than asserts where `long double` is not 80-bit. The macOS
runner is the only ARM host that runs host tests, and that measurement is the entire reason the
test runs there: it says how far this host's projection, rotation and distance rounding sits from
the x86-64 numbers a recording is replayed against, so the size of the ARM problem can be read off
a CI log by someone with no Mac.

**It never reached the log.** ctest prints nothing for a test that passes, and this one passes on
purpose, so `--output-on-failure` reported the verdict and hid the figures. Checked on the macOS
run of #597's merge commit: `67/69 Test #67: test_numeric_contract ... Passed`, and not one of the
lines the reporting branch exists to print. The design said the job log carries the numbers, and
the job log did not.

Re-running that one test verbosely after the suite costs about a hundredth of a second and is the
only place the figures appear.

## And the first result changes what the test should say

With the measurement reaching the log, macOS arm64 reports **largest difference 0** across all 161
values. The line printed underneath said "a recording made on x86-64 does not replay here until
that is 0", which now reads as though the condition were met and the question settled.

It is neither, because most of these cases cannot discriminate:

- The rotation matrix is a Z-rotation, so its third row copies its input. A third of the rotation
  values are the input echoed back: `LongRotatePointF[2].Z` is 16777217 because 16777217 went in.
- A 25-bit coordinate times a 24-bit float mantissa needs at most 49 bits, so it is exact in a
  53-bit double whatever the host.
- Distance takes the square root of an exact integer and truncates.
- The eight projections carry a real division, and are the only cases here with much to say.

So the zero is real and it is weak evidence. The reporting branch now says a zero is necessary and
a long way from sufficient, and keeps the stronger sentence for the branch where the difference is
not zero. Better cases are worth having and are their own change: a full rotation matrix with three
non-zero terms a row, and projection inputs chosen so the factor's low bits reach the rounding.

## Testing

`actionlint` clean. The ARM-only branch was compiled and run by forcing
`HAS_X87_LONG_DOUBLE` to 0 locally, since no Linux or Windows build ever reaches it. `ctest -R
test_numeric_contract -V` does surface the test's stdout. Linux 69/69 unchanged, vector unmoved.
