### PR TITLE
feat(record): a playback puts the player back where it found them

### DIFF
--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -2309,9 +2309,17 @@ void Record_TickHook(void) {
             return; /* ChangeCube has not consumed it yet */
         record_reload_landed();
         s_reloadState = 0;
-        if (s_reloadAbort)
+        if (s_reloadAbort) {
             s_reloadAbort = 0;
-        else
+            /* A playback stopped between `rec play` and its reload landing. The load
+               cannot be taken back -- the engine changes cube either way -- so the player
+               is standing in the recording's world with the session called off, and
+               Record_Stop could not ask for the way back because this reload was still in
+               flight when it ran. Measured: stopping in that window left the hero at the
+               recording's start rather than where the playback found him. Ask here
+               instead, where the state machine is free again. */
+            record_restore_player();
+        } else
             s_beginAtPoll = (s_reloadForPlay == REC_RELOAD_RESTORE)
                                 ? 0
                                 : (s_reloadForPlay == REC_RELOAD_PLAY ? 2 : 1);

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -2185,6 +2185,12 @@ int Record_Play(const char *path) {
                    the playback still runs, because refusing to play a recording is a
                    worse answer than playing it and saying the way back is missing. */
                 s_returnPoint[0] = 0;
+                /* s_replayFromCli stays set for the life of the run, unlike its
+                   recording counterpart, which clears on use: the replay's exit code is
+                   decided from it when the stream ends. So a run given --replay that
+                   later plays something from the console takes no return point either.
+                   That run is a harness run with no player session in it, and clearing
+                   the flag here to change that would take the exit code with it. */
                 if (!s_replayFromCli && Control_HasLiveScene()) {
                     char ret[ADELINE_MAX_PATH];
                     if (record_write_snapshot_as(ret, sizeof ret, "return"))

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -2145,6 +2145,29 @@ int Record_Play(const char *path) {
                 from = snap;
             }
 
+            /* A recording that reloads needs a game to reload into, and the reload is
+               issued from MainLoop's tick hook. The menu runs its own loop and never
+               reaches that hook, so a playback asked for from the main menu sat armed
+               forever while the two lines below reported it had started, and left the
+               staged snapshot behind. Measured: `rec info` still said idle six seconds
+               later and the scene was still Cube -1, Obj 0.
+
+               Refused here rather than made to work. Playing into the menu means starting
+               a game from the recording's snapshot and putting the menu back afterwards,
+               which is the demo reel's shape and a larger piece than a guard. */
+            if (from != NULL && !Control_HasLiveScene()) {
+                Console_Print("rec: %s replays into a game, and none is in progress", path);
+                fprintf(stderr, "[rec] %s replays into a game, and none is in progress\n", path);
+                if (s_inlineSnap[0]) {
+                    remove(s_inlineSnap);
+                    s_inlineSnap[0] = 0;
+                }
+                fclose(s_f);
+                s_f = NULL;
+                s_recPath[0] = 0;
+                return 0;
+            }
+
             if (from != NULL) {
                 U32 clk = 0;
                 if (RecFmt_ReadU32(s_headerBuf, "setup.reload_clock=", &clk))

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -261,6 +261,13 @@ static char s_recPath[ADELINE_MAX_PATH] = "";
 /* The last recording this run wrote, which is not s_recPath: that one moves to whatever
    was replayed last. Empty in a session that has only replayed. */
 static char s_lastRecorded[ADELINE_MAX_PATH] = "";
+/* The player's own session, saved where a playback takes it over, empty when there is
+   nothing to go back to (a replay from the flag, which owns the whole run, or one started
+   with no scene live). */
+static char s_returnPoint[ADELINE_MAX_PATH] = "";
+/* Set once the run is on its way out, so the teardown does not ask for work that needs a
+   tick to happen in. */
+static int s_atExit = 0;
 /* Whether this session reloaded the snapshot before its first recorded or replayed
    frame, and the header line that says so. A mid-session recording does, because a
    save restores actor kinematics by re-deriving them and only a run that took the same
@@ -754,13 +761,20 @@ static void record_save_to(const char *out) { Control_WriteSnapshot(out); }
  * about to reload, and a savegame from somebody else's session is a far quieter failure
  * than a missing file. Two runs recording to the same name are already contending for
  * the recording itself, so there is nothing left for this to protect. */
-static void record_scratch_path(char *out, size_t n) {
+/* Staging under a name of the recording's, with `suffix` separating the two kinds: the
+   snapshot a session is loaded from, and the player's own game held while a playback runs
+   over it. Two names because a playback needs both at once and one file cannot be both. */
+static void record_scratch_path_as(char *out, size_t n, const char *suffix) {
     char p[ADELINE_MAX_PATH];
     char name[ADELINE_MAX_PATH];
-    snprintf(name, sizeof name, "%s.staging.lba",
-             s_recPath[0] ? path_leaf(s_recPath) : "rec");
+    snprintf(name, sizeof name, "%s.%s.lba",
+             s_recPath[0] ? path_leaf(s_recPath) : "rec", suffix);
     GetRecordingsPath(p, ADELINE_MAX_PATH, name);
     snprintf(out, n, "%s", p);
+}
+
+static void record_scratch_path(char *out, size_t n) {
+    record_scratch_path_as(out, n, "staging");
 }
 
 /* Stage a snapshot, and report whether one is actually there.
@@ -771,8 +785,8 @@ static void record_scratch_path(char *out, size_t n) {
  * that into a failure rather than a surprise: without it a run whose save failed reloads
  * whatever a previous run left behind, which is a live session replaced by an unrelated
  * one. */
-static S32 record_write_snapshot(char *out, size_t n) {
-    record_scratch_path(out, n);
+static S32 record_write_snapshot_as(char *out, size_t n, const char *suffix) {
+    record_scratch_path_as(out, n, suffix);
     remove(out);
     record_save_to(out);
     if (ExistsFileOrDir(out))
@@ -780,6 +794,10 @@ static S32 record_write_snapshot(char *out, size_t n) {
     fprintf(stderr, "[rec] could not write the snapshot at %s\n", out);
     out[0] = 0;
     return 0;
+}
+
+static S32 record_write_snapshot(char *out, size_t n) {
+    return record_write_snapshot_as(out, n, "staging");
 }
 
 /* Copy a staged snapshot into the stream as a chunk, and drop the staging file.
@@ -923,6 +941,11 @@ static S32 replay_read_chunk(U8 want, char *outPath, size_t n) {
  * permanently over the player's own. Restored here unconditionally, because Record_Stop
  * returns early once the stream is closed and would skip it. */
 static void record_flush_at_exit(void) {
+    /* No ticks left, so nothing can issue a reload and there is no game to return to.
+       Without this the exit path asks for one anyway and says so, which is a line
+       promising something that will not happen. The return point is removed below
+       instead. */
+    s_atExit = 1;
     Record_Stop();
     bindings_restore();
     /* A replay that ended before its reload landed still has the snapshot staged. The
@@ -932,6 +955,13 @@ static void record_flush_at_exit(void) {
     if (s_inlineSnap[0]) {
         remove(s_inlineSnap);
         s_inlineSnap[0] = 0;
+    }
+    /* The player's session, if the run ends before it could be put back. Removing it is
+       all that is left to do here: there are no more ticks, so the reload Record_Stop
+       asked for is never going to be issued. */
+    if (s_returnPoint[0]) {
+        remove(s_returnPoint);
+        s_returnPoint[0] = 0;
     }
 }
 
@@ -973,8 +1003,15 @@ static void record_arm_atexit(void) {
  * runs after it. */
 static char s_reloadSave[ADELINE_MAX_PATH];
 static char s_reloadThen[ADELINE_MAX_PATH];
-static int s_reloadForPlay = 0; /* 0 = begin recording after it lands, 1 = begin replay */
-static int s_reloadState = 0;   /* 1 = asked for, 2 = issued and waiting for the cube */
+/* 0 = begin recording after it lands, 1 = begin replay, 2 = restore and begin nothing.
+   The third is the way back out of a playback: a replay loads the recording's world over
+   the player's, and the player's has to be put back afterwards or watching a recording
+   costs them their session. */
+#define REC_RELOAD_RECORD 0
+#define REC_RELOAD_PLAY 1
+#define REC_RELOAD_RESTORE 2
+static int s_reloadForPlay = REC_RELOAD_RECORD;
+static int s_reloadState = 0; /* 1 = asked for, 2 = issued and waiting for the cube */
 /* The tick hook sees the load land; the poll hook is where the session begins. Keeping
    that split matters for one measured reason: the header's clock baseline is sampled
    where recording starts and re-applied where replay starts, so the two have to be the
@@ -1021,7 +1058,7 @@ static void record_reload_issue(void) {
      *
      * The replay takes the step out of the recording's header rather than the default,
      * so a session played at some other step replays at that one. */
-    if (!Timer_FixedDtActive()) {
+    if (s_reloadForPlay != REC_RELOAD_RESTORE && !Timer_FixedDtActive()) {
         Timer_EnableFixedDt((U32)(s_reloadDt > 0 ? s_reloadDt : REC_DEFAULT_DT));
         s_recArmedDt = 1;
     }
@@ -1032,9 +1069,11 @@ static void record_reload_issue(void) {
        reading, since writing the snapshot costs the recording a frame the replay never
        spends. Same state at tick 0 either way, and one actor's heading apart 300 ticks
        later, which is what this closes. */
-    if (s_reloadForPlay)
+    /* A restore is going back to ordinary play, where the clock is the host's again and
+       nothing is being reproduced, so it neither carries a reading nor stamps one. */
+    if (s_reloadForPlay == REC_RELOAD_PLAY)
         SetTimerHR((U32)s_reloadClock);
-    else
+    else if (s_reloadForPlay == REC_RELOAD_RECORD)
         s_reloadClock = (unsigned)TimerRefHR;
 
     Control_BorrowSaveContext();
@@ -1061,6 +1100,11 @@ static void record_reload_landed(void) {
     if (s_inlineSnap[0] && !strcmp(s_reloadSave, s_inlineSnap)) {
         remove(s_inlineSnap);
         s_inlineSnap[0] = 0;
+    }
+    /* Same for the player's own session once it has been put back. */
+    if (s_returnPoint[0] && !strcmp(s_reloadSave, s_returnPoint)) {
+        remove(s_returnPoint);
+        s_returnPoint[0] = 0;
     }
 }
 
@@ -1224,7 +1268,7 @@ int Record_Start(const char *path, int verbose) {
         return 0;
     }
     snprintf(s_snapshot, sizeof s_snapshot, "%s", snap);
-    record_reload_request(snap, path, 0);
+    record_reload_request(snap, path, REC_RELOAD_RECORD);
     Console_Print("rec: reloading %s; recording starts from the post-load state", snap);
     return 1;
 }
@@ -1255,6 +1299,23 @@ static void record_release_step(void) {
         return;
     s_recArmedDt = 0;
     Timer_DisableFixedDt();
+}
+
+/* Put the player back where the playback found them.
+ *
+ * The same pair `rec start` uses, in the other direction: a snapshot, then a reload. It
+ * runs from Record_Stop, so it covers both ways a playback ends -- the replay reaching
+ * the end of its stream, and the player stopping it.
+ *
+ * Not while another reload is in flight. The state machine holds one request, and a
+ * playback stopped before its own reload landed is already committed to that load; a
+ * second request would replace the first and strand FlagLoadGame, which is the one thing
+ * about this path that must not be got wrong. The file is left for the exit cleanup. */
+static void record_restore_player(void) {
+    if (!s_returnPoint[0] || s_reloadState || s_atExit)
+        return;
+    record_reload_request(s_returnPoint, "", REC_RELOAD_RESTORE);
+    Console_Print("rec: returning to your game");
 }
 
 int Record_Stop(void) {
@@ -1313,6 +1374,7 @@ int Record_Stop(void) {
     s_recPath[0] = 0;
     bindings_restore();
     record_release_step();
+    record_restore_player();
     return 1;
 }
 
@@ -2087,7 +2149,28 @@ int Record_Play(const char *path) {
                 U32 clk = 0;
                 if (RecFmt_ReadU32(s_headerBuf, "setup.reload_clock=", &clk))
                     s_reloadClock = clk;
-                record_reload_request(from, "", 1);
+                /* Save the player's own session before the recording's world is loaded
+                   over it. Without this a playback is one-way: the replay ends and the
+                   player is left standing wherever the recording finished, in its world
+                   rather than theirs. Measured before it existed -- a player who walked
+                   away from the recording's end point and then watched it back was put
+                   at the recording's end, 1585 units from where they had been.
+
+                   Not for a replay armed from the flag: that run has no player session
+                   to protect, it exists to replay and exit. And not where no scene is
+                   live, since there is nothing to save. A failure here is reported and
+                   the playback still runs, because refusing to play a recording is a
+                   worse answer than playing it and saying the way back is missing. */
+                s_returnPoint[0] = 0;
+                if (!s_replayFromCli && Control_HasLiveScene()) {
+                    char ret[ADELINE_MAX_PATH];
+                    if (record_write_snapshot_as(ret, sizeof ret, "return"))
+                        snprintf(s_returnPoint, sizeof s_returnPoint, "%s", ret);
+                    else
+                        Console_Print("rec: could not save your session; "
+                                      "playback will not return to it");
+                }
+                record_reload_request(from, "", REC_RELOAD_PLAY);
                 /* After the request, which clears it: the step this replay pins comes
                    from the recording's header, and a session played at some other
                    --fixed-dt reproduces on that one and on nothing else. */
@@ -2206,7 +2289,9 @@ void Record_TickHook(void) {
         if (s_reloadAbort)
             s_reloadAbort = 0;
         else
-            s_beginAtPoll = s_reloadForPlay ? 2 : 1;
+            s_beginAtPoll = (s_reloadForPlay == REC_RELOAD_RESTORE)
+                                ? 0
+                                : (s_reloadForPlay == REC_RELOAD_PLAY ? 2 : 1);
         return;
     }
 

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -34,7 +34,7 @@ Mid-session, from the console (F12), which records from a point you choose rathe
 |---|---|
 | `rec start [name] [verbose]` | Write a snapshot, reload it, and start recording from the post-load state. `verbose` adds the telemetry below |
 | `rec stop` | Stop and flush |
-| `rec play [name]` | Replay a recording into the running engine |
+| `rec play [name]` | Replay a recording into the running engine, then put your game back |
 | `rec info [name]` | Report the current session, or compare a file's mode lines against this run |
 
 The name is optional at both ends, and without one nothing has to be typed or kept track of:
@@ -47,6 +47,11 @@ rec: stopped
 > rec play
 rec: replaying /home/you/.local/share/Twinsen/LBA2/recordings/session-20260820-150408.rec
 ```
+
+Playback borrows the session and gives it back. `rec play` saves where you are before it loads
+the recording's world over yours, and returns you there when the replay ends or you stop it, so
+watching a recording does not cost you your game. `--replay` does not, and does not need to: that
+run exists to replay and exit, and has no session to protect.
 
 `rec start` names the session after the time of day. `rec play` takes the recording this run
 recorded, and in a session that has recorded nothing -- the next launch, say -- the most recently

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -560,8 +560,17 @@ if [ "$idle_xz" = "$rec_xz" ]; then
     fail "movement: the hero is at $rec_xz with input and $idle_xz without it — the recorded session never moved, so a clean replay of it would prove nothing"
 fi
 
-moveout="$(LBA2_USER_DIR="$movedir" ctl --load "$movesave" \
-    --exec-at 20 "rec play" --tick 900 --dump-state "$movedir/play.json" --exit 2>&1)" ||
+# Replayed through --replay rather than the console `rec play`, because this arm asks
+# where the replay *left* the hero and `rec play` no longer leaves him there: a
+# console-driven playback saves the player's session first and puts it back when the
+# replay ends, so the state at exit would be the restore rather than the replay. The flag
+# path takes no return point -- that run exists to replay and exit -- so it is the one
+# that can still be asked this question. The restore has an arm of its own below.
+moverec="$(ls "$movedir"/recordings/*.rec 2>/dev/null | head -1)"
+[ -n "$moverec" ] || fail "movement: the recording run wrote no recording to $movedir/recordings"
+
+moveout="$(LBA2_USER_DIR="$movedir" ctl --load "$movesave" --replay "$moverec" \
+    --tick 900 --dump-state "$movedir/play.json" --exit 2>&1)" ||
     fail "movement: the replay run exited non-zero ($?) — hang or crash"
 
 case "$moveout" in
@@ -627,5 +636,56 @@ case "$flagarmed" in
     ;;
 esac
 
+# Watching a recording must not cost the player their game.
+#
+# A playback loads the recording's world over the live one. Before this it was one-way:
+# the replay ended and the player was left standing wherever the recording finished, in
+# its world rather than theirs. Measured over the control socket, a player who walked away
+# from the recording's end point and then watched it back was put at the recording's end,
+# 1585 units from where they had been.
+#
+# The arm has to prove the two destinations are actually different, or it passes on a
+# coincidence. So the hero walks one way while recording and a different way afterwards,
+# and all three positions come out of one run: `dumpstate` at a chosen tick for the two
+# mid-run ones, `--dump-state` for the last.
+#
+# Not the flag path. `--replay` takes no return point by design -- that run exists to
+# replay and exit, and has no player session to protect -- so the question only means
+# something for a playback started from inside a session.
+retdir="$(mktemp -d)"
+trap 'rm -rf "$here" "$loopdir" "$emptydir" "$movedir" "$stepdir" "$retdir"' EXIT
+
+LBA2_USER_DIR="$retdir" ctl --load "$movesave" \
+    --exec-at 20 "rec start" --exec-at 200 "key up 250" --exec-at 520 "rec stop" \
+    --exec-at 560 "dumpstate $retdir/recend.json" \
+    --exec-at 600 "key down 250" \
+    --exec-at 920 "dumpstate $retdir/before.json" \
+    --exec-at 960 "rec play" \
+    --tick 2000 --dump-state "$retdir/after.json" --exit >/dev/null 2>&1 ||
+    fail "return: the run exited non-zero ($?) — hang or crash"
+
+for f in recend before after; do
+    [ -s "$retdir/$f.json" ] || fail "return: no $f state dump was written"
+done
+recend_xz="$(hero_xz "$retdir/recend.json")" || fail "return: could not read the recording's end"
+before_xz="$(hero_xz "$retdir/before.json")" || fail "return: could not read the pre-playback state"
+after_xz="$(hero_xz "$retdir/after.json")" || fail "return: could not read the post-playback state"
+
+# Without this the arm below passes whenever the two happen to coincide, which is most of
+# the ways it could be broken.
+[ "$recend_xz" != "$before_xz" ] ||
+    fail "return: the hero is at $before_xz both at the recording's end and when playback started, so this arm cannot tell a restore from doing nothing"
+
+[ "$after_xz" = "$before_xz" ] ||
+    fail "return: playback started with the hero at $before_xz and left him at $after_xz (the recording ended at $recend_xz) — the player's session was not put back"
+
+# The return point is scratch and belongs to the recorder, not to the player's save folder,
+# and it has to be gone once it has been read.
+for leftover in "$retdir"/recordings/*.return.lba "$retdir"/recordings/*.staging.lba; do
+    if [ -e "$leftover" ]; then
+        fail "return: $leftover was left behind"
+    fi
+done
+
 pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; mode.audio was written from the driver and reported both ways; a session recorded in one run replayed in the next with no flags and no paths; \
-'rec start verbose' carried telemetry and a plain one carried none; a recorded walk moved the hero and the replay walked it again; the recorder gave the step back and left the flag's alone"
+'rec start verbose' carried telemetry and a plain one carried none; a recorded walk moved the hero and the replay walked it again; the recorder gave the step back and left the flag's alone; a playback put the player back where it found them"

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -687,5 +687,31 @@ for leftover in "$retdir"/recordings/*.return.lba "$retdir"/recordings/*.staging
     fi
 done
 
+# Stopping a playback early has to return the player too, and the narrow window is the one
+# that got this wrong: between `rec play` and the reload it asks for landing, two ticks
+# later. The load cannot be taken back once issued -- the engine changes cube either way --
+# so the player is standing in the recording's world with the session called off, and
+# Record_Stop cannot ask for the way back because that reload is still in flight when it
+# runs. Measured before it was handled: the hero was left at the recording's start.
+#
+# `rec stop` one tick after `rec play` lands in that window; the arm below it stops well
+# clear of it, so the two together cover the abort path and the ordinary one.
+for stopat in 961 1100; do
+    LBA2_USER_DIR="$retdir/early$stopat" ctl --load "$movesave" \
+        --exec-at 20 "rec start" --exec-at 200 "key up 250" --exec-at 520 "rec stop" \
+        --exec-at 600 "key down 250" \
+        --exec-at 920 "dumpstate $retdir/early$stopat-before.json" \
+        --exec-at 960 "rec play" --exec-at "$stopat" "rec stop" \
+        --tick 1600 --dump-state "$retdir/early$stopat-after.json" --exit >/dev/null 2>&1 ||
+        fail "return: the early-stop run (stop at $stopat) exited non-zero ($?) — hang or crash"
+
+    early_before="$(hero_xz "$retdir/early$stopat-before.json")" ||
+        fail "return: could not read the pre-playback state for stop at $stopat"
+    early_after="$(hero_xz "$retdir/early$stopat-after.json")" ||
+        fail "return: could not read the post-stop state for stop at $stopat"
+    [ "$early_after" = "$early_before" ] ||
+        fail "return: a playback stopped at tick $stopat started with the hero at $early_before and left him at $early_after — stopping a playback has to put the player back too"
+done
+
 pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; mode.audio was written from the driver and reported both ways; a session recorded in one run replayed in the next with no flags and no paths; \
-'rec start verbose' carried telemetry and a plain one carried none; a recorded walk moved the hero and the replay walked it again; the recorder gave the step back and left the flag's alone; a playback put the player back where it found them"
+'rec start verbose' carried telemetry and a plain one carried none; a recorded walk moved the hero and the replay walked it again; the recorder gave the step back and left the flag's alone; a playback put the player back where it found them, stopped early or run out"


### PR DESCRIPTION
`rec play` loads the recording's world over the live one, and nothing put the live one
back. A player who watched a recording lost their game.

## Measured, before

Over the control socket, with the hero walked one way during the recording and a different
way afterwards so the two destinations are distinguishable:

| | Hero |
|---|---|
| Player when they pressed `rec play` | (11295, 27463) |
| The recording ended at | (11522, 25964) |
| After playback | (11522, 25964) — the recording's end, 1516 from the player |

After: the player is put back at (11295, 27463), distance 0.

## How

The mechanism `rec start` already uses two lines away, in the other direction: a snapshot,
then a reload. `rec play` saves the player's session before requesting the recording's, and
`Record_Stop` reloads it, which covers both ways a playback ends -- the replay reaching the
end of its stream, and the player stopping it.

Not for `--replay`: that run exists to replay and exit, has no player session to protect,
and taking a return point there would change what the flag does.

The reload state machine grows a third mode. It had begin-recording and begin-replay, and a
restore has to begin neither; it also must not pin the step or carry a clock reading,
because it is going back to ordinary play where the clock is the host's again and nothing
is being reproduced. The staging file gets a name of its own, because a playback needs the
recording's snapshot and the player's game at the same moment and one file cannot be both.

`Record_Stop` is also the exit path, where there are no ticks left to issue a reload and no
game to return to, so the teardown skips it rather than asking for work that cannot happen
and printing a line promising it. Verified: a playback that finishes says it once, a run cut
off mid-playback says nothing and leaves no staging file.

## Second commit: a playback with no game to replay into

Asked while reviewing: what if the player plays a recording from the menu rather than
in-game? It reported success and did nothing.

The reload is issued by `Record_TickHook`, which runs from MainLoop. The menu runs its own
loop and never reaches it, so the request sat armed forever while two success lines said
otherwise. Measured over the socket: `rec info` still said idle six seconds later, the
scene was still `Cube -1 / Obj 0`, and the staged snapshot was left in the recordings
folder.

It now refuses, says what is missing, and cleans up what it staged.

Refused rather than made to work: playing into the menu means starting a game from the
recording's snapshot and putting the menu back afterwards, which is the demo reel's shape
and a larger piece than a guard.

**No fixture covers that one, and cannot as things stand** -- `--exec` and `--exec-at` are
both driven from the same tick hook, so no harness command can be issued at the menu at
all. Verified by hand over `--listen`, which is serviced per present and does reach the
menu.

## Testing

The new arm proves the two destinations differ before asserting the restore -- otherwise it
passes whenever they coincide, which is most of the ways this could break -- and checks that
neither staging file is left behind. With the restore disabled it fails, naming both places.

The movement arm changes with it: it asks where the replay *left* the hero, and `rec play`
no longer leaves him there, so it replays through `--replay`, now the only path whose final
state is the replay's own.

70/70 host tests, full automation suite 73 pass / 2 skip / 0 fail, clang-format and
check-arch clean.


---

## Rebased onto main, and two more from reviewing it

Rebased over #615 and #617. The only conflict was the fixture's `pass` line, which #617
also extended; both clauses are kept. `SOURCES/RECORD.CPP` auto-merged, so the interaction
was checked by hand rather than trusted: #617 changed `Record_Start`'s signature and added
`s_teleAsked`, this branch only calls `Record_Play`, and inside `Record_Stop` the two land
in a sane order (`s_teleWrite = 0`, then the step release, then the restore).

**Stopping a playback early left the player stranded.** Reviewing `Record_Stop`'s early
returns turned up a window: between `rec play` and the reload it asks for landing, two
ticks later, the state machine already holds one request, so the guard against replacing it
declines. The load cannot be taken back once issued -- the engine changes cube either way
-- so the session is called off with the player standing in the recording's world and
nothing to return them. Measured: `rec stop` one tick after `rec play` left the hero at the
recording's start, `9844 4189`, rather than the `11295 27463` the playback found him at.
Asked from where the aborted reload lands instead, the first moment the state machine is
free. The arm covers both windows and fails naming both places when the restore is removed.

**Reviewed and left alone:** `s_replayFromCli` is not cleared on use where its recording
counterpart is, which reads like an oversight and is not -- the replay's exit code is
decided from it when the stream ends. Now says so in a comment, since the consequence (a
`--replay` run takes no return point for a later console play) is correct but not obvious.

70/70 host tests, full automation suite 73 pass / 2 skip / 0 fail on the rebased branch.
