### PR TITLE
docs(record): the two code comments still named --verbose for telemetry

### DIFF
--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -164,10 +164,10 @@ extern "C" {
  * actors and all 336 script variables entirely. This carries the lot, every tick, so
  * the first mismatching tick names the field that moved.
  *
- * About 2 KB a tick, so it is opt-in (--verbose) rather than the default: a diagnostic
- * recording, made once, to answer a question a normal one cannot. The bytes are the
- * cost and the time is not -- measured, 0.10 ms of CPU a tick, which is the loop that
- * marshals the values rather than the write.
+ * About 2.8 KB a tick, so it is opt-in (--record-telemetry, or `rec start verbose`)
+ * rather than the default: a diagnostic recording, made once, to answer a question a
+ * normal one cannot. The bytes are the cost and the time is not -- measured, 0.10 ms of
+ * CPU a tick, which is the loop that marshals the values rather than the write.
  */
 #define REC_TELE 0x51
 

--- a/SOURCES/RECORD.H
+++ b/SOURCES/RECORD.H
@@ -26,10 +26,10 @@ void Record_ClockHook(U32 *now);
 /* Control_TickHook(): one state hash per tick, the recording's own oracle. */
 void Record_TickHook(void);
 
-/* `verbose` records the telemetry --verbose asks for: every value the digest mixes,
-   every tick, so a divergence names the field rather than only the tick. It costs a few
-   kilobytes a tick, so it belongs to the session that asked for it rather than to the
-   run -- a player who has just seen the bug can start a diagnostic recording without
+/* `verbose` records the telemetry --record-telemetry asks for: every value the digest
+   mixes, every tick, so a divergence names the field rather than only the tick. It costs
+   a few kilobytes a tick, so it belongs to the session that asked for it rather than to
+   the run -- a player who has just seen the bug can start a diagnostic recording without
    relaunching. */
 int Record_Start(const char *path, int verbose);
 int Record_Stop(void);


### PR DESCRIPTION
## What & why

Third and final pass at the `--verbose` / `--record-telemetry` split (#623, #629). Two code
comments still named the old flag as the thing that arms telemetry:

- **`SOURCES/RECORD.H:29`**, the contract above `Record_Start`, which says the console
  `verbose` word records "the telemetry `--verbose` asks for". It does not any more.
- **`SOURCES/RECORD.CPP:167`**, the block explaining why the telemetry record type exists,
  which said "opt-in (`--verbose`) rather than the default".

Both now name `--record-telemetry`, with `rec start verbose` beside it so a console reader
is not sent to a CLI flag they never use.

`RECORD.CPP`'s figure was stale for a second, unrelated reason: it said 2 KB a tick, where
`docs/RECORDING.md` now says 2.8 KB, measured at 2787 bytes over 668 values after the
digest gained fields. A number stated in two places drifts in one of them, and this is the
copy that drifted.

## Notes for reviewers

Comments only -- no behaviour change, and the build is here purely to prove the headers
still compile.

**Three passes, and the class each one missed is the useful part.** The first swept the two
reference docs and the automation fixtures. The second swept `scripts/` and `docs/plan/`.
Neither swept code comments, which is where the two most-read explanations of the feature
live: the contract a caller reads above the function, and the block that explains why a
record type exists. A whole-tree grep for the flag name catches all of it in one pass and
should have been the first move, not the third.

Three `--verbose` references remain in the tree and all three are correct:
`CONTROL.CPP:355` (the parse site), `CONTROL.CPP:843` (a note that `--exec-at` ticks are
0-based to match `--verbose`'s output), and `CONTROL.CPP:1130` (the comment on the logging
block itself). `tests/automation/test_cli_flag_contract.sh` lists it as a flag under test,
which is also correct.

## Checklist

- [x] Build passes on my platform (Linux)
- [ ] If LIB386 / 3DEXT touched: ASM equivalence tests pass (`./run_tests_docker.sh`) -- not touched
- [x] If behavior changes: opt-in via flag/cvar/config (preserves default game feel) -- comments only
- [x] Docs updated in the same PR if behavior or workflow changed
- [x] French comments and ASCII art preserved in any modified files
