### PR TITLE
feat(record): carry the settings an analog-camera session turns on

### DIFF
--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -1768,6 +1768,31 @@ S32 Control_HasLiveScene(void) { return NumCube >= 0 && NbObjets > 0; }
                                                                  off, and rain draws from the one
                                                                  shared random stream)
 
+   The mouse block came from a third sweep, over a session that orbits rather than walks,
+   because the two before it drove the keyboard and could not have moved any of these. A
+   recording stores the raw motion the frame will deliver, and the *replaying* run's
+   config is what scales it (SOURCES/EXTFUNC.CPP, MouseCameraSensX / MouseCameraDivisor),
+   so the same bytes turn the camera by a different amount and the camera is in the digest:
+
+     MouseCamera 1 -> 0                    diverges at tick 61  (the motion is discarded)
+     MouseSensitivityX 4 -> 8                          tick 61  (the first gesture is X-only)
+     MouseCameraDivisor 4 -> 2                         tick 61
+     MouseSensitivityY 4 -> 8                          tick 131 (the first gesture with a Y)
+     MouseInvertY 0 -> 1                               tick 131
+     FollowCamOrbitGlide 75 -> 20                      tick 101 (where the first gesture ends
+                                                                 and the glide takes over)
+     MouseCameraDrag 1 -> 0                            tick 61  (on a second session, whose
+                                                                 motion holds no button: with
+                                                                 one held both settings orbit
+                                                                 and nothing can tell them apart)
+
+   Each tick is the gesture that setting shapes, which is the check that these are the
+   settings moving the camera rather than a session that diverges anyway.
+
+   Still out, and unexercised rather than shown harmless: ManualCameraSmoothing read clean
+   on both sessions, and reaching it needs an orbit that leaves FollowCamTargetBeta far
+   enough from BetaCam to take the stepped branch in SOURCES/FOLLOWCAM.CPP.
+
    Named by their lba2.cfg keys, so a mismatch names the line the player would edit. */
 S32 Control_DescribeState(char *out, size_t n) {
     int wrote = snprintf(out, n,
@@ -1789,6 +1814,13 @@ S32 Control_DescribeState(char *out, size_t n) {
                          "settings.FollowCamHDPitchGain=%d\n"
                          "settings.FollowCamHDDistGain=%d\n"
                          "settings.FollowCamHDLeanGain=%d\n"
+                         "settings.FollowCamOrbitGlide=%d\n"
+                         "settings.MouseCamera=%d\n"
+                         "settings.MouseCameraDrag=%d\n"
+                         "settings.MouseSensitivityX=%d\n"
+                         "settings.MouseSensitivityY=%d\n"
+                         "settings.MouseInvertY=%d\n"
+                         "settings.MouseCameraDivisor=%d\n"
                          "settings.DetailLevel=%d\n",
                          (int)FixedTimestep,
                          (int)DisplayVSync,
@@ -1806,6 +1838,13 @@ S32 Control_DescribeState(char *out, size_t n) {
                          (int)FollowCamHDPitchGain,
                          (int)FollowCamHDDistGain,
                          (int)FollowCamHDLeanGain,
+                         (int)FollowCamOrbitGlide,
+                         (int)FlagMouseCamera,
+                         (int)FlagMouseCameraDrag,
+                         (int)MouseCameraSensX,
+                         (int)MouseCameraSensY,
+                         (int)MouseCameraInvertY,
+                         (int)MouseCameraDivisor,
                          (int)DetailLevel);
     return wrote > 0 && (size_t)wrote < n;
 }

--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -1789,6 +1789,25 @@ S32 Control_HasLiveScene(void) { return NumCube >= 0 && NbObjets > 0; }
    Each tick is the gesture that setting shapes, which is the check that these are the
    settings moving the camera rather than a session that diverges anyway.
 
+   The right stick is the same story, on a session that orbits with the stick instead of
+   the mouse. Every one of them lands on the gesture for its axis, and none was carried:
+
+     GamepadCameraAnalog 1 -> 0                        tick 61  (the axes are not read)
+     GamepadCameraSensX 5 -> 9                         tick 61
+     GamepadCamMaxBeta 36 -> 72                        tick 61
+     GamepadDeadzone 8000 -> 12000                     tick 61
+     GamepadCameraSensY 5 -> 9                         tick 131 (the gesture on Y)
+     GamepadCameraInvertY 0 -> 1                       tick 131
+     GamepadCamMaxAlpha 10 -> 20                       tick 131
+
+   GamepadDeadzone is the widest of the set and the likeliest to differ between two
+   players, being what a stick with drift gets tuned on. It is not only a camera setting:
+   SOURCES/JOYSTICK.CPP applies it to the left stick's axis-to-scancode conversion too, so
+   it decides what a recorded deflection means for movement as well.
+
+   These are read in SOURCES/INPUT.CPP rather than SOURCES/CONFIG_FILE.CPP, which is worth
+   knowing before concluding that a settings sweep has seen the whole config.
+
    Still out, and unexercised rather than shown harmless: ManualCameraSmoothing read clean
    on both sessions, and reaching it needs an orbit that leaves FollowCamTargetBeta far
    enough from BetaCam to take the stepped branch in SOURCES/FOLLOWCAM.CPP.
@@ -1821,6 +1840,13 @@ S32 Control_DescribeState(char *out, size_t n) {
                          "settings.MouseSensitivityY=%d\n"
                          "settings.MouseInvertY=%d\n"
                          "settings.MouseCameraDivisor=%d\n"
+                         "settings.GamepadCameraAnalog=%d\n"
+                         "settings.GamepadCameraSensX=%d\n"
+                         "settings.GamepadCameraSensY=%d\n"
+                         "settings.GamepadCameraInvertY=%d\n"
+                         "settings.GamepadCamMaxBeta=%d\n"
+                         "settings.GamepadCamMaxAlpha=%d\n"
+                         "settings.GamepadDeadzone=%d\n"
                          "settings.DetailLevel=%d\n",
                          (int)FixedTimestep,
                          (int)DisplayVSync,
@@ -1845,6 +1871,13 @@ S32 Control_DescribeState(char *out, size_t n) {
                          (int)MouseCameraSensY,
                          (int)MouseCameraInvertY,
                          (int)MouseCameraDivisor,
+                         (int)GamepadCameraAnalog,
+                         (int)GamepadCameraSensX,
+                         (int)GamepadCameraSensY,
+                         (int)GamepadCameraInvertY,
+                         (int)GamepadCamMaxBeta,
+                         (int)GamepadCamMaxAlpha,
+                         (int)JoystickDeadzone,
                          (int)DetailLevel);
     return wrote > 0 && (size_t)wrote < n;
 }

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -107,6 +107,15 @@ extern "C" {
    up sessions that work to protect sessions that never did. */
 #define REC_VERSION_MIN 9
 
+/* Every buffer the text header passes through, named once so growing it is one decision
+   rather than five. A real header runs about 1.6 KB: the mode block, the settings, and
+   two binding tables that scale with how much the player has rebound. It grows whenever a
+   setting is shown to move a replay, and the failure at the far end is quiet in both
+   directions -- the writer drops the lines at the end of it, and the reader truncates
+   mid-binding-table and installs a partial one -- so the margin is deliberate rather than
+   a round number that happened to fit. */
+#define REC_HEADER_MAX 4096
+
 /* Versions 9 to 11 wrote the keyframe with no count and exactly this many fields. */
 #define REC_KF_LEGACY_FIELDS 23
 
@@ -205,7 +214,7 @@ static long s_hashMismatchTick = -1;
 static long s_ticksChecked = 0;
 static int s_eof = 0;
 
-static char s_headerBuf[2048];
+static char s_headerBuf[REC_HEADER_MAX];
 
 /* Console commands issued during the session. A recording that carries only input
    cannot reproduce a harness-driven fixture: the walkthrough drives with `teleport`,
@@ -925,7 +934,7 @@ static int record_begin(const char *path, int haveSnapshot) {
        where the staging savegame took its name from. */
     snprintf(s_recPath, sizeof s_recPath, "%s", path);
 
-    char mode[2048];
+    char mode[REC_HEADER_MAX];
     if (!haveSnapshot)
         record_write_snapshot(s_snapshot, sizeof s_snapshot);
     s_snapInline = 1;
@@ -1261,13 +1270,18 @@ static int mode_line_ignored(const char *line) {
    session was played under are not part of the save, and a config edited between the
    recording and the replay reads as the simulation diverging. */
 static void replay_report_mode(void) {
-    char live[2048];
-    char hdr[2048];
+    char live[REC_HEADER_MAX];
+    char hdr[REC_HEADER_MAX];
     char *p, *nl;
     S32 diffs = 0;
 
-    if (!write_mode_lines(live, sizeof live))
+    /* Said rather than returned quietly. This is the run's whole account of what it does
+       not match, so skipping it looks exactly like a run with nothing to report. */
+    if (!write_mode_lines(live, sizeof live)) {
+        fprintf(stderr, "[rec] this run's header did not fit, so nothing was compared "
+                        "against the recording's\n");
         return;
+    }
     snprintf(hdr, sizeof hdr, "%s", s_headerBuf);
 
     for (p = hdr; (nl = strchr(p, '\n')) != NULL; p = nl + 1) {
@@ -2360,7 +2374,7 @@ unsigned long Record_Squeeze(const char *path) {
 /* ---- reporting ------------------------------------------------------------ */
 
 void Record_Report(const char *path) {
-    char live[2048];
+    char live[REC_HEADER_MAX];
     write_mode_lines(live, sizeof live);
 
     if (!path || !path[0]) {

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -271,10 +271,27 @@ found by changing one cfg key at a time on the replay side of a recorded session
 | `MouseSensitivityY` 4 to 8 | tick 131 | Same, on the first gesture with a Y component |
 | `MouseInvertY` 0 to 1 | tick 131 | Same motion, opposite sign |
 | `FollowCamOrbitGlide` 75 to 20 | tick 101 | Where a gesture ends and the glide takes over |
+| `GamepadCameraAnalog` 1 to 0 | tick 61 | The recorded axes are not read at all |
+| `GamepadCameraSensX` 5 to 9 | tick 61 | Same deflection, different orbit speed |
+| `GamepadCamMaxBeta` 36 to 72 | tick 61 | The ceiling that speed scales to |
+| `GamepadDeadzone` 8000 to 12000 | tick 61 | Decides whether a deflection registers |
+| `GamepadCameraSensY` 5 to 9 | tick 131 | Same, on the gesture with a Y component |
+| `GamepadCameraInvertY` 0 to 1 | tick 131 | Same deflection, opposite sign |
+| `GamepadCamMaxAlpha` 10 to 20 | tick 131 | The elevation ceiling |
 
-The mouse rows needed a session that orbits. Two earlier sweeps drove the keyboard and returned a
+The analog rows needed a session that orbits. Two earlier sweeps drove the keyboard and returned a
 column of "none" for all of them, which is why the tick each one fires on is worth reading: it is
-the gesture that setting shapes, not an arbitrary point in a session that would diverge anyway.
+the gesture that setting shapes, not an arbitrary point in a session that would diverge anyway. The
+mouse and stick rows split by axis in exactly the same way, X keys on the X gesture and Y keys on
+the first gesture with a Y component.
+
+`GamepadDeadzone` is the widest of the set and the likeliest to differ between two players, being
+what a stick with drift gets tuned on. It is not only a camera setting: `SOURCES/JOYSTICK.CPP`
+applies it to the left stick's axis-to-scancode conversion too, so it decides what a recorded
+deflection means for movement as well.
+
+The gamepad keys are read in `SOURCES/INPUT.CPP` rather than `SOURCES/CONFIG_FILE.CPP`, which is
+worth knowing before concluding that a sweep has seen the whole config.
 
 The header carries all of these, and a replay names the ones that differ as it starts, by the key
 the player would edit:

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -256,27 +256,40 @@ mid-session recording is not yet self-contained either. Naming the save the sess
 the outstanding work; until then, pass it.
 
 **Some settings have to match, and they are not in the save.** A replay reads the live config, so a
-config edited between recording and replay reads as the simulation diverging. Three are known to do
-it, each found by changing one cfg key at a time on the replay side:
+config edited between recording and replay reads as the simulation diverging. Each of these was
+found by changing one cfg key at a time on the replay side of a recorded session:
 
 | Setting | Diverges at | Why |
 |---|---|---|
 | `FollowCamera` | tick 0 | The camera is in the digest |
 | `FollowCamGroundClearance` | tick 2 | The camera settles at a different distance |
 | `DetailLevel` 3 to 0 | tick 235 | `SetDetailLevel` turns `RainEnable` off, and rain draws from the one shared `rand()` stream |
+| `MouseCamera` 1 to 0 | tick 61 | The recorded motion is discarded instead of turning the camera |
+| `MouseCameraDrag` 1 to 0 | tick 61 | Orbits on motion the recording made with no button held |
+| `MouseSensitivityX` 4 to 8 | tick 61 | The recording stores raw motion; the replay scales it |
+| `MouseCameraDivisor` 4 to 2 | tick 61 | The other half of that scaling |
+| `MouseSensitivityY` 4 to 8 | tick 131 | Same, on the first gesture with a Y component |
+| `MouseInvertY` 0 to 1 | tick 131 | Same motion, opposite sign |
+| `FollowCamOrbitGlide` 75 to 20 | tick 101 | Where a gesture ends and the glide takes over |
 
-The header carries those and the rest of the Auto camera's block, and a replay names the ones that
-differ as it starts, by the key the player would edit:
+The mouse rows needed a session that orbits. Two earlier sweeps drove the keyboard and returned a
+column of "none" for all of them, which is why the tick each one fires on is worth reading: it is
+the gesture that setting shapes, not an arbitrary point in a session that would diverge anyway.
+
+The header carries all of these, and a replay names the ones that differ as it starts, by the key
+the player would edit:
 
 ```
-[rec] mode differs: settings.FollowCamGroundClearance=20000 (this run: 600)
+[rec] mode differs: settings.MouseSensitivityX=4 (this run: 8)
 [rec] 1 mode line(s) differ; this replay may not reproduce
 ```
 
-Clean on the sessions swept so far, and so deliberately not carried: `AllCameras`, the mouse
-settings, and `Shadow` (`SetDetailLevel` overwrites it at MainLoop entry anyway). The boundary is
-empirical rather than principled: a setting joins the block when a replay is shown to turn on it,
-and a sweep that came back clean was run on one session rather than on every path.
+Not carried, and the distinction matters: `Shadow` is inert because `SetDetailLevel` overwrites it
+at MainLoop entry, while `AllCameras`, `ManualCameraSmoothing` and `FlagDisplayText` have only read
+clean on the sessions swept so far. `ManualCameraSmoothing` needs an orbit that leaves the camera
+far enough from its target to take the stepped branch in `SOURCES/FOLLOWCAM.CPP`, and
+`FlagDisplayText` needs a dialogue, which none of these sessions has. The boundary is empirical
+rather than principled: a setting joins the block when a replay is shown to turn on it.
 
 **The console is not recorded, and used to take the clock with it.** Its toggle arrives as an
 SDL key event rather than through the polled key table the recorder samples, so a replay never


### PR DESCRIPTION
Stacked on #608, which is the same argument for a different unrecorded input. Review that
one first; this diff is two commits on top of it, one per input device.

## The gap

A recording stores the **raw** motion or deflection the frame will deliver, and the
*replaying* run's config is what turns it into camera movement:

```c
/* SOURCES/EXTFUNC.CPP, mouse */
S32 dx = rawX * MouseCameraSensX / MouseCameraDivisor;

/* SOURCES/EXTFUNC.CPP, right stick */
S32 dBeta = StickAxisToCamStep(rsx, GamepadCameraSensX, GamepadCamMaxBeta);
```

So the same bytes turn the camera by a different amount on a machine configured
differently, and the camera is in the state digest. **Fourteen settings, none carried.**
For an analog session `MouseCamera` and `GamepadCameraAnalog` are what `FollowCamera` is
for any session: the recorded input is discarded and the replay never orbits at all.

## Measured, on sessions that orbit instead of walking

The house rule for this block is that a setting joins it when a replay is *shown* to turn
on it, so this starts with the sweep rather than the code.

| Setting | First mismatch | What fires there |
|---|---|---|
| `MouseCamera` 1 to 0 | **61** | The motion is discarded |
| `MouseSensitivityX` 4 to 8 | **61** | The first gesture is X-only |
| `MouseCameraDivisor` 4 to 2 | **61** | The other half of the scaling |
| `MouseCameraDrag` 1 to 0 | **61** | Second session, motion with no button held |
| `MouseSensitivityY` 4 to 8 | **131** | The first gesture with a Y component |
| `MouseInvertY` 0 to 1 | **131** | Same motion, opposite sign |
| `FollowCamOrbitGlide` 75 to 20 | **101** | Where the gesture ends and the glide takes over |
| `GamepadCameraAnalog` 1 to 0 | **61** | The axes are not read at all |
| `GamepadCameraSensX` 5 to 9 | **61** | Same deflection, different orbit speed |
| `GamepadCamMaxBeta` 36 to 72 | **61** | The ceiling that speed scales to |
| `GamepadDeadzone` 8000 to 12000 | **61** | Decides whether a deflection registers |
| `GamepadCameraSensY` 5 to 9 | **131** | Same, on the gesture with a Y |
| `GamepadCameraInvertY` 0 to 1 | **131** | Same deflection, opposite sign |
| `GamepadCamMaxAlpha` 10 to 20 | **131** | The elevation ceiling |

**The tick each one fires on is the evidence.** Both devices split by axis in exactly the
same way: X keys on the X gesture, Y keys on the first gesture with a Y, the glide where
the first gesture stops. That is what separates this from a session that would have
diverged anyway.

`MouseCameraDrag` needed a second recording. With a button held, `orbitActive` is true
either way and nothing can tell the two settings apart; motion with no button is what
discriminates.

Two earlier sweeps drove the keyboard and returned "none" for all fourteen, which is why
the block was drawn where it was. `FollowCamOrbitGlide` was already inside its stated
boundary, the Auto camera's own block, and outside the list.

## Two things worth knowing beyond the list

`GamepadDeadzone` is the widest of the set and the likeliest to differ between two
players, being what a stick with drift gets tuned on. It is **not only a camera setting**:
`SOURCES/JOYSTICK.CPP` applies it to the left stick's axis-to-scancode conversion too, so
it decides what a recorded deflection means for movement as well.

The gamepad keys are read in `SOURCES/INPUT.CPP`, not `SOURCES/CONFIG_FILE.CPP`. A sweep
of the config file alone does not find them, which is said in both the comment and the doc
because the next person auditing this block will grep the same file first.

## After

The divergence still happens, because the header carries settings rather than applying
them. What changes is that the replay names the cause before it starts:

```
[rec] mode differs: settings.GamepadDeadzone=8000 (this run: 12000)
[rec] 1 mode line(s) differ; this replay may not reproduce
```

Confirmed for all fourteen: every row above now names its own cfg key, and the baseline
stays clean with no mode line.

## Left out on purpose

`ManualCameraSmoothing` read clean on both mouse sessions. Reaching it needs an orbit that
leaves the camera far enough from its target to take the stepped branch in
`SOURCES/FOLLOWCAM.CPP`, and I did not produce one. Unexercised is not harmless, and the
doc now separates the two: `Shadow` is genuinely inert (`SetDetailLevel` overwrites it at
MainLoop entry), while `AllCameras`, `ManualCameraSmoothing` and `FlagDisplayText` have
only read clean so far. `FlagDisplayText` needs a dialogue, which none of these sessions
has.

## The sweep guards its own worst failure

A `sed` that matches nothing reads exactly like a clean result, which is how a settings
sweep produces a column of false negatives. Every key is confirmed present in the fixture
config, and the edit is confirmed to have changed the file, before the replay runs.

The fixture also had to move scenes: the default test save loads cube 3, which is
interior, and the Auto camera is exterior-only. That is the documented reason two earlier
sweeps were thrown away.

## The buffer, which this PR is what consumes

Fourteen lines took the header from 1.3 KB to 1.8 KB against a 2 KB buffer. The size is
now named once instead of repeated at five sites, and raised to 4 KB.

Worth raising rather than leaving: the failure at that boundary is quiet in **both**
directions. The writer drops the lines at the end of the header, and the reader truncates
mid-binding-table and installs a partial one. The mode comparison also returned silently
when its own header did not fit, which reads exactly like a run with nothing to report;
it now says so.

## Verification

`ctest -L host_quick` 69/69, `test_record_replay.sh` and `test_record_analog.sh` pass,
check-arch and check-build-graph clean, docs links and symbols clean.
