### PR TITLE
feat(boot): name the recordings folder in the banner, under Saves

### DIFF
--- a/SOURCES/INITADEL.C
+++ b/SOURCES/INITADEL.C
@@ -122,11 +122,13 @@ void InitAdeline(S32 argc, char *argv[]) {
     {
         char resFolderPath[ADELINE_MAX_PATH] = "";
         char saveFolderPath[ADELINE_MAX_PATH] = "";
+        char recFolderPath[ADELINE_MAX_PATH] = "";
         char cfgFilePath[ADELINE_MAX_PATH] = "";
         char logFilePath[ADELINE_MAX_PATH] = "";
 
         GetResPath(resFolderPath, ADELINE_MAX_PATH, NULL);
         GetSavePath(saveFolderPath, ADELINE_MAX_PATH, NULL);
+        GetRecordingsPath(recFolderPath, ADELINE_MAX_PATH, NULL);
         GetCfgPath(cfgFilePath, ADELINE_MAX_PATH, CFG_NAME);
         GetLogPath(logFilePath, ADELINE_MAX_PATH, LOG_NAME);
 
@@ -175,6 +177,11 @@ void InitAdeline(S32 argc, char *argv[]) {
             }
         }
         Log_Raw("Saves:  %s", saveFolderPath);
+        /* Beside the saves rather than under them, so a player looking for what they
+           just recorded does not find it by opening save/. A recording named without a
+           directory lands here, which is what `rec` with no argument does, so the one
+           place the name has to be resolvable from is a pasted banner. */
+        Log_Raw("Recs:   %s", recFolderPath);
         Log_Raw("Config: %s", cfgFilePath);
         Log_Raw("Log:    %s", logFilePath);
         /* Where the three above came from. The Assets line names the probe that

--- a/docs/DISC_IMAGE_SOURCE.md
+++ b/docs/DISC_IMAGE_SOURCE.md
@@ -100,7 +100,7 @@ gap; today's target (`../LBA2-GOG`) ships the HQRs extracted, so discovery succe
 media comes from the image.
 
 ## Boot log
-Today's happy-path banner is a header block (`Assets:/Saves:/Config:/Log:`) then an aligned status
+Today's happy-path banner is a header block (`Assets:/Saves:/Recs:/Config:/Log:`) then an aligned status
 block (`Events/Joystick/Audio/Display/Assets/Language`) and a `Ready in ...` line. The mount is
 **visible only when it happens, silent otherwise**:
 

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -57,7 +57,15 @@ the reload it already performs, so the recipe below is for the from-boot flags a
 
 ## Where recordings live
 
-`<userDir>/recordings/`, beside `save/`. An argument with no directory in it is a name in there, which is
+`<userDir>/recordings/`, beside `save/`. The boot banner names it, under `Saves:`, so a pasted log
+says where a run's recordings went without anyone having to know the layout:
+
+```
+Saves:  /home/you/.local/share/Twinsen/LBA2/save/
+Recs:   /home/you/.local/share/Twinsen/LBA2/recordings/
+```
+
+An argument with no directory in it is a name in there, which is
 why the commands above take a name and not a path: a session recorded as `session.rec` replays as
 `session.rec`, from whatever directory the run is started in.
 

--- a/tests/automation/test_user_dirs.sh
+++ b/tests/automation/test_user_dirs.sh
@@ -92,6 +92,13 @@ case "$out" in
         printf '%s' "$out" | grep -m1 'could not create')" ;;
 esac
 
+# The banner names the folder, beside the saves. A recording named without a directory
+# lands there and nowhere else, so a pasted log has to be enough to find it.
+recline="$(printf '%s' "$out" | sed -n 's/^Recs:  *//p' | head -1)"
+[ -n "$recline" ] || fail "the banner did not name the recordings folder"
+[ "$(norm_path "$recline")" = "$(norm_path "$fresh/recordings")" ] \
+    || fail "the banner named '$recline' as the recordings folder, not $fresh/recordings"
+
 # --- a folder that cannot be made is named at boot -------------------------------------
 # A file where save/ belongs, which is what a stray download or a half-restored backup
 # leaves behind. The point is the timing: the run has to say it here, with the folder in
@@ -108,4 +115,4 @@ printf '%s' "$blockedout" | grep -q "could not create.*save.*: ." \
 [ -d "$blocked/recordings" ] \
     || fail "one folder it could not make stopped it making the others"
 
-pass "a boot from $root created save/, save/shoot/ and recordings/ in a fresh user directory; a blocked save/ was named at boot with its reason"
+pass "a boot from $root created save/, save/shoot/ and recordings/ in a fresh user directory and named the recordings folder in the banner; a blocked save/ was named at boot with its reason"


### PR DESCRIPTION
## What & why

The banner's header block exists so a pasted log says where a run read and wrote.
Recordings were the one user-writable folder missing from it, and the one whose location
is least guessable: `recordings/` sits *beside* `save/` rather than under it, so a player
who has just recorded a session and goes looking in the save folder does not find it.

It is also the folder a name resolves against. `rec` with no argument, and `--record` with
a bare name, write there and nowhere else, so a log naming the saves, the config and the
log but not this one leaves the only path the player cannot derive unstated.

```
Assets: /home/you/games/LBA2/Common/  (LBA2_GAME_DIR)
Saves:  /home/you/.local/share/Twinsen/LBA2/save/
Recs:   /home/you/.local/share/Twinsen/LBA2/recordings/
Config: /home/you/.local/share/Twinsen/LBA2/lba2.cfg
Log:    /home/you/.local/share/Twinsen/LBA2/adeline.log
```

## Notes for reviewers

**Appended, not reformatted.** Every line that was already there is byte-identical, and
the new one uses the same eight-column label field, so anything parsing the banner keeps
working. `Recs:` is the only spelling that fits that field (`Recordings:` would widen every
line); happy to change the word if you prefer another that fits.

**It follows the profile.** The line comes from `GetRecordingsPath`, so `--user-dir` and
`--profile` move it with everything else rather than printing a path the run does not use.

**Tested, not just eyeballed.** `tests/automation/test_user_dirs.sh` now reads the line back
and compares it to the run's own user directory through `norm_path`, so the platform's
separator and trailing slash are not part of the assertion. Replacing the path with a
constant fails the fixture:

```
FAIL: user_dirs: the banner named 'BROKEN' as the recordings folder, not /tmp/lba2-userdirs-Q7hlDN/recordings
```

## Verification

- Linux: `ctest -L host_quick` 69/69; `test_user_dirs`, `test_record_replay` and
  `test_profile_bind` pass (the last two both read the banner).
- `docs-links` 0 errors, `docs-symbols` clean, `check-arch` clean, clang-format and
  shellcheck clean.
- `docs/RECORDING.md` gains the two banner lines under "Where recordings live";
  `docs/DISC_IMAGE_SOURCE.md` describes the header block and now lists `Recs:` with the rest.

## Checklist

- [x] Build passes on my platform (Linux)
- [ ] If LIB386 / 3DEXT touched: ASM equivalence tests pass — n/a, not touched
- [x] If behavior changes: opt-in via flag/cvar/config (preserves default game feel) — n/a, one added log line; no game behaviour
- [x] Docs updated in the same PR if behavior or workflow changed
- [x] French comments and ASCII art preserved in any modified files
