### PR TITLE
docs(record): the socket reaches a modal the recorder cannot record through

### DIFF
--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -236,8 +236,18 @@ and no digest reported it, because a replay that is waiting is not a replay that
 `GetAscii` takes the poll now, so the screen is in the stream like any other. The general form is
 worth more than the case: **a loop that takes no input and advances no tick is invisible to the
 recorder in both directions** -- a replay cannot inject into it, and a command staged for it has
-neither a poll nor a tick to run at. Finding one means finding a screen with no seam in it, and the
-fix is to give it the seam rather than to teach the recorder about the screen.
+neither a poll nor a tick to run at. The fix is to give such a loop the seam the recorder needs
+rather than to teach the recorder about the screen.
+
+**That is a statement about the recorder and not about the harness, and the difference is the whole
+of the `--listen` socket.** `Control_ServiceListen` is called from `ControlPrePresent`
+([SOURCES/PERSO.CPP](../SOURCES/PERSO.CPP)), which is registered as the pre-present callback and
+runs inside the one present routine ([LIB386/SVGA/SDL.CPP](../LIB386/SVGA/SDL.CPP)). Every mode
+presents frames, so a driver on the socket reaches any loop that draws -- including this one,
+before the change above. So a modal with no poll and no tick still has a seam; it is not one the
+recorder can record through, because a command arriving on a present has no position in a stream
+indexed by polls and ticks. Read the sentence above as "the file cannot carry it", never as "the
+harness cannot reach it".
 
 **What it reproduces is the keys, not the characters.** The poll record carries `Key`, a scancode,
 and `GetAscii` resolves it through the *replaying* machine's keymap. So a name typed as `azerty` on


### PR DESCRIPTION
A clause in the recorder note merged in #646 is wrong and invites a wider reading than it should.

The scoped claim is right: a loop that takes no input and advances no tick is invisible **to the
recorder** in both directions — a replay cannot inject into it, and a command staged for it has
neither a poll nor a tick to land at. The sentence after it said such a loop has "no seam in it",
and it has one.

`Control_ServiceListen` is called from `ControlPrePresent` (`SOURCES/PERSO.CPP`), registered with
`SetPrePresentCallback` and invoked inside the single present routine (`LIB386/SVGA/SDL.CPP`). The
comment at that call site already states the design intent: a cinematic, dialogue or menu runs its
own inner loop that never reaches `Control_TickHook`, and *"every mode presents frames, so this is
the one point that is always reached"*. So a driver on `--listen` reaches any loop that draws,
including the save-name screen before #646 gave it a poll.

**Two sessions over-read the merged sentence within a day**, one of them concluding that a stalling
fixture could not be driven — while having spent the afternoon driving mid-frame commands over that
socket. That is what the phrasing cost, so the exception is named rather than left to be inferred.

It also says why the socket is not a fourth recorder seam: a command arriving on a present has no
position in a stream indexed by polls and ticks. That is a property of the format, not of the loop.

Docs only. `check-docs-links` and `check-docs-symbols` clean. Found by the session that owns the
replay deadlock detector, who checked it down to the present routine rather than trusting the
comment.
