### PR TITLE
docs(record): a stalled replay prints no verdict, and says so elsewhere

### DIFF
--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -28,6 +28,14 @@ A clean replay ends with `first hash mismatch -1`. Anything else names the tick:
 [rec] replay ended at poll 10305: 397 ticks checked, first hash mismatch 296, clock drift max 0 ms
 ```
 
+A replay that gives up rather than ending prints no `replay ended` line at all. A run waiting on
+input the recording does not contain says so under `[rec] replay stalled`, and the figures the
+verdict would have carried follow it under `[rec] at the stall`. That split is deliberate: the
+verdict line is the string a caller greps to mean the simulation reproduced, so a run that gave up
+must never print it. **Anything reading these lines wants all three prefixes** -- a sweep that greps
+only `replay ended` silently drops every run that stalled, which is the compound case of a recording
+that both drifts and gives up.
+
 Mid-session, from the console (F12), which records from a point you choose rather than from boot:
 
 | Command | What it does |


### PR DESCRIPTION
A gap left by #644, found by the session sweeping recordings for a #646 regression.

`docs/RECORDING.md` introduces `first hash mismatch -1` as the thing to look for in a replay's output. Since #644 a replay that *gives up* prints no `replay ended` line at all — the stall says so under its own prefix, and the figures the verdict would have carried follow under `[rec] at the stall`.

That split is deliberate and is the point of the change: the verdict line is the string a caller greps to mean the simulation reproduced, so a run that gave up must never print it. But it means anything reading a replay's output needs all three prefixes, and the doc said only one.

The cost of not knowing is specific rather than theoretical: a sweep that greps only `replay ended` silently drops every run that stalled — which is precisely the compound case of a recording that both drifts and gives up, since the drift figures are then on the stall's line and the verdict never arrives. That was about to cost a real measurement on 15 player recordings.

Docs only. `check-docs-links.sh` and `check-docs-symbols.py` clean.
