### PR TITLE
fix(cli): arg --verbose armed the recording telemetry as well, undocumented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   someone else as a file that reproduces it. A recording carries the input, the
   console commands, the binding tables, a savegame at each end, and a per-tick
   digest of the simulation, which is what lets a replay check rather than merely
-  re-press the keys. `--verbose` adds every value behind that digest, so a
-  divergence names the field that moved instead of only the tick. Requires
+  re-press the keys. `--record-telemetry` adds every value behind that digest, so
+  a divergence names the field that moved instead of only the tick. Requires
   `--fixed-dt`, and `docs/RECORDING.md` says why. Console verbs `rec
   start|stop|play|info` do the same from a point you choose.
 

--- a/SOURCES/CLI_ARGS.CPP
+++ b/SOURCES/CLI_ARGS.CPP
@@ -130,6 +130,9 @@ static const T_CLI_FLAG CliFlags[] = {
                                              "loading included; a bare name lands in the\n"
                                              "recordings folder (the `rec` console verb\n"
                                              "starts mid-session)"},
+    {"--record-telemetry", 0, 0, 0, 0, NULL, "", "store every value the state digest mixes, every\n"
+                                                 "tick, so a divergence names the field and not\n"
+                                                 "only the tick; about 2 KB a tick"},
     {"--replay", 1, 0, 0, 0, NULL, "<name>", "replay a recording and report where it stops matching"},
     {"--ignore-focus", 0, 0, 0, 0, NULL, "", "keep the clock running when the window loses focus\n"
                                              "(--listen implies this)"},

--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -94,6 +94,7 @@ static char s_projrec_hash_path[ADELINE_MAX_PATH];
 static int s_exit = 0;
 static int s_demo = 0;
 static int s_verbose = 0;
+static int s_record_telemetry = 0;
 static int s_have_log_level = 0;
 static LogSeverity s_log_level = LOG_INFO;
 
@@ -357,6 +358,12 @@ void Control_ParseArgs(int *argc, char *argv[]) {
             read += 1;
             continue;
         }
+        if (!strcmp(a, "--record-telemetry")) {
+            s_record_telemetry = 1;
+            s_active = 1;
+            read += 1;
+            continue;
+        }
         if (!strcmp(a, "--log-level") && has_val) {
             /* Master log level for every sink (file, terminal, F12 console).
                Applied in PERSO.CPP right after Log_Init. Not a harness flag, so
@@ -592,6 +599,10 @@ void Control_SetDigestVersion(S32 v) {
 
 int Control_IsVerbose(void) {
     return s_verbose;
+}
+
+int Control_RecordTelemetry(void) {
+    return s_record_telemetry;
 }
 
 int Control_HasLogLevel(void) {

--- a/SOURCES/CONTROL.H
+++ b/SOURCES/CONTROL.H
@@ -58,8 +58,17 @@ void Control_ServiceListen(void);
 int Control_UnfiredExecAt(void);
 
 /* Non-zero if --verbose was supplied: log scene/hero progress and modal entries to stderr,
-   so a headless run is self-explaining and a hang shows what blocked it. */
+   so a headless run is self-explaining and a hang shows what blocked it. This is all it
+   does -- the recording telemetry has its own flag below, because the two have nothing to
+   do with each other and one of them costs megabytes. */
 int Control_IsVerbose(void);
+
+/* Non-zero if --record-telemetry was supplied: a recording made by this run stores every
+   value the state digest mixes, every tick, so a divergence names the field rather than
+   only the tick. About 2 KB a tick (docs/RECORDING.md). Named for the recording rather
+   than called --telemetry on its own, which in a game reads as phone-home analytics and
+   is not what this is: nothing leaves the machine. */
+int Control_RecordTelemetry(void);
 
 /* Log verbosity via --log-level <debug|info|warn|error>. Control_HasLogLevel is
    non-zero if the flag was supplied; Control_GetLogLevel returns the LogSeverity

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -558,7 +558,7 @@ static S32 write_mode_lines(char *out, size_t n) {
                          Control_IsHeadless(),
                          Control_AudioActive(),
                          (int)Timer_FixedDtValue(),
-                         s_teleWrite || Control_IsVerbose(),
+                         s_teleWrite || Control_RecordTelemetry(),
                          BUILD_FLAGS_STR,
                          Sys_PlatformName(),
                          Rnd_StreamName(),
@@ -1178,9 +1178,9 @@ static int record_begin(const char *path, int haveSnapshot) {
     ManageTime();
     /* Telemetry is a diagnostic recording, several megabytes larger, made deliberately
        when a plain one has already said a tick and cannot say a field. Either way of
-       asking arms it: --verbose for the whole run, `rec start verbose` for this session.
-       Before the header, because the header reports it. */
-    s_teleWrite = s_teleAsked || Control_IsVerbose();
+       asking arms it: --record-telemetry for the whole run, `rec start verbose` for this
+       session. Before the header, because the header reports it. */
+    s_teleWrite = s_teleAsked || Control_RecordTelemetry();
     s_teleAsked = 0;
     s_teleSaid = 0;
     if (!write_mode_lines(mode, sizeof mode))

--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -695,6 +695,7 @@ records the console commands alongside the input so a recording can stand in for
 |---|---|
 | `--record <name>` | Record from the first input poll, menus included. One file, holding the savegames at each end of the session. A name with no directory in it lands in `<userDir>/recordings/` |
 | `--replay <name>` | Replay a recording and report where it stops matching. Resolved the same way |
+| `--record-telemetry` | Store every value the state digest mixes, every tick, so a divergence names the field and not only the tick. About 2 KB a tick. Only the recording run needs it; a replay reads the values out of the file |
 
 Both need `--fixed-dt`: on the host-sampled clock a replay is not exact, which was measured rather
 than assumed. Give the replay more ticks than the recording holds, or it ends on `--tick` before

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -184,7 +184,7 @@ wrong.
 | A savegame at each end | Where the session started, and where it finished. Both inside the file |
 | An FNV-1a digest of simulation state, per tick | Scene, hero, camera, the other actors, the open modal, and all 336 script variables |
 | A keyframe of named state, every 32 ticks | The digest says *when* a replay stopped matching; this says *what* moved |
-| Every value the digest mixes, per tick, with `--verbose` or `rec start verbose` | The keyframe names 23 fields. This names all of them, so a divergence in another actor or a script variable is named too |
+| Every value the digest mixes, per tick, with `--record-telemetry` or `rec start verbose` | The keyframe names 23 fields. This names all of them, so a divergence in another actor or a script variable is named too |
 | The settings a replay is known to turn on | They are not in the save, and a config edited in between reads as the simulation diverging |
 | The mode the session ran in, audio included | Whether a sample driver came up decides what the simulation computes, and no save or config records it |
 
@@ -321,8 +321,8 @@ never explain one: roughly 1300 values go into it and the digest names none of t
 narrows that to 23 named fields every 32 ticks, which covers the hero, the camera and the open
 modal, and covers no other actor and none of the 336 script variables.
 
-`--verbose` on the recording run, or `rec start verbose` on the command, stores every value the
-digest mixes, every tick, so the first rejected tick names the fields that moved:
+`--record-telemetry` on the recording run, or `rec start verbose` on the command, stores every
+value the digest mixes, every tick, so the first rejected tick names the fields that moved:
 
 ```
 [rec] verbose telemetry: 668 values a tick
@@ -345,11 +345,12 @@ the per-tick flush is absorbed by the page cache, and the 0.10 ms is the loop th
 values rather than the write. So the question of whether to record it is about the size of the file
 somebody has to keep or send, and not about what the run does while it is being made.
 
-The two ways of asking differ in when you can ask. `--verbose` is a decision made before the run
-starts, which is the wrong moment for a bug you have just watched happen: relaunching to arm the
-flag costs you the session that showed it. `verbose` on the command arms the same telemetry from
+The two ways of asking differ in when you can ask. `--record-telemetry` is a decision made before
+the run starts, which is the wrong moment for a bug you have just watched happen: relaunching to arm
+the flag costs you the session that showed it. `verbose` on the command arms the same telemetry from
 wherever you are, and the header records which recordings carry it, so `rec info` on a file from
-last week still says. Nothing else about the recording changes -- telemetry is written beside the
+last week still says. Only the recording run needs either: a replay reads the values out of the
+file, so passing the flag to a replay arms nothing. Nothing else about the recording changes -- telemetry is written beside the
 digest and read back by the replay's reporter, and never reaches the simulation.
 
 ## Limits worth knowing before you trust a result
@@ -560,8 +561,9 @@ A mismatch reports the tick, and the next keyframe reports the fields:
 ```
 
 The keyframe covers the hero, the camera and the open modal, which is most of what goes wrong. When
-what moved is outside it (another actor, or a script variable), a recording made with `--verbose`
-or `rec start verbose` names it directly and the rest of this section is unnecessary. Without one,
+what moved is outside it (another actor, or a script variable), a recording made with
+`--record-telemetry` or `rec start verbose` names it directly and the rest of this section is
+unnecessary. Without one,
 the tick is still the starting point:
 
 1. **Compare the recorded clock, not just the hashes.** Each tick record carries `TimerRefHR`

--- a/tests/automation/test_cli_flag_contract.sh
+++ b/tests/automation/test_cli_flag_contract.sh
@@ -65,6 +65,7 @@ MODES="
 --save-load-test|--save-load-test \"$tmp/slt.lba\"
 --ignore-focus|--ignore-focus
 --record|--record \"$tmp/contract.rec\"
+--record-telemetry|--record-telemetry
 --replay|--replay \"$tmp/contract.rec\"
 "
 # --replay reads the file the --record case above just wrote, so the order of those

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -285,18 +285,20 @@ case "$lsummary" in
 esac
 
 # Verbose telemetry. A plain recording carries one digest a tick, which can say that a
-# tick stopped matching and never which of ~1300 values moved; --verbose stores them all.
+# tick stopped matching and never which of ~1300 values moved; --record-telemetry stores
+# them all. Only the recording run needs it: the replay's reporter reads the values out of
+# the file, so a replay that passed the flag would be arming nothing.
 # Recorded once and replayed twice: once expecting clean, and once with a variable
 # deliberately changed part-way through. The second run is the point. A reporter that
 # printed nothing would pass the first check exactly like one that works, and this is a
 # diagnostic whose whole job is to be believed on the day something real diverges.
 rm -f "$rec" "$rec".lba "$rec".end.lba
 
-ctl --verbose --fixed-dt 16 --load "$LBA2_TEST_SAVE" --record "$rec" \
+ctl --record-telemetry --fixed-dt 16 --load "$LBA2_TEST_SAVE" --record "$rec" \
     --exec-at 30 "key up 60 2" --tick 300 --exit >/dev/null 2>&1 ||
     fail "verbose: recording run exited non-zero ($?) — hang or crash"
 
-vout="$(ctl --verbose --fixed-dt 16 --load "$LBA2_TEST_SAVE" --replay "$rec" --tick 400 --exit 2>&1)" ||
+vout="$(ctl --fixed-dt 16 --load "$LBA2_TEST_SAVE" --replay "$rec" --tick 400 --exit 2>&1)" ||
     fail "verbose: replay run exited non-zero ($?) — hang or crash"
 case "$vout" in
 *"consistency failure"*)
@@ -310,7 +312,7 @@ esac
 # that diverges under --tick still exits 0: the exit code carries the replay's verdict
 # only on the path that has no tick budget (SOURCES/RECORD.CPP, Record_PollHook). The
 # `|| true` is there for that path rather than this one.
-bout="$(ctl --verbose --fixed-dt 16 --load "$LBA2_TEST_SAVE" --replay "$rec" --tick 400 \
+bout="$(ctl --fixed-dt 16 --load "$LBA2_TEST_SAVE" --replay "$rec" --tick 400 \
     --exec-at 200 "vargame 77 42" --exit 2>&1 || true)"
 case "$bout" in
 *"var.game[77]"*) ;;
@@ -339,7 +341,7 @@ assert len(n) == len(d) and n != d, "the flip has to be one byte and has to chan
 open(sys.argv[2], "wb").write(n)
 EOF
 
-aout="$(ctl --verbose --fixed-dt 16 --load "$LBA2_TEST_SAVE" --replay "$flipped" \
+aout="$(ctl --fixed-dt 16 --load "$LBA2_TEST_SAVE" --replay "$flipped" \
     --tick 400 --exit 2>&1)" ||
     fail "audio: replay run exited non-zero ($?): hang or crash"
 rm -f "$flipped"
@@ -466,12 +468,12 @@ esac
 
 # `rec start verbose`: the diagnostic recording, asked for from inside the game.
 #
-# --verbose arms the same telemetry for a whole run, and that is the wrong shape for the
-# case that wants it. A player watching something go wrong cannot go back and relaunch
-# with the flag, and by the time they have, the session that showed it is gone. The word
-# on the command is the same telemetry from the middle of a session, and it has one thing
-# to prove: that the ask survives the snapshot-and-reload a mid-session start goes
-# through, which lands a couple of ticks after the command that made it.
+# --record-telemetry arms the same telemetry for a whole run, and that is the wrong shape
+# for the case that wants it. A player watching something go wrong cannot go back and
+# relaunch with the flag, and by the time they have, the session that showed it is gone.
+# The word on the command is the same telemetry from the middle of a session, and it has
+# one thing to prove: that the ask survives the snapshot-and-reload a mid-session start
+# goes through, which lands a couple of ticks after the command that made it.
 #
 # Read back with no engine in the loop, because the question is what the file carries.
 # The console saying it armed something and the stream holding the records are separate


### PR DESCRIPTION
## What & why

`--verbose` was one flag driving two behaviours that have nothing to do with each other,
and the help text documented only one of them.

Eight sites read the flag: seven call `Control_IsVerbose()`, and `CONTROL.CPP` reads its
own `s_verbose` static directly. Six of the eight log scene and hero state as the run
proceeds, plus the modal markers, so a headless run is self-explaining and a hang names
what blocked it -- `CONTROL.CPP:1123` (the direct read), `INVENT.CPP:1041` and `:1458`,
`MESSAGE.CPP:2099`, `PLAYACF.CPP:377`, `PERSO.CPP:2531`. The other two decided whether a
recording stored every value the state digest mixes, about 2.8 KB a tick --
`RECORD.CPP:561` and `:1183`. Those two are what this moves; the six are untouched, the
direct read included.

The help text read `"log scene and hero state as the run proceeds"` and stopped there. So
somebody passing `--verbose` to find where a headless run was hanging had no way to learn
from `--help` that they had also turned on megabytes in any recording that run made. The
sharp version is not "two behaviours on one switch" but **two behaviours on one switch
where only one is written down.**

`--record-telemetry` now arms the recorder, and `--verbose` does what its help says.
`Control_IsVerbose()` is down to its five logging callers, plus CONTROL.CPP's own direct read.

## Notes for reviewers

**On the name.** `--telemetry` on its own, in a game, reads as phone-home analytics.
Nothing here leaves the machine -- it is per-tick simulation state written into the
recording file beside the digest -- so the flag is named for the recording it belongs to.
The reasoning is in `SOURCES/CONTROL.H` next to the accessor so it does not have to be
rediscovered.

**Only the recording run ever needed it.** The replay's reporter reads the values back out
of the file, so a replay passing the flag arms nothing. Three of the four `--verbose` uses
in `test_record_replay.sh` were on replay runs and were doing nothing; they now pass
nothing, and the comment says why so they do not come back.

**No behaviour change for `rec start verbose`.** The console word is untouched and still
arms telemetry for one session. This only moves the CLI half.

**Not a rename.** `--verbose` keeps its name, its flag row and all six of its logging
sites; what it loses is the undocumented second job.

Found while investigating making telemetry the default for every recording, which was
measured and deliberately parked -- a replay names at most 3 ticks by 8 fields whatever
the file holds, so default-on would pay ~30x file size for a report that stops at 24
values. This part of that work stands on its own.

## Checklist

- [x] Build passes on my platform (Linux)
- [ ] If LIB386 / 3DEXT touched: ASM equivalence tests pass (`./run_tests_docker.sh`) -- not touched
- [x] If behavior changes: opt-in via flag/cvar/config (preserves default game feel) -- a run that passed neither flag is unaffected
- [x] Docs updated in the same PR if behavior or workflow changed
- [x] French comments and ASCII art preserved in any modified files

Verified: `test_record_replay.sh`, `test_record_analog.sh` and `test_cli_flag_contract.sh`
green (the last now covers `--record-telemetry`, 27 flags), 70/70 `host_quick`,
`check-arch`, `check-docs-links`, `check-docs-symbols`, `clang-format` clean. `--help-all`
renders both rows.
