### PR TITLE
test(demo): the determinism arm compared two host clock readings

### DIFF
--- a/tests/automation/test_demo.sh
+++ b/tests/automation/test_demo.sh
@@ -38,15 +38,36 @@ ctl --exec "cube $DEMO_CUBE" --demo --tick $TICKS --fixed-dt 16 --dump-state "$c
     || fail "demo tick $TICKS rerun: non-zero exit ($?)"
 
 # Determinism: the two $TICKS runs must agree on all simulation state including timer_ref_hr.
-# Drop only fps (wall-clock-derived) and the console log (run-specific).
+#
+# Dropped are the fields no two runs can agree on: fps and the two clock readings are
+# taken from the host, and the console log carries paths and boot timings. Everything
+# else is compared, which is the point -- timer_ref_hr is in the comparison and is the
+# field that says the simulation advanced the same way twice.
+#
+# The drop list is the part of this arm that ages. It is a list of what a dump holds
+# that is run-specific, written when the dump held fewer fields, and --dump-state has
+# gained fields since: wall_ms and clock_src_ms arrived together and the arm went red
+# on every run without either the engine or the arm changing. `clock_src_ms` is not
+# obviously wall-clock at a glance, which is what made it hard to see -- under a pinned
+# step it reads FixedDtNow, which Timer_EnableFixedDt seeds from TimerSystemHR
+# (LIB386/SYSTEM/TIMER.CPP), so it is host-derived after all. A field added to the dump
+# has to be classified here as well as there, and if it cannot be, the diff is what
+# says so.
 python3 - "$b" "$c" <<'PY' || fail "scripted playthrough not reproducible (runs differ)"
 import json, sys
 def norm(p):
     d = json.load(open(p))
-    for k in ("fps", "log"):
+    for k in ("fps", "log", "wall_ms", "clock_src_ms"):
         d.pop(k, None)
     return d
-sys.exit(0 if norm(sys.argv[1]) == norm(sys.argv[2]) else 1)
+a, b = norm(sys.argv[1]), norm(sys.argv[2])
+if a != b:
+    # Name the fields rather than the verdict: "runs differ" sent two readers into the
+    # engine looking for a regression that was a stale drop list.
+    for k in sorted(set(a) | set(b)):
+        if a.get(k) != b.get(k):
+            print("differs: %s  %r vs %r" % (k, a.get(k), b.get(k)), file=sys.stderr)
+    sys.exit(1)
 PY
 
 # Liveness: the simulation advanced between tick 1 and tick $TICKS (scripts ran, not frozen).


### PR DESCRIPTION
`test_demo.sh` has been failing on main, on every build, since `8c9af309`. There is no engine regression: the arm compares two host clock readings and calls the difference non-reproducibility.

## What it actually compares

`--dump-state` writes two host-derived fields — `wall_ms` from `SDL_GetTicks()` and `clock_src_ms` from `Timer_ClockSource()` — and the determinism arm dropped only `fps` and `log` before diffing the two dumps whole. Two runs cannot agree on either.

Measured, with every differing key named rather than the arm's yes/no:

```
keys total: 17
keys differing: clock_src_ms, fps, log, wall_ms
  clock_src_ms  8300 vs 8290
  wall_ms       2362 vs 2380
```

`fps` and `log` were already dropped. **Nothing simulational differs** — `timer_ref_hr`, which the arm's own comment names as the point of the check, agrees.

`clock_src_ms` is the one that hides in plain sight. Under a pinned step it reads `FixedDtNow`, which `Timer_EnableFixedDt` seeds from `TimerSystemHR`, so a field that looks like the generated clock is host-derived and differs in every process.

## Why it looked like a regression

`8c9af309`, "feat(control): report the wall clock and the clock source beside the game clock", added both fields. It is in `b7a5846a..7d71aad4` and not in `b7a5846a`, so it sits exactly where a bisect would put a boundary — and a bisect would have named it, about a commit whose entire content is two `fprintf`s of diagnostics, and reported it as a clock regression.

Every observation is consistent with this and with an engine regression equally: `b7a5846a` passes because the fields did not exist yet, everything after fails, it is not intermittent because it is guaranteed rather than variance, and three separately built binaries fail identically because the fixture is the same in all of them.

## The fix

Two keys added to the drop list, and the comparison now names the fields that differ instead of only the verdict — "runs differ" sent two readers into the engine looking for a cause that was three lines above the comparison.

The comment says which fields are dropped and why, so the next field added to `--dump-state` prompts someone to classify it here as well as there.

## Verified

The arm passes 3/3 with the fix, and the widened drop list has not widened it into a check that cannot fail: perturbing `hero`, `scene`, `timer_ref_hr` or `tick` in a real dump is caught and named in every case, while the unperturbed pair passes. `bash -n` and `shellcheck` clean.

Found in a code review by the session on `fix/getascii-polled-sample`, which went looking for why it was shipping a red suite record; reproduced independently here before this change.
