### PR TITLE
fix(record): a failed start leaves its telemetry ask behind

### DIFF
--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -154,8 +154,10 @@ extern "C" {
  * actors and all 336 script variables entirely. This carries the lot, every tick, so
  * the first mismatching tick names the field that moved.
  *
- * About 5 KB a tick, so it is opt-in (--verbose) rather than the default: a diagnostic
- * recording, made once, to answer a question a normal one cannot.
+ * About 2 KB a tick, so it is opt-in (--verbose) rather than the default: a diagnostic
+ * recording, made once, to answer a question a normal one cannot. The bytes are the
+ * cost and the time is not -- measured, 0.10 ms of CPU a tick, which is the loop that
+ * marshals the values rather than the write.
  */
 #define REC_TELE 0x51
 

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -1119,6 +1119,10 @@ static int record_begin(const char *path, int haveSnapshot) {
     s_f = fopen(path, "wb");
     if (!s_f) {
         Console_Print("rec: cannot write %s", path);
+        /* With the ask that came in, for the same reason the refusal in Record_Start
+           clears it: a start that did not happen must not leave `verbose` behind for the
+           next one, which would then record telemetry nobody asked it for. */
+        s_teleAsked = 0;
         return 0;
     }
     /* Behind the open, so Record_Path never names a session that does not exist. On the
@@ -1265,6 +1269,7 @@ int Record_Start(const char *path, int verbose) {
            wrote is how a failed save becomes a scene change nobody asked for. */
         Console_Print("rec: cannot write the starting snapshot; not recording");
         s_recPath[0] = 0;
+        s_teleAsked = 0;
         return 0;
     }
     snprintf(s_snapshot, sizeof s_snapshot, "%s", snap);

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -298,7 +298,7 @@ modal, and covers no other actor and none of the 336 script variables.
 digest mixes, every tick, so the first rejected tick names the fields that moved:
 
 ```
-[rec] verbose telemetry: 524 values a tick
+[rec] verbose telemetry: 578 values a tick
 [rec] consistency failure at tick 201: recorded 2060ee23…, replayed ab660bc5…
 [rec] tick 201 state differs: var.game[77] 0/42  (recorded/replayed)
 ```
@@ -308,8 +308,15 @@ same name: `hero->Obj.LastFrame`, `obj[12].Anim`, `var.cube[7]`. A field added t
 named without anyone having to name it.
 
 The first rejected tick is reported along with the two after it, which is usually enough to tell a
-value that moved once from one that is drifting. About 2 KB a tick, so it is recorded deliberately
-rather than by default: roughly 4 MB for a session of a few thousand ticks.
+value that moved once from one that is drifting. About 2 KB a tick -- measured at 2319 bytes a tick
+over a 198-tick session -- so it is recorded deliberately rather than by default: roughly 4 MB for a
+session of a few thousand ticks, and about 200 MB of telemetry alone on a half-hour one.
+
+The bytes are the cost, and the time is not: writing them adds 0.10 ms of CPU a tick, measured
+against the same build without them, which is 0.6% of a 16 ms step. System time does not move --
+the per-tick flush is absorbed by the page cache, and the 0.10 ms is the loop that marshals the
+values rather than the write. So the question of whether to record it is about the size of the file
+somebody has to keep or send, and not about what the run does while it is being made.
 
 The two ways of asking differ in when you can ask. `--verbose` is a decision made before the run
 starts, which is the wrong moment for a bug you have just watched happen: relaunching to arm the

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -604,7 +604,7 @@ play_xz="$(hero_xz "$movedir/play.json")" || fail "movement: could not read the 
 # `rec info` reports the live run's mode, which makes this a question about a printed
 # number rather than about elapsed time.
 stepdir="$(mktemp -d)"
-trap 'rm -rf "$here" "$loopdir" "$emptydir" "$movedir" "$stepdir"' EXIT
+trap 'rm -rf "$here" "$loopdir" "$emptydir" "$verbdir" "$movedir" "$stepdir"' EXIT
 
 # Through a file rather than a pipeline. The suite does not set `pipefail`, so a pipeline
 # carries the status of its last command -- `tr` here, which succeeds whatever the engine
@@ -653,7 +653,7 @@ esac
 # replay and exit, and has no player session to protect -- so the question only means
 # something for a playback started from inside a session.
 retdir="$(mktemp -d)"
-trap 'rm -rf "$here" "$loopdir" "$emptydir" "$movedir" "$stepdir" "$retdir"' EXIT
+trap 'rm -rf "$here" "$loopdir" "$emptydir" "$verbdir" "$movedir" "$stepdir" "$retdir"' EXIT
 
 LBA2_USER_DIR="$retdir" ctl --load "$movesave" \
     --exec-at 20 "rec start" --exec-at 200 "key up 250" --exec-at 520 "rec stop" \


### PR DESCRIPTION
## What & why

`Record_Start` clears the telemetry ask on the refusal it makes itself, and two later
failures return without doing the same, so a `rec start verbose` that could not open its
file or write its snapshot left the flag set for the next recording to pick up. Alongside
it, the two places that state what telemetry costs disagreed with each other, and the
figure nobody had measured was the one that matters to the claim it never reaches the
simulation.

Three commits, reviewable in order:

**`fix(record)`** -- the stale ask. Two `s_teleAsked = 0` lines, on the file that would not
open and the snapshot that would not write. It costs bytes rather than correctness while
telemetry is opt-in, since a recording carrying more than it was asked to still replays;
it is the ask outliving the start that is wrong.

**`fix(test)`** -- `test_record_replay.sh` leaked one temp directory per run. Each arm
rewrites the EXIT trap with its own `mktemp` directory appended, so every list has to
repeat the ones before it, and the last three arms dropped the telemetry arm's.

**`docs(record)`** -- the figures. `SOURCES/RECORD.CPP` said 5 KB a tick and
`docs/RECORDING.md` said 2 KB. Measured, it is 2319 bytes a tick, so the doc was right and
the comment was not. The sample output alongside it named 524 values a tick where the
digest now mixes 578.

The time it costs was never measured at all, which left "telemetry never reaches the
simulation" resting on reading the code path. Measured against the same build without it,
on the loose path so no pacer slack hides it: **0.10 ms of CPU a tick, 0.6% of a 16 ms
step, and no measurable system time** -- the per-tick flush is absorbed by the page cache
and the time goes on marshalling the values rather than on the write. So the decision to
record telemetry is about the size of the file somebody has to keep or send, and not about
what the run does while it is being made.

## Notes for reviewers

No behaviour change for anyone recording normally. The only code change is on two failure
paths that already returned 0.

**What this deliberately does not do.** It started as making telemetry the default for
every recording, and that is parked rather than abandoned. The argument against landing it
now is that the divergence report is capped three ways -- `s_kfReported >= 3`,
`s_teleReported < 3`, `shown >= 8` in `SOURCES/RECORD.CPP` -- so a replay names at most 3
ticks by 8 fields, 24 values, however much the file holds. Default-on would pay roughly
200 MB of telemetry on a half-hour session to store something nothing can currently read
past the 24th line. `scripts/dev/dump_recording.py` reports telemetry counts, not values,
so there is no offline reader either. The default is worth flipping once those caps are
lifted, and the two are really one change.

The half-hour scaling in the doc is there because that is the size that decides it: a
30-minute session is already ~97 MB from analog input alone before any telemetry.

## Checklist

- [x] Build passes on my platform (Linux)
- [ ] If LIB386 / 3DEXT touched: ASM equivalence tests pass (`./run_tests_docker.sh`) -- not touched
- [x] If behavior changes: opt-in via flag/cvar/config (preserves default game feel) -- failure-path fix only, telemetry stays opt-in
- [x] Docs updated in the same PR if behavior or workflow changed
- [x] French comments and ASCII art preserved in any modified files

Verified: `tests/automation/test_record_replay.sh` green, 70/70 `host_quick`, `check-arch`,
`check-docs-links`, `check-docs-symbols`, `clang-format` clean.
