### PR TITLE
fix(record): three places still sent the reader to --verbose for telemetry

### DIFF
--- a/docs/plan/INPUT_PLAN.md
+++ b/docs/plan/INPUT_PLAN.md
@@ -168,10 +168,10 @@ express one.
 limit.** `Control_StateDigest` mixes `hero->GenAnim`, so a change to the general animation is
 caught; the keyframe's 23 names did not include it, so a non-verbose replay reported the concrete
 `hero.anim` instead and left the reader translating. Every combo below is stated in `GenAnim`
-terms, so the keyframe now names it too and a divergence reads `hero.gen_anim 0->18`. `--verbose`
-named it all along, from the expression the digest mixes. The lesson is that the record format is
-this project's to shape: where a replay cannot say what moved, the answer is to teach it the name,
-not to work around it.
+terms, so the keyframe now names it too and a divergence reads `hero.gen_anim 0->18`. The per-tick
+telemetry (`--record-telemetry`) named it all along, from the expression the digest mixes. The
+lesson is that the record format is this project's to shape: where a replay cannot say what moved,
+the answer is to teach it the name, not to work around it.
 
 Adding a field wants both readers touched. The C table carries a comment saying writer, reader and
 reporter all walk it so a field cannot be added to one and missed by another, and that holds inside

--- a/docs/plan/RECORDING_RESEARCH.md
+++ b/docs/plan/RECORDING_RESEARCH.md
@@ -335,10 +335,10 @@ Two things narrow that, at different costs:
 - **A keyframe every 32 ticks**, 23 named fields: the hero, the camera, and the open modal. Cheap
   enough to be unconditional, and it covers most of what goes wrong. It covers no other actor and
   none of the 336 script variables.
-- **`--verbose`, which stores every value the digest mixes, every tick.** About 2 KB a tick, so it
-  is a deliberate second recording rather than the default. The first rejected tick then names the
-  fields, along with the two ticks after it, which distinguishes a value that moved once from one
-  that is drifting.
+- **`--record-telemetry`, which stores every value the digest mixes, every tick.** About 2 KB a
+  tick, so it is a deliberate second recording rather than the default. The first rejected tick
+  then names the fields, along with the two ticks after it, which distinguishes a value that moved
+  once from one that is drifting.
 
 The names come from the expression the digest mixes rather than from a parallel list, which is the
 part worth keeping: a field cannot be hashed under one name and reported under another, and a field
@@ -773,8 +773,8 @@ a repeatable reproducer rather than a flaky one, which is what the loose path ha
 The qualifier is not decoration: with `IsSamplePlaying` still answered from the mixer, one file
 replayed five times gives clean on some runs and the same divergence on others, and a single replay
 cannot tell a race from a reproducer. Replay a file five times before reading a verdict off it.
-Chasing one with `--verbose` names the field, and that is the next step for anyone who wants the
-requirement gone.
+Chasing one with `--record-telemetry` names the field, and that is the next step for anyone who
+wants the requirement gone.
 
 What this retires is the direction, not the goal: reproducing the clock more faithfully is finished
 as an idea, and the residual behind tick 850 is the whole of what remains.

--- a/scripts/dev/dump_recording.py
+++ b/scripts/dev/dump_recording.py
@@ -380,7 +380,8 @@ def show_tele(teles, changing_only, header=""):
     reports a divergence for at most three ticks and eight values, and before this the
     offline reader counted them without printing any."""
     if not teles:
-        print("no verbose telemetry in this recording (record with --verbose)")
+        print("no verbose telemetry in this recording "
+              "(record with --record-telemetry, or `rec start verbose`)")
         return
     teles.sort()
     n = len(teles[0][1])


### PR DESCRIPTION
## What & why

Follow-up to #623, which split `--record-telemetry` out of `--verbose`. That change swept
the CLI, `docs/RECORDING.md`, `docs/CONTROL.md`, the changelog and the automation
fixtures, and missed `scripts/` and `docs/plan/` entirely. Three sites still point at the
old flag.

**`scripts/dev/dump_recording.py` is the one that matters.** Reading a recording with no
telemetry printed `"no verbose telemetry in this recording (record with --verbose)"` --
user-facing text naming a flag that no longer does it. Somebody following that advice gets
a second recording with no telemetry and no indication why. It now names
`--record-telemetry`, and `rec start verbose` alongside it, since the console word is the
other way to ask and did not change.

**`docs/plan/RECORDING_RESEARCH.md`** (two sites) and **`docs/plan/INPUT_PLAN.md`** (one)
describe the mechanism rather than the workflow, so they are stale rather than actively
misleading -- but they are what a reader searching the tree for how to arm telemetry finds
first.

## Notes for reviewers

Two `--verbose` references are left alone on purpose:

- `docs/plan/BOOT_LOG_PLAN.md:529` refers to "the `--verbose` pattern", meaning how
  `Control_ParseArgs` reads a boolean flag. Still accurate; the flag is still parsed that
  way and this is not about telemetry.
- The released `CHANGELOG.md` entry describes what shipped at the time and should keep
  saying so.

`tests/automation/test_cli_flag_contract.sh` has `--verbose` as a flag under test, which is
correct and unrelated.

**How it was missed, and it takes two to make this defect.** The sweep for #623 was scoped
to the two reference docs and the test fixtures, on the assumption that a CLI flag lives in
the CLI docs. It also lives in a tool that prints advice, and in the plan docs that argued
for the feature. A whole-tree grep catches all three in one pass and is the cheaper habit.

That is only half of it. The advice string was added in #622, hours before #623 changed
what the flag meant. It was correct when written and became wrong without being touched.
Neither change was defective on its own -- the defect is in the pair, and nothing warns you
about a pair. So the other half of the habit belongs to whoever writes the advice: **a tool
that prints advice naming a flag is a doc**, and it has taken on a dependency on that flag's
meaning that no compiler and no test will remind anyone of.

`REC_TELE`'s comment at :144 and the `"verbose telemetry: %d values a tick"` label at :453
are both correct and stay -- one describes the record type, the other labels output. Only
advice pointing at a flag goes stale this way.

## Checklist

- [x] Build passes on my platform (Linux) -- no engine code touched
- [ ] If LIB386 / 3DEXT touched: ASM equivalence tests pass (`./run_tests_docker.sh`) -- not touched
- [x] If behavior changes: opt-in via flag/cvar/config (preserves default game feel) -- text only
- [x] Docs updated in the same PR if behavior or workflow changed
- [x] French comments and ASCII art preserved in any modified files

Verified: `python3 -m py_compile` on the reader, `check-docs-links` and `check-docs-symbols`
clean, doc prose rewrapped to the file's 100-column width.
