### PR TITLE
docs(recording): the RNG split is the right shape and not what unblocks the step

### DIFF
--- a/docs/plan/RECORDING_RESEARCH.md
+++ b/docs/plan/RECORDING_RESEARCH.md
@@ -1611,6 +1611,22 @@ symptom: the `DetailLevel` 3 to 0 divergence at tick 235, which is rain and noth
 ambience half of the audio problem, which is currently answered by taking `IsSamplePlaying` off the
 mixer under `--fixed-dt` and so holds only in a mode no player runs.
 
+Measured since, and it bounds what the split is worth. The instrument is not in the tree yet: a
+draw counter added to the digest for the pinned-step work, `Rnd_Draws()` surfaced as `rng.draws`.
+It shows both ends of an audio-on session drawing the same number of times at and before a
+divergence that reproduces five times out of five. That one is not a stream offset, so
+two streams would leave it exactly where it is. The two failures above are stream offsets and the
+split would kill them; the audio divergence still open is a different animal. The split is the
+right shape and it is not what unblocks the pinned step, which is worth knowing before anyone pays
+the price in the next paragraph for it.
+
+One bound on that counter, because it is easy to read as proving more than it does. The play path
+in `HQ_MixSample` draws where the early return does not, `MyRnd(decalage)` inside the branch the
+re-trigger guard skips, so a matching count proves the `IsSamplePlaying` predicate agreed on a tick
+where a script had set `ParmSampleDecalage`. That defaults to zero and is written by one Track
+opcode and two Life ones, so on an ordinary tick both paths draw identically and the counter cannot
+see a predicate divergence at all. The right instrument, with a blind spot.
+
 The cost is why this is not a line item in the section above. Removing 17 draws from the shared
 ring changes the sequence every other draw sees, so it invalidates every committed baseline, corpus
 digest and existing recording on one commit. That is a decision about


### PR DESCRIPTION
## What & why

Follow-up to #618, which priced a `P_Random`/`M_Random` split against every committed
baseline, corpus digest and existing recording, and named two failures it would remove.
Docs only, same file.

A draw counter added to the digest for the pinned-step work shows both ends of an audio-on
session drawing the same number of times at and before a divergence that reproduces five
times out of five. That divergence is therefore not a stream offset, and two streams would
leave it exactly where it is. The two failures #618 named are stream offsets and still
stand: the `DetailLevel` 3 to 0 rain case, and the documented tick-1410 ambience case.

The distinction is worth carrying because of the price. A reader arriving at that section
should not conclude the split unblocks the pinned-step work, because it does not.

## Notes for reviewers

**The instrument is not on `main`.** `Rnd_Draws()` and `rng.draws` come from the
`rec-drop-fixed-dt` work in progress. The doc says so in the same sentence that names them,
so a reader who greps and finds nothing knows why rather than filing it as rot.

**The second paragraph bounds the counter, and that part is from reading this tree.**
`HQ_MixSample` draws `MyRnd(decalage)` on the play path and not on the early return
(`SOURCES/AMBIANCE.CPP`), so a matching draw count proves the `IsSamplePlaying` predicate
agreed only on a tick where a script had set `ParmSampleDecalage`. That defaults to 0 and is
written by one Track opcode (`GERETRAK.CPP:883`) and two Life ones (`GERELIFE.CPP:2452`,
`2463`), so on an ordinary tick both paths draw identically and the counter cannot see a
predicate divergence. This does not weaken the conclusion above, it fences it.

**One sentence in that section will go stale when the pinned-step work lands.** The doc says
the ambience fix is "currently answered by taking `IsSamplePlaying` off the mixer under
`--fixed-dt`". That is still true of `main` (`VoiceHeardBySim` gates on
`Timer_FixedDtActive()`, `LIB386/AIL/SDL/SAMPLE.CPP`), and the branch re-gating it on a
sim-audio-clock seam should update that line when it merges. Deliberately not pre-written
here, since the doc describes the tree.

## Checklist

- [x] Build passes on my platform (docs only, no code touched)
- [x] If LIB386 / 3DEXT touched: ASM equivalence tests pass (not touched)
- [x] If behavior changes: opt-in via flag/cvar/config (no behavior change)
- [x] Docs updated in the same PR if behavior or workflow changed (this is the docs)
- [x] French comments and ASCII art preserved in any modified files (none in this file)
