### PR TITLE
docs(recording): what a more forgiving playback would take

### DIFF
--- a/docs/plan/RECORDING_RESEARCH.md
+++ b/docs/plan/RECORDING_RESEARCH.md
@@ -1534,6 +1534,82 @@ the index or the clock question, and it compares one artifact at the end rather 
 A session recorder is the same idea extended along time, and the two questions time adds are the
 two this doc spends its measurements on.
 
+## What would make a playback survive more
+
+Four things break a replay that is otherwise sound. They are not the same kind of problem and
+they do not cost the same, so the ordering below is the point rather than the list. The limits as
+they stand are in [RECORDING.md](../RECORDING.md); this is what closing each of them would take.
+
+### The settings are carried and never applied
+
+`write_mode_lines` writes thirteen `settings.*` keys and `replay_report_mode` only prints the
+ones that differ. The values are in the file, the fields are plain `extern S32` globals, and the
+cost of a mismatch is measured: `FollowCamera` diverges at tick 0, `FollowCamGroundClearance` at
+tick 2, `DetailLevel` 3 to 0 at tick 235. A replay that read its own header could reproduce all
+three.
+
+The shape to copy is in the same file. `bindings_install` and `bindings_restore` borrow the
+recording's key tables for the replay's duration and return the player's on the way out, on the
+same borrow-and-return the snapshot reload uses for the save context. Settings are that shape and
+simpler, because there is no combined table to rebuild afterwards.
+
+Worth doing as one table of key and pointer rather than a second hand-written list. The header
+writer and the installer then cannot disagree about what a setting is, which is the argument the
+mode block already makes for being built from one place: a setting that joins the header has to
+be remembered once, not twice.
+
+Twelve of the thirteen are values a write settles. `DetailLevel` is not: `SetDetailLevel`
+(SOURCES/GAMEMENU.CPP) derives `RainEnable` and `Shadow` from it and runs at MainLoop entry, which
+is why `Shadow` is deliberately not carried. Installing that one means calling through it rather
+than assigning the field, and getting the order wrong would leave a replay reporting the setting
+as matched while the state it drives does not.
+
+This is the cheapest of the four and the only one with measured failures already behind it.
+
+### A replay still needs the `--load` the recording ran under
+
+A recording carries the savegame it started from, and a replay that reloads it still diverges at
+tick 4 without the same `--load`. So something the reload does not restore differs between a run
+that booted into the save and one that booted fresh, and a switch that skipped the `--load` would
+move that divergence rather than remove it.
+
+This is the highest-value item here and the one that needs a measurement session rather than an
+afternoon. The comparison sets up from the file alone: `scripts/dev/dump_recording.py <rec> saves`
+writes the starting savegame back out, so booting into it and booting fresh and reloading it can
+be diffed with `--dump-state` without re-recording anything.
+
+### A truncated check reads like a pass
+
+The replay reports what the file holds as it opens, and ends itself when the stream runs out. What
+it cannot see is the tick budget, so a run bounded below the extent prints no summary at all --
+and a run that reported nothing looks exactly like a run that passed. The extent is already
+computed; comparing it against the budget needs one accessor and a line at open time.
+
+### A divergence is one number
+
+`Record_TickHook` records the first mismatching tick and then keeps checking without saying
+anything else. Counting what matched and what did not after that point separates a value that
+moved once from a run that has parted, and the summary currently cannot tell them apart. A few
+lines, and it improves every diagnosis rather than one.
+
+### What the chunk format now makes possible
+
+A playback cannot start part way through. The keyframes every 32 ticks are diagnosis rather than
+state: 23 named fields, enough to say what moved and not enough to restore anything. A chunk
+stream carries periodic savegames as easily as it carries two, which would give seek and resume,
+and a replay of tick 3000 without the 3000 ticks in front of it.
+
+The cost is a savegame every N ticks and the work of showing that a resumed replay reaches what a
+run-through one reaches. Not now, but it is a format question rather than an architectural one,
+which is the part that decides how expensive it would be to change one's mind about.
+
+### And one that is not a fragility
+
+Time spent in a modal has no oracle. The digest fires once per tick and a modal spins polls
+without advancing one, so a recorded session that sat in a dialogue choice held 707,624 polls
+against 1,472 ticks. Nothing about that makes a replay fail; it makes a pass mean less, and it is
+the one item here that a more forgiving playback would make worse rather than better.
+
 ## Open questions
 
 1. **What is the sample change rate under a real player?** The prototype answers this for
@@ -1561,10 +1637,11 @@ two this doc spends its measurements on.
    function of `Input`, which is a function of what was recorded. Worth confirming rather than
    assuming.
 
-5. **Should a recording be able to start from a mid-session state rather than a save?** Attaching
-   a `--dump-state` snapshot as the setup would let a recording start anywhere. It would also mean
-   the format carries a second, larger notion of state that has to stay in step with the engine.
-   Probably not worth it, but it is the question a scenario library would ask first.
+5. **Should a recording be able to start from a mid-session state rather than a save?** Settled
+   the other way: the setup is a savegame, and the recording carries it inside itself rather than
+   beside it. That keeps the format on the one notion of state the engine already serialises,
+   instead of a second and larger one that would have to stay in step with it. What a scenario
+   library would ask next is seek and resume, which is the last part of the section above.
 
 ## Reproduce
 


### PR DESCRIPTION
Docs only. A new section in [RECORDING_RESEARCH.md](docs/plan/RECORDING_RESEARCH.md) for
what a more forgiving playback would take, written in the order the items should be taken
rather than as a list, because the ordering is the part worth arguing with.

## The four

**The settings are carried and never applied.** `write_mode_lines` writes thirteen
`settings.*` keys into every header and `replay_report_mode` only prints the ones that
differ, while the measured cost of a mismatch is a divergence at tick 0 (`FollowCamera`),
tick 2 (`FollowCamGroundClearance`) and tick 235 (`DetailLevel` 3 to 0). The shape to copy
is in the same file: `bindings_install` / `bindings_restore` already borrows the
recording's key tables for the replay's duration and returns the player's on the way out.
Cheapest of the four and the only one with measured failures already behind it.

**A replay still needs the `--load` the recording ran under.** A recording that reloads its
own savegame still diverges at tick 4 without it, so something the reload does not restore
differs between booting into a save and booting fresh. Highest value here, and a
measurement session rather than a switch: a flag that skipped the `--load` would move the
divergence, not remove it. The comparison sets up from the recording alone now that
`dump_recording.py <rec> saves` writes the starting savegame back out.

**A truncated check reads like a pass.** The replay reports what the file holds and ends
itself at EOF, but cannot see the tick budget, so a run bounded below the extent prints no
summary at all.

**A divergence is one number.** The first mismatching tick is recorded and then checking
continues silently, so the summary cannot separate a value that moved once from a run that
has parted.

## Two notes that are not items

**Seek and resume** is now a format question rather than an architectural one: a chunk
stream carries periodic savegames as easily as it carries two. Not proposed, just recorded,
because that is what decides how expensive it would be to change one's mind about.

**Time in a modal has no oracle** and is kept deliberately apart from the four. It breaks
no replay -- it makes a pass mean less, and it is the one item a more forgiving playback
would make worse rather than better.

## Also

Open question 5 is settled the way the work went rather than the way it was leaning. It
asked whether a recording should start from a `--dump-state` snapshot; the setup is a
savegame the file carries, which keeps the format on the one notion of state the engine
already serialises instead of a second and larger one.

## Two corrections while writing it

The key count is thirteen, not the fourteen I had from memory. And installing the settings
does not reduce to assigning thirteen fields: `SetDetailLevel` derives `RainEnable` and
`Shadow` from `DetailLevel` and runs at MainLoop entry, which is why `Shadow` is
deliberately not carried at all. That one has to be installed through the function, and the
wrong order would leave a replay reporting the setting as matched while the state it drives
is not. Both are in the doc, since the second is what would bite whoever builds it.
