### PR TITLE
fix(record): land the two review fixes that #635 reported and did not carry

### DIFF
--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -154,6 +154,13 @@ All ten sites are bracketed, `MUSIC.CPP`'s two volume fades and `RES_SWITCH.CPP`
 so the rewind is not what separates them. What survives a rewind is `LastTime`, and nothing restores
 that: a rewind that puts back one of a pair of coupled variables is not a rewind.
 
+What the fixed step costs is frames, not duration. A recorded fade ramps in thirteen steps whatever
+the display can draw, where the same fade unrecorded ramps in as many as the frame rate allows,
+measured at 47 under the dummy video driver. The duration is unchanged, measured at 1.22s against a
+1.21s unrecorded control, and on a 60 Hz display the two counts are the same anyway. It is the trade
+`--fixed-dt` already makes for these loops, and it is the same shape as the pacing note above:
+the right duration, not the right frames.
+
 **This makes such a session recordable, and does not make it reproduce.** See the rate below: a
 loose recording reproduces some of the time whether or not it crosses a fade, and the wedge was
 hiding the scene-change half of that question rather than answering it.

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -915,11 +915,14 @@ ctl --load "$LBA2_TEST_SAVE" --record "$loosedir/s.rec" \
 # the arm keeps passing on the day the scripted `cube` stops arriving, having crossed no
 # fade and tested nothing. The keyframe records the cube it changed to, so the reader can
 # be asked rather than the exit code trusted.
-loosekf="$(python3 "$REPO/scripts/dev/dump_recording.py" "$loosedir/s.rec" |
-    grep -c "cube 3->154")" ||
+# Matched with `case` rather than counted with `grep -c`, which exits 1 on no match: the
+# `||` would then report the reader as broken on the one failure this check is here for.
+loosedump="$(python3 "$REPO/scripts/dev/dump_recording.py" "$loosedir/s.rec")" ||
     fail "loose clock: could not read the recording back"
-[ "$loosekf" -ge 1 ] ||
-    fail "loose clock: the recording carries no cube 3->154 keyframe, so the run never crossed a scene change and this arm tested nothing"
+case "$loosedump" in
+*"cube 3->154"*) ;;
+*) fail "loose clock: the recording carries no cube 3->154 keyframe, so the run never crossed a scene change and this arm tested nothing" ;;
+esac
 
 pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; mode.audio was written from the driver and reported both ways; a session recorded in one run replayed in the next with no flags and no paths; \
 'rec start verbose' carried telemetry and a plain one carried none; a recorded walk moved the hero and the replay walked it again; the recorder gave the step back and left the flag's alone; a playback put the player back where it found them, stopped early or run out; a window holding a scene change ran at ${modalrate}x real, not faster; a recording on a host-sampled clock crossed a scene change instead of wedging in the fade"


### PR DESCRIPTION
#635's last commit said it fixed four things and changed one file. Two of the four never
reached it. Both are here, unchanged from what that commit described.

## The defect

The loose-clock arm reads the recording back for the keyframe naming the cube it changed
to, so a run that ended without ever crossing a fade cannot pass on its exit code alone.
It counted:

```sh
loosekf="$(python3 ... | grep -c "cube 3->154")" ||
    fail "loose clock: could not read the recording back"
[ "$loosekf" -ge 1 ] || fail "...carries no keyframe, this arm tested nothing"
```

`grep -c` exits 1 when it counts nothing. So the one failure the check exists for --
the scripted scene change no longer arriving -- reported the *reader* as broken, and the
line underneath it was unreachable. A misleading diagnosis sends the next person to the
Python reader rather than to the arm.

Matched with `case` now, one reader call, each failure keeping its own diagnosis. All
three branches exercised: a recording carrying the change, one without it, and an
unreadable file.

## The doc gap

`docs/RECORDING.md` gains what the fixed step actually trades, which is frames and not
duration: a recorded fade ramps in thirteen steps whatever the display can draw, against
47 unrecorded under the dummy driver, at 1.22s versus a 1.21s control. The same document
says exactly that about the pinned clock two sections earlier, so the loose path was
reading as though it escaped a cost it pays identically.

## How both were lost

Worth stating, because the mechanism is duller and more repeatable than the defect.

The six edits ran from one script. It stops at the first hunk that does not match, and
the fourth did not, so the fifth and sixth never ran. The failing hunk was then fixed on
its own and the script never re-run. `git add` of three files where only one had changed
committed cleanly and said nothing, and the commit message described all four.

`git show --stat` would have shown one file against a message claiming three. It is the
same shape as the two findings the review itself turned up -- a tool stopping early and
saying so, and the output being read as the whole answer -- which is three instances of
one failure in a single change.

Found by a reviewer reading the merged branch rather than by me.

## Swept, not just patched

Three other `grep -c` uses exist under `tests/` and `scripts/`. None is exposed: two
already carry `|| true`, and the remaining two are in files without `set -e` where the
count is consumed rather than tested. So this was the only instance, which is worth
saying rather than leaving as an unexamined risk.

## Gates

`test_record_replay.sh` passes, 142.9s; the arm's three branches verified individually;
doc links clean, 0 errors.
