### PR TITLE
fix(console): the command table was full, so zonelist and perftrace never registered

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE.CPP
+++ b/SOURCES/CONSOLE/CONSOLE.CPP
@@ -23,8 +23,17 @@
 #define CONSOLE_WRAP_WIDTH 78
 #define CONSOLE_PANEL_HEIGHT 140
 #define CONSOLE_LINE_HEIGHT 9
-#define CONSOLE_MAX_CMDS 48  /* ~27 registered today; headroom before the loud drop */
-#define CONSOLE_MAX_CVARS 48 /* ~28 registered today; headroom before the loud drop */
+/* Table sizes for the registered commands and cvars. `cmdlist` and `varlist`
+ * print what is actually in each table, so occupancy is one console line away
+ * and never has to be taken from a comment.
+ *
+ * Bumped from 48, which the command table had reached: `zonelist` and
+ * `perftrace` register last, were dropped, and were absent from every build
+ * while the documentation went on describing them. The drop was reported all
+ * along, but only on a boot-time stderr line, which is why it went unseen; it
+ * now also lands in the scrollback, beside the `cmdlist` that shows the gap. */
+#define CONSOLE_MAX_CMDS 96
+#define CONSOLE_MAX_CVARS 96
 #define CONSOLE_MAX_ARGV 16
 #define CONSOLE_KEY_QUEUE_SIZE 32
 /* Sentinel scancode for a queued text-input character (vs a physical key). */
@@ -1527,6 +1536,8 @@ void Console_RegisterCommandEx(const char *name, Console_CmdFn callback, const c
     if (s_cmd_count >= CONSOLE_MAX_CMDS) {
         fprintf(stderr, "console: command table full (%d), dropped '%s' (raise CONSOLE_MAX_CMDS)\n",
                 CONSOLE_MAX_CMDS, name ? name : "(null)");
+        Console_PrintColored(CONSOLE_COL_ERROR, "command table full (%d), dropped '%s' (raise CONSOLE_MAX_CMDS)",
+                             CONSOLE_MAX_CMDS, name ? name : "(null)");
         return;
     }
     s_cmds[s_cmd_count].name = name;
@@ -1546,6 +1557,8 @@ void Console_RegisterCvarCoerced(const char *name, void *ptr, Console_CvarType t
     if (s_cvar_count >= CONSOLE_MAX_CVARS) {
         fprintf(stderr, "console: cvar table full (%d), dropped '%s' (raise CONSOLE_MAX_CVARS)\n",
                 CONSOLE_MAX_CVARS, name ? name : "(null)");
+        Console_PrintColored(CONSOLE_COL_ERROR, "cvar table full (%d), dropped '%s' (raise CONSOLE_MAX_CVARS)",
+                             CONSOLE_MAX_CVARS, name ? name : "(null)");
         return;
     }
     s_cvars[s_cvar_count].name = name;


### PR DESCRIPTION
`CONSOLE_MAX_CMDS` was 48, and a stock `linux` preset build registers exactly 48 commands. The last two registrations were thrown away:

```
console: command table full (48), dropped 'zonelist' (raise CONSOLE_MAX_CMDS)
console: command table full (48), dropped 'perftrace' (raise CONSOLE_MAX_CMDS)
```

Neither command existed in any shipped build, while `zonelist` had a table row in [docs/CONSOLE.md](https://github.com/LBALab/lba2-classic-community/blob/main/docs/CONSOLE.md) and `perftrace` had the whole of [docs/PERFTRACE.md](https://github.com/LBALab/lba2-classic-community/blob/main/docs/PERFTRACE.md) describing it. The comment on the constant still read "~27 registered today".

## The change

One file, `SOURCES/CONSOLE/CONSOLE.CPP`:

- `CONSOLE_MAX_CMDS` and `CONSOLE_MAX_CVARS` go from 48 to 96. The cvar table was at 39 of 48, so raising only the command table would leave the same trap armed nine cvars from now.
- The stale counts in the comment are replaced by rationale and a pointer to `cmdlist` / `varlist`, which print the live occupancy so it never has to be taken from a comment again.
- The overflow now also reaches the console scrollback in error red. It was already reported, but only by an `fprintf` to stderr during registration, which happens long before anyone is looking at a terminal. That is why it went unseen.

`Console_PrintColored` is in the same TU, so this adds no link dependency to the `console` library and the host tests need no new stubs.

## Verification

Driving `cmdlist; varlist` headlessly on the `linux` preset:

| Check | Result |
| --- | --- |
| Table before to after | 48 cmds / 39 cvars, then 50 / 39 |
| Diff of the two listings | gained `perftrace` and `zonelist`, lost nothing |
| Overflow path, ceilings forced to 45 and 37 | 5 command and 2 cvar drops, on both stderr and the console |
| `ctest -R console` | 6/6 passed |
| `scripts/ci/check-arch.py` | 8 rules over 571 files, clean |

The forced-low arm is the point of the verification. Without it, "no drops after the bump" only proves the check did not run.
