### PR TITLE
fix(record): a recorder-armed step left the game clock frozen

### DIFF
--- a/LIB386/H/SYSTEM/TIMER.H
+++ b/LIB386/H/SYSTEM/TIMER.H
@@ -33,7 +33,13 @@ void SetTimerHR(U32 time);
 // carries no default step (the caller supplies it). Default builds and any run that
 // does not call Timer_EnableFixedDt() are byte-for-byte unaffected. See docs/CONTROL.md.
 void Timer_EnableFixedDt(U32 dt_ms); // arm fixed-dt; seeds the virtual clock to now
-void Timer_FixedDtAdvance();         // advance the virtual clock by dt_ms (once per tick)
+// Hand the clock back to SDL_GetTicks(). For a step armed mid-session by something that
+// ends -- a recording -- rather than by a flag that owns the whole run: without it the
+// session keeps advancing game time by dt per frame with nothing pacing it, so the game
+// runs at whatever rate it renders at for as long as it lasts. TimerRefHR is left where
+// it has reached; only the source of new time changes. Inert if not armed.
+void Timer_DisableFixedDt(void);
+void Timer_FixedDtAdvance(); // advance the virtual clock by dt_ms (once per tick)
 S32 Timer_FixedDtActive();
 S32 Timer_FixedDtValue(void); // armed step in ms, 0 when not armed
 U32 Timer_ClockSource(void);  // what ManageTime would read right now

--- a/LIB386/SYSTEM/TIMER.CPP
+++ b/LIB386/SYSTEM/TIMER.CPP
@@ -108,6 +108,24 @@ void Timer_EnableFixedDt(U32 dt_ms) {
     FixedDtSkipPresent = 0;
 }
 
+void Timer_DisableFixedDt(void) {
+    if (!FixedDtActive)
+        return;
+    FixedDtActive = 0;
+    FixedDtTicking = 0;
+    FixedDtSkipPresent = 0;
+    FixedDtOverlayPresent = 0;
+    // Resync LastTime to the wall clock before any of it can be banked. The two clocks
+    // have been running at different rates since the arm -- the virtual one moves dt per
+    // frame, the wall one moves in wall time -- so by now they are far apart, and the
+    // first ManageTime() after this would bank the whole difference into TimerRefHR:
+    // forwards if the wall clock is ahead, and much further if it is behind, since the
+    // subtraction is unsigned. Re-anchor the FPS window for the same reason.
+    LastTime = SDL_GetTicks();
+    LastEvaluate = LastTime;
+    CmptFrame = 0;
+}
+
 /* The expression ManageTime reads, evaluated now. Recording SDL_GetTicks() directly is
    wrong under fixed-dt, where the game runs on the virtual clock and the wall clock is
    unrelated to it. */

--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -1087,6 +1087,16 @@ void Control_TickHook(void) {
        harness flag at all, so the hook is otherwise dead for exactly the run that
        matters most. */
     Record_TickHook();
+    /* The recorder arms the fixed-dt clock itself for a mid-session `rec start`, and
+       nothing else was advancing it. s_have_fixed_dt is set by --fixed-dt and by nothing
+       else, and the advance that reads it sits below the armed check, so a run that armed
+       the step any other way was left with a virtual clock that was armed and frozen.
+       Game time stopped: the hero stopped walking, and the recording still replayed clean
+       because both ends agreed about a stopped game. The step comes from whoever armed
+       it, so this cannot double-advance the harness path -- record_reload_issue only arms
+       when Timer_FixedDtActive() is false. */
+    if (!s_have_fixed_dt && Timer_FixedDtActive())
+        Timer_FixedDtAdvance();
     if (!s_armed)
         return;
     s_hook_calls++;

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -273,6 +273,10 @@ static unsigned s_reloadClock = 0;
    recorded under `--fixed-dt 20` reproduces on 20 and on nothing else, and the default
    below would silently replay it at a different rate. */
 static S32 s_reloadDt = 0;
+/* Whether the step in force is one the recorder armed. Only then is it the recorder's to
+   put back: a run given --fixed-dt is pinned for its whole length by something that is
+   not this. */
+static int s_recArmedDt = 0;
 /* Frame pacing while recording. A pinned step makes game time advance by a constant
    per frame, and the engine has no frame limiter, so without holding each frame back
    the session runs at whatever rate it renders at: 600 ticks of a 16 ms step took
@@ -1006,8 +1010,10 @@ static void record_reload_issue(void) {
      *
      * The replay takes the step out of the recording's header rather than the default,
      * so a session played at some other step replays at that one. */
-    if (!Timer_FixedDtActive())
+    if (!Timer_FixedDtActive()) {
         Timer_EnableFixedDt((U32)(s_reloadDt > 0 ? s_reloadDt : REC_DEFAULT_DT));
+        s_recArmedDt = 1;
+    }
 
     /* Before the load, because the load is what reads it. A savegame restores the
        fields the hash covers and re-derives the rest, and some of what it re-derives is
@@ -1206,6 +1212,34 @@ int Record_Start(const char *path) {
     return 1;
 }
 
+/* Give the simulation step back, if it was the recorder that took it.
+ *
+ * A pinned step advances game time by dt per rendered frame rather than by wall clock,
+ * and the recorder paces frames to match only while it is recording. So a session that
+ * kept the step after `rec stop` ran at whatever rate it rendered at: measured headless,
+ * 1.00x real time before a recording and 3.12x after one. On a vsynced 60 Hz window it
+ * would read as roughly right and on a 144 Hz one as more than twice too fast, which is
+ * the worse failure of the two -- it looks like the game, only wrong.
+ *
+ * Not for a run given --fixed-dt: there the step belongs to the whole run and to whoever
+ * asked for it, and this is only ever putting back what a mid-session `rec start` took. */
+static void record_release_step(void) {
+    /* The frame clock belongs to the session rather than to the step, and it has to go
+       first. While fixed-dt is armed Record_ClockHook returns before ever reading it, so
+       a stale one is invisible -- until the step is handed back, and then it pins
+       ManageTime at whatever reading the session ended on and game time stops dead.
+       Measured on the way to this: 3.12x real time before clearing it, 0.00x after
+       handing back the step without. Cleared for every session, armed or not, so the
+       two cannot come apart again. */
+    s_frameClock = 0;
+    s_frameClockValid = 0;
+
+    if (!s_recArmedDt)
+        return;
+    s_recArmedDt = 0;
+    Timer_DisableFixedDt();
+}
+
 int Record_Stop(void) {
     int wasRecording = s_recording;
     char endPath[ADELINE_MAX_PATH];
@@ -1219,12 +1253,16 @@ int Record_Stop(void) {
         else
             s_reloadState = 0;
         s_beginAtPoll = 0;
-        if (!s_f)
+        if (!s_f) {
+            record_release_step();
             return 1;
+        }
     }
 
-    if (!s_f)
+    if (!s_f) {
+        record_release_step();
         return 0;
+    }
 
     /* A second snapshot where the recording ends, on the same mechanics as the one at
        the start. The per-tick hash says which tick a replay stopped matching; this says
@@ -1254,6 +1292,7 @@ int Record_Stop(void) {
     s_snapInline = 0;
     s_recPath[0] = 0;
     bindings_restore();
+    record_release_step();
     return 1;
 }
 

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -97,6 +97,12 @@ Who pins it depends on where the recording starts, and the split is not a conven
 A replay pins whatever step the recording's header names, so a session played at some other step
 replays at that one rather than at the default.
 
+A recording whose step the recorder pinned carries `setup.reload_clock=0`, where one made
+under the flag carries the real reading. That is not a defect and not worth reconciling:
+`Timer_EnableFixedDt` zeroes `TimerRefHR`, so on that path the reload genuinely is
+performed at clock 0, on both ends, every time. The post-load `clock.timer_ref_hr` is
+identical either way, because the savegame is what restores it.
+
 **Both ends have to arm it the same way, and matching values is not enough.** Arming at boot and
 arming at the reload are different points in the run, and `Timer_EnableFixedDt` reseeds the clock
 where it is called, so a recording made one way and replayed the other diverges even at the same

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -89,13 +89,21 @@ Who pins it depends on where the recording starts, and the split is not a conven
 
 - **From boot, with `--record`,** the run has no load to hide a clock reset behind, so the step has
   to be on the command line: `--fixed-dt 16`.
-- **Mid-session, with `rec start`,** the recorder pins it. It can, because it already writes a
+- **Mid-session, with `rec start`,** the recorder pins it, and gives it back on `rec stop`
+  or when a replay ends. It can, because it already writes a
   snapshot and reloads it, and `Timer_EnableFixedDt` zeroes `TimerRefHR` -- which is safe only where
   a load follows to put the clock back. A player whose session is already in progress cannot be
   told to relaunch, so this is the path that makes recording something they can reach.
 
 A replay pins whatever step the recording's header names, so a session played at some other step
 replays at that one rather than at the default.
+
+The step is given back where it was taken. A pinned step advances game time by dt per rendered
+frame rather than by wall clock, and frames are paced to match only while a recording is running,
+so a session that kept the step afterwards ran at whatever rate it rendered at -- measured
+headless, 1.00x real time before a recording and 3.12x after one. `rec stop` and the end of a
+replay hand it back, and a run given `--fixed-dt` keeps its own: that step belongs to the whole
+run and to whoever asked for it.
 
 A recording whose step the recorder pinned carries `setup.reload_clock=0`, where one made
 under the flag carries the real reading. That is not a defect and not worth reconciling:

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -452,4 +452,71 @@ case "$emptyout" in
 *) fail "console loop: 'rec play' with no recordings to play said nothing about it" ;;
 esac
 
-pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; mode.audio was written from the driver and reported both ways; a session recorded in one run replayed in the next with no flags and no paths"
+# Did the session do anything?
+#
+# Every arm above asserts that a replay agrees with its recording, and none asserts that
+# there was anything to agree about. A recording of a hero who never moved replays clean
+# and says nothing, and that is not hypothetical here: LBA2_TEST_SAVE is the game opening,
+# where the scene's own script owns the hero and injected input is inert, so those arms
+# record a stationary session and the per-tick digest faithfully confirms that one
+# stationary session reproduces another. A bug that froze the game clock outright -- hero
+# unable to walk, game time not advancing at all -- passed every one of them.
+#
+# So this arm walks the hero and asks three separate questions: did he move while
+# recording, did the replay move him, and did it put him in the same place.
+#
+# The in-tree corpus save rather than LBA2_TEST_SAVE, because the answer has to come from
+# a scene where input reaches the hero and that cannot depend on which save a machine
+# happens to point at. No --fixed-dt either: the step the recorder pins for itself is the
+# path the frozen clock was on, and the flag hid it.
+movesave="$REPO/tests/savegame/corpus/saves/steam_classic_2023/Anon1.LBA"
+[ -f "$movesave" ] || fail "movement: the corpus save is missing from $movesave"
+
+movedir="$(mktemp -d)"
+trap 'rm -rf "$here" "$loopdir" "$emptydir" "$movedir"' EXIT
+
+# hero_xz <state.json> -- the engine's own dump, because `status` reports Nxw/Nyw/Nzw,
+# which are collision scratch and not the hero.
+hero_xz() {
+    python3 -c "
+import json, sys
+h = json.load(open(sys.argv[1]))['hero']
+print(h['x'], h['z'])" "$1"
+}
+
+# Idle control: the same save, the same length of run, no input. This is what 'the hero
+# moved' is measured against, so that no coordinate has to be written down here.
+LBA2_USER_DIR="$movedir" ctl --load "$movesave" --tick 700 \
+    --dump-state "$movedir/idle.json" --exit >/dev/null 2>&1 ||
+    fail "movement: the idle control run exited non-zero ($?) — hang or crash"
+
+LBA2_USER_DIR="$movedir" ctl --load "$movesave" \
+    --exec-at 20 "rec start" --exec-at 200 "key up 300" --exec-at 620 "rec stop" \
+    --tick 700 --dump-state "$movedir/rec.json" --exit >/dev/null 2>&1 ||
+    fail "movement: the recording run exited non-zero ($?) — hang or crash"
+
+idle_xz="$(hero_xz "$movedir/idle.json")" || fail "movement: could not read the idle state dump"
+rec_xz="$(hero_xz "$movedir/rec.json")" || fail "movement: could not read the recorded state dump"
+
+if [ "$idle_xz" = "$rec_xz" ]; then
+    fail "movement: the hero is at $rec_xz with input and $idle_xz without it — the recorded session never moved, so a clean replay of it would prove nothing"
+fi
+
+moveout="$(LBA2_USER_DIR="$movedir" ctl --load "$movesave" \
+    --exec-at 20 "rec play" --tick 900 --dump-state "$movedir/play.json" --exit 2>&1)" ||
+    fail "movement: the replay run exited non-zero ($?) — hang or crash"
+
+case "$moveout" in
+*"first hash mismatch -1"*) ;;
+*)
+    fail "movement: $(printf '%s\n' "$moveout" |
+        grep -m1 -e 'replay ended' -e 'cannot open' -e 'recordings in' ||
+        echo 'the replay said nothing')"
+    ;;
+esac
+
+play_xz="$(hero_xz "$movedir/play.json")" || fail "movement: could not read the replayed state dump"
+[ "$play_xz" = "$rec_xz" ] ||
+    fail "movement: the recording left the hero at $rec_xz and the replay left him at $play_xz — the digest matched every tick, so this is the replay ending somewhere else, not diverging"
+
+pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; mode.audio was written from the driver and reported both ways; a session recorded in one run replayed in the next with no flags and no paths; a recorded walk moved the hero and the replay walked it again"

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -484,18 +484,30 @@ h = json.load(open(sys.argv[1]))['hero']
 print(h['x'], h['z'])" "$1"
 }
 
-# Idle control: the same save, the same length of run, no input. This is what 'the hero
-# moved' is measured against, so that no coordinate has to be written down here.
-LBA2_USER_DIR="$movedir" ctl --load "$movesave" --tick 700 \
-    --dump-state "$movedir/idle.json" --exit >/dev/null 2>&1 ||
-    fail "movement: the idle control run exited non-zero ($?) — hang or crash"
+# The control is the same command line with the input taken out, rather than a plain idle
+# run: `rec start` pins the step and a run without it free-runs on the host clock, so a
+# control missing both would be answering about two variables at once and could pass on
+# the wrong one. Here the only difference between the two runs is the key.
+#
+# `key` rather than `input`, and that is not interchangeable. `key` holds a raw scancode in
+# TabKeys, which is where a player's input arrives and what the recorder captures at the
+# poll hook. `input` is OR'd straight into Input by MainLoop and never touches TabKeys, so
+# a recording only reproduces it because the console command itself was recorded and runs
+# again -- which would leave this arm passing while testing command replay rather than
+# input replay.
+# Its own profile, so the folder the replay below reads holds exactly one recording and
+# `rec play` with no argument cannot pick the control's by accident.
+LBA2_USER_DIR="$movedir/control" ctl --load "$movesave" \
+    --exec-at 20 "rec start" --exec-at 620 "rec stop" \
+    --tick 700 --dump-state "$movedir/idle.json" --exit >/dev/null 2>&1 ||
+    fail "movement: the control run exited non-zero ($?) — hang or crash"
 
 LBA2_USER_DIR="$movedir" ctl --load "$movesave" \
     --exec-at 20 "rec start" --exec-at 200 "key up 300" --exec-at 620 "rec stop" \
     --tick 700 --dump-state "$movedir/rec.json" --exit >/dev/null 2>&1 ||
     fail "movement: the recording run exited non-zero ($?) — hang or crash"
 
-idle_xz="$(hero_xz "$movedir/idle.json")" || fail "movement: could not read the idle state dump"
+idle_xz="$(hero_xz "$movedir/idle.json")" || fail "movement: could not read the control state dump"
 rec_xz="$(hero_xz "$movedir/rec.json")" || fail "movement: could not read the recorded state dump"
 
 if [ "$idle_xz" = "$rec_xz" ]; then

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -531,4 +531,54 @@ play_xz="$(hero_xz "$movedir/play.json")" || fail "movement: could not read the 
 [ "$play_xz" = "$rec_xz" ] ||
     fail "movement: the recording left the hero at $rec_xz and the replay left him at $play_xz — the digest matched every tick, so this is the replay ending somewhere else, not diverging"
 
-pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; mode.audio was written from the driver and reported both ways; a session recorded in one run replayed in the next with no flags and no paths; a recorded walk moved the hero and the replay walked it again"
+# Giving the step back.
+#
+# A mid-session `rec start` pins the simulation step, and a pinned step advances game time
+# by dt per rendered frame rather than by wall clock. The recorder paces frames to match
+# only while it is actually recording, so a session that kept the step afterwards ran at
+# whatever rate it rendered at: measured headless, 1.00x real time before a recording and
+# 3.12x after one. On a vsynced 60 Hz window that reads as roughly right and on a 144 Hz
+# one as more than twice too fast, which is the worse of the two -- it looks like the game,
+# only wrong.
+#
+# A run given --fixed-dt is the other case and must not be touched: there the step belongs
+# to the whole run and to whoever asked for it. So both directions are asserted here, and
+# the arm is the reason: a release that fired for everyone would silently unpin every
+# harness fixture in this file.
+#
+# `rec info` reports the live run's mode, which makes this a question about a printed
+# number rather than about elapsed time.
+stepdir="$(mktemp -d)"
+trap 'rm -rf "$here" "$loopdir" "$emptydir" "$movedir" "$stepdir"' EXIT
+
+# Through a file rather than a pipeline. The suite does not set `pipefail`, so a pipeline
+# carries the status of its last command -- `tr` here, which succeeds whatever the engine
+# did -- and a `|| fail ... exited non-zero` hung off one can never fire. Run, check, then
+# read.
+step_after_stop() { # step_after_stop <extra ctl args...>
+    LBA2_USER_DIR="$stepdir" ctl --load "$movesave" "$@" \
+        --exec-at 20 "rec start" --exec-at 300 "rec stop" --exec-at 320 "rec info" \
+        --tick 400 --exit > "$stepdir/out.txt" 2>&1 || return $?
+    # The last one: `rec stop` prints this same block itself, before it stops.
+    grep 'mode.fixed_dt=' "$stepdir/out.txt" | tail -1 | tr -d ' '
+}
+
+recarmed="$(step_after_stop)" ||
+    fail "step: the recorder-armed run exited non-zero ($?) — hang or crash"
+case "$recarmed" in
+*"mode.fixed_dt=0") ;;
+*)
+    fail "step: the recorder pinned the step and still held it after rec stop ($recarmed) — the session keeps running at frame rate instead of wall clock"
+    ;;
+esac
+
+flagarmed="$(step_after_stop --fixed-dt 16)" ||
+    fail "step: the flag-armed run exited non-zero ($?) — hang or crash"
+case "$flagarmed" in
+*"mode.fixed_dt=16") ;;
+*)
+    fail "step: --fixed-dt 16 was given and rec stop unpinned it anyway ($flagarmed) — the recorder is releasing a step it did not take"
+    ;;
+esac
+
+pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; mode.audio was written from the driver and reported both ways; a session recorded in one run replayed in the next with no flags and no paths; a recorded walk moved the hero and the replay walked it again; the recorder gave the step back and left the flag's alone"


### PR DESCRIPTION
Found by driving a record/replay loop over the control socket and watching the hero
instead of the hashes. #610 is on main, and the mid-session recording it enables does not
work: the game clock stops.

## The bug

A mid-session `rec start` pins the step by calling `Timer_EnableFixedDt`, which arms the
virtual clock. Nothing then advanced it. `Timer_FixedDtAdvance` is driven by
`s_have_fixed_dt`, which the `--fixed-dt` flag sets and nothing else does, and the call
sits below `Control_TickHook`'s `if (!s_armed) return` -- so a player who passed no
harness flag could not reach it from either direction.

Armed and stopped. `TimerRefHR` sampled at three points across such a run:

```
with --fixed-dt 16 : 6798705  6800145  6802225
no flag            : 6798097  6798097  6798097
```

Game time not advancing means the hero cannot walk. Same save, same `key up 300`:

| Run | Hero ends at |
|---|---|
| `key up 300`, `--fixed-dt 16`, no recording | (10142, 20284) |
| `rec start` then `key up 300`, no flag | **(4831, 10873)** — where he started |
| `rec start` then `key up 300`, `--fixed-dt 16` | (10142, 20284) |

## Why every check passed anyway

The recordings replayed clean: 398 ticks checked, first hash mismatch -1, clock drift
0 ms. Both ends agreed about a stopped game. A per-tick state digest cannot tell a
faithful reproduction from two identical stalls, and it is the recorder's only oracle.

The fix advances the step above the armed check, and only when the flag did not, so the
harness path is untouched: `record_reload_issue` arms only when `Timer_FixedDtActive()` is
false, so the two can never both advance.

## The second half: the suite could not see it

Every arm in `test_record_replay.sh` records `LBA2_TEST_SAVE`, which is the game opening.
The scene's own script owns the hero there and injected input is inert, so those sessions
never moved -- before this bug, not because of it. A recording of a hero who never moved
replays clean and says nothing, and eight arms of it say nothing eight times.

The new arm walks the hero and asks three questions none of the others do: did he move
while recording, did the replay move him, and did it put him in the same place. It
measures against an idle control run rather than a coordinate written down here, uses the
in-tree corpus save because input has to reach the hero, and passes no `--fixed-dt`
because the flag is exactly what hid this.

With the fix reverted it is the only arm in the file that fails:

```
FAIL: record_replay: movement: the hero is at 9844 4189 with input and 9844 4189
without it -- the recorded session never moved, so a clean replay of it would prove
nothing
```

## Confirmed end to end

Driven over `--listen`, `rec start` -> `key up 300` -> `rec stop` -> `rec play`, with the
hero position read from the engine's own state dump each sample. The recording walks him
from (4831, 2500, 10873) to (10142, 250, 20284) -- a walk and then a fall, animation 67
then 5 then 11 -- and the replay retraces the same 302 sampled positions and ends in the
same place.

One thing to know before reading such a session: `status` reports `Nxw/Nyw/Nzw`, which are
collision scratch and not the hero. It looks frozen whatever the hero is doing. The hero is
`hero->Obj.X/Y/Z`, which `--dump-state` and the `dumpstate` verb write as `hero.x/y/z`.

## Testing

69/69 host tests, the full automation suite (72 pass, 2 skip), clang-format and check-arch
clean. `test_record_replay.sh` goes from 2m13s to 2m31s.


---

## Also: the step is now given back

Asked while reviewing this: does anything reset the pinned step afterwards? It did not.
`Timer_EnableFixedDt` had no counterpart at all, so a mid-session `rec start` pinned the
step for the rest of the session. A pinned step advances game time by dt per rendered
frame rather than by wall clock, and frames are paced to match only while a recording is
running. Measured headless over the control socket:

| | Game time per wall second |
|---|---|
| Before any recording | 1.00x |
| While recording | 1.00x |
| After `rec stop` | **3.12x** |

On a vsynced 60 Hz window that reads as roughly right and on a 144 Hz one as more than
twice too fast, which is the worse of the two because it looks like the game.

`Timer_DisableFixedDt` resyncs `LastTime` to the wall clock before handing back: the two
clocks have been running at different rates since the arm, so the first `ManageTime` after
the handover would otherwise bank the whole difference into `TimerRefHR` -- forwards if the
wall clock is ahead, and much further if it is behind, since the subtraction is unsigned.
`TimerRefHR` itself is left where the session reached.

Only the step the recorder took. A run given `--fixed-dt` keeps its own: that step belongs
to the whole run, and releasing it for everyone would silently unpin every harness fixture
in the suite.

### What releasing it exposed

The frame clock the recorder feeds `Record_ClockHook` is set up in `record_begin` and was
never torn down. While fixed-dt is armed that hook returns before ever reading it, so a
stale one is invisible. Handing the step back made it live again, pinned at whatever
reading the session ended on: 3.12x became 0.00x and game time stopped dead. It is cleared
for every session now, armed or not, so the two cannot come apart again.

### Confirmed

Over the socket: 1.00x before, 0.99x after `rec stop`, 0.99x after a playback, the replay
itself clean at 436 ticks and `first hash mismatch -1`, and the hero still walks
afterwards.

The new arm asserts both directions -- after `rec stop`, a recorder-armed run reports
`mode.fixed_dt=0` and a `--fixed-dt 16` run still reports `16`. `rec info` makes that a
question about a printed number rather than about elapsed time. Each direction was
confirmed to fail when the code it covers is broken.

Full automation suite: 72 pass, 2 skip, 0 fail. 69/69 host tests, clang-format and
check-arch clean.
