### PR TITLE
fix(timer): pace the pinned clock where it mints time, not where a tick lands

### DIFF
--- a/LIB386/H/SYSTEM/TIMER.H
+++ b/LIB386/H/SYSTEM/TIMER.H
@@ -64,6 +64,19 @@ void Timer_FixedDtOverlayPresent();
 // inside them, so they would spin forever. Call this once per iteration of such a loop.
 // Unlike Timer_FixedDtPresent() there is no free first step. Inert outside fixed-dt.
 void Timer_FixedDtPump();
+// Hold the pinned clock to real time: every step the clock hands out costs a step of wall
+// time, wherever it is handed out from. Off by default, which is what a batch run wants --
+// the point of --fixed-dt for the harness is to finish sooner than real time. A player
+// recording a session wants the opposite, because the recording has to be of the game as
+// it plays, and a session that races is not one.
+//
+// Armed here rather than in the caller because pacing per tick, which is the only unit a
+// caller outside the timer can see, covers the main loop and misses every modal: a fade,
+// a menu or a dialogue runs its own loop that presents and pumps without reaching the
+// main-loop tick, and takes as much virtual time as it wants for free. That is the
+// too-fast transitions, the menus that scroll several entries a keypress and the dialogue
+// that skips itself. Inert outside fixed-dt. Cleared when the clock is disarmed.
+void Timer_SetFixedDtPaced(S32 on);
 
 // Answer the simulation's "is this voice still playing" from the sample's own length on
 // the game clock instead of from the mixer. True whenever the pinned clock is armed, and

--- a/LIB386/SYSTEM/TIMER.CPP
+++ b/LIB386/SYSTEM/TIMER.CPP
@@ -164,7 +164,8 @@ S32 Timer_FixedDtValue(void) {
    step, so the error does not accumulate: a step that overruns is paid for by the next
    one arriving early rather than by every later step sliding. */
 static void FixedDtStep(void) {
-    U32 target, now;
+    U32 target;
+    S32 ahead;
 
     FixedDtNow += FixedDt;
 
@@ -173,13 +174,20 @@ static void FixedDtStep(void) {
 
     PaceSteps++;
     target = PaceAnchor + PaceSteps * FixedDt;
-    now = SDL_GetTicks();
-    if (now < target)
-        SDL_Delay(target - now);
-    else if (now - target > PACE_GIVEUP_MS) {
+    /* A signed difference of two unsigned readings, not a comparison of their magnitudes.
+       Both wrap -- the host clock every 49.7 days, and the anchor plus the step count with
+       it -- and either one wrapping first makes a magnitude test read the gap as nearly
+       2^32 ms, so the sleep below would be weeks rather than milliseconds. The subtraction
+       wraps to the true small difference and survives it. */
+    ahead = (S32)(target - (U32)SDL_GetTicks());
+    if (ahead > 0)
+        SDL_Delay((U32)ahead);
+    else if (ahead < -PACE_GIVEUP_MS) {
         /* Too far behind to catch up. Give the time up rather than sprint to win it
-           back, which would run the game fast to make up for having run it slow. */
-        PaceAnchor = now;
+           back, which would run the game fast to make up for having run it slow. The
+           ordinary way to reach this is a window that lost focus: the clock stops, the
+           wall clock does not, and the run resumes owing more time than it can repay. */
+        PaceAnchor = (U32)SDL_GetTicks();
         PaceSteps = 0;
     }
 }

--- a/LIB386/SYSTEM/TIMER.CPP
+++ b/LIB386/SYSTEM/TIMER.CPP
@@ -35,14 +35,20 @@ U32 LastEvaluate;
 // unchanged.
 #define FPS_EVAL_WINDOW_MS 250
 
+// How far behind real time the paced clock may fall before it stops trying to catch up.
+#define PACE_GIVEUP_MS 1000
+
 // Fixed-dt deterministic clock (harness-only). Inert unless Timer_EnableFixedDt() is
 // called: while active, ManageTime() reads FixedDtNow instead of SDL_GetTicks().
 static S32 FixedDtActive = 0;
 static U32 FixedDt = 0;
-static U32 FixedDtNow = 0;
+static U32 FixedDtNow = 0;            // minted only by FixedDtStep(); seeded by Timer_EnableFixedDt
 static S32 FixedDtTicking = 0;        // set on the first tick advance; gates present-stepping past boot
 static S32 FixedDtSkipPresent = 0;    // makes the first present after each tick advance free
 static S32 FixedDtOverlayPresent = 0; // the next present draws an overlay, not a frame
+static S32 FixedDtPaced = 0;          // spend real time per step; see Timer_SetFixedDtPaced
+static U32 PaceAnchor = 0;            // wall clock when pacing was armed or last re-anchored
+static U32 PaceSteps = 0;             // steps minted since then
 static S32 SimAudioClock = 0;         // see Timer_SimAudioClock (TIMER.H)
 
 // --- Initialization ----------------------------------------------------------
@@ -108,6 +114,7 @@ void Timer_EnableFixedDt(U32 dt_ms) {
     FixedDtActive = 1;
     FixedDtTicking = 0;
     FixedDtSkipPresent = 0;
+    FixedDtPaced = 0;
 }
 
 void Timer_DisableFixedDt(void) {
@@ -117,6 +124,7 @@ void Timer_DisableFixedDt(void) {
     FixedDtTicking = 0;
     FixedDtSkipPresent = 0;
     FixedDtOverlayPresent = 0;
+    FixedDtPaced = 0;
     // Resync LastTime to the wall clock before any of it can be banked. The two clocks
     // have been running at different rates since the arm -- the virtual one moves dt per
     // frame, the wall one moves in wall time -- so by now they are far apart, and the
@@ -139,11 +147,48 @@ S32 Timer_FixedDtValue(void) {
     return FixedDtActive ? (S32)FixedDt : 0;
 }
 
+/* Mint one step of virtual time, and -- when something is holding the clock to real time
+   -- spend a step of real time on it.
+
+   Every dt the pinned clock hands out passes through here, from all three sites that
+   hand one out: the tick advance, an extra present, and a non-presenting pump. That is
+   the whole point of the funnel. Pacing per tick instead covers the main loop and misses
+   the other two, which are exactly the modal ones: a fade, a menu or a dialogue box runs
+   its own loop that presents and pumps without ever reaching the main-loop tick, so it
+   would draw as much virtual time as it liked at no cost in wall time. Measured on the
+   FadeToBlack path (SOURCES/AMBIANCE.CPP), which waits out FADE_DELAY of game time:
+   208 ms of clock in 26 ms of wall, eight times real speed, inside a run whose overall
+   rate read 1.02x because the paced main loop averaged the spike away.
+
+   The target is computed from the anchor and the step count rather than from the last
+   step, so the error does not accumulate: a step that overruns is paid for by the next
+   one arriving early rather than by every later step sliding. */
+static void FixedDtStep(void) {
+    U32 target, now;
+
+    FixedDtNow += FixedDt;
+
+    if (!FixedDtPaced)
+        return;
+
+    PaceSteps++;
+    target = PaceAnchor + PaceSteps * FixedDt;
+    now = SDL_GetTicks();
+    if (now < target)
+        SDL_Delay(target - now);
+    else if (now - target > PACE_GIVEUP_MS) {
+        /* Too far behind to catch up. Give the time up rather than sprint to win it
+           back, which would run the game fast to make up for having run it slow. */
+        PaceAnchor = now;
+        PaceSteps = 0;
+    }
+}
+
 void Timer_FixedDtAdvance() {
     // One fixed step per tick. The next unlocked ManageTime() banks it into TimerRefHR;
     // every other ManageTime() in the tick sees an unchanged FixedDtNow and adds nothing.
     if (FixedDtActive) {
-        FixedDtNow += FixedDt;
+        FixedDtStep();
         FixedDtTicking = 1;
         // The main-loop render that follows this advance presents one frame; let it pass
         // for free so a normal tick stays exactly +dt. Extra presents in this tick come
@@ -166,7 +211,7 @@ void Timer_FixedDtPresent() {
         if (FixedDtSkipPresent) {
             FixedDtSkipPresent = 0;
         } else {
-            FixedDtNow += FixedDt;
+            FixedDtStep();
         }
     }
 }
@@ -174,12 +219,20 @@ void Timer_FixedDtPresent() {
 void Timer_FixedDtPump() {
     // No free first step: a non-presenting wait loop owns every iteration's time.
     if (FixedDtActive && FixedDtTicking) {
-        FixedDtNow += FixedDt;
+        FixedDtStep();
     }
 }
 
 S32 Timer_FixedDtActive() {
     return FixedDtActive;
+}
+
+void Timer_SetFixedDtPaced(S32 on) {
+    FixedDtPaced = on ? 1 : 0;
+    /* Anchor on the arm, not on the first step: the caller arms this at the moment it
+       wants real time to start counting from. */
+    PaceAnchor = SDL_GetTicks();
+    PaceSteps = 0;
 }
 
 void Timer_SetSimAudioClock(S32 on) {

--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -895,6 +895,21 @@ static void control_dump_state(const char *path) {
     fprintf(f, "  \"schema\": 1,\n");
     fprintf(f, "  \"tick\": %ld,\n", ticks_done);
     fprintf(f, "  \"timer_ref_hr\": %u,\n", (unsigned int)TimerRefHR);
+    /* The wall clock beside the game clock, so a reader can ask how fast the game ran
+       between two dumps rather than only how far it got. Over a whole run that question
+       answers itself badly -- boot is inside the wall time and outside the game time --
+       so the pair is only worth much across a window, which is exactly what it takes to
+       see a modal: a fade or a dialogue box advances game time in its own loop, and
+       whether it spends real time on it is invisible in any figure averaged over a
+       session. Unrelated to the pinned clock: always the host's. */
+    fprintf(f, "  \"wall_ms\": %u,\n", (unsigned int)SDL_GetTicks());
+    /* What ManageTime would read right now: the pinned clock when one is armed, the host
+       clock otherwise. Beside wall_ms this gives the rate the game is running at, which
+       timer_ref_hr cannot -- that one is the accumulated play time and moves backwards
+       through a scene change or a load, so a window bracketing one reads negative. This
+       is monotonic while the clock is armed, and on a run with no pinned clock it is the
+       wall clock, so the ratio is 1 by construction and the check still means something. */
+    fprintf(f, "  \"clock_src_ms\": %u,\n", (unsigned int)Timer_ClockSource());
     fprintf(f, "  \"fps\": %d,\n", (int)NbFramePerSecond);
     fprintf(f, "  \"throws\": %d,\n", (int)DbgHeroThrows);
     fprintf(f, "  \"action_resets\": %d,\n", (int)DbgHeroActionResets);

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -302,13 +302,6 @@ static S32 s_reloadDt = 0;
    put back: a run given --fixed-dt is pinned for its whole length by something that is
    not this. */
 static int s_recArmedDt = 0;
-/* Frame pacing while recording. A pinned step makes game time advance by a constant
-   per frame, and the engine has no frame limiter, so without holding each frame back
-   the session runs at whatever rate it renders at: 600 ticks of a 16 ms step took
-   3.53 s of wall clock rather than 9.6. Only while recording, and only when the step
-   is pinned; a replay wants to go as fast as it can. */
-static U32 s_paceAnchor = 0;
-static U32 s_paceFrames = 0;
 static int s_pendingBaseline = 0;
 static int s_frameClockValid = 0;
 static int s_hash32 = 0;    /* LBA2_REC_HASH32: store a 32-bit digest */
@@ -1221,8 +1214,11 @@ static int record_begin(const char *path, int haveSnapshot) {
         Console_Print("rec: warning, the simulation step is not pinned, so this "
                       "recording will not replay exactly. Relaunch with --fixed-dt 16.");
 
-    s_paceAnchor = SDL_GetTicks();
-    s_paceFrames = 0;
+    /* Hold the game to real time for as long as this recording lasts. Asked of the timer
+       rather than done here per tick: the clock hands out a step from three places and
+       only one of them is the tick, so pacing from this hook left every modal loop --
+       fades, menus, dialogue -- taking virtual time for free. */
+    Timer_SetFixedDtPaced(1);
     s_polls = s_ticks = s_bytes = s_quietPolls = 0;
     s_bytesTicks = s_maxPollsInTick = s_pollsThisTick = 0;
     s_nCmds = s_cmdRead = 0;
@@ -1330,6 +1326,10 @@ static void record_release_step(void) {
     s_frameClock = 0;
     s_frameClockValid = 0;
     Timer_SetSimAudioClock(0);
+    /* Unconditionally, like the two above and for the same reason: a run given --fixed-dt
+       keeps the step after `rec stop` but has no reason to keep being held to real time,
+       and leaving it armed would slow a harness run to a crawl with nothing saying why. */
+    Timer_SetFixedDtPaced(0);
 
     if (!s_recArmedDt)
         return;
@@ -2392,21 +2392,6 @@ void Record_TickHook(void) {
     if (!s_recording && !s_replaying)
         return;
     h = Control_StateDigest();
-
-    if (s_recording && Timer_FixedDtActive()) {
-        U32 step = (U32)Timer_FixedDtValue();
-        U32 now, target;
-        s_paceFrames++;
-        target = s_paceAnchor + s_paceFrames * step;
-        now = SDL_GetTicks();
-        if (now < target)
-            SDL_Delay(target - now);
-        else if (now - target > 1000) {
-            /* A long stall gives up the time rather than sprinting to win it back. */
-            s_paceAnchor = now;
-            s_paceFrames = 0;
-        }
-    }
 
     if (s_recording) {
         long before = s_bytes;

--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -325,7 +325,7 @@ Schema-versioned, hand-written, all-integer fields:
   "tick": 30,
   "timer_ref_hr": 41234,
   "wall_ms": 8231,
-  "clock_src_ms": 41234,
+  "clock_src_ms": 8229,
   "fps": 60,
   "scene": { "island": 4, "cube": 154, "cube_mode": "interior",
              "num_objects": 13, "num_zones": 4, "num_tracks": 5, "num_patches": 16 },
@@ -356,9 +356,12 @@ Schema-versioned, hand-written, all-integer fields:
   change or a load installs a clock rather than advancing one, so it moves backwards
   through both, measured at -4096 ms across a single `cube` change. Its advance is
   meaningful within a stretch of ordinary play, not across a transition.
-- `wall_ms`: the host clock (`SDL_GetTicks`), unaffected by `--fixed-dt`.
-- `clock_src_ms`: what `ManageTime` would read right now, which is the pinned clock when
-  one is armed and the host clock otherwise. Against `wall_ms` across two dumps this gives
+- `wall_ms` is the host clock (`SDL_GetTicks`), unaffected by `--fixed-dt`. Note the scale
+  against `timer_ref_hr` above: this one counts from process start, that one from whatever
+  play time the save carried, so the two are unrelated numbers and only their *deltas*
+  belong in the same sentence.
+- `clock_src_ms` is what `ManageTime` would read right now, which is the pinned clock when
+  one is armed and the host clock otherwise. It tracks `wall_ms`, not `timer_ref_hr`. Against `wall_ms` across two dumps this gives
   the rate the game ran at over that window, and a window is the only way to see a modal.
   A fade or a dialogue box advances the clock inside its own loop, and whether it spent
   real time doing so disappears into any figure averaged over a session. Unlike

--- a/docs/CONTROL.md
+++ b/docs/CONTROL.md
@@ -324,6 +324,8 @@ Schema-versioned, hand-written, all-integer fields:
   "schema": 1,
   "tick": 30,
   "timer_ref_hr": 41234,
+  "wall_ms": 8231,
+  "clock_src_ms": 41234,
   "fps": 60,
   "scene": { "island": 4, "cube": 154, "cube_mode": "interior",
              "num_objects": 13, "num_zones": 4, "num_tracks": 5, "num_patches": 16 },
@@ -350,8 +352,18 @@ Schema-versioned, hand-written, all-integer fields:
 - `timer_ref_hr` — the engine's master clock in ms (accumulated play time). It is
   persisted in saves and restored on `--load` (`SAVEGAME.CPP:845`), so a loaded game's
   clock starts at the save's play-time, not zero — e.g. an early save reads a few hours,
-  a late one ~12 h. Expect a large value; only its monotonic advance across ticks is
-  meaningful for the harness.
+  a late one ~12 h. Expect a large value, and do not expect it to only go up: a scene
+  change or a load installs a clock rather than advancing one, so it moves backwards
+  through both, measured at -4096 ms across a single `cube` change. Its advance is
+  meaningful within a stretch of ordinary play, not across a transition.
+- `wall_ms`: the host clock (`SDL_GetTicks`), unaffected by `--fixed-dt`.
+- `clock_src_ms`: what `ManageTime` would read right now, which is the pinned clock when
+  one is armed and the host clock otherwise. Against `wall_ms` across two dumps this gives
+  the rate the game ran at over that window, and a window is the only way to see a modal.
+  A fade or a dialogue box advances the clock inside its own loop, and whether it spent
+  real time doing so disappears into any figure averaged over a session. Unlike
+  `timer_ref_hr` it is monotonic while a step is pinned, so a window may bracket a scene
+  change.
 - `scene` — island/cube and live object/zone/track/patch counts.
 - `hero` — `ListObjet[0]`: world position, local angles, life, current behaviour and
   weapon, body/anim ids, animation frame, movement and zone state, flag words.

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -139,11 +139,41 @@ A replay pins whatever step the recording's header names, so a session played at
 replays at that one rather than at the default.
 
 The step is given back where it was taken. A pinned step advances game time by dt per rendered
-frame rather than by wall clock, and frames are paced to match only while a recording is running,
-so a session that kept the step afterwards ran at whatever rate it rendered at -- measured
-headless, 1.00x real time before a recording and 3.12x after one. `rec stop` and the end of a
-replay hand it back, and a run given `--fixed-dt` keeps its own: that step belongs to the whole
-run and to whoever asked for it.
+frame rather than by wall clock, and the clock is held to real time only while a recording is
+running, so a session that kept the step afterwards ran at whatever rate it rendered at --
+measured headless, 1.00x real time before a recording and 3.12x after one. `rec stop` and the end
+of a replay hand it back, and a run given `--fixed-dt` keeps its own: that step belongs to the
+whole run and to whoever asked for it.
+
+## Holding a recorded session to real time
+
+A pinned clock hands out its step from three places, not one: the tick advance, an extra present
+inside a frame, and a non-presenting pump. `Timer_SetFixedDtPaced` makes each of them cost a step
+of wall time, because the pacing lives at the single point in `TIMER.CPP` that all three go
+through.
+
+Not per tick, which is the only unit a caller outside the timer can see and the one unit that
+misses every modal. A fade, a menu, a dialogue box and an inventory screen each run their own loop
+that presents and pumps without ever reaching the main-loop tick, so a pacer sitting on the tick
+leaves all of them free to draw as much game time as they like at no cost in real time.
+`FadeToBlack` (`SOURCES/AMBIANCE.CPP`) waits out `FADE_DELAY`, 200 ms of game time; paced at the
+tick it spends 26 ms of wall clock doing so, eight times real speed. That is what the too-fast
+transitions are, along with the save menu that scrolls several entries to a keypress, the loading
+that fast-forwards and the dialogue that skips itself before its voice line finishes. Paced at the
+mint site the same fade spends 208 ms of wall for 208 ms of clock.
+
+None of this moves the step *sequence*. Each of the three sites mints the same number of steps
+whether the clock is held to real time or not, which is what makes pacing safe for a format that
+compares per-tick hashes: it spends wall time and changes no value the simulation reads.
+
+Off unless a recording asks for it. A batch run under `--fixed-dt` wants the opposite, and
+outrunning real time is most of why the harness has the flag.
+
+Two things it does not cover. A **replay** is not paced, which is right for verifying a recording
+and wrong for a player watching one back with `rec play`, where it races. And `FadeToBlack` pumps
+*and* presents on each iteration, so it mints 32 ms a time rather than 16 and renders half the
+frames it should; pacing gives it the right duration but not the frames, and correcting the double
+step moves the clock sequence, so it wants its own change.
 
 A recording whose step the recorder pinned carries `setup.reload_clock=0`, where one made
 under the flag carries the real reading. That is not a defect and not worth reconciling:

--- a/tests/automation/test_dump.sh
+++ b/tests/automation/test_dump.sh
@@ -16,7 +16,8 @@ python3 - "$json" <<'PY' || fail "schema/shape check failed"
 import json, sys
 d = json.load(open(sys.argv[1]))
 assert d.get("schema") == 1, "schema != 1"
-for k in ("tick", "timer_ref_hr", "fps", "scene", "hero", "inventory", "actors", "vars", "log"):
+for k in ("tick", "timer_ref_hr", "wall_ms", "clock_src_ms", "fps", "scene", "hero",
+          "inventory", "actors", "vars", "log"):
     assert k in d, "missing top-level key: " + k
 for k in ("island", "cube", "cube_mode", "num_objects"):
     assert k in d["scene"], "missing scene." + k
@@ -26,4 +27,4 @@ assert isinstance(d["actors"], list)
 assert "nonzero" in d["vars"]
 PY
 
-pass "valid JSON, schema=1, required keys present"
+pass "valid JSON, schema=1, required keys present including the wall and clock-source pair"

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -844,9 +844,14 @@ ctl --fixed-dt 16 --load "$LBA2_TEST_SAVE" --record "$modaldir/s.rec" \
     --exec-at 300 "cube 154" \
     --exec-at 340 "dumpstate $modaldir/w1.json" \
     --tick 600 --exit >/dev/null 2>&1 ||
-    fail "modal pacing: the scene-change run exited non-zero"
+    fail "modal pacing: the scene-change run exited non-zero ($?) — hang or crash"
 [ -s "$modaldir/w0.json" ] && [ -s "$modaldir/w1.json" ] ||
     fail "modal pacing: the run dumped no window — it never reached the scene change"
+# Before the rate is read, and not merely for tidiness: pacing is armed by a recording
+# starting, so a run whose --record never opened is unpaced for a reason that has nothing
+# to do with modal loops. It would fail the rate check below with a message blaming them.
+[ -s "$modaldir/s.rec" ] ||
+    fail "modal pacing: the run wrote no recording, so nothing armed the pacing and the rate below would describe the wrong fault"
 
 # Two numbers out of one reader, so the window is described once.
 modalout="$(python3 -c "
@@ -858,6 +863,8 @@ wall = b['wall_ms'] - a['wall_ms']
 ticks = b['tick'] - a['tick']
 if wall <= 0 or game <= 0 or ticks <= 0:
     raise SystemExit(1)
+# The 16 is the --fixed-dt above. Written twice on one command, so it is the one thing
+# here that has to move in step if the arm is ever re-pinned.
 print('%.3f %d %d' % (game / wall, game, ticks * 16))")" ||
     fail "modal pacing: the window dumped no usable clock — a stopped clock, or a bracket that caught nothing"
 

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -835,6 +835,11 @@ analog_ok="$(python3 -c "print(1 if $rateanalog <= $ratepolls // 10 else 0)")"
 # One-sided on purpose. A slow or loaded machine only ever pushes the rate down, so a
 # ceiling cannot fail for being busy; the failure it is looking for is the game running
 # faster than the player, which is the whole complaint.
+#
+# The ceiling is 1.15 because the two states it separates are 1.00 and 1.31, measured on
+# this window. Pacing can only ever sleep, never hurry, so the passing side is bounded
+# above by 1.00 and the 15% is headroom for timer granularity rather than a tolerance
+# anything is expected to use.
 modaldir="$(mktemp -d)"
 clean_add "$modaldir"
 

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -818,5 +818,64 @@ analog_ok="$(python3 -c "print(1 if $rateanalog <= $ratepolls // 10 else 0)")"
 [ "$analog_ok" = 1 ] ||
     fail "rate: $rateanalog of $ratepolls polls carry an analog block, so the gate at RECORD.CPP is firing on most of them — the rate result above is not describing an ordinary recording"
 
+# --- a modal loop is held to real time too -------------------------------------------
+#
+# The arm above asks the question over a whole run, and over a whole run it cannot see
+# this. A fade, a menu or a dialogue box advances the game clock inside its own loop, and
+# that loop is short: measured, FadeToBlack (SOURCES/AMBIANCE.CPP) took 208 ms of game
+# clock in 26 ms of wall, eight times real speed, inside a session whose overall rate read
+# 1.02x because the paced main loop averaged the spike away. Every figure averaged over a
+# session has that blind spot, so this one is asked over a window instead.
+#
+# Read from clock_src_ms and not timer_ref_hr: timer_ref_hr is accumulated play time and
+# moves backwards through a scene change -- measured -4096 ms across this very window --
+# so a bracket around a transition reads negative. clock_src_ms is what ManageTime would
+# read, which is the pinned clock while one is armed and the host clock otherwise.
+#
+# One-sided on purpose. A slow or loaded machine only ever pushes the rate down, so a
+# ceiling cannot fail for being busy; the failure it is looking for is the game running
+# faster than the player, which is the whole complaint.
+modaldir="$(mktemp -d)"
+clean_add "$modaldir"
+
+ctl --fixed-dt 16 --load "$LBA2_TEST_SAVE" --record "$modaldir/s.rec" \
+    --exec-at 40 "key up 200" \
+    --exec-at 295 "dumpstate $modaldir/w0.json" \
+    --exec-at 300 "cube 154" \
+    --exec-at 340 "dumpstate $modaldir/w1.json" \
+    --tick 600 --exit >/dev/null 2>&1 ||
+    fail "modal pacing: the scene-change run exited non-zero"
+[ -s "$modaldir/w0.json" ] && [ -s "$modaldir/w1.json" ] ||
+    fail "modal pacing: the run dumped no window — it never reached the scene change"
+
+# Two numbers out of one reader, so the window is described once.
+modalout="$(python3 -c "
+import json
+a = json.load(open('$modaldir/w0.json'))
+b = json.load(open('$modaldir/w1.json'))
+game = b['clock_src_ms'] - a['clock_src_ms']
+wall = b['wall_ms'] - a['wall_ms']
+ticks = b['tick'] - a['tick']
+if wall <= 0 or game <= 0 or ticks <= 0:
+    raise SystemExit(1)
+print('%.3f %d %d' % (game / wall, game, ticks * 16))")" ||
+    fail "modal pacing: the window dumped no usable clock — a stopped clock, or a bracket that caught nothing"
+
+modalrate="${modalout%% *}"
+modalgame="$(printf '%s\n' "$modalout" | cut -d" " -f2)"
+modalticks="$(printf '%s\n' "$modalout" | cut -d" " -f3)"
+
+# The condition the check rests on: that this window holds a modal at all. Ticks mint dt
+# each and nothing else in a quiet window does, so a window whose clock advanced no
+# further than its ticks account for never entered one -- and would pass the rate check
+# below by having nothing in it to fail. Without this the arm quietly stops testing the
+# moment the scripted scene change stops landing.
+[ "$modalgame" -gt "$modalticks" ] ||
+    fail "modal pacing: the window advanced ${modalgame} ms over ticks worth ${modalticks} ms, so no modal ran inside it — the scene change did not land and this arm tested nothing"
+
+modal_ok="$(python3 -c "print(1 if $modalrate <= 1.15 else 0)")"
+[ "$modal_ok" = 1 ] ||
+    fail "modal pacing: a window holding a scene change advanced ${modalrate}s of game time per wall second while recording — the modal loops are minting clock they do not pay for, which is the too-fast transitions players report"
+
 pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; mode.audio was written from the driver and reported both ways; a session recorded in one run replayed in the next with no flags and no paths; \
-'rec start verbose' carried telemetry and a plain one carried none; a recorded walk moved the hero and the replay walked it again; the recorder gave the step back and left the flag's alone; a playback put the player back where it found them, stopped early or run out"
+'rec start verbose' carried telemetry and a plain one carried none; a recorded walk moved the hero and the replay walked it again; the recorder gave the step back and left the flag's alone; a playback put the player back where it found them, stopped early or run out; a window holding a scene change ran at ${modalrate}x real, not faster"


### PR DESCRIPTION
## What this is

The perturbation players actually report. #625 measured it and did not fix it: a pinned step runs the game faster than real time, and the recorder's pacer was only holding back part of it.

Fixes the part that is felt: transitions, menus, loading and dialogue. Ordinary gameplay was already paced and is unchanged, measured at 1.00x both ways.

## The pinned clock mints time from three places, and the pacer sat on one

`Timer_FixedDtAdvance` (the tick), `Timer_FixedDtPresent` (an extra present inside a frame), `Timer_FixedDtPump` (a non-presenting wait). The recorder held the game to real time from its own tick hook, which is the first of the three.

The other two are exactly the modal ones. A fade, a menu, a dialogue box and an inventory screen each run their own loop that presents and pumps without ever reaching the main-loop tick, so pacing from the tick leaves all of them free to draw as much game time as they like at no cost in wall time.

`FadeToBlack` (`SOURCES/AMBIANCE.CPP`) waits out `FADE_DELAY`, 200 ms of **game** time. Instrumented per step:

```
STEP pump    1705 1699      <- game clock 1705 ms, wall clock 1699 ms
STEP present 1721 1699
...
STEP present 1913 1725      <- game +208 ms, wall +26 ms
```

**208 ms of clock in 26 ms of wall. Eight times real speed.**

That is the too-fast transitions, the save menu that scrolls several entries to a keypress, the loading that fast-forwards, and the dialogue that skips itself before its voice line finishes. `INVENT.CPP:1155` documents another of the same shape, ~600 ms minted through the present hook.

## The instrument that was already here could not have found it

The same run's overall rate reads **1.02x**. The paced main loop averages the spike away, so the rate arm added in #625 passes while a player watches transitions race.

That arm is still right for what it guards, which is a recorder that slows the run it observes. It was implicitly standing for more than it can carry: **an aggregate rate assertion cannot see a modal.** Only a per-step instrument shows this, and the new arm asks the question over a window instead.

## The fix

All three sites go through one `FixedDtStep()` in `TIMER.CPP`, and that is where the wall time is spent, so a step costs a step wherever it is minted. New seam `Timer_SetFixedDtPaced(S32 on)`; `RECORD.CPP` drops its own per-tick pacer and asks for this instead.

Asked of the timer rather than done in the recorder because the timer owns the clock and the recorder should not have to know a present from a pump. It also puts the accumulator beside what it accumulates.

**Off by default.** A batch run under `--fixed-dt` wants the opposite, and outrunning real time is most of why the harness has the flag. Only a recording arms it.

## Measured

Windowed, so boot is outside the measurement (it is inside the wall time and outside the game time, which is what makes a whole-run figure useless here):

| window | before | after |
|---|---|---|
| holding a scene change | **1.31x real** | **1.00x** |
| ordinary gameplay | 1.00x | 1.00x |

The quiet window is identical, which is the point: this changes nothing where the old pacer already worked.

Self-consistent with the per-step trace. 944 ms of game clock in 720 ms of wall, and 720 ms is exactly 45 ticks x 16 ms, so the main loop paid for every tick it took and the fade's 224 ms was free.

**The step sequence does not move.** Identical counts from each of the three sites with and without pacing (601 advance / 7 present / 7 pump both ways). That is what makes this safe for a format that compares per-tick hashes: pacing spends wall time and changes no value the simulation reads. `test_record_replay.sh` replays clean.

## Reading the rate needed a field that did not exist

`--dump-state` carried `timer_ref_hr` and nothing to divide it by. Two fields added: `wall_ms` (the host clock) and `clock_src_ms` (what `ManageTime` would read, so the ratio is 1 by construction on a run with no pinned step).

`timer_ref_hr` cannot stand in. It is accumulated play time, and a scene change installs a clock rather than advancing one, so it moves backwards through a transition: **measured at -4096 ms across a single `cube` change**, which reads as a negative rate. `docs/CONTROL.md` said only its monotonic advance was meaningful and now says where that stops being true.

Appended, not reformatted. The shape check reads keys by name; the two new ones join its required list, since a test now depends on them.

## The guard

A windowed rate over a scripted scene change, with a second check for the condition it rests on: ticks mint dt each and nothing else in a quiet window does, so a window whose clock advanced no further than its ticks account for never entered a modal and would pass by having nothing in it to fail. Without that the arm quietly stops testing the moment the scripted scene change stops landing.

One-sided on purpose. A slow or loaded machine only pushes the rate down, so the ceiling cannot fail for being busy, and the failure it looks for is the game running faster than the player.

Validated by breaking it: against the per-tick pacer it fails at **1.311**, the figure the A/B predicts, and passes at 1.000 with the funnel.

## What this is not

**Not step B of `ENGINE_RENDER_SPLIT_RESEARCH.md`.** An earlier framing of mine had them as the same change reached from two directions and that was wrong. Step B is structural, one shared pump for the modal loops. This makes the *cost* uniform at the one place virtual time is created and touches no loop structure. Step B stays open and stays worth doing.

## Still open

- **A replay is not paced.** Right for verifying a recording, wrong for a player watching one back with `rec play`, which still races. Telling the two apart is a policy call and did not belong inside this change.
- **`FadeToBlack` pumps *and* presents each iteration**, so it mints 32 ms a time rather than 16 and renders half the frames it should. Pacing gives it the right duration but not the frames; correcting the double step moves the clock sequence, so it wants its own change.
- **A loose-clock recording still hangs on a scene change** (exit 124 at the first fade). Verified identical on main, so it is not from this branch. It is the documented consequence of the frame-clock quantisation freezing inside a fade loop that never polls input, and it is the current hard floor under dropping the `--fixed-dt` requirement.

## Gates

`test_record_replay.sh`, `test_dump.sh`, `test_load.sh`, `test_exec.sh` pass; ctest 70/70; `check-arch` clean; `check-build-graph` **57 unchanged** against a tree configured the way CI configures one (`LBA2_BUILD_TESTS=ON`, `LBA2_BUILD_ASM_EQUIV_TESTS=OFF`) rather than whichever build directory happened to be found first; `clang-format-18` clean on all four sources; doc links clean.

## Review

Reviewed after opening; three findings, all fixed in the last two commits.

The load-bearing one is in my own arithmetic. `now < target` compared two U32 readings that both track the host clock, and both wrap: `SDL_GetTicks` is truncated to 32 bits here, so it turns over every 49.7 days of host uptime and the anchor plus the step count turns over with it. Whichever goes first, a magnitude test reads the gap as nearly 2^32 ms and `SDL_Delay` sleeps for weeks. It needs a host up for 49.7 days and a session running across the turnover, which is nothing on a desktop and ordinary on a machine that is never switched off. A signed difference wraps to the true value and survives it. The structure was inherited from the per-tick pacer this replaces, so the defect predates the branch, but the code is rewritten here and it is fixed here.

The other two are in the arm. Pacing is armed by a recording starting, so a run whose `--record` never opened is unpaced for a reason unrelated to modal loops and would have failed the rate check blaming them; the recording is now asserted first, so that failure names itself. And the step is written twice on one command line, `--fixed-dt 16` and the `ticks * 16` the window check divides by, which is now said rather than left to be discovered.

### Second pass

Three more, all fixed.

The one that mattered is in the documentation rather than the code, and it would have taught the wrong thing about a field this PR adds. The `--dump-state` sample printed `clock_src_ms` equal to `timer_ref_hr`. It is not: it counts from process start where `timer_ref_hr` counts from whatever play time the save carried. On a real dump, 4792 against 4,272,829. A reader taking the sample at face value would have used the new field as accumulated play time. Both entries now say which of the two they track, and that only their deltas belong in the same sentence.

The window ceiling, 1.15, was a bare constant. It now says what it separates: 1.00 and 1.31 measured on that window, with the passing side bounded above by 1.00 because pacing can only sleep and never hurry, so the margin is headroom for timer granularity rather than a tolerance anything is expected to use. And the two new doc entries separated name from gloss differently from every other entry in that list.

### Investigated, no defect

Recorded here because each was a plausible failure and the answer is not obvious from the diff.

- **A playback inheriting the arm.** `Record_Play` returns 0 while `s_recording || s_replaying`, so `rec play` mid-recording is refused and pacing cannot leak into a replay.
- **Pacing surviving `rec stop`.** All three `record_release_step()` call sites are inside `Record_Stop`, and the clear is unconditional, beside the frame clock and the sim audio clock.
- **Arm ordering.** The recorder pins the step in `record_reload_issue` and begins on a later tick, so `Timer_EnableFixedDt` (which clears the flag) always precedes `record_begin` (which sets it).
- **`PaceSteps * FixedDt` overflowing** at about 52 days of continuous paced recording. The signed difference survives it, because the target and the wall clock track each other through the wrap.
- **Pacing armed on a loose recording.** `record_begin` arms it unconditionally, including when the step is not pinned. `FixedDtStep` is unreachable outside fixed-dt, so it is inert, and `Timer_EnableFixedDt` clears it if a step is later armed.
- **Appending dump-state fields breaking a golden.** Nothing diffs whole dump files; `test_cli_flag_contract.sh` diffs settings, not dumps, and the shape check reads keys by name.

### Measured, hypothesis falsified

Pacing makes every recorded test run advance at 1.0x where it previously advanced at 3.49x, so I expected a CI cost. Timed the record/replay suite both ways on the same machine: **218.3s on main, 228.4s with pacing, +4.6%** — and the new arm accounts for most of that. Per-process boot dominates the suite, so pacing short recording runs costs almost nothing. No action.
