### PR TITLE
feat(record): write the analog block on change, not on non-zero

### DIFF
--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -83,7 +83,7 @@ extern "C" {
 /* ---- live state ---------------------------------------------------------- */
 
 #define REC_MAGIC "LBA2REC"
-#define REC_VERSION 12
+#define REC_VERSION 13
 
 /* The oldest format this build still reads. Every version since has only added record
    types the reader probes for and steps over, so an older recording reads the same as
@@ -205,6 +205,12 @@ static int s_recording = 0;
 static int s_replaying = 0;
 
 static U8 s_prevKeys[TABKEYS_NUM_KEYS];
+/* The analog block's last WRITTEN value, so a poll whose analog state did not move can
+   be skipped. Compared against, never against zero: a held button and a held stick are
+   levels rather than edges, so the poll that RELEASES one differs from the last written
+   block and must be written, where comparing against zero would drop it and leave the
+   button down for the rest of the replay. */
+static S32 s_prevAnalog[6];
 static S32 s_prevKey = 0;
 static U32 s_prevSrcDelta = 0xFFFFFFFFu;
 static U32 s_prevSrc = 0;
@@ -1203,6 +1209,7 @@ static int record_begin(const char *path, int haveSnapshot) {
     record_write_chunk(REC_SNAP_START, s_snapshot);
 
     memset(s_prevKeys, 0, sizeof s_prevKeys);
+    memset(s_prevAnalog, 0, sizeof s_prevAnalog);
     s_prevKey = 0;
     s_prevSrcDelta = 0xFFFFFFFFu;
     s_prevSrc = Timer_ClockSource();
@@ -1462,8 +1469,22 @@ static void record_poll(void) {
         padFirst = 0;
         mdx = mdy = click = 0;
     }
-    if (rsx || rsy || padFirst || mdx || mdy || click)
-        flags |= 0x04;
+    {
+        /* Written when the block CHANGES, not when it is non-zero. A value that is merely
+           constant then costs one block instead of one per poll: a contributed 30 minute
+           session carried an unchanging mouse delta on 4,472,955 of its 4,473,043 polls,
+           89.5 MB of a 96.7 MB file, which this takes to 20 bytes. Input that actually
+           varies still writes every poll, because a varying tuple differs every time.
+
+           It is also the rule the rest of this record already follows: the key table
+           writes the keys that changed and `key` is written only when it differs. The
+           analog block was the last group keyed on content rather than on change. */
+        const S32 now[6] = {rsx, rsy, (S32)padFirst, mdx, mdy, click};
+        if (memcmp(now, s_prevAnalog, sizeof now) != 0) {
+            flags |= 0x04;
+            memcpy(s_prevAnalog, now, sizeof now);
+        }
+    }
     if (delta != s_prevSrcDelta)
         flags |= 0x08;
 
@@ -1966,7 +1987,13 @@ static int replay_poll(void) {
         s_mdx = (S32)mx;
         s_mdy = (S32)my;
         s_click = (S32)cl;
-    } else {
+    } else if (s_recVersion < 13) {
+        /* Before 13 the writer emitted a block whenever any field was non-zero, so an
+           absent block meant every field was zero on this poll. From 13 it emits on
+           change, so absent means unchanged and the previous values stand. Same bytes,
+           opposite meaning, which is why the version moved: an old file read under the
+           new rule would hold inputs that had ended, and a new file read under the old
+           one would release inputs that were still held. Neither fails to parse. */
         s_rsx = s_rsy = 0;
         s_padFirst = 0;
         s_mdx = s_mdy = s_click = 0;
@@ -2004,6 +2031,9 @@ static void replay_begin(void) {
     Timer_SetSimAudioClock(1);
     memset(s_prevKeys, 0, sizeof s_prevKeys);
     s_prevKey = 0;
+    s_rsx = s_rsy = 0;
+    s_padFirst = 0;
+    s_mdx = s_mdy = s_click = 0;
     s_prevSrcDelta = 0;
     s_replaySrc = Timer_ClockSource();
     s_refDriftMax = 0;

--- a/scripts/dev/dump_recording.py
+++ b/scripts/dev/dump_recording.py
@@ -189,6 +189,7 @@ def parse(path):
     # session, which every session is until the two devices can be driven headlessly.
     analog = []
     ticks, keys, cmds, teles = [], [], [], []
+    held = None  # last analog tuple written, for the version >= 13 hold-last rule
     syncs = 0
     snaps = {}
 
@@ -269,8 +270,18 @@ def parse(path):
                 if flags & 0x02:      # Key
                     p += 4
                 if flags & 0x04:      # analog block
-                    analog.append((polls,) + struct.unpack_from("<hhIiii", data, p))
+                    held = struct.unpack_from("<hhIiii", data, p)
+                    analog.append((polls,) + held)
                     p += 20
+                elif version >= 13:
+                    # From 13 the writer emits a block only when the analog state
+                    # changes, so an absent block means the previous values still stand.
+                    # Before 13 absent meant every field was zero, which is why nothing
+                    # is carried forward for an older file. Reporting a held input as
+                    # absent would make a sustained stick or a held button look like it
+                    # ended, which is the divergence this version exists to prevent.
+                    if held is not None:
+                        analog.append((polls,) + held)
                 if flags & 0x08:      # clock delta
                     p += 4
         except (IndexError, struct.error):


### PR DESCRIPTION
Closes #632.

The analog block carries the right stick, the pad's first scancode, the mouse pair and the click mask, and it went out whenever any of them was non-zero. An input that is merely *held* therefore costs 20 bytes a poll for as long as it is held, and a value that never returns to zero costs them for the entire session.

A contributed 30-minute recording carried one unchanging mouse delta on **4,472,955 of its 4,473,043 polls** — 89.5 MB of a 96.7 MB file. Under this rule that is 20 bytes.

## The rule

Compare against the **last block written**, across all six fields, never against zero.

A held button and a held stick are levels rather than edges, so the poll that *releases* one differs from the last written block and still goes out. Comparing against zero would drop the release and leave the input held for the rest of the replay.

This is also the rule the rest of the poll record already follows: the key table writes the keys that changed, and `key` goes out only when it differs. The analog block was the last group keyed on content rather than on change.

## The version has to move

`REC_VERSION` 12 → 13, `REC_VERSION_MIN` left at 9.

Absent used to mean *every field was zero on this poll*. It now means *unchanged*. So an old file read under the new rule holds inputs that had ended, and a new file read under the old rule releases inputs that were still held. **Neither fails to parse** — the failure is a replay that quietly diverges, which is exactly what the version exists to prevent. Older recordings still replay, through a branch at the reader.

## Measured

120 polls of input, against a no-analog baseline of 19,785 bytes:

| | bytes | delta | |
|---|---|---|---|
| held stick | 19,815 | **+30** | one block and a release |
| held button | 19,813 | **+28** | one block and a release |
| varying motion | 22,191 | +2,406 | 120 blocks at 20, unchanged |

All four round-trip at `first hash mismatch -1`, as does a session with no analog at all.

- **Full record/replay suite passes**, including the format-10 arm that proves old files still read.
- **All four input-simulation fixtures pass** — `input_injection`, `input_hold_throttle`, `input_combos`, `combo_baseline`. Every one drives a sustained input, which is the regression this change could have caused, and `combo_baseline` reproduces 661 ticks of combinations against its committed baseline.
- A v12 recording replays with byte-identical results to before the change.

## Also

`scripts/dev/dump_recording.py` branches on the version with the same rule, so it reports a held input as held rather than as absent. Without that it would misreport every file written from here on.

The trap this could have fallen into, and the reasoning for the shape above, are recorded in #632 by a reviewer who found it before it was written rather than after.
