### PR TITLE
test(paths): put directory creation under ctest, on the platform it broke on

### DIFF
--- a/SOURCES/CONSOLE/CONSOLE_CMD.CPP
+++ b/SOURCES/CONSOLE/CONSOLE_CMD.CPP
@@ -20,7 +20,6 @@ extern S32 GfxDitherShading;
 #include "../MUSIC.H"
 #include "../AMBIANCE.H"
 #include <AIL/SAMPLE.H>
-#include "../DISKFUNC.H"
 #include "../SAVEGAME.H"
 #include "../INPUT.H"
 #include "../CONTROL.H" // Control_Input* harness timeline, Control_KeyHold

--- a/SOURCES/DIRECTORIES.CPP
+++ b/SOURCES/DIRECTORIES.CPP
@@ -753,6 +753,40 @@ void Directories_SeedSavesFromGameData(void) {
     }
 }
 
+/* Make `path` a directory, creating any missing parent on the way, and report whether
+   one is there when this returns.
+
+   SDL rather than a walk over the separators, which is what this was. That walk had a
+   Windows-shaped hole: the first component of an absolute path there is a drive spec,
+   and `_mkdir("C:")` asks for the current directory *of drive C*, which is refused
+   outright when the process sits on another drive or on that drive's root. The walk
+   stopped at the refusal, skipped the mkdir it existed to perform, and returned a
+   failure no caller read, so the folder was simply absent and the first write into it
+   failed instead -- naming a file, in a message that could not say the folder above it
+   was never made. Neither side of the tree reproduced it: an absolute path on Linux
+   begins with the separator, whose empty first component the walk skipped, and a
+   Windows run whose build tree and user directory share a drive resolves `C:` to a
+   directory that exists.
+
+   SDL_CreateDirectory creates the parents itself, reports success when the directory is
+   already there, and knows what a drive spec is. It also creates with 0770 against the
+   0754 the walk asked for, so a folder made from now on is one group-readable step
+   tighter and matches the user directory above it, which SDL has always made. */
+U8 AddDirIfNot(const char *path) {
+    /* So that a caller reporting a failure reads this attempt's reason rather than
+       whatever last set one, which under SDL is as likely to be a call that succeeded. */
+    SDL_ClearError();
+
+    /* Ahead of the create, so a path that exists as a file still answers no. That is
+       what a caller testing this return has always been told, and SDL is not asked to
+       have an opinion about it. */
+    if (ExistsFileOrDir(path)) {
+        return IsDirectory(path);
+    }
+
+    return SDL_CreateDirectory(path) ? TRUE : FALSE;
+}
+
 /* Beside the saves rather than under them, because a recording is a thing the player
    made rather than something about a save: it carries its own savegames, and one
    recording stands in for a whole session. `shoot` and `bugs` sit inside `save` because

--- a/SOURCES/DIRECTORIES.H
+++ b/SOURCES/DIRECTORIES.H
@@ -171,6 +171,15 @@ void GetLogPath(char *outPath, U16 pathMaxSize, const char *logFilename);
 void GetLogPathInDir(char *outPath, U16 pathMaxSize, const char *userDir,
                      const char *logFilename);
 
+/// Make \p path a directory, creating any missing parent, and report whether one
+/// is there when this returns. False for a path that exists and is not a
+/// directory, so a caller can tell a name it cannot have from one it now owns.
+///
+/// Lives here rather than with its callers so a host test can reach it: the
+/// walk this replaced was wrong on Windows for two years without a test that
+/// could fail, because the only thing linking it was the engine.
+U8 AddDirIfNot(const char *path);
+
 // =============================================================================
 #ifdef __cplusplus
 }

--- a/SOURCES/DISKFUNC.CPP
+++ b/SOURCES/DISKFUNC.CPP
@@ -5,7 +5,6 @@
 #include <SYSTEM/LOG.H>
 
 #include <SDL3/SDL_error.h>
-#include <SDL3/SDL_filesystem.h>
 
 #include "AMBIANCE.H"
 #include "BOOT_EXIT.H"
@@ -354,40 +353,6 @@ S32 LoadSceneCubeXY(S32 numcube, S32 *cubex, S32 *cubey) {
 }
 
 /*──────────────────────────────────────────────────────────────────────────*/
-
-/* Make `path` a directory, creating any missing parent on the way, and report whether
-   one is there when this returns.
-
-   SDL rather than a walk over the separators, which is what this was. That walk had a
-   Windows-shaped hole: the first component of an absolute path there is a drive spec,
-   and `_mkdir("C:")` asks for the current directory *of drive C*, which is refused
-   outright when the process sits on another drive or on that drive's root. The walk
-   stopped at the refusal, skipped the mkdir it existed to perform, and returned a
-   failure no caller read, so the folder was simply absent and the first write into it
-   failed instead -- naming a file, in a message that could not say the folder above it
-   was never made. Neither side of the tree reproduced it: an absolute path on Linux
-   begins with the separator, whose empty first component the walk skipped, and a
-   Windows run whose build tree and user directory share a drive resolves `C:` to a
-   directory that exists.
-
-   SDL_CreateDirectory creates the parents itself, reports success when the directory is
-   already there, and knows what a drive spec is. It also creates with 0770 against the
-   0754 asked for here before, so a folder made from now on is one group-readable step
-   tighter and matches the user directory above it, which SDL has always made. */
-U8 AddDirIfNot(const char *path) {
-    /* So that a caller reporting a failure reads this attempt's reason rather than
-       whatever last set one, which under SDL is as likely to be a call that succeeded. */
-    SDL_ClearError();
-
-    /* Ahead of the create, so a path that exists as a file still answers no. That is
-       what a caller testing this return has always been told, and SDL is not asked to
-       have an opinion about it. */
-    if (ExistsFileOrDir(path)) {
-        return IsDirectory(path);
-    }
-
-    return SDL_CreateDirectory(path) ? TRUE : FALSE;
-}
 
 /* A folder the engine needs, made here or named here.
 

--- a/SOURCES/DISKFUNC.H
+++ b/SOURCES/DISKFUNC.H
@@ -14,7 +14,5 @@ extern S32 LoadSceneCubeXY(S32 numcube, S32 *cubex, S32 *cubey);
 /*--------------------------------------------------------------------------*/
 extern void CreateLbaDirectories(void);
 /*--------------------------------------------------------------------------*/
-extern U8 AddDirIfNot(const char *path);
-/*--------------------------------------------------------------------------*/
 
 #endif // DISKFUNC_H

--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -109,7 +109,7 @@ x86 assembly is opt-in via the `ENABLE_ASM` CMake option (default OFF). Every AS
 Operating-system contact is concentrated in a thin layer. SDL3 wraps window, events, audio, video, and timer. Path manipulation is gated by `_WIN32` for the separator character; directory creation is SDL's. Asset and save discovery uses `SDL_GetBasePath` plus `LBA2_GAME_DIR` plus a candidate walk. Case-insensitivity on macOS APFS bit us once (`<version>` vs the build's `VERSION` text file) and is now sidestepped by writing `VERSION.txt` instead.
 
 - `_WIN32` path separator — `LIB386/H/SYSTEM/ADELINE.H:31-37`
-- Directory creation goes through `SDL_CreateDirectory`, which creates parents and understands a drive spec — `SOURCES/DISKFUNC.CPP` (`AddDirIfNot`), `SOURCES/DIRECTORIES.CPP`
+- Directory creation goes through `SDL_CreateDirectory`, which creates parents and understands a drive spec — `SOURCES/DIRECTORIES.CPP` (`AddDirIfNot`), covered by `tests/user_dirs`
 - `ADELINE_PATH_SEP` usage — `SOURCES/RES_DISCOVERY.CPP`
 - macOS case-insensitivity hazard (with explanation) — `cmake/git_version.cmake:15-20`
 - SDL3 window — `LIB386/SYSTEM/WINDOW.CPP:5,89`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -166,6 +166,12 @@ To run only the console suite: `ctest -R test_console_ --output-on-failure`.
 
 `tests/savegame/corpus/` holds the Layer-3 driver scripts (`run_harness.py`, `build_manifest.py`) that exercise the real `lba2cc --save-load-test` flag against a directory of `.lba` saves; requires retail game data so it runs locally only. See `tests/savegame/corpus/README.md`.
 
+### 7. Host tests — user directories (`tests/user_dirs`)
+
+`tests/user_dirs/test_user_dirs.cpp` links [SOURCES/DIRECTORIES.CPP](../SOURCES/DIRECTORIES.CPP) and exercises `AddDirIfNot`, which every user-writable folder is made through: a nested path with a trailing separator, a second call on a folder already there, and a name taken by a file.
+
+The last case is why it is a host test rather than a fixture. It moves the process to the root of the volume the folder is going on and creates from there, which on Windows makes the first component of an absolute path (`C:`) resolve to a directory that cannot be created. That is the shape that silently created nothing for years, and `tests/automation/test_user_dirs.sh` can only reach it on a Windows machine somebody runs it on by hand. This one runs in `ctest -L host_quick`, including the Windows PR job.
+
 ## Test harness
 
 `tests/test_harness.h` provides a minimal TAP-style harness with no external

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,7 @@ add_subdirectory(precision_paths)
 add_subdirectory(numeric_contract)
 add_subdirectory(ui_layout)
 add_subdirectory(settings)
+add_subdirectory(user_dirs)
 
 if(LBA2_BUILD_ASM_EQUIV_TESTS)
 include(cmake/asm_test_helpers.cmake)

--- a/tests/user_dirs/CMakeLists.txt
+++ b/tests/user_dirs/CMakeLists.txt
@@ -1,0 +1,25 @@
+# AddDirIfNot sits in DIRECTORIES.CPP so this target can link it. EMBEDDED_CFG_WRITE
+# and the generated cfg blob come with it, the same pair tests/discovery pulls in.
+set(_USERDIRS_SOURCES
+    ${CMAKE_SOURCE_DIR}/SOURCES/DIRECTORIES.CPP
+    ${CMAKE_SOURCE_DIR}/SOURCES/EMBEDDED_CFG_WRITE.CPP
+    ${CMAKE_BINARY_DIR}/SOURCES/embedded_lba2_cfg_data.cpp
+)
+
+add_executable(test_user_dirs test_user_dirs.cpp ${_USERDIRS_SOURCES})
+
+target_include_directories(test_user_dirs PRIVATE
+    ${CMAKE_SOURCE_DIR}/SOURCES
+    ${CMAKE_SOURCE_DIR}/LIB386/H
+    ${CMAKE_BINARY_DIR}
+)
+
+target_link_libraries(test_user_dirs PRIVATE sys SDL3::SDL3)
+
+target_compile_definitions(test_user_dirs PRIVATE LBA2_BUILD_TESTS)
+
+set_target_properties(test_user_dirs PROPERTIES CXX_STANDARD 11)
+
+add_test(NAME test_user_dirs COMMAND test_user_dirs)
+
+register_host_test(test_user_dirs)

--- a/tests/user_dirs/test_user_dirs.cpp
+++ b/tests/user_dirs/test_user_dirs.cpp
@@ -1,0 +1,165 @@
+/**
+ * Host tests for AddDirIfNot, the one place every user-writable folder is made.
+ *
+ * The last case is why this is a host test and not only a fixture. The first
+ * component of an absolute Windows path is a drive spec, and `C:` names the
+ * current directory *of drive C*, so creating a folder while the process sits
+ * on another drive, or on that drive's root, goes through path handling nothing
+ * else here reaches. A process can move itself, so one drive is enough: from the
+ * volume root, `C:` resolves to `C:\`, which cannot be created.
+ *
+ * The fixture beside this (tests/automation/test_user_dirs.sh) cannot stand in
+ * for it. It needs retail game data and a display, so no workflow runs it, and
+ * the folder it hands the engine comes from mktemp: on the build's own drive,
+ * spelt with forward slashes. This runs in ctest -L host_quick, Windows PR job
+ * included.
+ */
+
+#include <SYSTEM/ADELINE_TYPES.H>
+#include <SYSTEM/LIMITS.H>
+
+#include "DIRECTORIES.H"
+
+#ifdef _WIN32
+#include <direct.h>
+#include <windows.h>
+#include <cerrno>
+#else
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <sys/stat.h>
+
+static int g_failures = 0;
+
+static void check(bool cond, const char *what) {
+    if (!cond) {
+        printf("FAIL: %s\n", what);
+        g_failures++;
+    }
+}
+
+static bool is_dir(const char *path) {
+    struct stat st;
+    return stat(path, &st) == 0 && (st.st_mode & S_IFMT) == S_IFDIR;
+}
+
+#ifdef _WIN32
+
+static bool make_temp_dir(char *out, size_t out_sz) {
+    char base[MAX_PATH];
+    if (GetTempPathA(sizeof(base), base) == 0) {
+        return false;
+    }
+    for (int i = 0; i < 256; ++i) {
+        snprintf(out, out_sz, "%slba2dirs_%lu_%d", base, (unsigned long)GetCurrentProcessId(), i);
+        if (_mkdir(out) == 0) {
+            return true;
+        }
+        if (errno != EEXIST) {
+            return false;
+        }
+    }
+    return false;
+}
+
+static int chdir_portable(const char *p) { return _chdir(p); }
+static char *getcwd_portable(char *buf, size_t sz) { return _getcwd(buf, (int)sz); }
+
+/* The root of the drive `path` is on, which is a directory that always exists and
+   is never the one being created. `C:` alone would mean "wherever this process is
+   on drive C", which is the whole point being tested. */
+static void volume_root_of(const char *path, char *out, size_t out_sz) {
+    if (path[0] != '\0' && path[1] == ':') {
+        snprintf(out, out_sz, "%c:\\", path[0]);
+    } else {
+        snprintf(out, out_sz, "\\"); /* a UNC path: its own root is the best available */
+    }
+}
+
+#else
+
+static bool make_temp_dir(char *out, size_t out_sz) {
+    if (snprintf(out, out_sz, "/tmp/lba2dirs_XXXXXX") >= (int)out_sz) {
+        return false;
+    }
+    return mkdtemp(out) != NULL;
+}
+
+static int chdir_portable(const char *p) { return chdir(p); }
+static char *getcwd_portable(char *buf, size_t sz) { return getcwd(buf, sz); }
+
+static void volume_root_of(const char *path, char *out, size_t out_sz) {
+    (void)path;
+    snprintf(out, out_sz, "/");
+}
+
+#endif
+
+/* The platform's own separator, because that is what every caller passes: the
+   paths come from GetSavePath and friends, which append with it. */
+#ifdef _WIN32
+#define SEP "\\"
+#else
+#define SEP "/"
+#endif
+
+int main(void) {
+    char root[ADELINE_MAX_PATH];
+    if (!make_temp_dir(root, sizeof root)) {
+        printf("FAIL: could not make a temp directory to test in\n");
+        return 1;
+    }
+
+    /* Nested, and with a trailing separator, which is the shape every caller
+       passes: the paths come from GetSavePath and friends, which end with one. */
+    char nested[ADELINE_MAX_PATH];
+    snprintf(nested, sizeof nested, "%s" SEP "save" SEP "shoot" SEP, root);
+    check(AddDirIfNot(nested) != 0, "AddDirIfNot reported failure creating a nested path");
+    check(is_dir(nested), "the nested path was not created");
+
+    char parent[ADELINE_MAX_PATH];
+    snprintf(parent, sizeof parent, "%s" SEP "save", root);
+    check(is_dir(parent), "the missing parent was not created");
+
+    /* Idempotent: a folder already there is success, not a failure to report. */
+    check(AddDirIfNot(nested) != 0, "AddDirIfNot failed on a directory that already exists");
+
+    /* A name taken by a file is the one failure that never reaches SDL, and the
+       caller has to be able to tell it from success. */
+    char taken[ADELINE_MAX_PATH];
+    snprintf(taken, sizeof taken, "%s" SEP "afile", root);
+    FILE *f = fopen(taken, "wb");
+    check(f != NULL, "could not write the file that takes the name");
+    if (f != NULL) {
+        fclose(f);
+    }
+    check(AddDirIfNot(taken) == 0, "AddDirIfNot claimed a file was a directory");
+
+    /* The case the fixture cannot reach here. From the root of the volume the
+       folder is going on, the first component of its absolute path resolves to a
+       directory that cannot be created, and a create has to get past that to the
+       component that matters. */
+    char here[ADELINE_MAX_PATH];
+    char volume[ADELINE_MAX_PATH];
+    char fromroot[ADELINE_MAX_PATH];
+    if (getcwd_portable(here, sizeof here) == NULL) {
+        printf("FAIL: could not read the current directory\n");
+        return 1;
+    }
+    volume_root_of(root, volume, sizeof volume);
+    snprintf(fromroot, sizeof fromroot, "%s" SEP "recordings" SEP, root);
+    check(chdir_portable(volume) == 0, "could not move to the volume root to test from");
+    check(AddDirIfNot(fromroot) != 0, "AddDirIfNot failed when run from the volume root");
+    check(is_dir(fromroot), "the folder was not created when run from the volume root");
+    check(chdir_portable(here) == 0, "could not move back out of the volume root");
+
+    if (g_failures == 0) {
+        printf("OK: directory creation, from a fresh folder and from the volume root\n");
+    }
+    return (g_failures == 0) ? 0 : 1;
+}


### PR DESCRIPTION
## What & why

Follow-up to #613, which fixed `AddDirIfNot` creating nothing on Windows whenever the
process sat on a drive other than the one the folder was going on. That fix shipped with a
control-harness fixture, and a control-harness fixture cannot protect it: the suite needs
retail game data and a display, so no workflow runs it and none can. A Windows PR job
already builds with `LBA2_BUILD_TESTS=ON` and runs `ctest -L host_quick`, so a host test is
the only thing that can fail on a revert.

`AddDirIfNot` moves from `DISKFUNC.CPP` to `DIRECTORIES.CPP` to make that possible.
`DISKFUNC.CPP` does not compile outside the engine target (`C_EXTERN.H` pulls `DEFINES.H`
pulls the object model), while `DIRECTORIES.CPP` is linked by three host tests already and
owns every path these folders are made from.

`tests/user_dirs/test_user_dirs.cpp` pins four things: a nested path with a trailing
separator, which is the shape every caller passes; a second call on a folder already there;
a name taken by a file, which is the one failure that never reaches SDL; and creation from
the root of the volume the folder is going on, where the first component of an absolute
Windows path resolves to a directory that cannot be created. A process can move its own
current directory, so one drive is enough to reach the last case.

## Notes for reviewers

**The move is deliberately partial.** `AddDirOrWarn` and `CreateLbaDirectories` stay in
`DISKFUNC.CPP`: the wrapper has one caller, and building the folder tree at boot is a boot
step rather than a path operation. Only the primitive that had the bug moves.
`CONSOLE_CMD.CPP` loses its `DISKFUNC.H` include, which was there for this one call.

**The oracle is validated, on the platform that matters.** With the separator walk restored
in `DIRECTORIES.CPP`, built under UCRT64:

```
FAIL: AddDirIfNot failed when run from the volume root
FAIL: the folder was not created when run from the volume root
0% tests passed, 1 tests failed out of 1
```

Exactly those two assertions, and nothing else in the file: the earlier cases still pass
because the temp folder is on the drive the build sits on, which is the same blindness that
kept this bug alive. With the fix in place, 70/70.

**On POSIX the volume-root case is an ordinary create from `/`**, which cannot fail either
way. It is kept in the same code path rather than `#ifdef`-ed out, so there is one test to
read rather than two, and the platform detail sits in one helper (`volume_root_of`).

## Verification

- Windows (UCRT64): `ctest -L host_quick` 70/70; the same suite fails only the new test,
  and only its volume-root assertions, with the pre-#613 walk restored.
- Linux: `ctest -L host_quick` 70/70; `tests/automation/test_user_dirs.sh` still passes.
- `check-arch` clean (8 rules, 571 files), `docs-links` 0 errors, `docs-symbols` clean,
  clang-format clean.

## Checklist

- [x] Build passes on my platform (Linux and Windows)
- [ ] If LIB386 / 3DEXT touched: ASM equivalence tests pass — n/a, this PR touches `SOURCES/`, `tests/` and `docs/` only
- [x] If behavior changes: opt-in via flag/cvar/config (preserves default game feel) — n/a, no behaviour change; the function moves translation unit and gains a test
- [x] Docs updated in the same PR if behavior or workflow changed (`docs/TESTING.md` §7, `docs/PLATFORM.md`)
- [x] French comments and ASCII art preserved in any modified files
