### PR TITLE
feat(record): carry whether audio came up, because the simulation reads it

### DIFF
--- a/LIB386/AIL/MILES/SAMPLE.CPP
+++ b/LIB386/AIL/MILES/SAMPLE.CPP
@@ -879,6 +879,11 @@ U32 IsSamplePlaying(U32 sample) {
 
 // ████████████████████████████████████████████████████████████████████████████
 
+/* Miles really plays: the flag and this answer agree. */
+S32 Sample_DriverPlaysSound(void) { return Sample_Driver_Enabled; }
+
+// ████████████████████████████████████████████████████████████████████████████
+
 S32 GetSamplePosition(U32 sample) {
     S32 hnum;
 

--- a/LIB386/AIL/NULL/SOUND_NULL_BACKEND.CPP
+++ b/LIB386/AIL/NULL/SOUND_NULL_BACKEND.CPP
@@ -47,6 +47,9 @@ void StopSamples() {}
 void PauseSamples() {}
 void ResumeSamples() {}
 U32 IsSamplePlaying(U32 sample) { return FALSE; }
+/* Never, whatever the driver flag says: the line above is unconditional, and the
+   simulation branches on it. */
+S32 Sample_DriverPlaysSound(void) { return FALSE; }
 void SfxLogEnable(int enable) { (void)enable; }
 int SfxLogIsEnabled(void) { return 0; }
 S32 GetSamplesPausedCount(void) { return 0; }

--- a/LIB386/AIL/SDL/SAMPLE.CPP
+++ b/LIB386/AIL/SDL/SAMPLE.CPP
@@ -733,6 +733,9 @@ U32 IsSamplePlaying(U32 sample) {
     return result;
 }
 
+/* The SDL backend really plays: the flag and this answer agree. */
+S32 Sample_DriverPlaysSound(void) { return Sample_Driver_Enabled; }
+
 void SfxLogEnable(int enable) {
     sfxLogEnabled = (enable != 0) ? 1 : 0;
     MusicLogEnable(sfxLogEnabled);

--- a/LIB386/H/AIL/SAMPLE.H
+++ b/LIB386/H/AIL/SAMPLE.H
@@ -152,6 +152,24 @@ void ResumeSamples(void);
 U32 IsSamplePlaying(U32 sample);
 
 //--------------------------------------------------------------------------
+//	Sample_DriverPlaysSound :	can IsSamplePlaying above ever answer yes?
+//
+//	Not the same question as Sample_Driver_Enabled, which says the driver
+//	initialised. The null backend initialises and then returns FALSE from
+//	IsSamplePlaying for every sample, so a caller reading the flag would be
+//	told there is audio on a build that has none.
+//
+//	The simulation branches on IsSamplePlaying: the ambience pan is drawn
+//	only when it says no, and a dialogue with the text off runs until it does.
+//	So a run that can never hear a voice computes a different game, and this
+//	is how a caller asks which of the two it is on without knowing which
+//	backend it was built with.
+//
+//	Returns	:			TRUE if samples reach the simulation
+//--------------------------------------------------------------------------
+S32 Sample_DriverPlaysSound(void);
+
+//--------------------------------------------------------------------------
 //	SfxLogEnable :			toggle diagnostic logging in the backend
 //
 //			  enable :	1 = on, 0 = off

--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -20,7 +20,7 @@
 #include "CONTROL_SERVER.H" /* --listen: interactive command socket */
 
 #include <3D/PROJREC.H> /* Projrec_BeginCapture / Projrec_EndCapture */
-#include <AIL/SAMPLE.H> /* Sample_Driver_Enabled: whether audio actually came up */
+#include <AIL/SAMPLE.H> /* Sample_DriverPlaysSound: whether audio actually came up */
 #include <FILEIO/SAVEPNG.H>
 #include <SVGA/SCREEN.H>   /* Screen, ModeDesiredX/Y */
 #include <SVGA/VIDEO.H>    /* Palette() */
@@ -636,10 +636,14 @@ int Control_NoAudio(void) {
 }
 
 /* The flag says what was asked for; this says what the run got, and the simulation reads
-   the second one. Backend-independent: every AIL backend defines the same symbol, and
-   the NULL one leaves it FALSE. */
+   the second one.
+
+   Not `Sample_Driver_Enabled`, which answers a question one backend answers misleadingly:
+   the null backend initialises, sets the flag, and then returns FALSE from every
+   IsSamplePlaying, so reading the flag would report audio on a build with none. The
+   backends answer for themselves instead. */
 int Control_AudioActive(void) {
-    return Sample_Driver_Enabled ? 1 : 0;
+    return Sample_DriverPlaysSound() ? 1 : 0;
 }
 
 /* --- Boot ------------------------------------------------------------------- */

--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -20,6 +20,7 @@
 #include "CONTROL_SERVER.H" /* --listen: interactive command socket */
 
 #include <3D/PROJREC.H> /* Projrec_BeginCapture / Projrec_EndCapture */
+#include <AIL/SAMPLE.H> /* Sample_Driver_Enabled: whether audio actually came up */
 #include <FILEIO/SAVEPNG.H>
 #include <SVGA/SCREEN.H>   /* Screen, ModeDesiredX/Y */
 #include <SVGA/VIDEO.H>    /* Palette() */
@@ -632,6 +633,13 @@ int Control_GetVSync(void) {
 
 int Control_NoAudio(void) {
     return s_no_audio;
+}
+
+/* The flag says what was asked for; this says what the run got, and the simulation reads
+   the second one. Backend-independent: every AIL backend defines the same symbol, and
+   the NULL one leaves it FALSE. */
+int Control_AudioActive(void) {
+    return Sample_Driver_Enabled ? 1 : 0;
 }
 
 /* --- Boot ------------------------------------------------------------------- */

--- a/SOURCES/CONTROL.H
+++ b/SOURCES/CONTROL.H
@@ -107,6 +107,13 @@ int Control_GetVSync(void);
    this flag. */
 int Control_NoAudio(void);
 
+/* Whether a sample driver is actually up, which is not the same question as the flag
+   above: --headless implies --no-audio, and InitSampleDriver can fail on a host with no
+   audio device and let the run continue silently (SOURCES/INITADEL.C). All three land in
+   the same place, and the simulation reads that place, so a recording carries this
+   answer rather than the flag that usually produces it. */
+int Control_AudioActive(void);
+
 /* Set up the boot path and arm the tick hook. Call once, instead of MainGameMenu(),
    when active: applies --load (InitGame(-1) + ChangeCube while FlagLoadGame is set)
    or a fresh InitGame(1), then arms Control_TickHook. Returns 1 on success (caller

--- a/SOURCES/INITADEL.C
+++ b/SOURCES/INITADEL.C
@@ -345,6 +345,11 @@ void InitAdeline(S32 argc, char *argv[]) {
                in projection_demo); a player whose audio device fails just
                loses sound instead of being unable to launch the game. */
             Log_Warn("Audio      none - running silently");
+        } else if (!Sample_DriverPlaysSound()) {
+            /* The null backend initialises and reports success, then plays nothing.
+               Saying "44100 Hz stereo" there sends anyone debugging silence, or a
+               replay that diverges on audio, to look at the device. */
+            Log_Info("Audio      none - built without a sound backend");
         } else {
             Log_Info("Audio      44100 Hz stereo");
         }

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -454,6 +454,22 @@ static void snapshot_beside(const char *recPath, const char *name, char *out, si
    Auto camera's own block rather than the whole of the config, and a setting joins it
    when a replay is shown to turn on it.
 
+   `mode.audio` is there because whether audio came up decides what the simulation
+   computes, in two places. SOURCES/AMBIANCE.CPP draws its random pan only
+   `if (!IsSamplePlaying(...))`, from the one stream actor behaviour draws from, so one
+   draw either way and the next actor to reach TM_ANGLE_RND turns to a different angle.
+   And a dialogue with the text off spins on `TestSpeak()` until the voice sample ends
+   (SOURCES/MESSAGE.CPP), which is worth hundreds of ticks rather than one draw. With no
+   sample driver both answers are an unconditional no, which is a different branch and
+   not a quieter one.
+
+   It records what the run got rather than what was asked for, because three routes
+   reach the same place: `--no-audio`, `--headless` (which implies it), and a host where
+   InitSampleDriver fails and the run continues silently. A recording made with sound
+   cannot be reproduced by a replay without it, and since `--fixed-dt` requires
+   `--headless` today, that is every replay. Naming the line is what turns that into a
+   sentence at the top of the run instead of a divergence to be diagnosed.
+
    One line per key rather than a digest: `rec info` diffs the header line by line, so a
    named line reports the key that differs, and a digest could only report that
    something did.
@@ -465,6 +481,7 @@ static S32 write_mode_lines(char *out, size_t n) {
     int wrote = snprintf(out, n,
                          "engine=%s\n"
                          "mode.headless=%d\n"
+                         "mode.audio=%d\n"
                          "mode.fixed_dt=%d\n"
                          "mode.verbose=%d\n"
                          "build.flags=%s\n"
@@ -481,6 +498,7 @@ static S32 write_mode_lines(char *out, size_t n) {
                          "bindings.digest=%016llx\n",
                          LBA2_VERSION_STRING,
                          Control_IsHeadless(),
+                         Control_AudioActive(),
                          (int)Timer_FixedDtValue(),
                          Control_IsVerbose(),
                          BUILD_FLAGS_STR,

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -83,6 +83,7 @@ so a replay under a different `--fixed-dt` is reported rather than silently wron
 | A keyframe of named state, every 32 ticks | The digest says *when* a replay stopped matching; this says *what* moved |
 | Every value the digest mixes, per tick, with `--verbose` | The keyframe names 23 fields. This names all of them, so a divergence in another actor or a script variable is named too |
 | The settings a replay is known to turn on | They are not in the save, and a config edited in between reads as the simulation diverging |
+| The mode the session ran in, audio included | Whether a sample driver came up decides what the simulation computes, and no save or config records it |
 
 The header is `key=value` text, so a recording is readable without a decoder. `SOURCES/RECORD_FORMAT.H`
 owns the field readers, the binding-table lines and the frame around an inline savegame;
@@ -327,8 +328,25 @@ all. "1472 ticks checked, mismatch -1" means the simulation matched on every tic
 nothing about the forty seconds spent in the menu, and a replay that behaved differently in there
 would still report clean.
 
-**The mode has to match.** A recording made windowed with audio does not replay headless with the
-null backend, because a live audio thread branches the simulation. `rec info` will say so.
+**The mode has to match, and audio is the half of it that is not fixed at the source.** The fix
+above makes two runs that both have audio agree. It does nothing for a recording made with sound and
+replayed without it, because `--no-audio` skips `InitSampleDriver` entirely: `IsSamplePlaying` is
+then an unconditional no rather than a differently timed yes, which is a different branch and not a
+quieter one. It reaches further than the ambience draw, too. A dialogue with the text off spins on
+`TestSpeak()` until the voice sample ends, so the same line holds the game for hundreds of ticks in
+one run and none in the other. And since `--headless` implies `--no-audio` while `--fixed-dt`
+requires `--headless`, that is every replay today.
+
+So the header carries `mode.audio`, and a replay names it as it starts:
+
+```
+[rec] mode differs: mode.audio=1 (this run: 0)
+```
+
+It records whether a sample driver actually came up rather than which flag was passed, because
+`--no-audio`, `--headless` and a host whose audio device fails to open all land in the same place
+and the last of those is nobody's choice. A recording written before that line existed carries no
+answer, and a replay compares only the lines the file has.
 
 **Recording from boot headlessly needs `--exec "skipmodals 1"`.** The opening dialogue waits for a
 keypress that a headless run never sends.

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -317,9 +317,14 @@ Under `--fixed-dt` a sample's playing state is now answered from its own length 
 rather than from the mixer, so the simulation sees the same answer in both runs. The mixer is
 untouched: this only changes what the simulation is told, and only in a mode no player runs.
 
-This is also why the bug survived so long. Every fixture runs `--headless`, which uses the null
-audio backend, so nothing in the suite had ever exercised the audio path. A recording is the first
-fixture that runs with sound.
+This is also why the bug survived so long. Every fixture runs `--headless`, which skips
+`InitSampleDriver` altogether, so nothing in the suite had ever exercised the audio path. A
+recording fixture is the only one that runs with a sample device up.
+
+Skipping the driver is not the same as building the null backend, and the difference matters to
+anything asking whether a run had audio. `--headless` leaves `Sample_Driver_Enabled` false;
+`SOUND_BACKEND=null` initialises, sets it true, and then returns `FALSE` from every
+`IsSamplePlaying`. Ask `Sample_DriverPlaysSound()` instead, which each backend answers for itself.
 
 **Time spent in a modal is not checked.** The digest fires once per tick, and a modal that waits
 for input spins polls without advancing one: a recorded session that sat in a dialogue choice held

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -341,4 +341,37 @@ case "$aout" in
     ;;
 esac
 
-pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; a flipped mode.audio was reported"
+# Neither arm above can tell the engine writes anything but 0. Every other run in this
+# file is headless, so `mode.audio=0` is also exactly what an accessor stuck at 0 would
+# produce, and the flip is an edit to a file rather than something the engine said. This
+# one opens a real sample device and asks for the other answer.
+#
+# Not `ctl`, which pins --headless, and --headless is the thing under test. SDL's dummy
+# drivers give a device without needing a screen or a speaker. A box that will not start
+# SDL with them is not a recording defect, so skip, and name the reason so a skip cannot
+# quietly become the normal outcome.
+withaudio="$(user_dir)/with-audio.rec"
+rm -f "$withaudio"
+SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy \
+    timeout "$LBA2_TEST_TIMEOUT" "$LBA2_BIN" --no-autosave --load "$LBA2_TEST_SAVE" \
+    --record "$withaudio" --tick 60 --exit >/dev/null 2>&1 ||
+    skip "SDL would not start under its dummy video and audio drivers, so no recording can be made with a device up"
+[ -s "$withaudio" ] || skip "the run with a sample device wrote no recording"
+
+grep -aq 'mode.audio=1' "$withaudio" ||
+    fail "audio: a run with a sample device up still recorded mode.audio=0, so the line reports something other than the driver"
+
+# The case the line exists for, end to end. Only the mode line is asserted: this
+# recording pins no step, so what it diverges on afterwards is the clock rather than the
+# audio, and the warning is the part that has to arrive either way.
+wout="$(ctl --replay "$withaudio" --tick 200 --exit 2>&1 || true)"
+rm -f "$withaudio"
+case "$wout" in
+*"mode differs: mode.audio=1"*) ;;
+*)
+    fail "audio: a recording made with a device up replayed headless without a word; $(
+        printf '%s\n' "$wout" | grep -m1 'mode differs' || echo 'no mode line differed at all')"
+    ;;
+esac
+
+pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; mode.audio was written from the driver and reported both ways"

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -91,6 +91,15 @@ record_and_replay() { # record_and_replay <label> [extra record args...]
     *"numeric.long_double_bits="*) ;;
     *) fail "$label: the header does not declare numeric.long_double_bits" ;;
     esac
+    # Whether audio came up is a simulation input rather than a presentation detail: the
+    # ambience pan is drawn only `if (!IsSamplePlaying(...))`, from the one stream actor
+    # behaviour draws from, and a dialogue with the text off runs until the voice sample
+    # ends. Asserted as 0 rather than merely present, because every run in this file is
+    # headless and a line that reported the flag instead of the driver would say so.
+    case "$head" in
+    *"mode.audio=0"*) ;;
+    *) fail "$label: the header does not declare mode.audio=0, and this run is headless" ;;
+    esac
 
     # More ticks than the recording holds, so the stream runs out and the summary
     # prints. Ending on --tick first means no summary at all, and a run that reported
@@ -302,4 +311,34 @@ case "$bout" in
     ;;
 esac
 
-pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change"
+# The other half of the mode.audio check above. That one shows the line is written; this
+# shows the replay acts on it, which is the half that decides whether a recording made
+# with sound is caught or reported as the simulation diverging. With no sample driver
+# `IsSamplePlaying` is an unconditional no rather than a differently timed yes, so the
+# two runs take different branches and the line is the only warning there is.
+#
+# Flipping the recorded answer is what shows the comparison can fail. One byte, so the
+# stream behind the header is untouched and the replay still runs to the end.
+flipped="$(user_dir)/audio-flipped.rec"
+python3 - "$rec" "$flipped" <<'EOF' || fail "audio: could not flip the recorded audio state"
+import sys
+d = open(sys.argv[1], "rb").read()
+n = d.replace(b"mode.audio=0", b"mode.audio=1", 1)
+assert len(n) == len(d) and n != d, "the flip has to be one byte and has to change something"
+open(sys.argv[2], "wb").write(n)
+EOF
+
+aout="$(ctl --verbose --fixed-dt 16 --load "$LBA2_TEST_SAVE" --replay "$flipped" \
+    --tick 400 --exit 2>&1)" ||
+    fail "audio: replay run exited non-zero ($?): hang or crash"
+rm -f "$flipped"
+
+case "$aout" in
+*"mode differs: mode.audio=1"*) ;;
+*)
+    fail "audio: a recording made with sound replayed silently without a word; $(
+        printf '%s\n' "$aout" | grep -m1 'mode differs' || echo 'no mode line differed at all')"
+    ;;
+esac
+
+pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; a flipped mode.audio was reported"


### PR DESCRIPTION
A recording made with sound cannot be reproduced by a replay without it, and until now
nothing in the file said which one it was.

## Why it is a contract line and not provenance

Whether a sample driver came up changes what the simulation computes, in two places:

- `SOURCES/AMBIANCE.CPP` draws its random pan only `if (!IsSamplePlaying(...))`, from the
  one `rand()` stream actor behaviour draws from. One draw either way and the next actor
  to reach `TM_ANGLE_RND` turns to a different angle.
- A dialogue with the text off spins on `TestSpeak()` until the voice sample ends. That
  is worth hundreds of ticks rather than one draw.

Answering `IsSamplePlaying` from the game clock under fixed-dt made two runs that *both*
have audio agree. It does nothing for this case: `--no-audio` skips `InitSampleDriver`
entirely, so the answer is an unconditional no rather than a differently timed yes, which
is a different branch and not a quieter one. `--headless` implies `--no-audio` and
`--fixed-dt` requires `--headless`, so that is every replay today.

## What it records

The state the run got, not the flag it was passed. Three routes reach the same place:
`--no-audio`, `--headless`, and a host whose audio device fails to open and the run
continues silently (`SOURCES/INITADEL.C`). The last of those is nobody's choice, and it
is the one a player would never think to mention.

```
[rec] mode differs: mode.audio=1 (this run: 0)
[rec] 1 mode line(s) differ; this replay may not reproduce
```

## What prompted it

Three of five reference recordings diverge on replay, all the same shape: `obj[2].Anim
1138/1137`, and `obj[2].Beta` frozen on the replay side while it moves in the recording.
`obj.Anim` is `Obj.Anim.Num`, so that is a *different animation* rather than a frame of
lag, which is the `TM_ANGLE_RND` signature exactly.

All five start from a byte-identical save, same island, same cube, same `TimerRefHR`, so
the clean ones are a real control: session-003321 replays clean over all 1181 ticks from
the same start state and the same config, and session-003231 fails at tick 172. The two
files differ only in the snapshot filename. Nothing a reader could act on.

## Version

Additive, so no bump. A replay compares the lines the file has, so a recording written
before this carries no answer and gains no spurious warning. Confirmed against the
existing corpus: session-003231 still reports exactly one differing line, as before.

## Verification

`ctest -L host_quick` 69/69, `test_record_replay.sh` and `test_record_analog.sh` pass,
`check-arch` and `check-build-graph` clean, docs links and symbols clean.

The test asserts both halves, and both were shown to go red rather than assumed:

| Break | Which half fails |
|---|---|
| Rename the key in the writer | `the header does not declare mode.audio=0` |
| Add `mode.audio=` to the ignore list | `replayed silently without a word` |
