### PR TITLE
docs: correct the long double claim, and write down three ASM traps

### DIFF
--- a/docs/ASM_TO_CPP_REFERENCE.md
+++ b/docs/ASM_TO_CPP_REFERENCE.md
@@ -35,3 +35,62 @@ This page is a quick reference for which modules are ported (built as CPP) vs st
 ## LIB386 (engine libraries)
 
 LIB386 still contains many ASM files that are used in the build (3D, ANIM, SVGA, OBJECT, pol_work, SYSTEM, etc.). A full LIB386 ASM↔CPP map is not listed here; the focus of this reference is SOURCES and 3DEXT where the community has explicitly switched to C++ in the build. LIB386 ports can be documented here later if desired.
+
+## Known mistranslation classes
+
+Three ways a faithful-looking port has been wrong, each found more than once. Check a port against
+these before believing it, because all three compile cleanly, and two of them produce plausible
+output rather than obvious damage.
+
+### One-operand `imul` / `mul` feeding `idiv` is 64-bit
+
+`imul r/m32`, with one operand and no comma, multiplies EAX by the operand and leaves the **64-bit**
+product in EDX:EAX; a following `idiv r/m32` divides that whole 64-bit value. C's `a * b / c` in
+`S32` cannot express it, because the product truncates before the divide. **The comma is the tell**:
+the two-operand form (`imul eax, ebx`) really does truncate to 32 bits and maps to `*` correctly.
+
+Correct translation: `(S32)((S64)a * b / c)`.
+
+A sweep of every one-operand multiply with a divide within a few instructions found 95 that matter,
+across five files. `LIB386/pol_work/POLYLINE.ASM` (56 sites) and `LIB386/OBJECT/AFF_OBJ.ASM` (1) had
+been written 32-bit and are now `S64`; `LINERAIN.ASM`, `POLY.ASM` and `REGLE3.ASM` were already
+correct. Of the 271 one-operand multiplies in the tree, only those feeding a divide matter: a
+product whose high half is never read is just a 32-bit multiply.
+
+Sort live from latent before spending effort. POLYLINE's `DZ` is a 16.16 delta, so it overflows at
+ordinary scene depths; AFF_OBJ's needs a sphere radius in the millions against a focal length of
+600.
+
+### `neg` is two's complement, not `~`
+
+`neg eax` is `-x`. Porting it as `~x` loses the `+1`, which is invisible at most magnitudes and
+decisive at small ones: the interior sphere radius in `AFF_OBJ.CPP` came out exactly one pixel too
+large, and on 1 to 3 pixel character eyes that is the difference between a dot and a blob (#357).
+The exterior branch had a compensating second `neg`, so the symptom was interior-only.
+
+### U32 geometry relying on 32-bit address wraparound
+
+Watcom-era blitters "clip" a negative coordinate by letting unsigned arithmetic wrap:
+
+```c
+U32 xMin = HotX + x;                  /* x can be negative */
+if (xMin < ClipXMin || xMax > ClipXMax) { /* margin clip */ }
+U32 initialOffset = TabOffLine[yMin] + xMin;
+U8 *screen = Log + initialOffset;     /* 32-bit: wraps back. 64-bit: Log + 4 GiB */
+```
+
+Two coupled defects. The unsigned compare hides a negative `xMin`, so the clip branch never fires;
+and `U32` zero-extends to a 64-bit pointer instead of wrapping, so the write lands 4 GiB away.
+Intermittent by nature, because that address is only sometimes mapped: a segfault when you are
+lucky, silent corruption when you are not (#78, `LIB386/SVGA/COPYMASK.CPP`). Convert geometry locals
+to `S32`. Audit anything doing RLE or sprite blits with `HotX`/`HotY` headers and screen-relative x;
+`DrawOverBrick3` in `SOURCES/GRILLE.CPP` passes `colscreen = -24` for column 0.
+
+### Why grepping for the pattern is not enough
+
+Both misses in the 64-bit multiply sweep sat beside code that already knew the hazard, one of them
+two lines under a previous fix to the same function, with a test whose reference model was correct
+and whose inputs were too small to overflow. Reaching these needs inputs sized from the arithmetic:
+work out what makes the product exceed 2^31 and test on both sides of that boundary. The same
+applies per render mode, since an equivalence suite that only drives the perspective path never
+touches the iso branch. See [BUG_HUNTING.md](BUG_HUNTING.md) for the oracle discipline this feeds.

--- a/docs/BUG_HUNTING.md
+++ b/docs/BUG_HUNTING.md
@@ -119,6 +119,23 @@ capable of failing before its silence means a thing. Concretely, from this engin
 The habit that catches all of these: after any green result, ask what would have to be broken for
 this to go red, then break it.
 
+Those are all checks that could not fail. There is a second family, where the check is sound and you
+never see what it said:
+
+- **A build that cannot observe the fault.** A Release build has no sanitizers. A test written to
+  document the `DISTANCE.CPP` integer overflow walked into it, and the Release run was green: only
+  the `linux_sanitize` leg went red. Anything touching arithmetic wants
+  `cmake --preset linux_sanitize` and `ctest -L host_quick` before it is believed.
+
+- **A result nobody prints.** `ctest` shows nothing for a test that passes. A test that *measures*
+  rather than asserts, which is what a platform whose arithmetic differs needs, is therefore
+  invisible while reporting success. It needs `ctest -R <name> -V`, or the measurement it exists to
+  produce never reaches the log.
+
+- **A branch nothing compiles.** Code behind a platform predicate is never built on the platform you
+  are sitting at. Force the predicate locally and build it, or it ships unexecuted and the first
+  machine to reach it is a CI runner.
+
 ## From a report to a cause
 
 **Bisect the trigger before diagnosing.** A fault that arrived after two resolution switches and a

--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -61,7 +61,9 @@ The engine assumes little-endian throughout. HQR readers cast raw bytes through 
 
 ## 3. Floating-point precision and FPU semantics &nbsp;&nbsp;&nbsp;&nbsp; ⚠ partial
 
-Projection and rotation paths use `long double` + `lrintl()` to match the original x87 FPU's round-to-nearest `fistp` behavior. `long double` is 80-bit on Linux x86_64, 64-bit on macOS arm64 and Windows MSYS2. The result is small but real per-platform divergence in screen coordinates and Z values. Mitigated where it matters (projection, rotation, polygon slopes); tested in `tests/fpu_precision/`.
+Projection and rotation paths use `long double` + `lrintl()` to match the original x87 FPU's round-to-nearest `fistp` behavior.
+
+The split is between architectures, not between operating systems. Both x86-64 hosts carry a 64-bit mantissa (`LDBL_MANT_DIG`), Linux and Windows MSYS2 alike, because MinGW-w64 GCC keeps x87 extended precision; MSVC is the compiler that would not, and this tree does not build with it. ARM has no x87, so on macOS arm64 and Android `long double` is a plain double with a 53-bit mantissa. Measured on each toolchain rather than inferred: `lrintl`, `sqrtl` and the projection factor-and-round shape are bit-identical across the two x86-64 hosts, including at ties and near-ties.
 
 - `LongProjectPoint3D` — `LIB386/3D/LPROJ3DF.CPP:25-28`
 - `LongRotatePointF` — `LIB386/3D/LROT3DF.CPP:13-15`
@@ -69,7 +71,20 @@ Projection and rotation paths use `long double` + `lrintl()` to match the origin
 - FPU control word reference (test) — `tests/fpu_precision/fpu_ops.asm:15-16`
 - `volatile` barrier rationale (forces FPU stack → memory round-trip) — `tests/fpu_precision/test_fpu_precision.cpp:109,125`
 
-**Next:** Consolidate the `lrintl(long double)` callers behind a single helper TU (`lba_round_to_int`) so the platform divergence has one place to live. Quantify the per-platform delta in a regression test.
+`tests/numeric_contract` is what pins the values, and it runs on every platform: 161 results across
+`Distance2D`/`Distance3D`, the two rotations, `LongProjectPoint3D` and `LongRotate`, asserted where
+the mantissa is 64 bits and reported where it is not, so the macOS job log says how far ARM sits
+from the x86-64 numbers. Read that file's own header before drawing a conclusion from the figure:
+most of its cases cannot discriminate, and it says which ones can. `tests/fpu_precision` answers a
+different question, ASM against C, and needs the 32-bit toolchain, so it runs only in the Docker
+leg; `tests/precision_paths` drives these paths under the sanitizers without asserting values.
+
+Why it matters beyond the picture: a recorded session declares the mantissa width it was made under
+(`numeric.long_double_bits`, see [RECORDING.md](RECORDING.md)), because a replay cannot reproduce a
+simulation whose arithmetic rounds differently. `Distance` is the one entry point here that the
+simulation reads rather than the renderer.
+
+**Next:** Consolidate the `lrintl(long double)` callers behind a single helper TU (`lba_round_to_int`) so the platform divergence has one place to live.
 
 ---
 


### PR DESCRIPTION
Three pieces of engine knowledge that lived only in an agent's notes, moved into the docs that
should own them. No code changes.

## A correction, first

`PLATFORM.md` said:

> `long double` is 80-bit on Linux x86_64, 64-bit on macOS arm64 and **Windows MSYS2**.

Windows MSYS2 is **80-bit**, the same as Linux. MinGW-w64 GCC keeps x87 extended precision; MSVC is
the compiler that would not, and this tree does not build with it. Measured on each toolchain with
the same probe, including ties and near-ties through `lrintl` and `sqrtl`.

The distinction matters more than a wrong number usually does: it says the split is between
**architectures**, not operating systems. Read the old way, a Linux-versus-Windows divergence looks
like a floating-point problem, and it points the investigation at the two hosts that actually agree
instead of at the one that does not.

That section also asked for the per-platform delta to be "quantified in a regression test".
`tests/numeric_contract` does that now, so it is named, along with what the neighbouring tests
answer instead: `fpu_precision` is ASM against C behind the 32-bit toolchain, and `precision_paths`
drives the paths under sanitizers without asserting values. The old text credited `fpu_precision`
with coverage it cannot provide off the Docker leg.

## Three ASM mistranslation classes, previously undocumented

`ASM_TO_CPP_REFERENCE.md` was a file-mapping table with nothing about how a port goes wrong. It now
carries the three that have each bitten more than once:

- **One-operand `imul`/`mul` feeding `idiv` is 64-bit.** The comma is the tell: `imul eax, ebx`
  truncates and maps to `*`, `imul r/m32` does not. 95 sites across five files matter; POLYLINE (56)
  and AFF_OBJ (1) had been written 32-bit.
- **`neg` is two's complement, not `~`.** Losing the `+1` made every interior sphere one pixel too
  large, which on 1 to 3 pixel character eyes is a dot against a blob (#357).
- **U32 geometry relying on 32-bit address wraparound.** The Watcom clipping idiom writes 4 GiB away
  on 64-bit, intermittently, because that address is only sometimes mapped (#78).

Plus why grepping for them is not enough: both misses in the multiply sweep sat next to code that
already knew the hazard, with tests whose inputs were too small to overflow.

## The other half of oracle discipline

`BUG_HUNTING.md` covers checks that cannot fail. It gains the family where the check is sound and
its answer never reaches you:

- a Release build cannot observe a sanitizer finding
- `ctest` prints nothing for a passing test, so a test that *measures* is invisible while reporting
  success
- a branch behind a platform predicate is never compiled on the machine you are sitting at

All three are recent and concrete rather than general advice.

## Verification

`check-docs-links` 0 errors, `check-docs-symbols` clean, no new em-dashes. The two code claims were
checked against the tree rather than taken from notes: `POLYLINE.CPP` does use `S64`, and
`COPYMASK.CPP` does declare its geometry locals `S32`.
