### PR TITLE
fix(record): three pieces of state the pinned step was hiding

### DIFF
--- a/LIB386/AIL/SDL/SAMPLE.CPP
+++ b/LIB386/AIL/SDL/SAMPLE.CPP
@@ -205,7 +205,7 @@ S32 sampleVolume = 0;
 static int sfxLogEnabled = 0;
 
 extern volatile U32 TimerSystemHR;
-extern "C" S32 Timer_FixedDtActive(void);
+extern "C" S32 Timer_SimAudioClock(void);
 
 /* Is this voice still playing, as far as the simulation is concerned?
  *
@@ -219,11 +219,13 @@ extern "C" S32 Timer_FixedDtActive(void);
  * session diverged from its own replay at tick 1410 on obj[11].Beta, and the same session
  * recorded with --no-audio replayed clean.
  *
- * So under fixed-dt the answer comes from the sample's own length on the game clock. The
+ * So for any run that has to reproduce, the answer comes from the sample's own length on
+ * the game clock. That is the pinned clock, and also a recording or replay on a
+ * host-sampled one, which needs it more: nothing else holds its two ends together. The
  * mixer still stops the voice when the data runs out; this only changes what the
- * simulation is told, and only in a mode no player runs. */
+ * simulation is told. */
 static bool VoiceHeardBySim(const Voice *V) {
-    if (!Timer_FixedDtActive())
+    if (!Timer_SimAudioClock())
         return V->active;
     if (V->simEndMs == 0)
         return false;

--- a/LIB386/H/SYSTEM/RANDOM.H
+++ b/LIB386/H/SYSTEM/RANDOM.H
@@ -56,6 +56,12 @@ S32 Rnd_Next(void);
 // than a divergence a thousand ticks in. Change it whenever the sequence changes.
 const char *Rnd_StreamName(void);
 
+// How many draws this stream has served, seeding discards included. Not the state,
+// just the position: two runs that agree on every other field but disagree here have
+// taken a different number of draws, which is the one thing that moves actor decisions
+// without moving anything a digest already covers.
+U32 Rnd_Draws(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/LIB386/H/SYSTEM/TIMER.H
+++ b/LIB386/H/SYSTEM/TIMER.H
@@ -77,6 +77,14 @@ void Timer_FixedDtPump();
 // `*accMs` and return the step count, clamped to `maxSteps` (a spiral-of-death guard;
 // pass a negative value for no clamp). On clamp the backlog beyond the clamp is dropped,
 // keeping only the sub-dt remainder. Post-condition: `*accMs < dt`. Unit-tested directly.
+// #358: the game clock the last simulated sub-step ran at -- the accumulator
+// Timer_PlanSimSteps carries between frames. Simulation state, not a clock reading: it
+// decides where this frame's sub-step boundaries fall, so two runs that agree on
+// TimerRefHR to the millisecond still simulate differently if they disagree here. Lives
+// beside TimerRefHR because a session that hands over one has to hand over both, and
+// because the function that owns it is in this file.
+extern U32 LastSimRefHR;
+
 S32 Timer_FixedStepCount(U32 *accMs, U32 elapsedMs, U32 dt, S32 maxSteps);
 
 // Plan one rendered frame of the production sub-step loop (SOURCES/PERSO.CPP MainLoop). Pure:

--- a/LIB386/H/SYSTEM/TIMER.H
+++ b/LIB386/H/SYSTEM/TIMER.H
@@ -65,6 +65,15 @@ void Timer_FixedDtOverlayPresent();
 // Unlike Timer_FixedDtPresent() there is no free first step. Inert outside fixed-dt.
 void Timer_FixedDtPump();
 
+// Answer the simulation's "is this voice still playing" from the sample's own length on
+// the game clock instead of from the mixer. True whenever the pinned clock is armed, and
+// separately settable by the recorder, which needs the same answer on a host-sampled
+// clock: SOURCES/AMBIANCE.CPP draws its random pan only `if (!IsSamplePlaying(...))`, and
+// that draw comes from the one random stream actor behaviour uses, so a voice that
+// outlives its recording by a frame moves every actor decision after it.
+void Timer_SetSimAudioClock(S32 on);
+S32 Timer_SimAudioClock(void);
+
 // --- Fixed simulation timestep (production, issue #358) ----------------------
 // Movement/animation is only correct near ~60 fps because locomotion is baked into
 // animation keyframes advanced once per rendered frame (see docs/MOVEMENT_FRAMERATE.md).

--- a/LIB386/SYSTEM/RANDOM.CPP
+++ b/LIB386/SYSTEM/RANDOM.CPP
@@ -35,6 +35,7 @@ static S32 s_state[RND_DEG];
 static S32 s_front;
 static S32 s_rear;
 static S32 s_seeded;
+static U32 s_draws;
 
 //──────────────────────────────────────────────────────────────────────────
 void Rnd_Seed(U32 seed) {
@@ -76,11 +77,18 @@ const char *Rnd_StreamName(void) {
 }
 
 //──────────────────────────────────────────────────────────────────────────
+U32 Rnd_Draws(void) {
+    return s_draws;
+}
+
+//──────────────────────────────────────────────────────────────────────────
 S32 Rnd_Next(void) {
     U32 val;
 
     if (!s_seeded)
         Rnd_Seed(1);
+
+    s_draws++;
 
     // Unsigned so the sum wraps rather than overflowing a signed type.
     val = (U32)s_state[s_front] + (U32)s_state[s_rear];

--- a/LIB386/SYSTEM/TIMER.CPP
+++ b/LIB386/SYSTEM/TIMER.CPP
@@ -43,6 +43,7 @@ static U32 FixedDtNow = 0;
 static S32 FixedDtTicking = 0;        // set on the first tick advance; gates present-stepping past boot
 static S32 FixedDtSkipPresent = 0;    // makes the first present after each tick advance free
 static S32 FixedDtOverlayPresent = 0; // the next present draws an overlay, not a frame
+static S32 SimAudioClock = 0;         // see Timer_SimAudioClock (TIMER.H)
 
 // --- Initialization ----------------------------------------------------------
 void InitTimer() {
@@ -179,6 +180,14 @@ void Timer_FixedDtPump() {
 
 S32 Timer_FixedDtActive() {
     return FixedDtActive;
+}
+
+void Timer_SetSimAudioClock(S32 on) {
+    SimAudioClock = on ? 1 : 0;
+}
+
+S32 Timer_SimAudioClock(void) {
+    return FixedDtActive || SimAudioClock;
 }
 
 S32 Timer_FixedStepCount(U32 *accMs, U32 elapsedMs, U32 dt, S32 maxSteps) {

--- a/LIB386/SYSTEM/TIMER.CPP
+++ b/LIB386/SYSTEM/TIMER.CPP
@@ -16,6 +16,7 @@ volatile U32 TimerSystemHR;
 volatile U32 TimerRefHR;
 volatile S32 CmptFrame;
 volatile S32 NbFramePerSecond;
+U32 LastSimRefHR = 0; // #358 sub-step carry; see TIMER.H
 
 // --- Private state -----------------------------------------------------------
 volatile S32 TimerLock;

--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -579,8 +579,15 @@ int Control_IsActive(void) {
 
 /* Read by PERSO.CPP: a headless run must not open the modal game-data folder picker,
    which would hang forever with nobody to answer it. */
+/* See Control_SetDigestVersion. Current unless a replay lowers it. */
+static S32 s_digestVersion = CONTROL_DIGEST_VERSION;
+
 int Control_IsHeadless(void) {
     return s_headless;
+}
+
+void Control_SetDigestVersion(S32 v) {
+    s_digestVersion = (v > 0) ? v : 1;
 }
 
 int Control_IsVerbose(void) {
@@ -1555,11 +1562,23 @@ void Control_InputAdvance(int simTicks) {
 /* Filled by Control_StateDigest on every call, whether or not anything wants the
    values: a replay needs its own copy to compare against, and collecting costs less
    than the hashing it rides along with. */
-#define TELE_MAX (64 + 9 * MAX_OBJETS + MAX_VARS_GAME + MAX_VARS_CUBE)
+/* Per-object fields in the digest's actor loop below. Keep the two in step: the digest
+   mixes every value regardless, but the telemetry array silently stops collecting once
+   it is full, and the values that fall off the end are the ones written last -- the
+   script variables. Undersized, the hash still matches and the report just stops
+   naming the fields it can no longer see, which reads as "nothing else differs". */
+#define TELE_PER_OBJ 13
+#define TELE_MAX (64 + TELE_PER_OBJ * MAX_OBJETS + MAX_VARS_GAME + MAX_VARS_CUBE)
 static S32 s_tele[TELE_MAX];
 static const char *s_teleName[TELE_MAX];
 static S16 s_teleIdx[TELE_MAX];
 static S32 s_teleN = 0;
+/* Values the array had no room for. Counted rather than ignored: a full array reports a
+   shorter list and nothing about it looks wrong, so an undersized TELE_MAX would read as
+   "no other field differs" instead of "I stopped looking". */
+static S32 s_teleDropped = 0;
+extern "C" U32 Rnd_Draws(void);
+
 /* ---- the game state the harness reads ------------------------------------- */
 /*
  * Reading the engine's state belongs here rather than in whatever wants it. This module
@@ -1590,6 +1609,20 @@ static void mix(const void *p, unsigned n) {
    named without anyone remembering to name it. Scalars carry index -1; the loops below
    pass the array index they are on. */
 #define M(v) MI(#v, -1, v)
+/* Collected and named like MI, but never mixed: a field that describes how a divergence
+   happened rather than being part of what diverged. It shows up in every report and
+   changes no verdict. */
+#define R(nm, v)                        \
+    do {                                \
+        S32 t_ = (S32)(v);              \
+        if (s_teleN < TELE_MAX) {       \
+            s_teleName[s_teleN] = (nm); \
+            s_teleIdx[s_teleN] = -1;    \
+            s_tele[s_teleN++] = t_;     \
+        } else {                        \
+            s_teleDropped++;            \
+        }                               \
+    } while (0)
 #define MI(nm, ix, v)                       \
     do {                                    \
         S32 t_ = (S32)(v);                  \
@@ -1598,6 +1631,8 @@ static void mix(const void *p, unsigned n) {
             s_teleName[s_teleN] = (nm);     \
             s_teleIdx[s_teleN] = (S16)(ix); \
             s_tele[s_teleN++] = t_;         \
+        } else {                            \
+            s_teleDropped++;                \
         }                                   \
     } while (0)
 
@@ -1746,6 +1781,12 @@ unsigned long long Control_StateDigest(void) {
         MI("obj.Anim", i, o->Obj.Anim.Num);
         MI("obj.Move", i, o->Move);
         MI("obj.Flags", i, o->Flags);
+        if (s_digestVersion >= 2) {
+            MI("obj.Sample", i, (S32)o->SampleAlways);
+            MI("obj.LastFrame", i, o->Obj.LastFrame);
+            MI("obj.LastTimer", i, (S32)o->Obj.LastTimer);
+            MI("obj.NextTimer", i, (S32)o->Obj.NextTimer);
+        }
     }
     /* Modal and menu state. Without these a replay that opens a menu the recording
        never opened stays "matching" until the menu changes something else, which can
@@ -1756,6 +1797,14 @@ unsigned long long Control_StateDigest(void) {
     M(GameNbChoices);
     M(FlagFade);
     M(FlagBlackPal);
+    /* Probe: the two pieces of per-frame state a recording does not carry. */
+    if (s_digestVersion >= 2) {
+        /* The carry is hashed: it decides where the next frame's sub-step boundaries
+           fall, so two runs that disagree on it are already simulating differently. The
+           draw count is not, for the reason on R above. */
+        MI("sim.carry", -1, (S32)LastSimRefHR);
+        R("rng.draws", Rnd_Draws());
+    }
     for (i = 0; i < MAX_VARS_GAME; i++)
         MI("var.game", i, ListVarGame[i]);
     for (i = 0; i < MAX_VARS_CUBE; i++)
@@ -1763,7 +1812,19 @@ unsigned long long Control_StateDigest(void) {
     return s_h;
 }
 
-S32 Control_StateValueCount(void) { return s_teleN; }
+S32 Control_StateValueCount(void) {
+    if (s_teleDropped) {
+        static S32 said = 0;
+        if (!said) {
+            said = 1;
+            fprintf(stderr,
+                    "[control] telemetry array full: %d value(s) not collected. "
+                    "Raise TELE_PER_OBJ/TELE_MAX in SOURCES/CONTROL.CPP.\n",
+                    (int)s_teleDropped);
+        }
+    }
+    return s_teleN;
+}
 
 S32 Control_StateValue(S32 k) { return (k >= 0 && k < s_teleN) ? s_tele[k] : 0; }
 

--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -1817,9 +1817,12 @@ S32 Control_StateValueCount(void) {
         static S32 said = 0;
         if (!said) {
             said = 1;
+            /* No source path in the text: a player reads this one too, and a string
+               naming the repository is what rule 7 of check-arch is for. The comment on
+               TELE_PER_OBJ above says where to raise it. */
             fprintf(stderr,
-                    "[control] telemetry array full: %d value(s) not collected. "
-                    "Raise TELE_PER_OBJ/TELE_MAX in SOURCES/CONTROL.CPP.\n",
+                    "[control] telemetry array full: %d value(s) not collected, so a "
+                    "divergence report will not name every field that moved\n",
                     (int)s_teleDropped);
         }
     }

--- a/SOURCES/CONTROL.H
+++ b/SOURCES/CONTROL.H
@@ -34,6 +34,14 @@ int Control_IsActive(void);
 /* Non-zero if --headless was supplied: no window, no audio device. */
 int Control_IsHeadless(void);
 
+/* Which set of fields Control_StateDigest hashes. A replay sets it from the recording's
+   `numeric.digest` line so a file written against the older set still compares against
+   the set it was written with; a recording always uses the current one. Fields added
+   since are appended, never interleaved, so selecting the older version reproduces its
+   sequence exactly rather than approximating it. */
+#define CONTROL_DIGEST_VERSION 2
+void Control_SetDigestVersion(S32 v);
+
 /* Write the same JSON snapshot --dump-state writes, to \a path, right now. The flag
    captures once as the run ends, which is all a bounded run needs; a session driven
    from outside wants one per probe, so the console `dumpstate` verb routes here. */

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -448,8 +448,6 @@ S32 MainLoop() {
     U8 i;
     S32 pansample;
 
-    // #358 fixed-timestep simulation: game-clock time of the last simulated sub-step.
-    static U32 LastSimRefHR = 0;
     // Cap on sub-steps per rendered frame (spiral-of-death guard). Below ~8 fps the sim
     // stops fully catching up and slows in a bounded way rather than freezing on catch-up.
     const S32 FIXED_TIMESTEP_MAX_STEPS = 8;

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -111,6 +111,16 @@ extern "C" {
    up sessions that work to protect sessions that never did. */
 #define REC_VERSION_MIN 9
 
+/* Which set of fields Control_StateDigest hashes. Not REC_VERSION: the rule above puts a
+   change to what the engine computes in a third case that the format version does not
+   cover, because the bytes still mean what they meant and the reader can still read them.
+   What such a change does break is the comparison, and silently -- a recording whose
+   digests were computed over fewer fields mismatches on tick 0 and reads as a session
+   that diverged immediately. Declaring it puts that in the mode diff beside the
+   `numeric.` lines, where a replay names what it disagrees about instead of failing as
+   though the run came apart. Move it whenever a field is added to or removed from the
+   digest. */
+
 /* Every buffer the text header passes through, named once so growing it is one decision
    rather than five. A real header runs about 1.6 KB: the mode block, the settings, and
    two binding tables that scale with how much the player has rebound. It grows whenever a
@@ -533,6 +543,7 @@ static S32 write_mode_lines(char *out, size_t n) {
                          "build.flags=%s\n"
                          "build.platform=%s\n"
                          "numeric.rng=%s\n"
+                         "numeric.digest=%d\n"
                          "numeric.long_double_bits=%d\n"
                          "mode.resolution=%ux%u\n"
                          "mode.language=%d\n"
@@ -551,6 +562,7 @@ static S32 write_mode_lines(char *out, size_t n) {
                          BUILD_FLAGS_STR,
                          Sys_PlatformName(),
                          Rnd_StreamName(),
+                         CONTROL_DIGEST_VERSION,
                          (int)LDBL_MANT_DIG,
                          (unsigned)ModeDesiredX, (unsigned)ModeDesiredY,
                          (int)Language,
@@ -2125,6 +2137,12 @@ int Record_Play(const char *path) {
        holds the recording's value and the banked delta is zero. */
     {
         U32 v = 0;
+        /* Absent means a recording written before the digest declared itself, which is
+           the one field set that predates the line: version 1. Selected before the first
+           tick is checked, so the very first comparison is against the set the file was
+           written with rather than against this build's. */
+        Control_SetDigestVersion(RecFmt_ReadU32(s_headerBuf, "numeric.digest=", &v) ? (S32)v : 1);
+        v = 0;
         s_pendingBaseline = 0;
         if (RecFmt_ReadU32(s_headerBuf, "clock.timer_ref_hr=", &v)) {
             s_baseline = v;

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -1227,6 +1227,13 @@ static int record_begin(const char *path, int haveSnapshot) {
         if (s_hashEvery < 1)
             s_hashEvery = 1;
     }
+    /* Answer the simulation's sample-playing question from the game clock for the whole
+       session. Without it a voice's lifetime is the audio device's, which no replay
+       reproduces, and AMBIANCE.CPP's `if (!IsSamplePlaying(...))` pan draw comes off the
+       one random stream actor behaviour uses. Armed for a host-sampled session too, not
+       just a pinned one: a loose recording needs it more, having nothing else holding the
+       two ends together. */
+    Timer_SetSimAudioClock(1);
     s_recording = 1;
     return 1;
 }
@@ -1304,6 +1311,7 @@ static void record_release_step(void) {
        two cannot come apart again. */
     s_frameClock = 0;
     s_frameClockValid = 0;
+    Timer_SetSimAudioClock(0);
 
     if (!s_recArmedDt)
         return;
@@ -1975,6 +1983,7 @@ static int replay_poll(void) {
    asked for: a replay that reloads first takes a scene load between the two, and the
    clock it compares against has to be the one it begins on. */
 static void replay_begin(void) {
+    Timer_SetSimAudioClock(1);
     memset(s_prevKeys, 0, sizeof s_prevKeys);
     s_prevKey = 0;
     s_prevSrcDelta = 0;

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -247,6 +247,7 @@ static U32 s_prevMt = 0;
 static long s_mtCalls = 0;
 static U32 s_frameClock = 0;
 static U32 s_baseline = 0;
+static U32 s_baselineCarry = 0;
 static char s_snapshot[ADELINE_MAX_PATH] = "-";
 /* Whether the snapshot named above is going into the file rather than beside it. The
    header says which, so a reader that finds no chunk knows whether to look for a
@@ -539,6 +540,7 @@ static S32 write_mode_lines(char *out, size_t n) {
                          "setup.reloaded=%d\n"
                          "setup.reload_clock=%u\n"
                          "clock.timer_ref_hr=%u\n"
+                         "clock.sim_carry=%u\n"
                          "data.master=%s\n"
                          "bindings.digest=%016llx\n",
                          LBA2_VERSION_STRING,
@@ -555,6 +557,7 @@ static S32 write_mode_lines(char *out, size_t n) {
                          s_snapInline ? "(inline)" : path_leaf(s_snapshot),
                          s_reloaded, s_reloadClock,
                          (unsigned)TimerRefHR,
+                         (unsigned)LastSimRefHR,
                          Distrib_MasterName(Distrib_GetMaster()),
                          bindings_digest());
     if (wrote <= 0 || (size_t)wrote >= n)
@@ -1518,6 +1521,7 @@ static int line_present(const char *hay, const char *line) {
 static int mode_line_ignored(const char *line) {
     static const char *const skip[] = {
         "clock.timer_ref_hr=", /* the recorded baseline: restored, not matched */
+        "clock.sim_carry=",    /* the sub-step carry: restored with it */
         "setup.snapshot=",     /* the file it started from, named per recording */
         "setup.reloaded=",     /* how it started, which the reader acts on rather than matches */
         "setup.reload_clock=",
@@ -1957,6 +1961,7 @@ static int replay_poll(void) {
     if (s_pendingBaseline) {
         s_pendingBaseline = 0;
         SetTimerHR(s_baseline);
+        LastSimRefHR = s_baselineCarry;
     }
 
     replay_inject();
@@ -2116,6 +2121,18 @@ int Record_Play(const char *path) {
             s_baseline = v;
             s_pendingBaseline = 1;
         }
+        /* The sub-step carry goes back with the clock it is measured against, and for
+           the same reason: TimerRefHR says what time it is, this says where inside the
+           step the simulation last stopped. Restoring one without the other lands the
+           replay's sub-step boundaries a millisecond off the recording's, which is
+           invisible for a couple of hundred ticks and then is an actor on a different
+           animation. Absent in a recording written before this line existed, which
+           leaves the carry as the replay's own -- the behaviour those files were
+           recorded under. */
+        if (RecFmt_ReadU32(s_headerBuf, "clock.sim_carry=", &v))
+            s_baselineCarry = v;
+        else
+            s_baselineCarry = LastSimRefHR;
     }
 
     report_extent();

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -111,15 +111,15 @@ extern "C" {
    up sessions that work to protect sessions that never did. */
 #define REC_VERSION_MIN 9
 
-/* Which set of fields Control_StateDigest hashes. Not REC_VERSION: the rule above puts a
-   change to what the engine computes in a third case that the format version does not
-   cover, because the bytes still mean what they meant and the reader can still read them.
-   What such a change does break is the comparison, and silently -- a recording whose
-   digests were computed over fewer fields mismatches on tick 0 and reads as a session
-   that diverged immediately. Declaring it puts that in the mode diff beside the
-   `numeric.` lines, where a replay names what it disagrees about instead of failing as
-   though the run came apart. Move it whenever a field is added to or removed from the
-   digest. */
+/* The header declares CONTROL_DIGEST_VERSION (SOURCES/CONTROL.H), which is the set of
+   fields Control_StateDigest hashes, and it is deliberately not REC_VERSION: the rule
+   above puts a change to what the engine computes in a third case the format version does
+   not cover, because the bytes still mean what they meant and the reader can still read
+   them. What such a change does break is the comparison, and silently -- a recording whose
+   digests were computed over fewer fields mismatches on tick 0 and reads as a session that
+   diverged immediately. Declaring it puts that in the mode diff beside the `numeric.`
+   lines, where a replay names what it disagrees about instead of failing as though the run
+   came apart. */
 
 /* Every buffer the text header passes through, named once so growing it is one decision
    rather than five. A real header runs about 1.6 KB: the mode block, the settings, and
@@ -1246,6 +1246,12 @@ static int record_begin(const char *path, int haveSnapshot) {
        just a pinned one: a loose recording needs it more, having nothing else holding the
        two ends together. */
     Timer_SetSimAudioClock(1);
+    /* Back to this build's field set. A replay lowers it to whatever the file it opened
+       declared, and a session that played an old recording and then started a new one
+       would otherwise write numeric.digest=2 in the header over hashes computed the old
+       way -- a file that lies about itself, and mismatches on tick 0 of its own replay
+       forever. */
+    Control_SetDigestVersion(CONTROL_DIGEST_VERSION);
     s_recording = 1;
     return 1;
 }

--- a/SOURCES/SAVEGAME.CPP
+++ b/SOURCES/SAVEGAME.CPP
@@ -753,12 +753,16 @@ S32 LoadGame(void) {
     {
         T_OBJ_3D *heroanim = &ListObjet[NUM_PERSO].Obj;
 
-        if (heroanim->LastTimer != TimerRefHR) {
-            S32 shift = (S32)((U32)TimerRefHR - heroanim->LastTimer);
+        /* Unsigned throughout. The shift is a difference between two clock readings and
+           wraps rather than overflowing, where routing it through S32 would be undefined
+           for the large deltas this can legitimately carry: the gap between two saved
+           baselines runs to tens of minutes in either direction. */
+        U32 shift = (U32)TimerRefHR - heroanim->LastTimer;
 
-            heroanim->LastTimer = (U32)((S32)heroanim->LastTimer + shift);
-            heroanim->NextTimer = (U32)((S32)heroanim->NextTimer + shift);
-            heroanim->Time = (U32)((S32)heroanim->Time + shift);
+        if (shift) {
+            heroanim->LastTimer += shift;
+            heroanim->NextTimer += shift;
+            heroanim->Time += shift;
         }
     }
 

--- a/SOURCES/SAVEGAME.CPP
+++ b/SOURCES/SAVEGAME.CPP
@@ -729,6 +729,39 @@ S32 LoadGame(void) {
 
     CameraCenter(0);
     SetTimerHR(savetimerrefhr);
+
+    /* Put the hero's animation on the clock the rest of the scene is on.
+     *
+     * `InitAnim` stamps `LastTimer` from `TimerRefHR` where it runs, and for the hero that
+     * is during boot, before the line above installs the save's clock. Every other actor
+     * is stamped after it and comes out on the restored reading; the hero is left on
+     * whatever the wall clock said between process start and scene init, which is a
+     * different number on every run of the same save. Measured: two runs of one save land
+     * two to three milliseconds apart here, and that is enough for him to reach an
+     * animation transition a tick apart a couple of hundred ticks later.
+     *
+     * Shifted rather than assigned, so the interval survives: `NextTimer` is `LastTimer`
+     * plus the current frame's own duration, and moving both by one delta keeps that
+     * duration while moving where it starts. `Time` goes with them, being the same clock
+     * read by the interpolator.
+     *
+     * Not a loop over every object. The others are already right, and shifting them by
+     * this delta is wrong twice over: it moves anchors that are on the correct timeline,
+     * and the delta itself is the distance between two saved baselines, which for the
+     * shipped saves is tens of minutes and takes whichever sign the two files happen to
+     * give it. Measured, that shift takes tick 0 from one diverging object to four. */
+    {
+        T_OBJ_3D *heroanim = &ListObjet[NUM_PERSO].Obj;
+
+        if (heroanim->LastTimer != TimerRefHR) {
+            S32 shift = (S32)((U32)TimerRefHR - heroanim->LastTimer);
+
+            heroanim->LastTimer = (U32)((S32)heroanim->LastTimer + shift);
+            heroanim->NextTimer = (U32)((S32)heroanim->NextTimer + shift);
+            heroanim->Time = (U32)((S32)heroanim->Time + shift);
+        }
+    }
+
     SaveTimer();
 
     return flaginit;

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -89,14 +89,39 @@ directory. It cannot pick the wrong file, because a folder that has the name win
 `--user-dir` and `--profile` move the folder with the rest of the profile, so recordings made under
 one profile are the ones that profile replays.
 
-## The pinned step is required, not an optimisation
+## The pinned step is still required, and not for the reason it looks like
 
-A session recorded on the host-sampled clock does not replay exactly. Movement integrates per
-sub-step from `GetDeltaMove`, so two runs that reach a tick with the same clock reading but a
-different number of steps inside it end up in different places. Pinning the step is what makes a
-replay reproducible, and it was arrived at by measurement: reproducing the sampled clock,
-reconstructing it, and pinning the derived game clock every tick were each built and none of them
-worked.
+A session recorded on the host-sampled clock does not yet replay reliably, so record and replay
+with `--fixed-dt 16`. The reason is not the clock.
+
+A loose recording reproduces `TimerRefHR` at **0 ms drift at every tick, in every run measured**,
+so the host clock is not what a replay fails to reproduce. What `--fixed-dt` does is make every
+frame delta exactly 16 ms, which makes every value derived from frame timing trivially equal at
+both ends. That is a masking mechanism rather than a determinism one, and what it masks is
+simulation state no save, digest or recording carries. Each such value found is one less thing the
+pinned step has to hide, and the day the list is empty the step can go.
+
+Two are closed, both invisible under a pinned step by construction:
+
+- `LastSimRefHR`, the [#358](MOVEMENT_FRAMERATE.md) sub-step carry, decides where a frame's
+  sub-step boundaries fall. A replay that begins on its own boot's value rather than the
+  recording's diverges at tick 1 by a millisecond, and an actor is on a different animation two
+  hundred ticks later. At a constant 16 ms `Timer_PlanSimSteps` always returns one step and the
+  carry cannot matter, which is why a pinned session cannot see it either way. It lives in
+  `TIMER.H` beside `TimerRefHR`, the recording declares it as `clock.sim_carry`, and a replay
+  restores it beside the baseline.
+- `VoiceHeardBySim` answers from the sample's own length on the game clock for any run that has to
+  reproduce, not only a pinned one. Gated on the step, a loose session asks the mixer instead, whose
+  clock no replay reproduces. See "Audio used to move the answer" below.
+
+One is open: `InitAnim` stamps the hero's animation anchors during boot, from wall-clock time, and
+the load then moves the game clock without moving them. Every other actor is stamped from the
+restored clock and matches exactly.
+
+Reproducing the clock more faithfully is finished as a direction. Storing one sample per
+`ManageTime` call was built and measured and makes replays *worse*. What is left is
+finding the state, and the digest names it: see `numeric.digest` and the `sim.carry`,
+`obj.LastTimer`, `obj.NextTimer` and `rng.draws` fields.
 
 Who pins it depends on where the recording starts, and the split is not a convenience:
 
@@ -435,9 +460,14 @@ reproduces, so one draw either way offset the stream and the next actor to reach
 angle" instruction turned differently. Measured: a walking session diverged at tick 1410 on
 `obj[11].Beta`, with zero clock drift, and the same walk recorded `--no-audio` replayed clean.
 
-Under `--fixed-dt` a sample's playing state is now answered from its own length on the game clock
-rather than from the mixer, so the simulation sees the same answer in both runs. The mixer is
-untouched: this only changes what the simulation is told, and only in a mode no player runs.
+A sample's playing state is answered from its own length on the game clock rather than from the
+mixer for any run that has to reproduce, which is a pinned run and also a recording or a replay on
+a host-sampled one. The loose path needs it more, having nothing else holding its two ends
+together. The mixer is untouched: this only changes what the simulation is told.
+
+Measured on the loose path, audio on: one recording replayed five times went from clean on some
+runs and diverging on others to clean on all five, and a sweep of eight fresh record-and-replay
+pairs went from none clean to three.
 
 This is also why the bug survived so long. Every fixture runs `--headless`, which skips
 `InitSampleDriver` altogether, so nothing in the suite had ever exercised the audio path. A

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -323,7 +323,7 @@ modal, and covers no other actor and none of the 336 script variables.
 digest mixes, every tick, so the first rejected tick names the fields that moved:
 
 ```
-[rec] verbose telemetry: 578 values a tick
+[rec] verbose telemetry: 668 values a tick
 [rec] consistency failure at tick 201: recorded 2060ee23…, replayed ab660bc5…
 [rec] tick 201 state differs: var.game[77] 0/42  (recorded/replayed)
 ```
@@ -333,9 +333,9 @@ same name: `hero->Obj.LastFrame`, `obj[12].Anim`, `var.cube[7]`. A field added t
 named without anyone having to name it.
 
 The first rejected tick is reported along with the two after it, which is usually enough to tell a
-value that moved once from one that is drifting. About 2 KB a tick -- measured at 2319 bytes a tick
-over a 198-tick session -- so it is recorded deliberately rather than by default: roughly 4 MB for a
-session of a few thousand ticks, and about 200 MB of telemetry alone on a half-hour one.
+value that moved once from one that is drifting. About 2.8 KB a tick -- measured at 2787 bytes a
+tick over a 198-tick session -- so it is recorded deliberately rather than by default: roughly 5 MB
+for a session of a few thousand ticks, and about 240 MB of telemetry alone on a half-hour one.
 
 The bytes are the cost, and the time is not: writing them adds 0.10 ms of CPU a tick, measured
 against the same build without them, which is 0.6% of a 16 ms step. System time does not move --

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -114,9 +114,11 @@ Two are closed, both invisible under a pinned step by construction:
   reproduce, not only a pinned one. Gated on the step, a loose session asks the mixer instead, whose
   clock no replay reproduces. See "Audio used to move the answer" below.
 
-One is open: `InitAnim` stamps the hero's animation anchors during boot, from wall-clock time, and
-the load then moves the game clock without moving them. Every other actor is stamped from the
-restored clock and matches exactly.
+A third was the same shape and is closed with them: `InitAnim` stamps the hero's animation anchors
+during boot, from wall-clock time, and `LoadGame` installs the save's clock afterwards. Every other
+actor is stamped after that line and comes out on the restored reading, so the hero alone carried
+whatever the wall clock said between process start and scene init. `LoadGame` now puts him on the
+restored clock with his frame interval intact.
 
 Reproducing the clock more faithfully is finished as a direction. Storing one sample per
 `ManageTime` call was built and measured and makes replays *worse*. What is left is

--- a/docs/plan/RECORDING_RESEARCH.md
+++ b/docs/plan/RECORDING_RESEARCH.md
@@ -764,12 +764,17 @@ walking: clock drift max **0 ms** in all three. Two of the three still diverged 
 
 **And it mostly replays.** Eight loose record-and-replay pairs, 800 ticks, same scene and input:
 seven clean, one diverging at tick 407. `--fixed-dt` buys the last tenth rather than the capability,
-which is a smaller claim than "required, not an optimisation" reads as.
+which is a smaller claim than the requirement reads as.
 
-**A divergence is deterministic.** A recording that diverges does so at the same tick on every
-replay -- 850, three times over. That makes a loose recording that fails a repeatable reproducer
-rather than a flaky one, which is what the loose path has never had. Chasing one with `--verbose`
-names the field, and that is the next step for anyone who wants the requirement gone.
+**A divergence is deterministic, once audio is out of the way.** A recording that diverges does so
+at the same tick on every replay -- 850, three times over. That makes a loose recording that fails
+a repeatable reproducer rather than a flaky one, which is what the loose path has never had.
+
+The qualifier is not decoration: with `IsSamplePlaying` still answered from the mixer, one file
+replayed five times gives clean on some runs and the same divergence on others, and a single replay
+cannot tell a race from a reproducer. Replay a file five times before reading a verdict off it.
+Chasing one with `--verbose` names the field, and that is the next step for anyone who wants the
+requirement gone.
 
 What this retires is the direction, not the goal: reproducing the clock more faithfully is finished
 as an idea, and the residual behind tick 850 is the whole of what remains.
@@ -1608,8 +1613,8 @@ much argument: FLOW (17), GERETRAK (5), GERELIFE (5), EXTRA (5), OBJECT (4) and 
 RAIN (5), AMBIANCE (4), ANIMTEX (3), GAMEMENU (3) and CREDITS (2). Moving that second column, 17
 sites, to a second stream would remove two documented failures at the source rather than per
 symptom: the `DetailLevel` 3 to 0 divergence at tick 235, which is rain and nothing else, and the
-ambience half of the audio problem, which is currently answered by taking `IsSamplePlaying` off the
-mixer under `--fixed-dt` and so holds only in a mode no player runs.
+ambience half of the audio problem, which is answered by taking `IsSamplePlaying` off the mixer for
+any run that has to reproduce -- a pinned one, and a recording or replay on a host-sampled clock.
 
 Measured since, and it bounds what the split is worth. The instrument is not in the tree yet: a
 draw counter added to the digest for the pinned-step work, `Rnd_Draws()` surfaced as `rng.draws`.

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -206,7 +206,13 @@ rm -f "$recdir/$bare"
 # Removed by a trap rather than at the end of the arm: `fail` exits the shell, so every
 # assertion below is a way out of here that never reaches an inline rm.
 here="$(mktemp -d)"
-trap 'rm -rf "$here"' EXIT
+# Every temp directory this file makes goes on one list, and the trap reads the list.
+# The alternative, which this replaced, was a fresh trap per arm repeating every
+# directory before it: seven of them by the end, each a chance to drop one. One was
+# dropped, and the leak it left is invisible to every check the suite runs.
+CLEAN="$here"
+clean_add() { CLEAN="$CLEAN $1"; }
+trap 'rm -rf $CLEAN' EXIT
 
 (cd "$here" && ctl --fixed-dt 16 --load "$LBA2_TEST_SAVE" --record "$bare" --tick 200 --exit) \
     >/dev/null 2>&1 ||
@@ -399,7 +405,7 @@ esac
 # already put files in the suite's own, and "exactly one recording" is what says the
 # auto-name landed where it belongs rather than somewhere that already had a file.
 loopdir="$(mktemp -d)"
-trap 'rm -rf "$here" "$loopdir"' EXIT
+clean_add "$loopdir"
 
 LBA2_USER_DIR="$loopdir" ctl --load "$LBA2_TEST_SAVE" \
     --exec-at 20 "rec start" --exec-at 120 "key up 60 2" \
@@ -447,7 +453,7 @@ esac
 # Nothing to play. Reported rather than silent, and naming the folder it looked in:
 # without that the answer is indistinguishable from a replay that started and did nothing.
 emptydir="$(mktemp -d)"
-trap 'rm -rf "$here" "$loopdir" "$emptydir"' EXIT
+clean_add "$emptydir"
 emptyout="$(LBA2_USER_DIR="$emptydir" ctl --load "$LBA2_TEST_SAVE" \
     --exec-at 20 "rec play" --tick 60 --exit 2>&1)" ||
     fail "console loop: the empty-folder run exited non-zero ($?) — hang or crash"
@@ -469,7 +475,7 @@ esac
 # The console saying it armed something and the stream holding the records are separate
 # claims, and only the second one is any use a week later.
 verbdir="$(mktemp -d)"
-trap 'rm -rf "$here" "$loopdir" "$emptydir" "$verbdir"' EXIT
+clean_add "$verbdir"
 
 LBA2_USER_DIR="$verbdir" ctl --load "$LBA2_TEST_SAVE" \
     --exec-at 20 "rec start verbose" --exec-at 120 "key up 60 2" \
@@ -519,7 +525,7 @@ movesave="$REPO/tests/savegame/corpus/saves/steam_classic_2023/Anon1.LBA"
 [ -f "$movesave" ] || fail "movement: the corpus save is missing from $movesave"
 
 movedir="$(mktemp -d)"
-trap 'rm -rf "$here" "$loopdir" "$emptydir" "$verbdir" "$movedir"' EXIT
+clean_add "$movedir"
 
 # hero_xz <state.json> -- the engine's own dump, because `status` reports Nxw/Nyw/Nzw,
 # which are collision scratch and not the hero.
@@ -604,7 +610,7 @@ play_xz="$(hero_xz "$movedir/play.json")" || fail "movement: could not read the 
 # `rec info` reports the live run's mode, which makes this a question about a printed
 # number rather than about elapsed time.
 stepdir="$(mktemp -d)"
-trap 'rm -rf "$here" "$loopdir" "$emptydir" "$verbdir" "$movedir" "$stepdir"' EXIT
+clean_add "$stepdir"
 
 # Through a file rather than a pipeline. The suite does not set `pipefail`, so a pipeline
 # carries the status of its last command -- `tr` here, which succeeds whatever the engine
@@ -653,7 +659,7 @@ esac
 # replay and exit, and has no player session to protect -- so the question only means
 # something for a playback started from inside a session.
 retdir="$(mktemp -d)"
-trap 'rm -rf "$here" "$loopdir" "$emptydir" "$verbdir" "$movedir" "$stepdir" "$retdir"' EXIT
+clean_add "$retdir"
 
 LBA2_USER_DIR="$retdir" ctl --load "$movesave" \
     --exec-at 20 "rec start" --exec-at 200 "key up 250" --exec-at 520 "rec stop" \
@@ -712,6 +718,97 @@ for stopat in 961 1100; do
     [ "$early_after" = "$early_before" ] ||
         fail "return: a playback stopped at tick $stopat started with the hero at $early_before and left him at $early_after — stopping a playback has to put the player back too"
 done
+
+# --- recording does not perturb the run -------------------------------------------
+#
+# The claim the recorder rests on, and until this arm nothing checked it. Every other arm
+# here runs --fixed-dt 16, and under a pinned step the question cannot even be asked: the
+# game advances 16 ms per tick whatever the frame cost, so a recorder that doubled the
+# frame time would show up as the run taking longer and not as the game behaving
+# differently.
+#
+# Asked as a rate rather than as a state diff, and that is not a shortcut. On a loose
+# clock two runs of the same scripted session legitimately part -- game time is a function
+# of how long each frame took -- so diffing their states would be flaky from the first run
+# and the obvious repair would be to pin the step, which is the thing the arm exists to
+# rule out.
+#
+# Two questions, because either alone passes for the wrong reason. Whether each run is
+# real time catches a step pinned when it should not be: --fixed-dt 16 with no recorder at
+# all runs 600 ticks of game time in a fraction of the wall time they describe, measured
+# at 3.49x. Whether the two runs agree catches the recorder costing time without changing
+# the clock it reports.
+ratedir="$(mktemp -d)"
+clean_add "$ratedir"
+
+rate_of() { # rate_of <label> [extra args...] -- game seconds per wall second, on stdout
+    local label="$1"
+    shift
+    local ud="$ratedir/$label"
+    mkdir -p "$ud"
+    local t0 t1
+    t0="$(date +%s.%N)"
+    LBA2_USER_DIR="$ud" ctl --load "$LBA2_TEST_SAVE" \
+        --exec-at 20 "dumpstate $ud/before.json" \
+        --exec-at 40 "key up 800" \
+        --tick 900 --dump-state "$ud/after.json" --exit "$@" >/dev/null 2>&1 || return 1
+    t1="$(date +%s.%N)"
+    python3 -c "
+import json, sys
+b = json.load(open('$ud/before.json'))['timer_ref_hr']
+a = json.load(open('$ud/after.json'))['timer_ref_hr']
+game = (a - b) / 1000.0
+wall = $t1 - $t0
+if wall <= 0 or game <= 0:
+    sys.exit(1)
+print('%.3f' % (game / wall))"
+}
+
+# Not in a command substitution that swallows it: `fail` ends the shell it runs in, so a
+# failure inside $( ) would kill the subshell and let the caller print PASS over the top.
+rate_ctl="$(rate_of control)" ||
+    fail "rate: the control run exited non-zero or dumped no clock — hang, crash, or a stopped clock"
+rate_rec="$(rate_of recording --record "$ratedir/recording/s.rec")" ||
+    fail "rate: the recording run exited non-zero or dumped no clock — hang, crash, or a stopped clock"
+
+# The band is wide on purpose. It is sized to separate real time from a pinned step
+# (3.49x), not to measure the host: this suite shares a machine with whatever else is
+# running on it, and boot is inside the wall time while it is outside the game time, so
+# the honest floor is well under 1.
+for pair in "control:$rate_ctl" "recording:$rate_rec"; do
+    lbl="${pair%%:*}"
+    val="${pair#*:}"
+    ok="$(python3 -c "print(1 if 0.5 <= $val <= 1.6 else 0)")"
+    [ "$ok" = 1 ] ||
+        fail "rate: the $lbl run advanced ${val}s of game time per wall second, which is not real time — a step pinned here would read about 3.5"
+done
+
+# Between the two, where the recorder is the only difference. Machine load moves both, so
+# the ratio is the part that is about recording.
+rate_gap="$(python3 -c "print('%.3f' % ($rate_rec / $rate_ctl))")"
+gap_ok="$(python3 -c "print(1 if 0.7 <= $rate_gap <= 1.3 else 0)")"
+[ "$gap_ok" = 1 ] ||
+    fail "rate: recording ran at $rate_rec game seconds a wall second against $rate_ctl without it (${rate_gap}x) — recording is costing the run time"
+
+# The claim above is conditional, and this is the condition. RECORD.CPP writes a 20-byte
+# analog block per poll whenever any of the stick, pad, mouse or click fields is non-zero,
+# and on a host where the mouse delta never drains to zero that gate is always true: a
+# contributed 90,692-tick session came back 96.7 MB, of which 89.5 MB was an analog block
+# on every one of 4.5 million polls, against about 7 MB without. So "recording is free" is
+# free on the cheap side of that gate, and a run that quietly crossed it would still pass
+# the rate checks on a fast enough machine while describing nothing. Assert the side we
+# are on rather than let it go unsaid.
+ratecounts="$(python3 "$REPO/scripts/dev/dump_recording.py" "$ratedir/recording/s.rec" |
+    grep -m1 '^polls=')" ||
+    fail "rate: could not read the recording back"
+ratepolls="$(printf '%s\n' "$ratecounts" | sed 's/.*polls=\([0-9]*\).*/\1/')"
+rateanalog="$(printf '%s\n' "$ratecounts" | sed 's/.*analog=\([0-9]*\).*/\1/')"
+# Counted rather than inferred from the file size: a short session is mostly header and
+# the two savegames it carries, so bytes a poll says more about those than about the
+# analog gate.
+analog_ok="$(python3 -c "print(1 if $rateanalog <= $ratepolls // 10 else 0)")"
+[ "$analog_ok" = 1 ] ||
+    fail "rate: $rateanalog of $ratepolls polls carry an analog block, so the gate at RECORD.CPP is firing on most of them — the rate result above is not describing an ordinary recording"
 
 pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; mode.audio was written from the driver and reported both ways; a session recorded in one run replayed in the next with no flags and no paths; \
 'rec start verbose' carried telemetry and a plain one carried none; a recorded walk moved the hero and the replay walked it again; the recorder gave the step back and left the flag's alone; a playback put the player back where it found them, stopped early or run out"

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -210,9 +210,11 @@ here="$(mktemp -d)"
 # The alternative, which this replaced, was a fresh trap per arm repeating every
 # directory before it: seven of them by the end, each a chance to drop one. One was
 # dropped, and the leak it left is invisible to every check the suite runs.
-CLEAN="$here"
-clean_add() { CLEAN="$CLEAN $1"; }
-trap 'rm -rf $CLEAN' EXIT
+# An array, and quoted in the trap. A plain string would word-split, so a TMPDIR with a
+# space in it would hand `rm -rf` the pieces rather than the path.
+CLEAN=("$here")
+clean_add() { CLEAN+=("$1"); }
+trap 'rm -rf "${CLEAN[@]}"' EXIT
 
 (cd "$here" && ctl --fixed-dt 16 --load "$LBA2_TEST_SAVE" --record "$bare" --tick 200 --exit) \
     >/dev/null 2>&1 ||
@@ -747,12 +749,14 @@ rate_of() { # rate_of <label> [extra args...] -- game seconds per wall second, o
     local ud="$ratedir/$label"
     mkdir -p "$ud"
     local t0 t1
-    t0="$(date +%s.%N)"
+    # python rather than `date +%s.%N`: %N is GNU-only, and a BSD date passes the literal
+    # N through to the arithmetic below, where the arm fails as though the run had hung.
+    t0="$(python3 -c 'import time; print(time.time())')"
     LBA2_USER_DIR="$ud" ctl --load "$LBA2_TEST_SAVE" \
         --exec-at 20 "dumpstate $ud/before.json" \
         --exec-at 40 "key up 800" \
         --tick 900 --dump-state "$ud/after.json" --exit "$@" >/dev/null 2>&1 || return 1
-    t1="$(date +%s.%N)"
+    t1="$(python3 -c 'import time; print(time.time())')"
     python3 -c "
 import json, sys
 b = json.load(open('$ud/before.json'))['timer_ref_hr']
@@ -771,14 +775,16 @@ rate_ctl="$(rate_of control)" ||
 rate_rec="$(rate_of recording --record "$ratedir/recording/s.rec")" ||
     fail "rate: the recording run exited non-zero or dumped no clock — hang, crash, or a stopped clock"
 
-# The band is wide on purpose. It is sized to separate real time from a pinned step
-# (3.49x), not to measure the host: this suite shares a machine with whatever else is
-# running on it, and boot is inside the wall time while it is outside the game time, so
-# the honest floor is well under 1.
+# The band is wide on purpose, and the floor especially. It has one job -- separate real
+# time from a pinned step, which reads about 3.5 -- and two reasons not to be tight: boot
+# sits inside the wall time while it is outside the game time, and this suite shares a
+# machine with whatever else is running on it. A tight floor would fail the control arm on
+# a busy host and say nothing about recording. The ratio check below is the part that is
+# actually about the recorder, and it is not affected by either.
 for pair in "control:$rate_ctl" "recording:$rate_rec"; do
     lbl="${pair%%:*}"
     val="${pair#*:}"
-    ok="$(python3 -c "print(1 if 0.5 <= $val <= 1.6 else 0)")"
+    ok="$(python3 -c "print(1 if 0.25 <= $val <= 2.0 else 0)")"
     [ "$ok" = 1 ] ||
         fail "rate: the $lbl run advanced ${val}s of game time per wall second, which is not real time — a step pinned here would read about 3.5"
 done


### PR DESCRIPTION
## What this is

Three determinism bugs, the instrument that found them, the guard that was missing, and a doc that no longer states a false premise.

**It does not drop the `--fixed-dt` requirement.** A loose recording still does not replay reliably, and `rec start` still warns and still tells you to relaunch with the flag, because that is still the right advice. What changes is the method.

## The premise was wrong

`docs/RECORDING.md` said the pinned step is required because a host-sampled clock cannot be reproduced, and that reproducing it had been tried and had failed.

Measured: **a loose recording reproduces `TimerRefHR` at 0 ms drift at every tick, in every run.** The clock was never the problem.

What `--fixed-dt 16` actually does is make every frame delta exactly 16 ms, so every value derived from frame timing is trivially equal at both ends. It is a masking mechanism rather than a determinism one, and what it masks is simulation state that no save, digest or recording carries. Each such value found is one less thing the step has to hide.

Three were hiding under it.

## The three

**`LastSimRefHR`, the #358 sub-step carry** — a function-static inside `MainLoop`, in no digest, no save and no recording. It decides where a frame's sub-step boundaries fall, so a replay beginning on its own boot's value diverges at tick 1 by a millisecond and puts an actor on a different animation two hundred ticks later. At a constant 16 ms `Timer_PlanSimSteps` always returns one step and the carry cannot matter, which is why a pinned session cannot see it either way.

Moved to `TIMER.H` beside `TimerRefHR` rather than reached through a `Control` accessor: it is the accumulator for `Timer_PlanSimSteps`, which lives in `TIMER.CPP`, so `PERSO.CPP` holding it was the accident. `RECORD.CPP` already reads and writes `TimerRefHR` through that header, so this needed no new coupling.

**`VoiceHeardBySim`** — gated on `Timer_FixedDtActive()`, so a session recorded on a host-sampled clock asked the mixer instead, whose clock no replay reproduces. `AMBIANCE.CPP` draws its random pan only `if (!IsSamplePlaying(...))`, from the one stream actor behaviour draws from, so one draw either way moves every actor decision after it. Its own comment said this applied "only in a mode no player runs", which stopped being true when `rec start` began arming the step.

**The hero's animation anchors** — `InitAnim` stamps `LastTimer` from `TimerRefHR` where it runs, and for the hero that is during boot, before `LoadGame` installs the save's clock at its tail. Every other actor is stamped after that line and comes out on the restored reading; the hero alone carried whatever the wall clock said between process start and scene init, which is a different number on every run of the same save.

Deliberately **not** a loop over every object. The others are already on the restored clock, and the delta is the distance between two saved baselines rather than any elapsed time — for the shipped saves that is tens of minutes, taking whichever sign the two files give it. Applying it to everything takes tick 0 from one diverging object to four; that was measured before it was believed.

## The instrument

A divergence used to report a tick and a hash, and the fields that actually carry one were not in the digest. Adds `sim.carry`, `obj.Sample`, `obj.LastFrame`, `obj.LastTimer`, `obj.NextTimer`, and a report-only `rng.draws`.

`rng.draws` reports and does not judge, through an `R()` macro that collects a value without mixing it. A stream two draws apart with every value it fed identical is a real hazard and worth seeing, but it is not this tick failing to reproduce. It found one immediately: **a mid-session `rec start` reaches tick 0 with the stream 2 draws apart**, which the suite has been replaying clean for as long as it has existed. Left visible and non-gating rather than hidden or fatal.

The field set is versioned. Appending to the digest changes every hash, so a recording written against the older set would mismatch on tick 0 as though the session came apart; a replay selects the set from the header's `numeric.digest` (absent means version 1), so the format-10 fixture still replays — which is the arm that exists to catch a change breaking writer and reader together.

## The guard

Nothing checked the claim the recorder rests on. Every other arm runs `--fixed-dt 16`, and under a pinned step the question cannot be asked.

Asked as a rate, not a state diff: on a loose clock two runs of the same scripted session legitimately part, so diffing their states would be flaky by construction and the obvious repair would be to pin the step — the thing the arm exists to rule out.

```
control            wall  2.73s   game  2.58s   speed 0.94x real
record loose       wall  2.76s   game  2.60s   speed 0.94x real
control pinned     wall  2.75s   game  9.58s   speed 3.49x real
record pinned      wall  9.68s   game  9.58s   speed 0.99x real
```

Row 2 is the assertion. **Row 3 is the finding worth carrying out of this PR: `--fixed-dt 16` with no recorder running at all advances the game at 3.49x real.** The pin is the perturbation; the recorder is free. That is the shape of the playtest reports about recording running too fast, and this PR does not fix it — see below.

A third check asserts the condition the first two rest on. `RECORD.CPP` writes a 20-byte analog block per poll whenever any of the stick, pad, mouse or click fields is non-zero, and on a host whose mouse delta never drains that gate is always true: a contributed 90,692-tick session came back 96.7 MB, of which 89.5 MB was an analog block on every one of 4.5 million polls, against about 7 MB without. "Recording is free" is free on the cheap side of that gate, so the arm asserts which side it is on.

Validated by breaking it: with the step pinned in both arms it fails at 3.386, the figure the failure message predicts.

## Measured

| | before | after |
|---|---|---|
| loose, one file replayed 5x | bimodal, then deterministic at ~226 | 1 clean, first divergence moves to tick 233 |
| loose, 8 fresh pairs | 0/8 clean | 3/8 |
| load-heavy loose, 3 loads, both rewind signs | 0/3, tick 0 on `obj[0].LastTimer` | **3/3 clean** |
| pinned control | 3/3 clean | 3/3 clean |

Gates: `test_record_replay.sh` passes, `make savegame-corpus` clean (50 saves, two ABIs, `ok_init` on all, no probe-vs-harness divergence — the load path is every player's), `check-build-graph.py` and `check-format.sh` clean.

## What is still open

- **The residual**, now the first divergence: `obj[4].Anim 277/279` with `LastFrame 1/-1`. The `-1` is what `ObjectStoreFrame` writes, so the two sides are on a stored frame and a table frame — they disagree about which path the object took, not only about when.
- **The RNG 2-draw offset** on the mid-session reload path, above.
- **The perturbation players actually report.** Row 3 is untouched by this PR. The pacer covers main-loop ticks and not fades, menus or dialogue, because `Timer_FixedDtPresent` advances the clock per present while the pacer runs from the tick hook, which a modal never reaches. The fix is step B of `ENGINE_RENDER_SPLIT_RESEARCH.md` — one shared pump for the modal loops — reached independently from two directions.

## Review

Reviewed at `high`; seven findings, all fixed in the last commit, plus two CI caught after the first push: a warning string naming a source path (check-arch rule 7), and a `DEFINES_FANIN` lowering that was measurement error — the local count came from a tree configured without `LBA2_BUILD_TESTS`, so it was a translation unit short. This branch does not touch `C_EXTERN.H` and could not have moved that number; the constant is back where it was. The load-bearing one: a replay lowered the digest field set and nothing put it back, so a session that played an old recording and then started a new one wrote a header declaring the new field set over hashes computed the old way. A file that lied about itself and mismatched on tick 0 of its own replay forever.
