### PR TITLE
fix(record): run a replayed command where the recording ran it

### DIFF
--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -1130,8 +1130,14 @@ void Control_TickHook(void) {
        when Timer_FixedDtActive() is false. */
     if (!s_have_fixed_dt && Timer_FixedDtActive())
         Timer_FixedDtAdvance();
-    if (!s_armed)
+    if (!s_armed) {
+        /* A replay's commands still have to run, and everything below is dead for a
+           session played back from the console, which has passed no harness flag at
+           all. The step above is minted either way, so this is the same point in the
+           frame as the drain below. */
+        Record_ExecHook();
         return;
+    }
     s_hook_calls++;
     /* Apply --fixed-timestep once, on the first tick: it must land after ReadConfigFile (which
        set FixedTimestep from lba2.cfg during boot) so the flag overrides the cfg for this run
@@ -1163,6 +1169,12 @@ void Control_TickHook(void) {
             last_move = h->Move;
         }
     }
+    /* Where the recording ran its own: --exec-at fires from the line below, once this
+       tick's step has been minted, so that is the point in the frame a replay has to run
+       what it read. The recorder's own tick hook is above that advance, and a command run
+       from there is one minted step early -- which nothing shows until a verb spends
+       clock inline, because a modal's inner loop presents and every present is a step. */
+    Record_ExecHook();
     if (s_hook_calls == 1)
         control_run_exec();
     control_run_exec_at(s_hook_calls - 1);

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -277,6 +277,9 @@ typedef struct {
 static T_RecCmd s_cmds[REC_CMD_MAX];
 static int s_nCmds = 0;
 static int s_cmdRead = 0;
+/* Non-zero while a staged command is running. One of them can open a modal, whose inner
+   loop polls, and that poll drains the queue again. */
+static int s_cmdDepth = 0;
 /* The version the file being replayed was written at, for the records whose shape it
    decides. Set before the range check, so a refused file never reaches a reader. */
 static int s_recVersion = REC_VERSION;
@@ -1913,6 +1916,71 @@ static void replay_note_stale(void) {
         s_stalePeak = s_stalePolls;
 }
 
+/* Read every command sitting at this point in the stream and hold it, leaving the file
+   on the first record that is not one -- so a caller that finds none has not moved.
+   Reading and running are two different points in the frame: the writer put a command
+   where it ran, and the reader meets it wherever the record before it left off, which
+   is not the same place. The two drains below run what this stages, each from the point
+   in the frame the recording ran it from. */
+static void replay_stage_commands(void) {
+    for (;;) {
+        long back = ftell(s_f);
+        U8 flags;
+        U32 tick;
+        U16 n, j;
+        char line[sizeof s_cmds[0].line];
+
+        if (!get8(&flags) || !replay_take_sync(&flags)) {
+            fseek(s_f, back, SEEK_SET);
+            return;
+        }
+        /* Whatever take_sync stopped on begins one byte back. Markers are stepped over
+           for good rather than put back with the record: each carries the poll and tick
+           the recording was on, and reading one twice is taking the same drift check
+           twice. */
+        back = ftell(s_f) - 1;
+        if (flags != 0x40) {
+            fseek(s_f, back, SEEK_SET);
+            return;
+        }
+        if (!get32(&tick) || !get16(&n))
+            return;
+        for (j = 0; j < n; j++) {
+            U8 c;
+            if (!get8(&c))
+                return;
+            if ((size_t)(j + 1) < sizeof line)
+                line[j] = (char)c;
+        }
+        line[((size_t)(n + 1) < sizeof line) ? n : sizeof line - 1] = 0;
+        if (s_nCmds < REC_CMD_MAX) {
+            s_cmds[s_nCmds].tick = tick;
+            snprintf(s_cmds[s_nCmds].line, sizeof s_cmds[s_nCmds].line, "%s", line);
+            s_nCmds++;
+        }
+    }
+}
+
+/* Run what is staged, in the order the session ran it. Taken one at a time off the read
+   cursor rather than over a count read up front: a command can open a modal whose inner
+   loop polls, and that poll stages and runs the next command before this call returns.
+   Advancing the cursor before the call is what stops a nested drain running the same
+   line twice, and the queue is only emptied by the outermost one. */
+static void replay_run_staged(void) {
+    s_cmdDepth++;
+    /* `s_replaying` per line rather than once: a command can poll, that poll can find the
+       replay stalled, and the stall tears the session down from under this loop. The rest
+       of the queue belongs to a replay that is no longer running. */
+    while (s_replaying && s_cmdRead < s_nCmds) {
+        const char *line = s_cmds[s_cmdRead].line;
+        s_cmdRead++;
+        s_cmdsReplayed++;
+        Console_Execute(line);
+    }
+    if (--s_cmdDepth == 0)
+        s_nCmds = s_cmdRead = 0;
+}
+
 static int replay_poll(void) {
     U8 flags;
     long atFlags = ftell(s_f);
@@ -1983,9 +2051,10 @@ static int replay_poll(void) {
                 return 0;
             }
         } else if (flags == 0x40) {
-            /* Queued rather than run here: executing a command inside the keyboard path
-               re-enters this reader. It runs at the next tick boundary instead, so a
-               command typed during a tick lands one tick later than it did live. */
+            /* Held rather than run here: this reader is part-way through finding this
+               poll's record, and executing a command from inside it re-enters it. The
+               tail of the poll runs what this holds, which is the nearest point in the
+               frame to where the session issued it. */
             U32 ct;
             U16 n, j;
             char line[sizeof s_cmds[0].line];
@@ -2459,7 +2528,53 @@ void Record_PollHook(void) {
     if (s_recording)
         record_poll();
     else if (s_replaying) {
-        if (!replay_poll()) {
+        if (replay_poll()) {
+            /* The tail of the poll, which is where the console issues from: it runs
+               from the input path, so a line typed during this poll was written just
+               after this poll's record. Run it here rather than at the next tick
+               boundary -- that is simply the next place the reader is called from, and
+               it put a line typed during a tick a whole tick after the session ran it.
+               It is also the answer to a line issued while no tick is advancing at all,
+               which is the whole of menu time: polls carry on, so there is a point in
+               the frame for it either way.
+
+               Ahead of the stall check below, and not only because that check closes the
+               file this one reads from. A run with nothing left to take from the stream
+               is exactly the run a staged command might still move: a command held
+               through menu time is held precisely because no tick came to drain it. It
+               gets its chance before the run is called stuck. */
+            replay_stage_commands();
+            replay_run_staged();
+            /* Still replaying, because the drain above can have ended it: a recording
+               whose session finished at the console carries the command that finished
+               it, and a run that stopped deliberately is not a run that stalled. */
+            if (s_replaying && s_stalePolls >= REC_STALE_LIMIT && !s_staleReported) {
+                /* Ends the run the same way the stream running out does, and for the
+                   same reason: there is nothing left that can drive it. Saying so is the
+                   whole of the fix -- the deadlock is a symptom of a divergence that
+                   happened earlier, and the tick named here is where to start looking,
+                   not where the fault is. */
+                s_staleReported = 1;
+                fprintf(stderr,
+                        "[rec] replay stalled at poll %ld, tick %ld: %ld polls in a row took no "
+                        "input from the recording. The run is waiting on input the recording "
+                        "does not contain -- it has diverged into a screen it can only leave on "
+                        "a key. First hash mismatch %ld.\n",
+                        s_polls, s_ticks, s_stalePolls, s_hashMismatchTick);
+                Record_Stop();
+                /* Unlike the stream running out, this leaves regardless of the harness.
+                   The reason the end-of-stream path defers to it -- a tick budget still
+                   to spend and artifacts still to write -- cannot apply here: no tick
+                   will retire again, so the budget is unreachable and every later
+                   --exec-at is too. A run that cannot advance has nothing left to defer
+                   to, and deferring is what makes this a report about a hang rather than
+                   the end of one. Measured: without this the detector printed and the run
+                   went on holding a core until an outside timeout, which is the behaviour
+                   it exists to fix. */
+                if (s_replayFromCli)
+                    exit(2);
+            }
+        } else {
             /* The engine is mid-session with nothing left to drive it, and whatever it
                was waiting for will never arrive. Say what happened and leave. */
             fprintf(stderr,
@@ -2474,30 +2589,6 @@ void Record_PollHook(void) {
                the --dump-state the caller asked for. */
             if (s_replayFromCli && !Control_IsActive())
                 exit(s_hashMismatchTick < 0 ? 0 : 2);
-        } else if (s_stalePolls >= REC_STALE_LIMIT && !s_staleReported) {
-            /* Ends the run the same way the stream running out does, and for the same
-               reason: there is nothing left that can drive it. Saying so is the whole
-               of the fix -- the deadlock is a symptom of a divergence that happened
-               earlier, and the tick named here is where to start looking, not where
-               the fault is. */
-            s_staleReported = 1;
-            fprintf(stderr,
-                    "[rec] replay stalled at poll %ld, tick %ld: %ld polls in a row took no "
-                    "input from the recording. The run is waiting on input the recording "
-                    "does not contain -- it has diverged into a screen it can only leave on "
-                    "a key. First hash mismatch %ld.\n",
-                    s_polls, s_ticks, s_stalePolls, s_hashMismatchTick);
-            Record_Stop();
-            /* Unlike the stream running out, this leaves regardless of the harness. The
-               reason the end-of-stream path defers to it -- a tick budget still to spend
-               and artifacts still to write -- cannot apply here: no tick will retire
-               again, so the budget is unreachable and every later --exec-at is too. A
-               run that cannot advance has nothing left to defer to, and deferring is
-               what makes this a report about a hang rather than the end of one.
-               Measured: without this the detector printed and the run went on holding a
-               core until an outside timeout, which is the behaviour it exists to fix. */
-            if (s_replayFromCli)
-                exit(2);
         }
         /* Progress, so a long replay is not a silent one. */
         if ((s_polls % 20000) == 0)
@@ -2691,45 +2782,21 @@ void Record_TickHook(void) {
 
     /* Replay: the next record should be this tick's hash. */
     {
-        long pos = ftell(s_f);
+        long pos;
         U8 flags;
         U32 t;
         unsigned long long rh;
+        /* A command written before this tick's record was issued from a poll that has
+           already gone by -- the console runs from the input path, so a line typed
+           during a tick lands after that tick's last poll. Take it here rather than give
+           up on the tick: giving up left the tick unchecked and the record was then read
+           as a poll, which lost the stream on the first command a player typed. */
+        replay_stage_commands();
+        pos = ftell(s_f);
         if (!get8(&flags))
             return;
         if (!replay_take_sync(&flags))
             return;
-        /* A command issued from the console is written where it ran, which is the input
-           path, so it lands after the last poll of the tick and before the tick's own
-           record. Step over it here rather than giving up on the tick: giving up left the
-           tick unchecked and the record was then read as a poll, which lost the stream on
-           the first command a player typed. It runs at the bottom of this tick with the
-           rest. */
-        while (flags == 0x40) {
-            U32 ct;
-            U16 n, j;
-            char line[sizeof s_cmds[0].line];
-            if (!get32(&ct) || !get16(&n))
-                return;
-            for (j = 0; j < n; j++) {
-                U8 c;
-                if (!get8(&c))
-                    return;
-                if ((size_t)(j + 1) < sizeof line)
-                    line[j] = (char)c;
-            }
-            line[((size_t)(n + 1) < sizeof line) ? n : sizeof line - 1] = 0;
-            if (s_nCmds < REC_CMD_MAX) {
-                s_cmds[s_nCmds].tick = ct;
-                snprintf(s_cmds[s_nCmds].line, sizeof s_cmds[s_nCmds].line, "%s", line);
-                s_nCmds++;
-            }
-            pos = ftell(s_f);
-            if (!get8(&flags))
-                return;
-            if (!replay_take_sync(&flags))
-                return;
-        }
         if (!(flags & 0x80)) {
             fseek(s_f, pos, SEEK_SET);
             return;
@@ -2881,43 +2948,21 @@ void Record_TickHook(void) {
             }
         }
 
-        /* Commands run from here, not from the poll hook: executing one inside the
-           keyboard path re-enters the stream reader. A command issued while no tick is
-           advancing, which is all of menu time, therefore has nowhere to land. */
-        for (;;) {
-            U32 ct;
-            U16 n, j;
-            char line[96];
-            U8 f2;
-            long p2 = ftell(s_f);
-            if (!get8(&f2))
-                break;
-            if (f2 != 0x40) {
-                fseek(s_f, p2, SEEK_SET);
-                break;
-            }
-            if (!get32(&ct) || !get16(&n))
-                break;
-            for (j = 0; j < n && (size_t)(j + 1) < sizeof line; j++) {
-                U8 c;
-                if (!get8(&c))
-                    break;
-                line[j] = (char)c;
-            }
-            line[j] = 0;
-            s_cmdsReplayed++;
-            Console_Execute(line);
-        }
-
-        /* Anything the poll reader queued: a command typed at the console is written
-           mid-poll, and running it there would re-enter the stream reader. */
-        while (s_cmdRead < s_nCmds) {
-            const char *queued = s_cmds[s_cmdRead].line;
-            s_cmdRead++;
-            s_cmdsReplayed++;
-            Console_Execute(queued);
-        }
+        /* The commands the harness issued on this tick, which is where --exec-at
+           writes them: straight after the tick record, because that is where it runs
+           them. Read here and run from Record_ExecHook, which is the point in the frame
+           the harness runs its own from -- after the tick's step has been minted.
+           Running them here instead put them one minted step earlier than the session
+           had them. */
+        replay_stage_commands();
     }
+}
+
+/* Control_TickHook(), beside the harness's own --exec-at and after the tick's step:
+   run the commands read off the stream, where the session ran them. */
+void Record_ExecHook(void) {
+    if (s_replaying)
+        replay_run_staged();
 }
 
 /* Console_Execute: capture what the session was driven with, alongside what it was

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -280,6 +280,8 @@ static int s_cmdRead = 0;
 /* Non-zero while a staged command is running. One of them can open a modal, whose inner
    loop polls, and that poll drains the queue again. */
 static int s_cmdDepth = 0;
+/* The replay's verdict has been said, so the next path out does not repeat it. */
+static int s_endSaid = 0;
 /* The version the file being replayed was written at, for the records whose shape it
    decides. Set before the range check, so a refused file never reaches a reader. */
 static int s_recVersion = REC_VERSION;
@@ -1320,6 +1322,7 @@ static int record_begin(const char *path, int haveSnapshot) {
     s_polls = s_ticks = s_bytes = s_quietPolls = 0;
     s_bytesTicks = s_maxPollsInTick = s_pollsThisTick = 0;
     s_nCmds = s_cmdRead = 0;
+    s_endSaid = 0;
     s_cmdsRecorded = 0;
     s_cmdsReplayed = 0;
     s_prevMt = Timer_ClockSource();
@@ -1452,6 +1455,34 @@ static void record_restore_player(void) {
     Console_Print("rec: returning to your game");
 }
 
+/* The replay's verdict. Said once, from wherever the replay stops rather than from the
+   one path that runs out of stream: a recording whose session ended at the console ends
+   the replay there too, and a run that reported nothing reads exactly like a run that
+   matched. */
+/* What the verdict line carries that the stall line does not: ticks checked, both clock
+   drift figures and the stream drift poll. Said under its own prefix rather than the
+   verdict's, because `replay ended ... first hash mismatch -1` is the string a caller
+   greps to mean the replay reproduced and a stalled run must never print it. The drift
+   pair is the reason this exists at all: a stall is a symptom of a divergence that
+   happened earlier, so where the clock first moved is where to start looking. */
+static void replay_report_figures(void) {
+    fprintf(stderr, "[rec] at the stall: %ld ticks checked, clock drift max %ld ms first at "
+                    "tick %ld, stream drift first at poll %ld\n",
+            s_ticksChecked, s_refDriftMax, s_refDriftFirstTick, s_syncDriftPoll);
+}
+
+static void replay_report_end(void) {
+    if (s_endSaid)
+        return;
+    s_endSaid = 1;
+    fprintf(stderr,
+            "[rec] replay ended at poll %ld: %ld ticks checked, first hash mismatch %ld, "
+            "clock drift max %ld ms first at tick %ld, stream drift first at poll %ld, "
+            "longest stale run %ld\n",
+            s_polls, s_ticksChecked, s_hashMismatchTick, s_refDriftMax, s_refDriftFirstTick,
+            s_syncDriftPoll, s_stalePeak);
+}
+
 int Record_Stop(void) {
     int wasRecording = s_recording;
     char endPath[ADELINE_MAX_PATH];
@@ -1474,6 +1505,23 @@ int Record_Stop(void) {
     if (!s_f) {
         record_release_step();
         return 0;
+    }
+
+    /* The verdict, before the flags below drop it. Every way out of a replay comes
+       through here -- the stream running out, a `rec stop`, a command in the recording
+       that ends the run, and the atexit handler for the tick budget -- and the one that
+       reports is the one the run happened to take.
+
+       Except behind a stall. The line below reads `first hash mismatch -1` on a run that
+       never diverged, and that is what a caller greps for to mean the replay reproduced:
+       printing it after a stall would put a pass-shaped line on a run that ended by giving
+       up. The figures it carries beyond the stall's own four are still worth having, so
+       they go out under a prefix that cannot be read as a verdict. */
+    if (s_replaying) {
+        if (s_staleReported)
+            replay_report_figures();
+        else
+            replay_report_end();
     }
 
     /* A second snapshot where the recording ends, on the same mechanics as the one at
@@ -2231,6 +2279,7 @@ static void replay_begin(void) {
     s_staleReported = 0;
     s_bytesTicks = s_maxPollsInTick = s_pollsThisTick = 0;
     s_nCmds = s_cmdRead = 0;
+    s_endSaid = 0;
     s_cmdsRecorded = 0;
     s_cmdsReplayed = 0;
     s_prevMt = Timer_ClockSource();
@@ -2577,12 +2626,7 @@ void Record_PollHook(void) {
         } else {
             /* The engine is mid-session with nothing left to drive it, and whatever it
                was waiting for will never arrive. Say what happened and leave. */
-            fprintf(stderr,
-                    "[rec] replay ended at poll %ld: %ld ticks checked, first hash mismatch %ld, "
-                    "clock drift max %ld ms first at tick %ld, stream drift first at poll %ld, "
-                    "longest stale run %ld\n",
-                    s_polls, s_ticksChecked, s_hashMismatchTick, s_refDriftMax,
-                    s_refDriftFirstTick, s_syncDriftPoll, s_stalePeak);
+            replay_report_end();
             Record_Stop();
             /* Only when nothing else is driving the run. With the harness armed it has
                a tick budget and artifacts to write, and exiting from here would skip

--- a/SOURCES/RECORD.H
+++ b/SOURCES/RECORD.H
@@ -33,6 +33,12 @@ void Record_SeedHook(U32 *seed);
 /* Control_TickHook(): one state hash per tick, the recording's own oracle. */
 void Record_TickHook(void);
 
+/* Control_TickHook() again, further down: run the commands a replay has read off the
+   stream. Its own seam because reading one and running it are two different points in
+   the frame -- the reader meets a command where the record before it left off, and the
+   session ran it after that tick's step was minted, beside --exec-at. */
+void Record_ExecHook(void);
+
 /* `verbose` records the telemetry --record-telemetry asks for: every value the digest
    mixes, every tick, so a divergence names the field rather than only the tick. It costs
    a few kilobytes a tick, so it belongs to the session that asked for it rather than to

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -584,8 +584,8 @@ opens it. Two consequences, both found by replaying a real session and both now 
 - A command typed at the console is written where it ran, which is the input path, so it lands
   after the last poll of the tick and before that tick's own record. The reader expected commands
   only after the tick record, gave up on the tick when it found one, and then read the tick record
-  as a poll: a replay ended on the first command a player typed. Both readers now step over
-  commands and run them at the tick boundary.
+  as a poll: a replay ended on the first command a player typed. Both readers now take a command
+  wherever it sits.
 
 Recordings made before those fixes still diverge where the console was opened: the doubled clock is
 in the file, and no replay reproduces it.
@@ -595,6 +595,36 @@ the automation fixture exercises the harness layout and not this one. The consol
 produced headlessly, because the toggle is an SDL key event. It is covered by a real recorded
 session that opens the console, types, closes it and plays on, which replays with no mismatch and
 no clock drift.
+
+### Where a replayed command runs
+
+Reading a command off the stream and running it are two different points in the frame, and the
+second one is what has to match. The reader meets a command wherever the record before it left off;
+the session ran it somewhere else entirely, and the difference is what a digest sees.
+
+So the reader stages, and two drains run what it staged, each from the point in the frame the
+recording ran it from:
+
+| Written | By | Replayed from |
+|---|---|---|
+| Straight after the tick record | `--exec-at`, from the tick hook, once that tick's step is minted | `Record_ExecHook`, beside `--exec-at` |
+| After a poll record | The console, which runs from the input path | The tail of that poll |
+
+Run both at the next tick boundary instead, which is simply the next place the reader is called
+from, and each is out of position in its own direction. A harness command lands one minted step
+early, above `Timer_FixedDtAdvance` rather than below it. That is invisible to a verb that does not
+spend clock -- `teleport actor 1`, `varcube 0 7` and `behaviour 2` all replay clean over 301 ticks
+with it -- and a modal sees it, because a modal's inner loop presents and every present is a step:
+`ui inventory` at tick 60 diverges at tick 61, `sim.carry` one 16 ms sub-step apart. A console
+command lands a whole tick late, which any verb that moves the digest can see. The console cannot be
+driven headlessly, so that half is measured through the control socket, which issues from the present
+path and writes into the same layout: `varcube 0 7` recorded at tick 155 ran at 156, and the digest
+failed at 155 -- the same verb that is clean in the other layout.
+
+`cube` sees neither, and that is the control that names the mechanism rather than merely agreeing
+with it. It sets `NewCube`, whose work happens at the top of the next main-loop iteration, so a
+command that arrives out of position is re-synchronised to a tick boundary before it does anything.
+A verb that does its work inline is not.
 
 **Audio used to move the answer, and that is now fixed at the source.** The ambience system draws
 its random pan from the one `rand()` stream actor behaviour uses, and only `if

--- a/docs/plan/ENGINE_RENDER_SPLIT_RESEARCH.md
+++ b/docs/plan/ENGINE_RENDER_SPLIT_RESEARCH.md
@@ -191,8 +191,8 @@ the right patch for a design where a present is a tick. See
 The harness reached for the present as a tick source because the engine has no tick of its own to
 hook. The recorder then had to undo it: `Record_ClockHook`
 ([TIMER.CPP:268](../../LIB386/SYSTEM/TIMER.CPP#L268), called from `ManageTime` at line 273 and
-implemented at [RECORD.CPP:2292](../../SOURCES/RECORD.CPP#L2292)) latches one clock reading per
-frame ([RECORD.CPP:1390](../../SOURCES/RECORD.CPP#L1390)) so that every `ManageTime` call in a
+implemented at [RECORD.CPP:2448](../../SOURCES/RECORD.CPP#L2448)) latches one clock reading per
+frame ([RECORD.CPP:1419](../../SOURCES/RECORD.CPP#L1419)) so that every `ManageTime` call in a
 frame reads the same value. That latch is a per-frame tick, built inside the recorder, for want of
 one in the engine.
 
@@ -236,7 +236,7 @@ deletions cannot happen until every clock-terminated loop has a call of its own 
 clock with, and giving them one is step B. So the two are not consecutive: **the deletion half of
 step A is step B**, and the ordering below has them the wrong way round. The recorder's frame-clock
 latch is a third question again: `Record_ClockHook` returns before reading anything while the
-pinned clock is armed ([RECORD.CPP:2462](../../SOURCES/RECORD.CPP#L2462)), so it exists for the
+pinned clock is armed ([RECORD.CPP:2658](../../SOURCES/RECORD.CPP#L2658)), so it exists for the
 host-sampled clock, where an engine tick would give it a better place to latch than the input poll
 but would not retire it.
 

--- a/docs/plan/ENGINE_TICK_POLICY_SURVEY.md
+++ b/docs/plan/ENGINE_TICK_POLICY_SURVEY.md
@@ -34,7 +34,7 @@ Direct callers of the four, complete:
 
 | Policy | Call sites |
 |---|---|
-| Advance | [CONTROL.CPP:1132](../../SOURCES/CONTROL.CPP#L1132) (recorder-armed), [:1144](../../SOURCES/CONTROL.CPP#L1144) (`--fixed-dt`) |
+| Advance | [CONTROL.CPP:1132](../../SOURCES/CONTROL.CPP#L1132) (recorder-armed), [:1150](../../SOURCES/CONTROL.CPP#L1150) (`--fixed-dt`) |
 | Present | [DIRTYBOX.CPP:403](../../LIB386/SVGA/DIRTYBOX.CPP#L403), inside `BoxBlit` |
 | Overlay | [INPUT.CPP:267](../../SOURCES/INPUT.CPP#L267), the console |
 | Pump | [AMBIANCE.CPP:549](../../SOURCES/AMBIANCE.CPP#L549), [:577](../../SOURCES/AMBIANCE.CPP#L577), [:602](../../SOURCES/AMBIANCE.CPP#L602), [:627](../../SOURCES/AMBIANCE.CPP#L627), [:659](../../SOURCES/AMBIANCE.CPP#L659), [:702](../../SOURCES/AMBIANCE.CPP#L702), [:741](../../SOURCES/AMBIANCE.CPP#L741); [MUSIC.CPP:439](../../SOURCES/MUSIC.CPP#L439), [:496](../../SOURCES/MUSIC.CPP#L496); [RES_SWITCH.CPP:720](../../SOURCES/RES_SWITCH.CPP#L720) |
@@ -118,7 +118,7 @@ A range cannot be searched for. Those two shapes can.
 
 ### What it costs a player
 
-Every recording arms pacing ([RECORD.CPP:1293](../../SOURCES/RECORD.CPP#L1293)), so during a
+Every recording arms pacing ([RECORD.CPP:1321](../../SOURCES/RECORD.CPP#L1321)), so during a
 recording each minted step is slept out in real time. Clean build of `main`, 300 ticks, N=3:
 
 | Run | Wall time (ms) | Delta | Predicted from mint count |
@@ -270,7 +270,7 @@ Five of the seven poll input every iteration, and for those the wait hook is not
 but harmful. The hook exists because a loop that never polls gets no new reading from the clock
 hook, there being no poll to take one at; a loop that polls gets one per iteration already. Minting
 a second step there ends the wait early, and `Record_WaitHook` sleeps out the real time for every
-step it mints ([RECORD.CPP:2515](../../SOURCES/RECORD.CPP#L2515)), in loops that run thousands of
+step it mints ([RECORD.CPP:2713](../../SOURCES/RECORD.CPP#L2713)), in loops that run thousands of
 iterations a second on a host clock.
 
 Measured on a loose-clock recording that crosses `ShowLogo`, 534,570 polls over 258 ticks, replayed
@@ -345,12 +345,12 @@ every tick-hook entry as a per-run baseline, puts them on the same tick:
 
 Both run it with the recorder's tick counter at 61 and both from `Control_TickHook`
 ([PERSO.CPP:583](../../SOURCES/PERSO.CPP#L583)). The recording runs it from `control_run_exec_at`,
-which is below `Timer_FixedDtAdvance` ([CONTROL.CPP:1149](../../SOURCES/CONTROL.CPP#L1149)); the
+which is below `Timer_FixedDtAdvance` ([CONTROL.CPP:1150](../../SOURCES/CONTROL.CPP#L1150)); the
 replay ran it from `Record_TickHook`, which is that function's first statement, above the advance.
 Running above the advance is exactly what puts the modal's presents under the previous tick number
 in the trace above, so the two readings are one fact from two sides. Absolute clock values compare
 only within a pair: `Timer_EnableFixedDt` seeds `FixedDtNow` from `TimerSystemHR`
-([TIMER.CPP:112](../../LIB386/SYSTEM/TIMER.CPP#L112)), so the seed moves per process.
+([TIMER.CPP:111](../../LIB386/SYSTEM/TIMER.CPP#L111)), so the seed moves per process.
 
 **Not every verb that works inline shows it**, which the sentence above invites. On the same shape,
 `teleport actor 1`, `varcube 0 7` and `behaviour 2` each replay clean over 301 ticks with the command
@@ -377,7 +377,7 @@ on every extra present, identically on both sides.
 Two limits on the claim. Every modal above is opened by a console verb, because a player-path modal
 cannot be driven headlessly: the inventory opens on `I_INVENTORY`, which `input` can supply, and
 closes on `MyKey == K_ESC`, which comes from `Key` and not from the `TabKeys` that `key` pokes
-([CONTROL.CPP:1338](../../SOURCES/CONTROL.CPP#L1338)). A player-opened modal has no console command
+([CONTROL.CPP:1350](../../SOURCES/CONTROL.CPP#L1350)). A player-opened modal has no console command
 behind it, and a hand-played session that opens the inventory, selects and uses an item does replay
 correctly, so the divergence above is a claim about the console entry path and not about modals.
 And the `slide` row exists only because that wait now terminates under a pinned clock; before, there
@@ -469,7 +469,7 @@ they matter:
    The ladder's ordering has the two the wrong way round.
 3. **The recorder's frame-clock latch is not step A's to retire either, and for a different
    reason.** `Record_ClockHook` returns before reading anything while the pinned clock is armed
-   ([RECORD.CPP:2462](../../SOURCES/RECORD.CPP#L2462)); it exists for the host-sampled clock, where
+   ([RECORD.CPP:2658](../../SOURCES/RECORD.CPP#L2658)); it exists for the host-sampled clock, where
    there is no tick to hook either. An engine tick would give it a better place to latch than the
    input poll, but the latch itself is what makes a loose replay possible and it does not go away.
    "Moves" rather than "retires".

--- a/docs/plan/ENGINE_TICK_POLICY_SURVEY.md
+++ b/docs/plan/ENGINE_TICK_POLICY_SURVEY.md
@@ -329,12 +329,35 @@ while recording and at tick 59 while replaying. `cube 154`'s fade lands at tick 
 
 That is the whole of it, and the fade is what proves it: `cube` sets `NewCube` and its work happens
 at the top of the next `MainLoop` iteration ([PERSO.CPP:523](../../SOURCES/PERSO.CPP#L523)), so a
-command that arrives a tick early is re-synchronised to a tick boundary before it does anything.
-A verb that does its work inline is not. On the recording side a console command runs from
-`Control_TickHook` ([PERSO.CPP:583](../../SOURCES/PERSO.CPP#L583)), before that tick's input poll;
-on the replaying side it runs from the stream reader inside the poll
-([RECORD.CPP:2846](../../SOURCES/RECORD.CPP#L2846)). Two different points in the frame, one tick
-apart in effect.
+command that arrives out of position is re-synchronised to a tick boundary before it does anything.
+A verb that does its work inline is not.
+
+**The two positions are inside one function, and they are one minted step apart rather than one
+tick.** The reading above is a tick attribution, and the thing being attributed is what moved.
+Instrumenting both ends to print the tick counter and the clock at the moment the command runs, with
+every tick-hook entry as a per-run baseline, puts them on the same tick:
+
+| | recording | replay |
+|---|---|---|
+| tick-hook entry, tick 60 | clock 1010 | clock 1010 |
+| the command runs | clock 1026 | clock 1010 |
+| tick-hook entry, tick 61 | clock 2034, `sim.carry` 4268109 | clock 2018, `sim.carry` 4268125 |
+
+Both run it with the recorder's tick counter at 61 and both from `Control_TickHook`
+([PERSO.CPP:583](../../SOURCES/PERSO.CPP#L583)). The recording runs it from `control_run_exec_at`,
+which is below `Timer_FixedDtAdvance` ([CONTROL.CPP:1149](../../SOURCES/CONTROL.CPP#L1149)); the
+replay ran it from `Record_TickHook`, which is that function's first statement, above the advance.
+Running above the advance is exactly what puts the modal's presents under the previous tick number
+in the trace above, so the two readings are one fact from two sides. Absolute clock values compare
+only within a pair: `Timer_EnableFixedDt` seeds `FixedDtNow` from `TimerSystemHR`
+([TIMER.CPP:112](../../LIB386/SYSTEM/TIMER.CPP#L112)), so the seed moves per process.
+
+**Not every verb that works inline shows it**, which the sentence above invites. On the same shape,
+`teleport actor 1`, `varcube 0 7` and `behaviour 2` each replay clean over 301 ticks with the command
+a step out of position, and all three move fields the digest mixes: with command execution disabled
+outright, `teleport` goes red at tick 61 and a quiet session stays clean, so the arm can see them.
+A step of clock is invisible to a verb that does not spend one, and a modal spends it through the
+presents of its inner loop. The table above is a table of clock-spending verbs rather than of modals.
 
 So this is a command-scheduling defect in the recorder and not a clock defect, and the modals are
 only how it becomes visible: they are the commands that do enough work inside one tick to move the
@@ -359,6 +382,32 @@ behind it, and a hand-played session that opens the inventory, selects and uses 
 correctly, so the divergence above is a claim about the console entry path and not about modals.
 And the `slide` row exists only because that wait now terminates under a pinned clock; before, there
 was nothing to replay.
+
+### The position is now the recording's, and the table is clean
+
+The readers stage a command and neither of them runs it; two drains run what they staged, each from
+the point in the frame the recording ran it from -- `Record_ExecHook` from `Control_TickHook` beside
+`--exec-at`, and the tail of the poll. No format change: the writer already puts a command where it
+ran, so the stream position says which of the two a command is in. Re-measured on the same shape,
+`--exec-at 60`, 300 pinned ticks, replayed with `--tick 400`:
+
+| Session | Replay |
+|---|---|
+| quiet, no modal | 301 ticks checked, no mismatch, 0 ms drift |
+| `cube 154` | 301 ticks checked, no mismatch, 0 ms drift |
+| `ui inventory` | 301 ticks checked, no mismatch, 0 ms drift |
+| `ui dialog 1` | 301 ticks checked, no mismatch, 0 ms drift |
+| `ui menu-main` | 301 ticks checked, no mismatch, 0 ms drift |
+| `ui found-object 0` | 301 ticks checked, no mismatch, 0 ms drift |
+| `ui holomap` | 301 ticks checked, no mismatch, 0 ms drift |
+| `slide activision` | 301 ticks checked, no mismatch, 0 ms drift |
+
+The other half of the same defect runs in the opposite direction and is not visible from this
+table at all, because every row here is a command written at a tick boundary. A command written
+mid-frame -- which is where the console writes, since it runs from the input path -- replayed a
+whole tick late, and that one any digest-moving verb can see: driven through `--listen`, which
+issues from the present path and lands in the same on-disk layout, `varcube 0 7` recorded at tick
+155 ran at 156 and the digest failed at 155. The same verb is clean in the layout above.
 
 ### A modal can stall a replay with no clock in it anywhere
 

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -924,5 +924,72 @@ case "$loosedump" in
 *) fail "loose clock: the recording carries no cube 3->154 keyframe, so the run never crossed a scene change and this arm tested nothing" ;;
 esac
 
+# --- a command runs where the recording ran it ----------------------------------------
+#
+# A command is written where it ran, so a replay has to run it there too. Both ends run
+# it on the same tick and from the same function, Control_TickHook; what differs is the
+# position inside it. The harness fires --exec-at below `Timer_FixedDtAdvance`
+# (SOURCES/CONTROL.CPP), and a replay that ran the line from the recorder's own tick hook
+# ran it above that advance -- one minted step earlier than the session had it.
+#
+# Which is why the verb here opens a modal, and that is not a claim about modals. A step
+# of clock is invisible to a verb that does not spend one: measured on this same shape,
+# `teleport actor 1`, `varcube 0 7` and `behaviour 2` all replay clean over 301 ticks with
+# the command a step out of position. A modal's inner loop presents, and every present is
+# a step, so it is the cheapest verb that can see the difference at all.
+#
+# command_position <label> <verb> [artifact] -- record with the verb fired mid-session,
+# replay past the end of the stream, and require no mismatch. The artifact, where the verb
+# writes one, is asserted after both runs: a clean digest says the two ends agree, and
+# only the file says the replay ran the command rather than skipping it.
+command_position() {
+    local label="$1" verb="$2" artifact="${3:-}" out summary checked
+
+    rm -f "$rec" "$rec".lba "$rec".end.lba "$artifact"
+    ctl --fixed-dt 16 --load "$LBA2_TEST_SAVE" --record "$rec" \
+        --exec-at 60 "$verb" --tick 150 --exit >/dev/null 2>&1 ||
+        fail "command position ($label): the recording run exited non-zero ($?) — hang or crash"
+    [ -s "$rec" ] || fail "command position ($label): the run wrote no recording"
+    if [ -n "$artifact" ] && [ ! -s "$artifact" ]; then
+        fail "command position ($label): '$verb' left nothing at $artifact, so the recording never ran it and this arm tested nothing"
+    fi
+
+    rm -f "$artifact"
+    out="$(ctl --fixed-dt 16 --load "$LBA2_TEST_SAVE" --replay "$rec" --tick 250 --exit 2>&1)" ||
+        fail "command position ($label): the replay run exited non-zero ($?) — hang or crash"
+    if [ -n "$artifact" ] && [ ! -s "$artifact" ]; then
+        fail "command position ($label): the replay left nothing at $artifact, so it never ran '$verb'"
+    fi
+
+    summary="$(printf '%s\n' "$out" | grep -m1 'replay ended')" ||
+        fail "command position ($label): the replay printed no summary; it cannot be said to have matched"
+    checked="$(printf '%s\n' "$summary" | sed -n 's/.*: \([0-9]*\) ticks checked.*/\1/p')"
+    [ -n "$checked" ] && [ "$checked" -gt 100 ] ||
+        fail "command position ($label): only ${checked:-0} ticks checked — the run ended before the command ($summary)"
+    case "$summary" in
+    *"first hash mismatch -1"*) ;;
+    *) fail "command position ($label): $summary" ;;
+    esac
+}
+
+# Its own short directory, and that is load-bearing rather than tidiness: a recorded
+# command line is stored in 96 bytes (`T_RecCmd`, SOURCES/RECORD.CPP) and clipped
+# to fit, so a capture path long enough to push the line past that replays as a verb
+# writing somewhere else -- the modal still runs and the digest still matches, and only
+# the missing file says so. Measured: a 137-character path came back clipped at 95.
+cmdposdir="$(mktemp -d)"
+clean_add "$cmdposdir"
+
+command_position "inline verb" "ui inventory $cmdposdir/ui.png" "$cmdposdir/ui.png"
+
+# The control, and it is what makes the arm above a measurement rather than an assertion.
+# `cube` sets NewCube and the work happens at the top of the next main-loop iteration
+# (SOURCES/PERSO.CPP), so it is re-synchronised to a tick boundary before it does
+# anything and a command a step out of position cannot move it. It was clean before the
+# position was fixed and has to stay clean after: a fix that moved execution somewhere
+# the deferred work no longer lands would show here and nowhere else.
+command_position "deferred verb" "cube 154"
+
 pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; mode.audio was written from the driver and reported both ways; a session recorded in one run replayed in the next with no flags and no paths; \
-'rec start verbose' carried telemetry and a plain one carried none; a recorded walk moved the hero and the replay walked it again; the recorder gave the step back and left the flag's alone; a playback put the player back where it found them, stopped early or run out; a window holding a scene change ran at ${modalrate}x real, not faster; a recording on a host-sampled clock crossed a scene change instead of wedging in the fade"
+'rec start verbose' carried telemetry and a plain one carried none; a recorded walk moved the hero and the replay walked it again; the recorder gave the step back and left the flag's alone; a playback put the player back where it found them, stopped early or run out; a window holding a scene change ran at ${modalrate}x real, not faster; a recording on a host-sampled clock crossed a scene change instead of wedging in the fade; \
+a command ran where the recording ran it, for an inline verb and for a deferred one"

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -187,11 +187,39 @@ for how in cut magic; do
             printf '%s\n' "$tout" | grep -m1 'replay ended' || echo 'the replay said nothing')"
         ;;
     esac
-    # And refused means refused: a reader that reported the damage and then carried on
-    # into the savegame would check ticks out of bytes that are not a stream.
+    # What "refused" costs the rest of the file, which is not the same answer for the two
+    # damages and is the reason they are both here.
+    #
+    # `cut` takes the bytes away, so the length in the chunk head points past the end and
+    # there is no stream behind it: the reader has to check nothing rather than read a
+    # savegame's bytes as input.
+    #
+    # `magic` keeps every byte and damages only the word behind them, so the chunk is
+    # stepped over by its own length and the records after it are intact. The refusal is
+    # of the snapshot, not of the file, and the ticks behind it check normally: measured,
+    # 301 of them with no mismatch. That is worth knowing rather than asserting away --
+    # a replay that has refused the state the recording started from is answering from a
+    # precondition it could not establish, which is the shape
+    # [RECORDER_OBSERVER_REVIEW.md]'s first item is about. It is not a regression: the
+    # same file checked the same 301 ticks before the verdict was printed from every exit,
+    # and the count was invisible rather than zero.
     tchecked="$(printf '%s\n' "$tout" | sed -n 's/.*: \([0-9]*\) ticks checked.*/\1/p')"
-    [ "${tchecked:-0}" = "0" ] ||
-        fail "torn/$how: refused the snapshot and then checked $tchecked ticks anyway"
+    case "$how" in
+    cut)
+        [ "${tchecked:-0}" = "0" ] ||
+            fail "torn/cut: the bytes are gone, but the reader checked $tchecked ticks out of them"
+        ;;
+    magic)
+        # The positive half, and it is the one that would catch a reader stepping over the
+        # chunk by anything other than its own length: every byte is present, so the stream
+        # behind the damage has to still be a stream. A reader that lost its place here
+        # would check a handful of ticks out of savegame bytes, or none, rather than the
+        # whole file. Bounded below rather than pinned to the recording's exact length, so
+        # the arm does not have to move when the runs above change their tick count.
+        [ -n "$tchecked" ] && [ "$tchecked" -gt 100 ] ||
+            fail "torn/magic: every byte is present, but the reader checked only ${tchecked:-0} ticks behind the damaged chunk — it did not step over it by its length"
+        ;;
+    esac
 done
 rm -f "$torn"
 


### PR DESCRIPTION
Item 12 of `docs/plan/RECORDER_OBSERVER_REVIEW.md`: a replayed console command ran somewhere the recording did not.

## What was wrong

A command is written where it ran, and a replay ran it where the reader happened to meet it. There are two on-disk layouts and each was out of position in its own direction.

**A harness command**, written straight after the tick record, ran one minted clock step early. Both ends run it on the same tick and from the same function, `Control_TickHook`; `--exec-at` fires below `Timer_FixedDtAdvance` and the recorder's tick hook is that function's first statement. Instrumented, with each side compared against its own tick-hook entry:

| | recording | replay |
|---|---|---|
| tick-hook entry, tick 60 | clock 1010 | clock 1010 |
| the command runs | clock 1026 | clock 1010 |
| tick-hook entry, tick 61 | clock 2034, `sim.carry` 4268109 | clock 2018, `sim.carry` 4268125 |

**A console command**, written after a poll record because the console runs from the input path, ran a whole tick late.

## Which verbs can see it, which is not what the item predicted

A step of clock is invisible to a verb that does not spend one. On 300 pinned ticks with `--exec-at 60`, replayed `--tick 400`:

| verb | before | after |
|---|---|---|
| `ui inventory`, `ui dialog 1`, `ui menu-main`, `ui found-object 0`, `ui holomap`, `slide activision` | mismatch at tick 61 | clean, 301 ticks |
| `teleport actor 1`, `varcube 0 7`, `behaviour 2` | clean | clean |
| `cube 154`, quiet session | clean | clean |
| `varcube 0 7` issued mid-frame (socket) | mismatch at tick 155 | clean, 301 ticks |

`teleport`, `varcube` and `behaviour` all work inline and all move digest fields, and all three are clean with the command a step out of position — so "any inline-working verb shows it" is false for the tick-boundary layout. A modal spends clock through the presents of its inner loop, which is why the arm uses one. The mid-frame defect is a whole tick and any digest-moving verb sees it: `varcube 0 7` is red there and clean in the other layout.

`cube` sees neither, and that is the control that names the mechanism: it sets `NewCube`, whose work happens at the top of the next main-loop iteration, so a command out of position is re-synchronised to a tick boundary before it does anything.

## The fix

Both readers stage a command and neither runs it. Two drains run what they staged, each from the point in the frame the recording ran it from: `Record_ExecHook`, called from `Control_TickHook` beside `--exec-at`, and the tail of the poll. **No format change** — the writer already puts a command where it ran, so the stream position says which layout it is in.

Running a command from the tail of the poll is also the answer to one issued while no tick is advancing, which is the whole of menu time.

## The verdict commit, and why it is here

Running a recorded command where the session ran it means a recorded `exit` ends the replay there. Nine of the 16 mid-frame commands in the local corpus are `exit`, and four replays lost their summary line entirely as a result. The verdict is now said from wherever a replay stops, once, guarded — restoring identical numbers on all four.

## Measurement

Validated both ways before being trusted: with command execution disabled outright the arm goes red on `ui inventory` and on `teleport` while a quiet session stays clean, and the new suite arm fails against the pre-fix sources with `first hash mismatch 61`.

Swept over 41 recordings, in four locations: `$HOME/lba2-recordings` and the repo worktrees (25), and the two mounted-drive profiles that hold the Windows and macOS player sessions (16). Each replay is given the step its `mode.fixed_dt` declares and the savegame the file carries.

Of the first 25: 2 skipped for no start savegame, 7 refused as format 8, 16 replayed, of which 6 carry mode lines that make their absolute verdict meaningless while their delta still counts. 21 rows byte-identical; 4 changed, all of them a run that printed no verdict now printing one. Of the other 16: 14 carry no command at all, and the 2 that do were A/B'd against main — `checked=1006 mismatch=0` and `checked=3977 mismatch=0`, identical on both sides.

**No replay changed its verdict in either direction**, and the census says why. Of 63 recorded commands, the 45 at a tick boundary are `key`, `skipmodals`, `behaviour` and `load` — none spends a step, and `load` defers like `cube`. The 18 mid-frame ones are `exit` ten times, `help` once, `REC STOP` once and six lines of prose typed as notes. Not one can move a digest at any tick. The corpus contains the case and has never exercised it, which is the honest reason the flat result is the expected one rather than a fix with nothing to show.

`REC STOP` is worth a line: the recorder's own filter is `strncmp(line, "rec", 3)` and the console matches names with `strcmp`, so an uppercase `rec` escapes the filter into the file and then matches no command when replayed. The two case-sensitivities agree, so it is inert at both ends rather than a recorder command that survives into a replay.

Replay cost of the per-poll peek, on a 32 s replay consuming 11,681 polls, interleaved N=2 a side: before 31722/31982 ms, after 31654/31832 ms. Inside the run-to-run spread.

## Verified

`ctest` 70/70 · `check-arch.py` 8 rules over 571 files · `check-build-graph.py` against a tree configured with `LBA2_BUILD_TESTS=ON`, both rules · `clang-format-18` · `check-docs-links.sh` · `check-docs-symbols.py` · `tests/automation` 72 passed, 2 skipped, 1 failed.

That one failure is `test_demo.sh`, and it is not this branch. Built the engine at three points and ran it three times each: `b7a5846a` passes 3/3, `7d71aad4` fails 3/3, `01ccb118` fails 3/3, this branch fails 3/3 with the same message. Twelve runs, no intermittency. `b7a5846a` passing *today* — today's test file, today's data, this box — is what rules out the environment, so it is a commit in the 45-commit `b7a5846a..7d71aad4` window over `SOURCES`/`LIB386`.

The failing arm runs `--exec "cube 193" --demo --tick 500 --fixed-dt 16` twice and diffs the two dumps against each other, so it can only report run-to-run variance under a pinned step; a commit that legitimately changed the demo would move both runs identically. Two notes for whoever bisects it: check out `SOURCES` and `LIB386` only and build `--target lba2cc`, because today's host tests do not compile against an older engine and a full build dies at the first old commit as if that commit were broken; and the suspects are the ones that put a wall-clock reading into a path that is supposed to be generated rather than sampled.

## One finding handed on rather than fixed

Saying the verdict from every exit exposed a suite arm that had been passing for the wrong reason: it asserted that a recording whose start snapshot is refused checks zero ticks. It does not. The `magic` damage keeps every byte and corrupts only the tail word, so the chunk is stepped over by its own length and the 301 ticks behind it check clean — measured identically on the pre-fix build, where the count was invisible rather than zero, and the shell defaulted an unmatched parse to 0.

So a replay refused the state its recording started from and answered anyway. That is a refusal-policy question and belongs to item 1 of the review, not to a command-position change. The arm's assertion is split by damage kind and the finding is written into it.
