### PR TITLE
fix(paths): the folders under a Windows user directory were never created

### DIFF
--- a/LIB386/H/SYSTEM/ADELINE.H
+++ b/LIB386/H/SYSTEM/ADELINE.H
@@ -1,12 +1,5 @@
 #pragma once
 
-#ifdef _WIN32          // Portability - mkdir has different includes and signature
-#include <direct.h>    // For ADELINE_MKDIR
-#else                  // _WIN32
-#include <sys/stat.h>  // For ADELINE_MKDIR
-#include <sys/types.h> // For ADELINE_MKDIR
-#endif                 // _WIN32
-
 // -----------------------------------------------------------------------------
 #ifdef __cplusplus
 extern "C" {
@@ -41,14 +34,6 @@ extern "C" {
 #else // _WIN32
 #define ADELINE_PATH_SEP "/"
 #define ADELINE_PATH_SEP_CHAR '/'
-#endif // _WIN32
-
-// -----------------------------------------------------------------------------
-// There is no single portable mkdir function
-#ifdef _WIN32 // Portability - mkdir has different includes and signature
-#define ADELINE_MKDIR(path) _mkdir(path)
-#else // _WIN32
-#define ADELINE_MKDIR(path) mkdir(path, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH)
 #endif // _WIN32
 
 // =============================================================================

--- a/SOURCES/DISKFUNC.CPP
+++ b/SOURCES/DISKFUNC.CPP
@@ -2,8 +2,11 @@
 #include "DIRECTORIES.H"
 
 #include <SYSTEM/ADELINE.H>
+#include <SYSTEM/LOG.H>
 
-#include <errno.h>
+#include <SDL3/SDL_error.h>
+#include <SDL3/SDL_filesystem.h>
+
 #include "AMBIANCE.H"
 #include "BOOT_EXIT.H"
 
@@ -352,41 +355,62 @@ S32 LoadSceneCubeXY(S32 numcube, S32 *cubex, S32 *cubey) {
 
 /*──────────────────────────────────────────────────────────────────────────*/
 
+/* Make `path` a directory, creating any missing parent on the way, and report whether
+   one is there when this returns.
+
+   SDL rather than a walk over the separators, which is what this was. That walk had a
+   Windows-shaped hole: the first component of an absolute path there is a drive spec,
+   and `_mkdir("C:")` asks for the current directory *of drive C*, which is refused
+   outright when the process sits on another drive or on that drive's root. The walk
+   stopped at the refusal, skipped the mkdir it existed to perform, and returned a
+   failure no caller read, so the folder was simply absent and the first write into it
+   failed instead -- naming a file, in a message that could not say the folder above it
+   was never made. Neither side of the tree reproduced it: an absolute path on Linux
+   begins with the separator, whose empty first component the walk skipped, and a
+   Windows run whose build tree and user directory share a drive resolves `C:` to a
+   directory that exists.
+
+   SDL_CreateDirectory creates the parents itself, reports success when the directory is
+   already there, and knows what a drive spec is. It also creates with 0770 against the
+   0754 asked for here before, so a folder made from now on is one group-readable step
+   tighter and matches the user directory above it, which SDL has always made. */
 U8 AddDirIfNot(const char *path) {
+    /* So that a caller reporting a failure reads this attempt's reason rather than
+       whatever last set one, which under SDL is as likely to be a call that succeeded. */
+    SDL_ClearError();
+
+    /* Ahead of the create, so a path that exists as a file still answers no. That is
+       what a caller testing this return has always been told, and SDL is not asked to
+       have an opinion about it. */
     if (ExistsFileOrDir(path)) {
         return IsDirectory(path);
     }
 
-    char *copypath = strdup(path);
+    return SDL_CreateDirectory(path) ? TRUE : FALSE;
+}
 
-    { // If path ends in separator, remove it
-        size_t copyLen = strlen(copypath);
-        if ((copyLen > 0) && (copypath[copyLen - 1] == ADELINE_PATH_SEP_CHAR)) {
-            copypath[copyLen - 1] = '\0';
-        }
+/* A folder the engine needs, made here or named here.
+
+   Reporting it is the whole point of the wrapper. A folder that cannot be created is a
+   failure the run survives and the player meets much later, at whatever first tried to
+   write into it, in a message about a file. Saying it once at boot, next to the paths
+   the banner has just printed, is the difference between "the recordings folder could
+   not be created" and "unable to save game to <a path that reads as fine>". */
+static void AddDirOrWarn(const char *path) {
+    if (AddDirIfNot(path)) {
+        return;
     }
 
-    int status = 0;
-    char *pp = copypath;
-    char *sp;
-    while ((status == 0 || errno == EEXIST) &&
-           ((sp = strchr(pp, ADELINE_PATH_SEP_CHAR)) != NULL)) {
-        if (sp != pp) {
-            *sp = '\0';
-            status = ADELINE_MKDIR(copypath);
-            *sp = ADELINE_PATH_SEP_CHAR;
-        }
-        pp = sp + 1;
-    }
+    /* With the reason. "Could not create" alone sends a player to check permissions and
+       free space whichever of them it was, and the two that actually happen -- a name
+       already taken, and no permission to write there -- want opposite answers.
 
-    if (status == 0 || errno == EEXIST) {
-        errno = 0;
-        status = ADELINE_MKDIR(path);
-    }
-
-    free(copypath);
-
-    return (status == 0);
+       Empty is itself one of the two failures rather than a missing message: AddDirIfNot
+       answers a path that exists and is not a directory without reaching SDL, and clears
+       the error on the way in so this cannot report an older one. */
+    const char *why = SDL_GetError();
+    Log_Warn("Folders    could not create %s: %s", path,
+             (why[0] != '\0') ? why : "the name is taken by something that is not a folder");
 }
 
 /*──────────────────────────────────────────────────────────────────────────*/
@@ -395,18 +419,25 @@ void CreateLbaDirectories(void) {
     char tmpDirPath[ADELINE_MAX_PATH];
 
 #ifndef DEMO
+    /* Silent, unlike the rest, because this one is under the game data rather than the
+       user directory and cannot tell a real failure from an ordinary install. The
+       folder ships with the data, so this is a no-op wherever the voices exist; an
+       install on read-only media is a normal thing to have; and with a disc image
+       mounted, ExistsFileOrDir answers for this path out of the image (DISCIMG maps
+       anything under the install dir), so a folder that is only in the image reads as
+       present and not a directory. A warning here would fire on a healthy install. */
     GetVoicePath(tmpDirPath, ADELINE_MAX_PATH, NULL);
     AddDirIfNot(tmpDirPath);
 #endif
 
     GetSavePath(tmpDirPath, ADELINE_MAX_PATH, NULL);
-    AddDirIfNot(tmpDirPath);
+    AddDirOrWarn(tmpDirPath);
 
     GetShootPath(tmpDirPath, ADELINE_MAX_PATH, NULL);
-    AddDirIfNot(tmpDirPath);
+    AddDirOrWarn(tmpDirPath);
 
     GetRecordingsPath(tmpDirPath, ADELINE_MAX_PATH, NULL);
-    AddDirIfNot(tmpDirPath);
+    AddDirOrWarn(tmpDirPath);
 
 #ifdef DEBUG_TOOLS
     GetBugPath(tmpDirPath, ADELINE_MAX_PATH, NULL);
@@ -418,7 +449,7 @@ void CreateLbaDirectories(void) {
 #endif
 
     GetLogPath(tmpDirPath, ADELINE_MAX_PATH, NULL);
-    AddDirIfNot(tmpDirPath);
+    AddDirOrWarn(tmpDirPath);
 }
 
 /*══════════════════════════════════════════════════════════════════════════*/

--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -106,9 +106,10 @@ x86 assembly is opt-in via the `ENABLE_ASM` CMake option (default OFF). Every AS
 
 ## 5. OS boundary (filesystem, conditionals, SDL3) &nbsp;&nbsp;&nbsp;&nbsp; ✓ contained
 
-Operating-system contact is concentrated in a thin layer. SDL3 wraps window, events, audio, video, and timer. Path manipulation is gated by `_WIN32` for the separator character and `mkdir` signature. Asset and save discovery uses `SDL_GetBasePath` plus `LBA2_GAME_DIR` plus a candidate walk. Case-insensitivity on macOS APFS bit us once (`<version>` vs the build's `VERSION` text file) and is now sidestepped by writing `VERSION.txt` instead.
+Operating-system contact is concentrated in a thin layer. SDL3 wraps window, events, audio, video, and timer. Path manipulation is gated by `_WIN32` for the separator character; directory creation is SDL's. Asset and save discovery uses `SDL_GetBasePath` plus `LBA2_GAME_DIR` plus a candidate walk. Case-insensitivity on macOS APFS bit us once (`<version>` vs the build's `VERSION` text file) and is now sidestepped by writing `VERSION.txt` instead.
 
-- `_WIN32` mkdir signature + path separator — `LIB386/H/SYSTEM/ADELINE.H:38-44`
+- `_WIN32` path separator — `LIB386/H/SYSTEM/ADELINE.H:31-37`
+- Directory creation goes through `SDL_CreateDirectory`, which creates parents and understands a drive spec — `SOURCES/DISKFUNC.CPP` (`AddDirIfNot`), `SOURCES/DIRECTORIES.CPP`
 - `ADELINE_PATH_SEP` usage — `SOURCES/RES_DISCOVERY.CPP`
 - macOS case-insensitivity hazard (with explanation) — `cmake/git_version.cmake:15-20`
 - SDL3 window — `LIB386/SYSTEM/WINDOW.CPP:5,89`

--- a/tests/automation/README.md
+++ b/tests/automation/README.md
@@ -19,7 +19,7 @@ LBA2_GAME_DIR=/path/to/data bash tests/automation/test_cli_contract.sh   # one f
 Attaching the run record to a PR that touches engine behaviour is the cheapest way to show the
 suite still passes, since CI cannot say so.
 
-74 fixtures.
+75 fixtures.
 
 | Fixture | What it pins | Also needs |
 |---|---|---|
@@ -96,4 +96,5 @@ suite still passes, since CI cannot say so.
 | [test_ui_menu_options_uhd.sh](test_ui_menu_options_uhd.sh) | ui menu-options @ 1920x1080: the tallest framebuffer the engine accepts (ADELINE_MAX_Y_RES, which sizes TabOffLine[]), and so the largest vertical float the authored canvas ever sits at: UI_VCENTER_OFS is 300 here against 120 at 720. | UI goldens |
 | [test_ui_menu_options_wide.sh](test_ui_menu_options_wide.sh) | ui menu-options @ 768x480: re-renders the in-game options/pause menu at the Steam Deck render width and asserts the centred 640x480 crop of the capture is byte-identical to the existing 640 golden. | UI goldens |
 | [test_ui_video.sh](test_ui_video.sh) | ui video: capture the first composited frame of the INTRO cinematic, byte- compare to the committed golden. | UI goldens |
+| [test_user_dirs.sh](test_user_dirs.sh) | The folders the engine writes into have to exist before it writes into them, and it has to say so when one cannot be made. | - |
 | [test_walkthrough_opening.sh](test_walkthrough_opening.sh) | Walkthrough e2e: drive the OPENING of the game through the engine, from a cold boot, with no savegame. | - |

--- a/tests/automation/test_user_dirs.sh
+++ b/tests/automation/test_user_dirs.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# The folders the engine writes into have to exist before it writes into them, and it
+# has to say so when one cannot be made.
+#
+# CreateLbaDirectories makes save/, save/shoot/ and recordings/ at boot, and nothing
+# looked at whether it managed to. The first thing to notice was a recording: the
+# snapshot save failed, and the message named the file rather than the folder that had
+# never been made.
+#
+# Two things the first arm does deliberately, because the suite's own isolation had been
+# hiding a Windows failure in both of them at once:
+#
+#   the folder is named in the platform's own spelling. A path handed to the engine
+#   through MSYS2 arrives as `D:/tmp/x`, and forward slashes are a different code path
+#   there from the `C:\Users\...` that SDL hands back when nobody names a folder at all.
+#
+#   the engine is started from the root of the drive that folder is on. The first
+#   component of an absolute Windows path is a drive spec, and creating a folder on a
+#   drive whose current directory is its own root failed there and only there -- so one
+#   drive reproduces what a build tree and a user directory on two drives reproduce by
+#   themselves.
+#
+# Everywhere else both are the identity, and that arm cannot fail on a Linux or macOS
+# build however the engine is broken. The second arm is the one that runs everywhere: it
+# puts a file where a folder belongs, and pins the report. Deleting the warning fails the
+# fixture on any platform, which is what keeps this from being a Windows-only oracle.
+TESTNAME=user_dirs
+
+# Named before lib.sh, so the suite's own isolation does not make a second folder that
+# nothing uses. Fresh, and empty of every folder this asserts.
+#
+# `fresh` stays the spelling this shell can test with -d; LBA2_USER_DIR carries the one
+# the engine is given. lib.sh is not loaded yet, so this failure reports itself: an empty
+# `fresh` would silently move the whole fixture to a folder nothing looks at.
+native_path() { # native_path <path> -- the spelling the platform's own API hands back
+    if command -v cygpath >/dev/null 2>&1; then cygpath -w "$1"; else printf '%s\n' "$1"; fi
+}
+
+fresh="$(mktemp -d -t "lba2-userdirs-XXXXXX")" && [ -d "$fresh" ] || {
+    echo "FAIL: user_dirs: mktemp could not make a folder to test in"
+    exit 1
+}
+blocked="$(mktemp -d -t "lba2-blocked-XXXXXX")" && [ -d "$blocked" ] || {
+    echo "FAIL: user_dirs: mktemp could not make a folder to test in"
+    exit 1
+}
+LBA2_USER_DIR="$(native_path "$fresh")"
+. "$(dirname "$0")/lib.sh"
+trap 'rm -rf "$fresh" "$blocked"' EXIT
+precheck
+
+# Absolute, because this is the one fixture that runs the engine from another directory:
+# a relative LBA2_BIN or LBA2_GAME_DIR passes precheck here and then resolves against the
+# wrong folder inside the subshell below, failing for a reason that is not the engine's.
+abs_path() { # abs_path <path>
+    case "$1" in
+    /* | ?:[/\\]*) printf '%s\n' "$1" ;;
+    *) printf '%s\n' "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")" ;;
+    esac
+}
+LBA2_BIN="$(abs_path "$LBA2_BIN")"
+LBA2_GAME_DIR="$(abs_path "$LBA2_GAME_DIR")"
+export LBA2_GAME_DIR
+
+# The root of the drive the user directory is on, which is where this boots from. `/`
+# is not that root under MSYS2: it is the MSYS2 installation, a folder on some drive,
+# and booting from a folder that exists asserts nothing.
+boot_root() { # boot_root <path>
+    if command -v cygpath >/dev/null 2>&1; then
+        cygpath -u "$(engine_path "$1" | cut -c1-2)/"
+    else
+        printf '/\n'
+    fi
+}
+
+root="$(boot_root "$fresh")"
+[ -d "$root" ] || fail "cannot boot from $root: no such directory"
+
+# --- a fresh user directory gets its folders -----------------------------------------
+out="$(cd "$root" && ctl --tick 1 --exit 2>&1)" \
+    || fail "a boot from $root exited non-zero: $(printf '%s' "$out" | tail -3)"
+
+missing=""
+for d in save save/shoot recordings; do
+    [ -d "$fresh/$d" ] || missing="$missing $d"
+done
+[ -z "$missing" ] || fail "booted from $root and made no$missing under $fresh"
+
+case "$out" in
+*"could not create"*)
+    fail "the boot warned about a folder it did create: $(
+        printf '%s' "$out" | grep -m1 'could not create')" ;;
+esac
+
+# --- a folder that cannot be made is named at boot -------------------------------------
+# A file where save/ belongs, which is what a stray download or a half-restored backup
+# leaves behind. The point is the timing: the run has to say it here, with the folder in
+# hand, rather than leave it to whatever writes there first and reports a file instead.
+: > "$blocked/save" || fail "could not put a file where save/ goes"
+blockedout="$(LBA2_USER_DIR="$(native_path "$blocked")" ctl --tick 1 --exit 2>&1)" \
+    || fail "a boot with a file where save/ goes exited non-zero: it must survive one"
+
+printf '%s' "$blockedout" | grep -q "could not create.*save" \
+    || fail "a boot that could not make save/ said nothing about it"
+printf '%s' "$blockedout" | grep -q "could not create.*save.*: ." \
+    || fail "the warning named the folder but not the reason: $(
+        printf '%s' "$blockedout" | grep -m1 'could not create')"
+[ -d "$blocked/recordings" ] \
+    || fail "one folder it could not make stopped it making the others"
+
+pass "a boot from $root created save/, save/shoot/ and recordings/ in a fresh user directory; a blocked save/ was named at boot with its reason"


### PR DESCRIPTION
## What & why

On Windows, `save/`, `save/shoot/` and `recordings/` were never created under the user
directory whenever the run started from a drive other than the one that directory is on,
which is every run from a build tree on `D:` against `%APPDATA%` on `C:`.

`AddDirIfNot` walked the path creating each component. The first component of an absolute
Windows path is a drive spec, and `_mkdir("C:")` asks to create the current directory *of
drive C*, refused outright when the process sits elsewhere or on that drive's root. The
walk stopped at the refusal, skipped the mkdir it existed to perform, and returned a
failure nobody read. Measured:

```
mkdir("C:") -> -1 errno=13 (Permission denied)
loop exit: status=-1 errno=13
final mkdir SKIPPED
AddDirIfNot -> 0, exists=0
```

`SDL_CreateDirectory` does the same job, creates the parents itself, and knows what a
drive spec is. `Directories_ResolveUserDir` already used it for the user directory
itself, which is why that one folder always existed while everything under it did not.

Recording is what surfaced it, being the newest folder and the only one nothing else had
created by hand: the staging snapshot could not be written and the message named the
file. Screenshots had the same hole, which is why a Windows machine that has been playing
for months has no `save/shoot/`.

## Notes for reviewers

**The silence was the other half.** `CreateLbaDirectories` now names the folder it could
not make, and why, at boot:

```
[INFO] Assets     all present
[WARN] Folders    could not create D:\...\save\: the name is taken by something that is not a folder
[WARN] Folders    could not create D:\...\save\shoot\: Couldn't create directory: Cannot create a file when that file already exists.
[INFO] Language   English
```

Both branches of that message are live: `stat()` on `save\` with a trailing separator sees
the file on Windows and is hidden by `ENOTDIR` on Linux, so each platform gets whichever
reason it can actually produce. A healthy boot prints nothing new.

The voice folder stays on the silent `AddDirIfNot` deliberately. It is under the game data,
where `ExistsFileOrDir` answers out of a mounted disc image (`DISCIMG` maps anything under
the install dir), so a folder that exists only in the image reads as present-and-not-a-directory
and would warn on every boot of a healthy install.

**Permissions change.** SDL creates with 0770 where the old call asked for 0754, so a
folder made from now on is one group-readable step tighter (0750 against 0754 under umask
022, measured) and matches the user directory above it. Existing folders keep their modes.

**`ADELINE_MKDIR` is removed**, with the three includes carried for it: the walk was its
last caller, and a sanctioned-looking mkdir macro is how this comes back. The engine, all
69 host tests and the ASM-equivalence suite all build without them.

**Why no fixture caught this.** The suite hands every test `LBA2_USER_DIR="$(mktemp -d)"`,
which under MSYS2 is on the same drive as the build *and* arrives spelt with forward
slashes, so the walk had nothing to walk. Both differences had to go for the bug to be
visible. `tests/automation/test_user_dirs.sh` undoes both: it names the folder in the
platform's own spelling and boots from the root of the drive it is on, which reproduces on
one drive what two drives give for free. That arm cannot fail on Linux however the engine
is broken, so a second arm puts a file where `save/` belongs and pins the report, and that
one runs everywhere.

**Follow-up, not in this PR:** `AddDirIfNot` lives in `DISKFUNC.CPP`, which cannot be
linked outside the engine target, so no host test can reach it. Moving it to
`DIRECTORIES.CPP` (already linked by three host tests) would put it under
`ctest -L host_quick`, which Windows CI does run, and the drive-root condition is
forceable in-process with `_chdir`.

## Verification

Windows (UCRT64, build tree on `D:`, `%APPDATA%` on `C:`), same tree, one file apart:

```
origin/main:  FAIL: user_dirs: booted from /d/ and made no save save/shoot recordings
with fix:     PASS: user_dirs — ... created save/, save/shoot/ and recordings/ ...
```

Also on Windows, against the real `%APPDATA%` root via a throwaway `--profile`: console
`rec start` wrote `session-20260820-164822.rec` (21878 bytes), and `screenshot` landed
`save/shoot/shot_1787237987.png` where the unfixed build produced neither.

Linux: `test_user_dirs`, `test_record_replay`, `test_load`, `test_cli_contract` pass;
`ctest -L host_quick` 69/69; `./run_tests_docker.sh` 163/163. `docs-links`, `docs-symbols`,
`check-arch`, clang-format and shellcheck clean.

Both new assertions were validated by breaking them: silencing the warning fails the second
arm, dropping its reason fails the reason check, and removing the `recordings/` creation
fails the first arm.

## Checklist

- [x] Build passes on my platform (Linux and Windows)
- [x] If LIB386 / 3DEXT touched: ASM equivalence tests pass (`./run_tests_docker.sh`, 163/163)
- [x] If behavior changes: opt-in via flag/cvar/config (preserves default game feel) — n/a, this restores folders the engine already intended to create; the only new output is a warning on failure
- [x] Docs updated in the same PR if behavior or workflow changed (`docs/PLATFORM.md`)
- [x] French comments and ASCII art preserved in any modified files
