### PR TITLE
fix(record): mint a step where a wait loop has no poll to take one

### DIFF
--- a/LIB386/H/SYSTEM/TIMER.H
+++ b/LIB386/H/SYSTEM/TIMER.H
@@ -78,6 +78,11 @@ void Timer_FixedDtPump();
 // that skips itself. Inert outside fixed-dt. Cleared when the clock is disarmed.
 void Timer_SetFixedDtPaced(S32 on);
 
+/* Sleep until the wall clock reaches `target`; answers how far ahead of it the call was,
+   negative when it was already past. For anything that mints a step of clock and has to
+   spend the real time the step stands for. */
+S32 Timer_SleepUntil(U32 target);
+
 // Answer the simulation's "is this voice still playing" from the sample's own length on
 // the game clock instead of from the mixer. True whenever the pinned clock is armed, and
 // separately settable by the recorder, which needs the same answer on a host-sampled

--- a/LIB386/SYSTEM/TIMER.CPP
+++ b/LIB386/SYSTEM/TIMER.CPP
@@ -147,6 +147,23 @@ S32 Timer_FixedDtValue(void) {
     return FixedDtActive ? (S32)FixedDt : 0;
 }
 
+/* Sleep until the wall clock reaches `target`, and answer how far ahead of it this call
+   was. Shared by everything that mints a step of clock and then has to pay for it, so the
+   arithmetic below is written once.
+
+   That arithmetic is a signed difference of two unsigned readings, not a comparison of
+   their magnitudes. Both wrap -- the host clock every 49.7 days, and any anchor plus a
+   step count with it -- and either one wrapping first makes a magnitude test read the gap
+   as nearly 2^32 ms, so the sleep would be weeks rather than milliseconds. The subtraction
+   wraps to the true small difference and survives it. */
+S32 Timer_SleepUntil(U32 target) {
+    S32 ahead = (S32)(target - (U32)SDL_GetTicks());
+
+    if (ahead > 0)
+        SDL_Delay((U32)ahead);
+    return ahead;
+}
+
 /* Mint one step of virtual time, and -- when something is holding the clock to real time
    -- spend a step of real time on it.
 
@@ -164,7 +181,6 @@ S32 Timer_FixedDtValue(void) {
    step, so the error does not accumulate: a step that overruns is paid for by the next
    one arriving early rather than by every later step sliding. */
 static void FixedDtStep(void) {
-    U32 target;
     S32 ahead;
 
     FixedDtNow += FixedDt;
@@ -173,16 +189,8 @@ static void FixedDtStep(void) {
         return;
 
     PaceSteps++;
-    target = PaceAnchor + PaceSteps * FixedDt;
-    /* A signed difference of two unsigned readings, not a comparison of their magnitudes.
-       Both wrap -- the host clock every 49.7 days, and the anchor plus the step count with
-       it -- and either one wrapping first makes a magnitude test read the gap as nearly
-       2^32 ms, so the sleep below would be weeks rather than milliseconds. The subtraction
-       wraps to the true small difference and survives it. */
-    ahead = (S32)(target - (U32)SDL_GetTicks());
-    if (ahead > 0)
-        SDL_Delay((U32)ahead);
-    else if (ahead < -PACE_GIVEUP_MS) {
+    ahead = Timer_SleepUntil(PaceAnchor + PaceSteps * FixedDt);
+    if (ahead < -PACE_GIVEUP_MS) {
         /* Too far behind to catch up. Give the time up rather than sprint to win it
            back, which would run the game fast to make up for having run it slow. The
            ordinary way to reach this is a window that lost focus: the clock stops, the

--- a/LIB386/SYSTEM/TIMER.CPP
+++ b/LIB386/SYSTEM/TIMER.CPP
@@ -232,11 +232,22 @@ void Timer_FixedDtPresent() {
     }
 }
 
+/* Session recording: a loop that waits on the clock without polling input gets no new
+   reading from the clock hook below, because there is no poll to take one at. Weak, so
+   libsys.a still links without the recorder. */
+void Record_WaitHook(void);
+__attribute__((weak)) void Record_WaitHook(void) {}
+
+/* A wait that ends on the clock and does not poll input. The caller has nothing to do but
+   let time pass, so whatever is minting time for this run has to mint it here: the step
+   below under --fixed-dt, and the wait hook under a clock the recorder is holding. A run
+   with neither reads the host clock directly and needs nothing from this. */
 void Timer_FixedDtPump() {
     // No free first step: a non-presenting wait loop owns every iteration's time.
     if (FixedDtActive && FixedDtTicking) {
         FixedDtStep();
     }
+    Record_WaitHook();
 }
 
 S32 Timer_FixedDtActive() {

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -310,8 +310,22 @@ static S32 s_reloadDt = 0;
 static int s_recArmedDt = 0;
 static int s_pendingBaseline = 0;
 static int s_frameClockValid = 0;
+/* One step of held clock per iteration of a wait loop, and the run of them since the last
+   poll. 16 ms is the engine's nominal frame and the default --fixed-dt hands the very same
+   loops. Fixed rather than measured: see Record_WaitHook. */
+#define REC_WAIT_STEP_MS 16
+static U32 s_waitSteps = 0;
+static U32 s_waitAnchor = 0;
 static int s_hash32 = 0;    /* LBA2_REC_HASH32: store a 32-bit digest */
 static int s_hashEvery = 1; /* LBA2_REC_HASH_EVERY: hash one tick in N */
+
+/* Hold ManageTime at `src` until the next poll. A poll ends whatever run of wait steps
+   preceded it, so the two are set together. */
+static void record_hold_clock(U32 src) {
+    s_frameClock = src;
+    s_frameClockValid = 1;
+    s_waitSteps = 0;
+}
 
 /* ---- the binding table the recording was resolved through ----------------- */
 
@@ -1172,8 +1186,7 @@ static int record_begin(const char *path, int haveSnapshot) {
        run's first poll, and this changes nothing. After a mid-session reload it is one
        step, and that step was the whole of a 16 ms drift and a state mismatch at
        tick 1. */
-    s_frameClock = Timer_ClockSource();
-    s_frameClockValid = 1;
+    record_hold_clock(Timer_ClockSource());
     ManageTime();
     /* Telemetry is a diagnostic recording, several megabytes larger, made deliberately
        when a plain one has already said a tick and cannot say a field. Either way of
@@ -1430,8 +1443,7 @@ static void record_poll(void) {
     U32 delta = src - s_prevSrc;
     S32 mute;
     S32 key;
-    s_frameClock = src;
-    s_frameClockValid = 1;
+    record_hold_clock(src);
 
     /* Record what gameplay is about to be given, which is nothing while the console is
        open: SOURCES/INPUT.CPP clears keys, pad and mouse so typing cannot drive the hero.
@@ -2009,8 +2021,7 @@ static int replay_poll(void) {
 
     /* The clock this frame runs on, from the file. */
     s_replaySrc += s_prevSrcDelta;
-    s_frameClock = s_replaySrc;
-    s_frameClockValid = 1;
+    record_hold_clock(s_replaySrc);
     if (s_pendingBaseline) {
         s_pendingBaseline = 0;
         SetTimerHR(s_baseline);
@@ -2382,6 +2393,48 @@ void Record_ClockHook(U32 *now) {
         return;
     if (s_frameClockValid)
         *now = s_frameClock;
+}
+
+/* The hold above lasts until the next input poll, and a loop that waits on the clock
+   without polling therefore reads one value for as long as it runs. `FadeToPalAndSamples`
+   (SOURCES/AMBIANCE.CPP) ends when that value has moved FADE_DELAY, so under the hold it
+   never ends: the run spins at a full core, presenting a frame an iteration, until
+   something kills it. Mint a step here and the loop ends, one iteration per step, exactly
+   as it does under `--fixed-dt` -- which is where the shape comes from, and why the
+   pinned clock has never had this problem.
+
+   A FIXED step rather than the real time that has passed, and that is the whole of why
+   this reproduces. Real elapsed time makes the iteration count a property of the machine,
+   and although the fade itself is transparent -- these loops sit inside SaveTimer /
+   RestoreTimer, so TimerRefHR is rewound whatever the loop did to it -- the last reading
+   the loop leaves behind is not. ManageTime banks the next delta against it, so a fade
+   that ran 3 ms longer on one end than the other puts 3 ms into the game clock afterwards,
+   which is enough to plan one more simulation sub-step. Measured before the step was
+   fixed: `sim.carry` 16 ms apart and `obj[2].X` 32 units apart at the first tick after a
+   scene change, seven replays in ten. With a fixed step both ends run the same number of
+   iterations and leave the same reading, and the difference is not there to bank.
+
+   Paid for in real time, because a step minted is a step the run has not spent. Without
+   that a recorded fade would end in the time it takes to render thirteen frames rather
+   than in FADE_DELAY, which is the too-fast transitions the pinned clock is paced to
+   avoid, arriving by the other road. Recording and replay alike: a wait costs what it represents either way, and the
+   few hundred milliseconds a replay spends on a fade buy the same fade a player saw. */
+void Record_WaitHook(void) {
+    /* Under a generated clock the engine mints the step itself, which is the whole of
+       why these loops terminate there today. */
+    if (Timer_FixedDtActive())
+        return;
+    if (!s_frameClockValid)
+        return;
+
+    /* Anchored on the first step of the run rather than on the poll before it: the frame's
+       own work sits in between, and charging the wait for that would make it sleep less
+       than the time it is minting. */
+    if (!s_waitSteps)
+        s_waitAnchor = Timer_ClockSource();
+    s_waitSteps++;
+    s_frameClock += REC_WAIT_STEP_MS;
+    Timer_SleepUntil(s_waitAnchor + s_waitSteps * REC_WAIT_STEP_MS);
 }
 
 void Record_TickHook(void) {

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -310,10 +310,12 @@ static S32 s_reloadDt = 0;
 static int s_recArmedDt = 0;
 static int s_pendingBaseline = 0;
 static int s_frameClockValid = 0;
-/* One step of held clock per iteration of a wait loop, and the run of them since the last
-   poll. 16 ms is the engine's nominal frame and the default --fixed-dt hands the very same
-   loops. Fixed rather than measured: see Record_WaitHook. */
-#define REC_WAIT_STEP_MS 16
+/* This recorder's nominal frame, in two places: the step a recording pins when the run did
+   not ask for one, and the step a wait loop mints under a clock this file is holding. 16 ms
+   is what the harness and every fixture use, and what docs/RECORDING.md tells a player to
+   pass. The two want the same number, so they read the same one. */
+#define REC_DEFAULT_DT 16
+/* Wait steps minted since the last poll, and the wall clock the run of them began at. */
 static U32 s_waitSteps = 0;
 static U32 s_waitAnchor = 0;
 static int s_hash32 = 0;    /* LBA2_REC_HASH32: store a 32-bit digest */
@@ -1067,10 +1069,6 @@ static void record_reload_request(const char *save, const char *then, int forPla
     s_reloadDt = 0;
     s_reloadState = 1;
 }
-
-/* The step a recording pins when the run did not ask for one. 16 ms is what the harness
-   and every fixture use, and what docs/RECORDING.md tells a player to pass. */
-#define REC_DEFAULT_DT 16
 
 static void record_reload_issue(void) {
     /* Pin the step here, which is the one place a mid-session recording can.
@@ -2417,8 +2415,16 @@ void Record_ClockHook(U32 *now) {
    Paid for in real time, because a step minted is a step the run has not spent. Without
    that a recorded fade would end in the time it takes to render thirteen frames rather
    than in FADE_DELAY, which is the too-fast transitions the pinned clock is paced to
-   avoid, arriving by the other road. Recording and replay alike: a wait costs what it represents either way, and the
-   few hundred milliseconds a replay spends on a fade buy the same fade a player saw. */
+   avoid, arriving by the other road. Recording and replay alike: a wait costs what it
+   represents either way, and the few hundred milliseconds a replay spends on a fade buy
+   the same fade a player saw.
+
+   What it does cost is frames. A recorded fade ramps in ceil(FADE_DELAY / step) steps
+   whatever the display can draw, thirteen at 16 ms, where the same fade unrecorded ramps
+   in as many as the frame rate allows -- measured at 47 under the dummy video driver. The
+   duration is unchanged either way, measured at 1.22s against a 1.21s unrecorded control,
+   and the coarser ramp is the price of both ends running the same number of iterations. It
+   is the trade --fixed-dt already makes for the same loops. */
 void Record_WaitHook(void) {
     /* Under a generated clock the engine mints the step itself, which is the whole of
        why these loops terminate there today. */
@@ -2433,8 +2439,8 @@ void Record_WaitHook(void) {
     if (!s_waitSteps)
         s_waitAnchor = Timer_ClockSource();
     s_waitSteps++;
-    s_frameClock += REC_WAIT_STEP_MS;
-    Timer_SleepUntil(s_waitAnchor + s_waitSteps * REC_WAIT_STEP_MS);
+    s_frameClock += REC_DEFAULT_DT;
+    Timer_SleepUntil(s_waitAnchor + s_waitSteps * REC_DEFAULT_DT);
 }
 
 void Record_TickHook(void) {

--- a/SOURCES/RECORD.H
+++ b/SOURCES/RECORD.H
@@ -23,6 +23,10 @@ void Record_PollHook(void);
 /* ManageTime(): capture or supply the clock where the engine actually reads it. */
 void Record_ClockHook(U32 *now);
 
+/* Timer_FixedDtPump(): mint a step of the held clock, so a wait loop that never polls
+   still ends. */
+void Record_WaitHook(void);
+
 /* Control_TickHook(): one state hash per tick, the recording's own oracle. */
 void Record_TickHook(void);
 

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -125,6 +125,39 @@ Reproducing the clock more faithfully is finished as a direction. Storing one sa
 finding the state, and the digest names it: see `numeric.digest` and the `sim.carry`,
 `obj.LastTimer`, `obj.NextTimer` and `rng.draws` fields.
 
+### A wait loop that never polls needs a clock that moves
+
+`Record_ClockHook` holds `ManageTime` at the last input poll, so a loop that ends on the clock and
+does not poll reads one value for as long as it runs. `FadeToPalAndSamples`
+([SOURCES/AMBIANCE.CPP](../SOURCES/AMBIANCE.CPP)) is exactly that shape: it ends when the reading
+has moved `FADE_DELAY`, and it never polls. Held, it does not end at all, and the run spins at a
+full core presenting a frame an iteration until something kills it. That is the first scene change
+of any recording on the host clock, and the first fade after the menus when recording from boot.
+
+The wait loops already declare themselves. `Timer_FixedDtPump()` marks the ten places that end on
+the clock without polling, and under `--fixed-dt` it is what mints the step that ends them, which
+is why the pinned clock never meets it. A recording on the host clock mints one there too:
+a fixed 16 ms per iteration, with the real time that step stands for slept out, so the fade lasts
+what it lasts and the loop ends.
+
+Fixed rather than measured, and that is the part worth keeping. Advancing the held reading by real
+elapsed time also ends the loop, and the fade itself is transparent either way, because these loops
+sit inside `SaveTimer`/`RestoreTimer` and `TimerRefHR` is rewound whatever the loop did to it. What
+is not transparent is the last reading the loop leaves behind. `ManageTime` banks the next delta
+against it, so a fade that ran a few milliseconds longer on one end than on the other puts those
+milliseconds into the game clock after the rewind, which is enough to plan one more simulation
+sub-step. Measured with a measured step: `sim.carry` 16 ms apart and `obj[2].X` 32 units apart at
+the first tick after the scene change, in seven replays out of ten. With a fixed step both ends run
+the same number of iterations and leave the same reading, so there is no difference to bank.
+
+All ten sites are bracketed, `MUSIC.CPP`'s two volume fades and `RES_SWITCH.CPP`'s dialog included,
+so the rewind is not what separates them. What survives a rewind is `LastTime`, and nothing restores
+that: a rewind that puts back one of a pair of coupled variables is not a rewind.
+
+**This makes such a session recordable, and does not make it reproduce.** See the rate below: a
+loose recording reproduces some of the time whether or not it crosses a fade, and the wedge was
+hiding the scene-change half of that question rather than answering it.
+
 Who pins it depends on where the recording starts, and the split is not a convenience:
 
 - **From boot, with `--record`,** the run has no load to hide a clock reset behind, so the step has

--- a/docs/TIMING.md
+++ b/docs/TIMING.md
@@ -102,7 +102,8 @@ Inert in default builds. When `Timer_EnableFixedDt(dt_ms)` is called (from
   additional present in the same tick advances `FixedDtNow` by `dt` — that's how modal
   subloops avoid deadlocking on a `TimerRefHR` deadline.
 - `Timer_FixedDtPump()` advances `FixedDtNow` without a present, for non-presenting
-  busy-waits.
+  busy-waits. It is also where a session recording mints a step of the clock it is holding,
+  for the same reason and to the same end: see [RECORDING.md](RECORDING.md).
 - `Timer_FixedDtOverlayPresent()` marks the next present as an overlay refresh, so it
   neither advances `FixedDtNow` nor spends the tick's free present.
 
@@ -199,7 +200,9 @@ When adding code that touches the timer, in rough order of how often you'll need
    pumps animation): pre-2026-05 fix, this silently discarded the wall time. Post-fix it
    doesn't, but the standing rule is the same — only pump `ManageTime` inside loops that
    need the game clock to actually move, and call `Timer_FixedDtPump`/`Timer_FixedDtPresent`
-   alongside if the loop should also terminate under fixed-dt.
+   alongside if the loop should also terminate under fixed-dt. The pump is what ends such a
+   loop under a session recording too, which holds the clock at the last input poll: a wait
+   that does not poll and does not pump never ends there.
 4. **Adding a new modal/wait loop?** Mirror `SOURCES/MUSIC.CPP:312` (`PauseMusic`,
    fade-out): `SaveTimer()`, loop with `ManageTime()` + `Timer_FixedDtPump()`,
    `RestoreTimer()`.

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -889,5 +889,37 @@ modal_ok="$(python3 -c "print(1 if $modalrate <= 1.15 else 0)")"
 [ "$modal_ok" = 1 ] ||
     fail "modal pacing: a window holding a scene change advanced ${modalrate}s of game time per wall second while recording — the modal loops are minting clock they do not pay for, which is the too-fast transitions players report"
 
+# --- a recording on a host-sampled clock survives a scene change ----------------------
+#
+# Every arm above pins the step, and the pin hides this one completely: under a generated
+# clock the engine mints time inside a wait loop itself, so a fade there ends whatever the
+# recorder is doing. On a host-sampled clock the recorder holds the clock at the last
+# input poll, and FadeToPalAndSamples (SOURCES/AMBIANCE.CPP) ends when that clock has
+# moved FADE_DELAY while never polling input. Held, it never ends: the run spins at a full
+# core presenting a frame an iteration, against 2.1s for the same run unrecorded.
+#
+# Termination is the whole assertion, deliberately. On a host-sampled clock two runs do
+# not reach identical state, so a replay comparison here would be flaky by construction,
+# and the way to settle it would be to pin the step -- the one thing this arm exists to
+# run without.
+loosedir="$(mktemp -d)"
+clean_add "$loosedir"
+
+ctl --load "$LBA2_TEST_SAVE" --record "$loosedir/s.rec" \
+    --exec-at 40 "cube 154" --tick 200 --exit >/dev/null 2>&1 ||
+    fail "loose clock: a recording across a scene change did not finish (exit $?) — a wait loop is reading a clock the recorder is holding still"
+[ -s "$loosedir/s.rec" ] ||
+    fail "loose clock: the run finished but wrote no recording, so nothing here was recorded and the run ended for its own reasons"
+
+# That the scene change actually landed, and not merely that the run ended. Without this
+# the arm keeps passing on the day the scripted `cube` stops arriving, having crossed no
+# fade and tested nothing. The keyframe records the cube it changed to, so the reader can
+# be asked rather than the exit code trusted.
+loosekf="$(python3 "$REPO/scripts/dev/dump_recording.py" "$loosedir/s.rec" |
+    grep -c "cube 3->154")" ||
+    fail "loose clock: could not read the recording back"
+[ "$loosekf" -ge 1 ] ||
+    fail "loose clock: the recording carries no cube 3->154 keyframe, so the run never crossed a scene change and this arm tested nothing"
+
 pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; mode.audio was written from the driver and reported both ways; a session recorded in one run replayed in the next with no flags and no paths; \
-'rec start verbose' carried telemetry and a plain one carried none; a recorded walk moved the hero and the replay walked it again; the recorder gave the step back and left the flag's alone; a playback put the player back where it found them, stopped early or run out; a window holding a scene change ran at ${modalrate}x real, not faster"
+'rec start verbose' carried telemetry and a plain one carried none; a recorded walk moved the hero and the replay walked it again; the recorder gave the step back and left the flag's alone; a playback put the player back where it found them, stopped early or run out; a window holding a scene change ran at ${modalrate}x real, not faster; a recording on a host-sampled clock crossed a scene change instead of wedging in the fade"


### PR DESCRIPTION
A recording made without `--fixed-dt` cannot cross a scene change: the run stops
progressing at the first fade and spins at a full core until something kills it. This
fixes that, and the fix is one `Record_WaitHook` at the seam the engine already uses to
declare a wait.

## What happens

`Record_ClockHook` holds `ManageTime` at the last input poll, which is what makes a
replay on a host-sampled clock possible at all. `FadeToPalAndSamples`
(`SOURCES/AMBIANCE.CPP`) ends when that reading has moved
`FADE_DELAY`, and it never polls. Held, it does not end.

Named from a stack rather than inferred:

```
#0  SDL_Blit_ARGB8888_XRGB8888_Blend_Scale
...
#6  SDL_RenderPresent_REAL
#7  BoxBlit ()
#8  FadeToPalAndSamples(unsigned char*) ()
#9  AffScene(int) ()
#10 MainLoop() ()
```

It is the fade **in** after the load, not the fade out before it, and it presents every
iteration, which is why the process burns a core rather than sitting quietly.

The four-way matrix, `--headless`, `cube 154` at tick 100:

| run | result |
|---|---|
| loose clock, no `--record` | exits 0 in 2.1s |
| pinned clock, `--record` | exits 0 |
| loose clock, `--record`, no scene change | exits 0 |
| loose clock, `--record`, scene change | **wedges** |

The recorder names it and the scene change names the site, in both directions. Repeated
as the control for this change: **eight recordings across a scene change, eight wedges**.

## The fix

`Timer_FixedDtPump()` already marks the ten loops that end on the clock without polling,
and under `--fixed-dt` it is what mints the step that ends them, which is why the pinned
clock never meets this. A recording on the host clock mints one there too, and sleeps out
the real time the step stands for, so a fade lasts what it lasts.

**A fixed step rather than the elapsed time, and that is the part that matters.** All ten
loops sit inside `SaveTimer`/`RestoreTimer`, so `TimerRefHR` is rewound whatever the loop
did to it and the fade looks transparent. `LastTime` is not rewound. `ManageTime` banks
the next delta against it, so a fade that ran three milliseconds longer on one end than
the other puts three milliseconds into the game clock *after* the rewind, and that is
enough to plan one more simulation sub-step. Measured with an elapsed-time step, with
telemetry naming the field:

```
tick 109 state differs: obj[2].X 6144/6112  sim.carry 4268135/4268151
```

16 ms of carry and one movement step, in seven replays out of ten. A rewind that restores
one of a pair of coupled variables is not a rewind.

## Measured

Eight fresh recordings per arm, each replayed twice, `--headless`, same save:

| | records | reproduces | replays disagreed |
|---|---|---|---|
| across a scene change, before | 0/8 (all wedge) | n/a | n/a |
| across a scene change, after | 8/8 | 6/8 | 0/8 |
| no scene change, before | 8/8 | 1/8 | 2/8 |
| no scene change, after | 8/8 | 5/8 | 3/8 |

Two more paths, found while reviewing and each three runs a side. **Recording from boot**, no
`--load`, which the docs record as hanging at the first fade after the menus: `exit 124` at the
90s cap three times on `main`, `exit 0` in 3.5s three times here. **The demo reel**, entered
properly at cube 193: `exit 124` at 199.6s on `main`, `exit 0` in 9.1s here, against a 9.3s
control with no `--record` at all. Both were unrecordable and neither is any more.

**Read the last two rows as noise against noise, not as an improvement.** The hook does
not fire without a scene change, so those are two samples of one unchanged process and
the interval at K=8 is very wide. They are here because leaving them out would be the
more flattering choice.

**This makes such a session recordable. It does not make the loose path reproduce.**
Without a scene change the hook never fires -- measured as zero calls in a quiet
recording and zero in its replay -- so the rate there is exactly what it was, and what
it was is poor: `docs/RECORDING.md` already records three of eight
fresh pairs replaying clean. The wedge was hiding the scene-change half of that question
rather than answering it.

One methodological note that came out of measuring this, because it invalidates a rule
that has been used elsewhere: on the loose path **both the recording and the replay
vary**. A verdict read off one recording replayed N times is blind to the recording being
the dominant variable; a verdict read off N recordings replayed once is blind to the
replay disagreeing with itself, which it did on three of eight quiet pairs. K fresh
recordings, each replayed twice, is the shape that sees both.

The replay half of that is specific to the loose path, and the contrast is sharp. Replay
determinism on the **pinned** path has been measured at zero disagreements over 2840
diverging ticks, and again over 2869 with audio on. On the host clock, two identical
replays of the same file disagreed on three of eight files. So repetition is not a nicety
for a loose measurement, it is the difference between a number and a coin toss, and
nothing in the harness says so.

## The test arm

`tests/automation/test_record_replay.sh` gains one arm: record without `--fixed-dt`,
cross a scene change, require the run to finish, then read the recording back for the
keyframe naming the cube it changed to, so a run that ended without crossing a fade
cannot pass by exit code alone.

Termination is the whole assertion, deliberately. Two runs on a host-sampled clock do not
reach identical state, so a replay comparison here would be flaky by construction, and
the way to make it pass would be to pin the step -- the one thing the arm exists to run
without.

**Validated by breaking it:** the whole file run against a build without the fix fails on
this arm alone, with exit 124 and the message naming the held clock. Ten runs of the arm
on the fixed build: 10/10 finish, 10/10 carry the scene change, 1.22s each.

## Also here

`Timer_SleepUntil` is extracted from the pinned clock's pacer, so the signed-difference
arithmetic that survives the 49.7-day wrap is written once now that two callers need it.
Behaviour-preserving: a positive result cannot also be below the give-up threshold.

## What the fixed step costs

Frames, not duration. A recorded fade ramps in thirteen steps whatever the display can
draw, where the same fade unrecorded ramps in as many as the frame rate allows, measured
at 47 under the dummy driver. Duration is unchanged -- 1.22s recorded against 1.21s
unrecorded, five runs each, and 1.00s against 0.99s on a run with no scene change in it,
where the hook never fires. On a 60 Hz display the two step counts are the same anyway.
It is the trade `--fixed-dt` already makes for these loops.

**One risk found by reading and not reproduced.** The pace anchor is taken at the first
wait step and reset at the next input poll, so two wait loops with no poll between them
share it, and the second would find its targets already past and not sleep. A fade-out
bracketing a long operation is that shape: `GERETRAK.CPP:228-248` fades to black, plays a
video, and leaves the fade-in to `OBJECT.CPP:6225`, all inside one `SaveTimer` window.

Six different console `cube` targets each ran exactly one fade of thirteen steps with
every step sleeping, so the console warp does not produce the pair and I have no repro.
Which is its own small lesson, and one this repo already wrote down:
`docs/plan/RECORDING_RESEARCH.md` records the console `cube` verb as the one route that
skips the `SaveTimer` lock, "which made it the quiet path to have built a test on". Every
measurement of this fix went through that verb.

Left as a named risk rather than hardened, because the hardening would be speculative
code for a path I could not reach. If it is ever wanted it is the give-up branch
`FixedDtStep` already has.

## Gates

The suite shares one `LBA2_TEST_TIMEOUT` (`tests/automation/lib.sh`, default 90s) and reads a
timeout as a hang, and pacing a recorded run to real time changed what an arm costs. Measured
rather than assumed: across the 31 engine runs in `test_record_replay.sh`, the longest single
run is **14.7s**, so the margin is about sixfold and no arm is near the cap.

`test_record_replay`, `test_dump`, `test_exec`, `test_load` all pass; ctest 70/70;
check-arch clean; check-build-graph 57 translation units unchanged, measured against a
tree configured the way CI configures it; clang-format-18 clean; doc links and symbols
clean.
