### PR TITLE
fix(record): carry the seed the boot scene load ran on

### DIFF
--- a/LIB386/H/SYSTEM/RANDOM.H
+++ b/LIB386/H/SYSTEM/RANDOM.H
@@ -62,6 +62,10 @@ const char *Rnd_StreamName(void);
 // without moving anything a digest already covers.
 U32 Rnd_Draws(void);
 
+// The value the stream was last seeded with, after the zero substitution, so a caller
+// that has to reproduce a stream can record the seed rather than the state.
+U32 Rnd_LastSeed(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/LIB386/SYSTEM/RANDOM.CPP
+++ b/LIB386/SYSTEM/RANDOM.CPP
@@ -36,6 +36,7 @@ static S32 s_front;
 static S32 s_rear;
 static S32 s_seeded;
 static U32 s_draws;
+static U32 s_lastSeed;
 
 //──────────────────────────────────────────────────────────────────────────
 void Rnd_Seed(U32 seed) {
@@ -51,6 +52,8 @@ void Rnd_Seed(U32 seed) {
     // `int32_t word = seed` does. Schrage's identities hold either way: the
     // quotient and remainder both take the sign of the dividend, so the two
     // products stay inside S32 and the result stays inside the modulus.
+    s_lastSeed = seed;
+
     word = (S32)seed;
     s_state[0] = word;
     for (i = 1; i < RND_DEG; i++) {
@@ -79,6 +82,11 @@ const char *Rnd_StreamName(void) {
 //──────────────────────────────────────────────────────────────────────────
 U32 Rnd_Draws(void) {
     return s_draws;
+}
+
+//──────────────────────────────────────────────────────────────────────────
+U32 Rnd_LastSeed(void) {
+    return s_lastSeed;
 }
 
 //──────────────────────────────────────────────────────────────────────────

--- a/SOURCES/OBJECT.CPP
+++ b/SOURCES/OBJECT.CPP
@@ -4,6 +4,7 @@
 
 #include "DEMO_SEED.H"
 #include "FOLLOWCAM.H" /* FollowCamera: camera zones re-aim the Auto camera */
+#include "RECORD.H"    /* Record_SeedHook: the boot scene load's seed on a replay */
 #include "SAVEGAME.H"
 #include "ZONE_GEOM.H" // ZonePointInBox -- single source of truth for the zone box test
 
@@ -1191,7 +1192,15 @@ void ChangeCube() {
     // SHIFT+D / idle-attract path, and later cube transitions keep diverging).
     // Demo_RngSeed swaps the source to NewCube while DemoSlide -- canonical per
     // cube, deterministic on every host. Normal play unchanged. See issue #176.
-    Rnd_Seed(Demo_RngSeed(DemoSlide, TimerRefHR, NewCube));
+    {
+        /* On the --load path TimerRefHR here is boot-elapsed wall time, because LoadGame
+           installs the savegame's clock further down this function. A replay therefore
+           cannot reach this line on the reading the recording reached it on, and asks the
+           recorder for the seed instead. Outside a replay this changes nothing. */
+        U32 seed = Demo_RngSeed(DemoSlide, TimerRefHR, NewCube);
+        Record_SeedHook(&seed);
+        Rnd_Seed(seed);
+    }
 
     if (FlagChgCube)
         SaveTimer();

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -761,7 +761,7 @@ static int s_replayFromCli = 0;
 static U32 s_peekSeed = 0;
 static int s_havePeekSeed = 0;
 
-/* Read one field out of the header now, long before the replay itself starts.
+/* Read one field out of the header before the replay itself starts.
  *
  * ChangeCube seeds the shared RNG from TimerRefHR (SOURCES/OBJECT.CPP), and on the
  * --load path it does so about two hundred lines before LoadGame installs the savegame's
@@ -770,13 +770,18 @@ static int s_havePeekSeed = 0;
  * eleven times and seed 41 three times, and the one-millisecond difference decided the
  * verdict every time, clean at 40 and diverging at tick 225 at 41.
  *
- * A replay cannot ask the file for that seed when it needs it. The recorder starts on
- * the first input poll, which is after the boot scene load, and by then the stream has
- * been seeded and drawn from and no later correction can reach it. So the seed is read
- * here, where the flag is parsed and the load has not happened yet, and Record_SeedHook
- * hands it over when the load asks. Everything else in the header still waits for
- * Record_Play. */
+ * A replay cannot ask the file for that seed through the usual path. The recorder starts
+ * on the first input poll, which is after the boot scene load, and by then the stream has
+ * been seeded and drawn from and no later correction can reach it. So this runs from
+ * Record_SeedHook, at the load itself: late enough that the recordings folder resolves,
+ * early enough that the seed is still the one being asked for. Everything else in the
+ * header still waits for Record_Play.
+ *
+ * Not from Record_ArmReplay, which is where the flag is parsed. rec_resolve reads the
+ * recordings folder, and calling it that early does not merely fail to find a bare name
+ * -- it leaves Record_Play unable to open the same name later. */
 static void replay_peek_seed(const char *path) {
+    char resolved[ADELINE_MAX_PATH];
     char buf[2048];
     size_t got;
     FILE *f;
@@ -784,6 +789,14 @@ static void replay_peek_seed(const char *path) {
 
     s_havePeekSeed = 0;
     if (!path || !path[0])
+        return;
+    /* Through the same resolver Record_Play uses, because a bare name is a recording in the
+       recordings folder rather than one in the working directory, and opening the raw string
+       finds nothing. Measured before this went through it: the same file replayed clean when
+       named by its path and diverged at tick 223 when named `bare.rec`, which is the whole
+       fix silently not applying to the shorter of the two ways of asking. */
+    path = rec_resolve(path, resolved, sizeof resolved, 0);
+    if (!path[0])
         return;
     f = fopen(path, "rb");
     if (!f)
@@ -802,7 +815,6 @@ void Record_ArmReplay(const char *path) {
     s_armRecord[0] = 0;
     s_armed = 2;
     s_replayFromCli = 1;
-    replay_peek_seed(s_armReplay);
 }
 
 /* A recording that starts mid-session has no setup: replaying it would need the whole
@@ -2495,6 +2507,12 @@ void Record_WaitHook(void) {
    seed with a stale one. A recording made without the field -- any file written before it
    existed -- leaves the seed alone and replays exactly as it did before. */
 void Record_SeedHook(U32 *seed) {
+    static int peeked = 0;
+
+    if (!peeked && s_armed == 2) {
+        peeked = 1;
+        replay_peek_seed(s_armReplay);
+    }
     if (!s_havePeekSeed)
         return;
     s_havePeekSeed = 0;

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -567,6 +567,7 @@ static S32 write_mode_lines(char *out, size_t n) {
                          "setup.reload_clock=%u\n"
                          "clock.timer_ref_hr=%u\n"
                          "clock.sim_carry=%u\n"
+                         "clock.rng_seed=%u\n"
                          "data.master=%s\n"
                          "bindings.digest=%016llx\n",
                          LBA2_VERSION_STRING,
@@ -585,6 +586,7 @@ static S32 write_mode_lines(char *out, size_t n) {
                          s_reloaded, s_reloadClock,
                          (unsigned)TimerRefHR,
                          (unsigned)LastSimRefHR,
+                         (unsigned)Rnd_LastSeed(),
                          Distrib_MasterName(Distrib_GetMaster()),
                          bindings_digest());
     if (wrote <= 0 || (size_t)wrote >= n)
@@ -755,12 +757,52 @@ void Record_ArmRecord(const char *path) {
 }
 
 static int s_replayFromCli = 0;
+/* The boot scene load's seed, read out of the header at arm time; see replay_peek_seed. */
+static U32 s_peekSeed = 0;
+static int s_havePeekSeed = 0;
+
+/* Read one field out of the header now, long before the replay itself starts.
+ *
+ * ChangeCube seeds the shared RNG from TimerRefHR (SOURCES/OBJECT.CPP), and on the
+ * --load path it does so about two hundred lines before LoadGame installs the savegame's
+ * clock -- so the seed is how many milliseconds this process took to boot. Measured on
+ * one byte-identical recording replayed fourteen times on an idle machine: seed 40
+ * eleven times and seed 41 three times, and the one-millisecond difference decided the
+ * verdict every time, clean at 40 and diverging at tick 225 at 41.
+ *
+ * A replay cannot ask the file for that seed when it needs it. The recorder starts on
+ * the first input poll, which is after the boot scene load, and by then the stream has
+ * been seeded and drawn from and no later correction can reach it. So the seed is read
+ * here, where the flag is parsed and the load has not happened yet, and Record_SeedHook
+ * hands it over when the load asks. Everything else in the header still waits for
+ * Record_Play. */
+static void replay_peek_seed(const char *path) {
+    char buf[2048];
+    size_t got;
+    FILE *f;
+    U32 v;
+
+    s_havePeekSeed = 0;
+    if (!path || !path[0])
+        return;
+    f = fopen(path, "rb");
+    if (!f)
+        return; /* Record_Play reports a file it cannot open; this one stays quiet. */
+    got = fread(buf, 1, sizeof buf - 1, f);
+    fclose(f);
+    buf[got] = 0;
+    if (RecFmt_ReadU32(buf, "clock.rng_seed=", &v)) {
+        s_peekSeed = v;
+        s_havePeekSeed = 1;
+    }
+}
 
 void Record_ArmReplay(const char *path) {
     snprintf(s_armReplay, sizeof s_armReplay, "%s", path ? path : "");
     s_armRecord[0] = 0;
     s_armed = 2;
     s_replayFromCli = 1;
+    replay_peek_seed(s_armReplay);
 }
 
 /* A recording that starts mid-session has no setup: replaying it would need the whole
@@ -1579,6 +1621,7 @@ static int mode_line_ignored(const char *line) {
     static const char *const skip[] = {
         "clock.timer_ref_hr=", /* the recorded baseline: restored, not matched */
         "clock.sim_carry=",    /* the sub-step carry: restored with it */
+        "clock.rng_seed=",     /* the boot scene load's seed: installed, not matched */
         "setup.snapshot=",     /* the file it started from, named per recording */
         "setup.reloaded=",     /* how it started, which the reader acts on rather than matches */
         "setup.reload_clock=",
@@ -2441,6 +2484,21 @@ void Record_WaitHook(void) {
     s_waitSteps++;
     s_frameClock += REC_DEFAULT_DT;
     Timer_SleepUntil(s_waitAnchor + s_waitSteps * REC_DEFAULT_DT);
+}
+
+/* The first scene load of a replay runs on the seed the recording ran on, because on the
+   --load path that seed is this process's boot time in milliseconds and the two ends do
+   not boot in the same number of them. See replay_peek_seed for the measurement.
+
+   Once, for the first load only. Every later ChangeCube seeds from the clock the savegame
+   restored, which both ends agree on, and overriding those would replace a reproducible
+   seed with a stale one. A recording made without the field -- any file written before it
+   existed -- leaves the seed alone and replays exactly as it did before. */
+void Record_SeedHook(U32 *seed) {
+    if (!s_havePeekSeed)
+        return;
+    s_havePeekSeed = 0;
+    *seed = s_peekSeed;
 }
 
 void Record_TickHook(void) {

--- a/SOURCES/RECORD.H
+++ b/SOURCES/RECORD.H
@@ -27,6 +27,9 @@ void Record_ClockHook(U32 *now);
    still ends. */
 void Record_WaitHook(void);
 
+/* ChangeCube(): supply the seed a replay's first scene load has to run on. */
+void Record_SeedHook(U32 *seed);
+
 /* Control_TickHook(): one state hash per tick, the recording's own oracle. */
 void Record_TickHook(void);
 

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -134,6 +134,13 @@ recordings replayed twice each: **reproduced 4 of 12 before and 10 of 12 after**
 replays of one file disagreed on **5 of 12 before and 0 of 12 after** (Fisher two-sided
 p = 0.036 and p = 0.037).
 
+All of that is the `--load` path, which is the one where the scene load happens before the
+recorder holds the clock. **From boot with no `--load` the field is not read at all**, and does
+not need to be: by the time cube 0 loads, a replay is already taking its clock from the file,
+so both ends reach the seed on the same reading -- measured, they match every run. That path
+reproduces badly for its own reasons, which are not this and are not fixed here, so a loose
+recording reproducing is still a claim about `--load` rather than about recording generally.
+
 A third was the same shape and is closed with them: `InitAnim` stamps the hero's animation anchors
 during boot, from wall-clock time, and `LoadGame` installs the save's clock afterwards. Every other
 actor is stamped after that line and comes out on the restored reading, so the hero alone carried

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -114,6 +114,26 @@ Two are closed, both invisible under a pinned step by construction:
   reproduce, not only a pinned one. Gated on the step, a loose session asks the mixer instead, whose
   clock no replay reproduces. See "Audio used to move the answer" below.
 
+A fourth is closed and is **not** the same shape as the others, which is what makes it worth
+reading. Everything above is per-frame timing state. This is a **seed**. `ChangeCube`
+([SOURCES/OBJECT.CPP](../SOURCES/OBJECT.CPP)) seeds the one shared `rand()` stream from
+`TimerRefHR`, and on the `--load` path it does so about two hundred lines before `LoadGame`
+installs the savegame's clock, so the seed is **how many milliseconds the process took to
+boot**. Two runs do not boot in the same number of them. Measured on one byte-identical
+recording replayed fourteen times on an idle machine: seed 40 eleven times and seed 41 three
+times, and the one-millisecond difference decided the verdict every time, clean at 40 and
+diverging at tick 225 at 41. `--fixed-dt` hides it completely, because `Timer_EnableFixedDt`
+zeroes `TimerRefHR` and every pinned run therefore seeds with 0.
+
+A replay cannot ask the file for that seed at the moment it needs it: the recorder starts on
+the first input poll, which is after the boot scene load, and by then the stream has been
+seeded and drawn from. So the recording carries it as `clock.rng_seed`, `--replay` reads that
+one field when the flag is parsed, and `Record_SeedHook` hands it over when the load asks.
+A recording without the field replays exactly as it did before. Measured over twelve fresh
+recordings replayed twice each: **reproduced 4 of 12 before and 10 of 12 after**, and the two
+replays of one file disagreed on **5 of 12 before and 0 of 12 after** (Fisher two-sided
+p = 0.036 and p = 0.037).
+
 A third was the same shape and is closed with them: `InitAnim` stamps the hero's animation anchors
 during boot, from wall-clock time, and `LoadGame` installs the save's clock afterwards. Every other
 actor is stamped after that line and comes out on the restored reading, so the hero alone carried


### PR DESCRIPTION
A recording made without `--fixed-dt` reproduces some of the time and not the rest, and the
reason is one millisecond of boot jitter reaching the RNG.

## The mechanism

`ChangeCube` (`SOURCES/OBJECT.CPP`) seeds the engine's one shared `rand()` stream:

```c
Rnd_Seed(Demo_RngSeed(DemoSlide, TimerRefHR, NewCube));
```

`Demo_RngSeed` returns `TimerRefHR` outside the demo reel. On the `--load` path that line
runs about two hundred lines before `LoadGame` installs the savegame's clock, so **the seed
is how many milliseconds the process took to boot**, and two runs do not boot in the same
number of them.

Measured on one byte-identical recording replayed fourteen times on an idle machine:

| seed | replays | verdict |
|---|---|---|
| 40 (the recording's own) | 11 | clean every time |
| 41 | 3 | diverges at tick 225 every time |

No run of either seed gave two answers. The seed decides the verdict, and the difference
between the two seeds is one millisecond of boot time.

`--fixed-dt` hides this completely: `Timer_EnableFixedDt` zeroes `TimerRefHR`, so every
pinned run seeds with 0. That is why no pinned measurement has ever seen it, and it is a
second reason the pinned step "masks state rather than reproducing a clock".

## Why the recording has to carry it

A replay cannot ask the file for the seed at the moment it needs it. The recorder starts on
its first input poll, which is *after* the boot scene load, and by then the stream has been
seeded and drawn from — no later correction can reach it.

So the seed is read where the flag is parsed, before the load has happened:

- the recording writes `clock.rng_seed` into its header, from a new `Rnd_LastSeed()`
- `--replay` peeks that one field at arm time; everything else still waits for `Record_Play`
- `Record_SeedHook` hands it to `ChangeCube` when the load asks

Once, for the first load only. Every later `ChangeCube` seeds from the clock the savegame
restored, which both ends already agree on, and overriding those would replace a
reproducible seed with a stale one.

**Additive, so no version bump.** A recording without the field leaves the seed alone and
replays exactly as it did before — the format-10 arm in the suite covers that direction.

## Measured

Twelve fresh recordings, each replayed twice, quiet loose session on `--load`:

| | reproduced | the two replays disagreed |
|---|---|---|
| before | 4/12 | 5/12 |
| after | 10/12 | 0/12 |

Fisher two-sided p = 0.036 and p = 0.037.

**The replay column going to zero is the stronger result.** A replay takes its input, its
clock, its step and its bindings from the file, so two runs of one fixed file disagreeing
meant it was reading something the file did not carry. This was it.

Both remaining failures mismatch at tick 1 and give the same answer twice, so what is left
is recording-side and deterministic — a different residual, and a narrower one.

## Attribution

Found by another maintainer's session, measuring the replay-disagreement column against a
hypothesis of mine that turned out to be wrong: the wait-loop clock leak fixed in #635
cannot move this rate, because `Timer_FixedDtPump` is called zero times in a quiet
recording. That negative is what sent them looking somewhere else. The mechanism and every
figure above are re-derived here rather than taken.

## Gates

`test_record_replay`, `test_dump`, `test_exec`, `test_load` pass; ctest 70/70; check-arch
clean; check-build-graph 57 translation units unchanged; clang-format-18 clean on all five
sources; doc links 0 errors.
