### PR TITLE
fix(record): install the clock baseline before the first delta, not after it

### DIFF
--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -2072,14 +2072,31 @@ static int replay_poll(void) {
         s_prevSrcDelta = d;
     }
 
-    /* The clock this frame runs on, from the file. */
-    s_replaySrc += s_prevSrcDelta;
-    record_hold_clock(s_replaySrc);
+    /* Before this frame's delta rather than after it, because the recording banks that
+       delta and a replay installing the baseline on top of it does not. `record_begin`
+       settles the clock on the reading it takes the baseline from, and the first
+       `record_poll` then holds the next reading, so the interval between the two is one
+       the recorded run spent and wrote down. Installed after the hold, `SetTimerHR`
+       assigns straight over it, and the two ends part by exactly that interval.
+
+       Measured on a failing file, each end at its own tick 1: `TimerRefHR` 4268111
+       recorded against 4268110 replayed, with `sim.carry` and the first stamped actor's
+       animation anchors carrying the same millisecond. Forced by holding the first poll
+       three milliseconds back, it is not intermittent at all: fifteen recordings out of
+       fifteen failed before this and one of fourteen after.
+
+       Under `--fixed-dt` the two readings are the same and there is nothing to discard,
+       which is the whole reason only a host-sampled run shows it. */
     if (s_pendingBaseline) {
         s_pendingBaseline = 0;
+        record_hold_clock(s_replaySrc);
         SetTimerHR(s_baseline);
         LastSimRefHR = s_baselineCarry;
     }
+
+    /* The clock this frame runs on, from the file. */
+    s_replaySrc += s_prevSrcDelta;
+    record_hold_clock(s_replaySrc);
 
     replay_inject();
 

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -141,6 +141,17 @@ so both ends reach the seed on the same reading -- measured, they match every ru
 reproduces badly for its own reasons, which are not this and are not fixed here, so a loose
 recording reproducing is still a claim about `--load` rather than about recording generally.
 
+A fifth is the mirror of the fourth, on the reading side. The recording banks the interval
+between the reading it takes its baseline from and the reading its first poll holds --
+`record_begin` settles the clock, and the first `record_poll` then holds the next one -- and
+it writes that interval down as the first poll's delta. A replay that installs the baseline
+*after* holding that delta assigns straight over it, so the two ends part by exactly that
+interval. It is a millisecond, and a millisecond is one animation sub-step on the first actor
+stamped. Forcing the first poll three milliseconds back makes it deterministic rather than
+occasional: **fifteen recordings out of fifteen failed before the baseline was moved ahead of
+the delta, and one of fourteen after**. `--fixed-dt` takes both readings from the same
+generated step, so there is nothing to discard and no pinned run has ever shown it.
+
 A third was the same shape and is closed with them: `InitAnim` stamps the hero's animation anchors
 during boot, from wall-clock time, and `LoadGame` installs the save's clock afterwards. Every other
 actor is stamped after that line and comes out on the restored reading, so the hero alone carried


### PR DESCRIPTION
**Stacked on #637** — based on `fix/loose-boot-rng-seed`, so this diff is the second commit
only. GitHub will retarget it to `main` when #637 merges.

This is the residual #637 left behind: after the seed is pinned, about one loose recording in
twenty still mismatches at tick 1, the same answer twice.

## The mechanism

A recording banks the interval between the reading it takes its baseline from and the reading
its first poll holds. `record_begin` settles the clock, the first `record_poll` then holds the
next reading, and the interval between them is one the recorded run spent — and wrote down,
as the first poll's delta.

A replay held that delta and *then* called `SetTimerHR`, which assigned straight over it. The
two ends parted by exactly that interval.

One millisecond, and one millisecond is a whole animation sub-step on the first actor stamped:

```
tick 1 state differs: obj[1].LastTimer 4268111/4268110  obj[1].NextTimer 4268511/4268510
                      sim.carry 4268111/4268110   (recorded/replayed)
```

The fix moves the baseline install ahead of the delta, so the replay banks the same first
interval the recording did.

## Why the evidence is not statistical

The interval is usually zero — about one recording in twenty crosses a millisecond boundary
between the two readings, which is why this looked intermittent and why a pass-rate
measurement at any affordable K would have been weak.

So the condition was forced instead, by holding the first poll three milliseconds back:

| | recordings that failed |
|---|---|
| before | **15 of 15** |
| after | **1 of 14** |

Under the forced condition the old behaviour is not occasional, it is certain. That is a much
stronger claim than a rate, and it costs the same number of runs.

`--fixed-dt` takes both readings from the same generated step, so there is nothing to discard.
That is why no pinned run has ever shown this — and why `record_begin`'s own comment, which
describes this exact failure, concluded the pending delta was zero on the flag path. It is
zero on the *pinned* flag path.

## Two hypotheses killed on the way

Neither is worth re-deriving, so both are in the commit message:

- **The header baseline is not stale.** Traced over twenty runs: the value written into the
  header and the value the recording's own first tick runs on are equal every time, clean and
  failing alike. My first reading of this bug was wrong.
- **The residual is not a digest-membership defect.** Telemetry names an actor's animation
  anchors and the carry — none of the five globals `Control_StateDigest` mixes that no
  savegame carries. That was a reviewer's hypothesis, offered with a discriminator that cost
  one run, and the run killed it.

## What is left

One of fourteen still fails under the forced condition, with the same signature a millisecond
wide, so a second interval between the two ends is unaccounted for. Recorded, not fixed here.

## Gates

`test_record_replay`, `test_dump`, `test_exec`, `test_load` pass; ctest 70/70; clang-format-18
clean; doc links 0 errors.
