### PR TITLE
fix(record): read the keyframe count in the dump tool

### DIFF
--- a/scripts/dev/dump_recording.py
+++ b/scripts/dev/dump_recording.py
@@ -33,7 +33,11 @@ import os
 import struct
 import sys
 
-# The keyframe fields, in the order RECORD.CPP writes them (s_kfNames).
+# The keyframe fields, in the order RECORD.CPP writes them (s_kfNames). From version 12
+# the record says how many it carries, so this list only supplies the *names*; a file
+# with more fields than are named here reads them and reports them by index. Versions 9
+# to 11 wrote no count and always the first 23 of these.
+KF_LEGACY_FIELDS = 23
 KF = [
     "cube", "cubemode", "hero.x", "hero.y", "hero.z", "hero.beta",
     "hero.anim", "hero.body", "hero.move", "hero.life", "hero.zone",
@@ -42,7 +46,7 @@ KF = [
     "cinema", "dial.obj", "choice", "choices", "fade", "blackpal",
 ]
 
-REC_KEY = 0x50   # keyframe: u32 tick, then one s32 per KF entry
+REC_KEY = 0x50   # keyframe: u32 tick, u16 count (v12+), then count * s32
 REC_TELE = 0x51  # verbose telemetry: u32 tick, u16 count, then count * s32
 REC_CMD = 0x40   # console command: u32 tick, u16 len, then len bytes
 REC_SYNC = 0x60  # sync marker: u32 magic, u32 poll, u32 tick
@@ -78,6 +82,12 @@ def parse(path):
     if split < 0:
         raise SystemExit("%s: no header (not a recording?)" % path)
     header = data[:split].decode("latin1")
+
+    # "LBA2REC <ver>" is the first line, and the keyframe's shape depends on it.
+    try:
+        version = int(header.split("\n", 1)[0].split()[1])
+    except (IndexError, ValueError):
+        version = 0
     p, n = split + 2, len(data)
 
     polls = 0
@@ -115,8 +125,13 @@ def parse(path):
             elif flags == REC_KEY:
                 tick = struct.unpack_from("<I", data, p)[0]
                 p += 4
-                vals = list(struct.unpack_from("<%di" % len(KF), data, p))
-                p += 4 * len(KF)
+                if version >= 12:
+                    count = struct.unpack_from("<H", data, p)[0]
+                    p += 2
+                else:
+                    count = KF_LEGACY_FIELDS
+                vals = list(struct.unpack_from("<%di" % count, data, p))
+                p += 4 * count
                 keys.append((tick, vals))
             elif flags == REC_TELE:
                 tick, count = struct.unpack_from("<IH", data, p)
@@ -218,14 +233,20 @@ def main(argv):
             print("  cmd @tick %d: %s" % (tick, line))
 
     if what in ("all", "keys"):
+        def kfname(i):
+            # A file may carry a field this list does not name yet, and reporting it by
+            # index beats dropping it or shifting every name after it along.
+            return KF[i] if i < len(KF) else "field[%d]" % i
+
         prev = None
         for tick, vals in keys:
             if prev is None:
                 print("kf %5d: %s" % (tick, "  ".join(
-                    "%s=%d" % (KF[i], vals[i]) for i in range(len(KF)))))
+                    "%s=%d" % (kfname(i), vals[i]) for i in range(len(vals)))))
             else:
-                moved = ["%s %d->%d" % (KF[i], prev[i], vals[i])
-                         for i in range(len(KF)) if prev[i] != vals[i]]
+                shared = min(len(prev), len(vals))
+                moved = ["%s %d->%d" % (kfname(i), prev[i], vals[i])
+                         for i in range(shared) if prev[i] != vals[i]]
                 print("kf %5d: %s" % (tick, "  ".join(moved) if moved else "(no change)"))
             prev = vals
 


### PR DESCRIPTION
Follow-up to #604, which moved the C++ half of the keyframe length and left
`scripts/dev/dump_recording.py` on the old shape.

The tool takes the first two bytes of the count as part of the first field, and every
record after that drifts. Measured on a 121-poll version 12 recording: it reports **141
polls**. Not an error, just a wrong number, which is the failure mode the count was added
to remove in the first place.

Same rule as the engine's readers. Versions 9 to 11 wrote no count and always 23 fields,
which the version line already in the header decides; 12 and later say so themselves.

Two smaller things in the same read, both about surviving the next change to `s_kfNames`:
a field the name list does not carry yet is reported by index rather than dropped, and two
keyframes of different lengths are compared over the fields both have rather than
mislabelling everything after the insertion point.

Checked both ways: `recordings/legacy-v10.rec` still reads its 198 polls, and a fresh
format-12 recording reads 121 where it read 141 before.