### PR TITLE
fix(control): clear the injected mouse motion when its span ends

### DIFF
--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -1443,6 +1443,16 @@ static U32 s_mouse_buttons = 0;
 static T_ControlSpan s_mouse_span;
 
 void Control_MouseClear(void) {
+    /* The accumulator too, not only this module's copy of what it was feeding.
+       control_mouse_apply writes through SetMouseMotion, which is a store rather than
+       a queue, and the only thing that empties LibMouseXDep is ManageMouse -- which a
+       shipping build reaches only from GereExtKeys, past a return that fires when the
+       cube is interior or when no key is held and the Auto camera is off. So a span
+       that ends leaves its last value sitting there, and every later poll reads it
+       back: `mouse 8 0 1` on an interior save leaves 8 in the accumulator for the rest
+       of the run, which a recording captures on all 280 remaining polls. Clearing what
+       this put there is this function's job whatever the engine does about the rest. */
+    SetMouseMotion(0, 0);
     s_mouse_dx = s_mouse_dy = 0;
     s_mouse_span.end = 0;
     /* Lift the buttons rather than leaving them for something else to notice: Click is a


### PR DESCRIPTION
**Rewritten.** The first version of this PR changed `GereExtKeys` and claimed a 280-to-4 improvement across three cases. That evidence was wrong: the reproducer drives the mouse through the harness, and the harness was the cause. See the comment above. What follows is only what is demonstrated.

## The bug

`control_mouse_apply` writes through `SetMouseMotion`, which is a store into `LibMouseXDep` rather than a queue. `Control_MouseClear` cleared this module's own state -- `s_mouse_dx`, the span, the buttons -- and never the accumulator it had been writing.

The only thing that empties `LibMouseXDep` is `ManageMouse`, and a shipping build reaches it from exactly one place: inside `GereExtKeys`, past a return that fires when the cube is interior, or when no key is held and the Auto camera is off. None of which is the harness's business to depend on.

So a span that ended left its last value sitting in the accumulator and every later poll read it back.

## Measured

Injecting one poll of motion and then sitting still through 400 ticks, on an interior save:

| | analog blocks in the recording |
|---|---|
| before | **280** |
| after | **1** |

The recorder writes a 20-byte analog block for any poll whose motion is non-zero, so a stuck value is written on every poll for the rest of the run.

The drag orbit still moves, which is the part that had to survive: same scripted drag, exterior, Auto camera on, `cam.beta` 2048 to 3385 and `cam.addbeta` 0 to 2759.

## What this is not

This is the injector cleaning up after itself. It is **not** a claim about the engine.

A real session writes the same accumulator through `HandleEventsMouse`, which never fires under `--headless` and so was never exercised by the reproducer here. A contributed 30-minute recording made on real hardware carries a mouse delta stuck at 8 across 4,472,955 of 4,473,043 polls -- 89.5 MB of a 96.7 MB file -- and that is a separate question with a separate cause, still open. It wants a reproducer that is not synthetic before anything in the engine is changed for it.