### PR TITLE
fix(input): take the poll at the screen that lacks one, not in the reader

### DIFF
--- a/LIB386/SYSTEM/KEYBOARD.CPP
+++ b/LIB386/SYSTEM/KEYBOARD.CPP
@@ -105,30 +105,37 @@ void EndKeyboard() {
 }
 
 // --- Interface ---------------------------------------------------------------
-/* The character behind this poll's first held key, once per press.
+/* The character behind the last poll's first held key, once per press.
  *
- * Takes the poll rather than reading SDL again: `Key` is the same first-held
- * scancode, off the same array, scanned in the same order, so a player at a
- * keyboard is answered exactly as before. What changes is everything that puts
- * a key there without a device. Whatever writes `Key` reaches the screens that
- * read characters, and a replayed recording and the control harness both do --
- * which is what a reader of its own made unreachable. Not every injector does:
- * the touch overlay writes TabKeys and leaves `Key` alone, and a pad button
- * never becomes a scancode at all, so those two still cannot type.
+ * Reads `Key` rather than SDL's array again: it is the same first-held scancode,
+ * off the same array, scanned in the same order, so a player at a keyboard is
+ * answered exactly as before. What changes is everything that puts a key there
+ * without a device. Whatever writes `Key` reaches the screens that read
+ * characters, and a replayed recording and the control harness both do -- which
+ * is what a reader of its own made unreachable. Not every injector does: the
+ * touch overlay writes TabKeys and leaves `Key` alone, and a pad button never
+ * becomes a scancode at all, so those two still cannot type.
  *
- * It reads the sample and does not take it. Taking one here would consume a
- * recorded poll wherever a character is read, and one of the two callers --
- * cheat-code entry, from the menu loop -- already sits inside a frame that
- * polled. Adding a second consumed the stream faster than the session that
- * wrote it, so the menu closed sooner on the replay than it had live, and every
- * actor came out 128 ms behind: a recording made before that change replayed
- * clean and after it did not. The screen that has no poll of its own takes one
- * for itself instead (`InputPlayerName`, SOURCES/GAMEMENU.CPP), which is the
- * only place where a poll is genuinely missing.
+ * THE RULE FOR A NEW CALLER: this reads the sample and does not take it, so call
+ * it only from a frame that has polled -- one that reaches MyGetInput, or one
+ * that calls ManageKeyboard itself. A loop that does neither reads one sample
+ * for as long as it runs, which for `while (GetAscii())` is forever. That shape
+ * is not hypothetical: `InputString` (LIB386/MENU/MENUFUNC.CPP) is written that
+ * way already, and is saved only by not being linked.
  *
- * A held key still yields one character: the edge is remembered rather than
- * read off the device, because a poll cannot tell a key held from a key struck
- * again on the next frame. */
+ * Taking the poll here instead was tried and reverted. It consumes a recorded
+ * poll wherever a character is read, and cheat-code entry already sits inside a
+ * frame that polled; the second poll consumed the stream faster than the session
+ * that wrote it, so a replayed menu closed sooner than it had live and every
+ * actor came out 128 ms behind. A poll is a unit of the recording, so adding one
+ * anywhere a recording already covers rewrites what that recording means. The
+ * screen that has no poll of its own takes one for itself instead
+ * (`InputPlayerName`, SOURCES/GAMEMENU.CPP), which is the only place one is
+ * genuinely missing.
+ *
+ * A held key still yields one character: the edge is remembered rather than read
+ * off the device, because a poll cannot tell a key held from a key struck again
+ * on the next frame. */
 S32 GetAscii() {
     static SDL_Keycode lastReturnedAscii = 0;
 

--- a/LIB386/SYSTEM/KEYBOARD.CPP
+++ b/LIB386/SYSTEM/KEYBOARD.CPP
@@ -116,12 +116,15 @@ void EndKeyboard() {
  * the touch overlay writes TabKeys and leaves `Key` alone, and a pad button
  * never becomes a scancode at all, so those two still cannot type.
  *
- * The poll is why this calls UpdateKeyboardState and not just ManageEvents.
- * The name-entry screen runs a frame of its own -- it presents, it waits, and
- * it never calls MyGetInput -- so `Key` would hold whatever the last poll
- * outside it left, for as long as it ran. Polling here also gives that screen a
- * place in the recorded poll stream, which it had none of before: a session
- * sitting on it wrote nothing at all, and a replay had nothing to hand back.
+ * It reads the sample and does not take it. Taking one here would consume a
+ * recorded poll wherever a character is read, and one of the two callers --
+ * cheat-code entry, from the menu loop -- already sits inside a frame that
+ * polled. Adding a second consumed the stream faster than the session that
+ * wrote it, so the menu closed sooner on the replay than it had live, and every
+ * actor came out 128 ms behind: a recording made before that change replayed
+ * clean and after it did not. The screen that has no poll of its own takes one
+ * for itself instead (`InputPlayerName`, SOURCES/GAMEMENU.CPP), which is the
+ * only place where a poll is genuinely missing.
  *
  * A held key still yields one character: the edge is remembered rather than
  * read off the device, because a poll cannot tell a key held from a key struck
@@ -129,7 +132,7 @@ void EndKeyboard() {
 S32 GetAscii() {
     static SDL_Keycode lastReturnedAscii = 0;
 
-    UpdateKeyboardState();
+    ManageEvents();
 
     if (Key) {
         SDL_Keycode asciiValue = SDL_GetKeyFromScancode((SDL_Scancode)Key, SDL_KMOD_NONE, true);

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -1222,6 +1222,10 @@ S32 InputPlayerName(S32 choice, char *name) {
     CursorActif = TRUE;
 
     while (flag != -1) {
+        /* The one screen that reads characters and never reaches MyGetInput, so the
+           sample it reads has to be taken here. */
+        ManageKeyboard();
+
         ManageTime();
         if (TimerRefHR < timeraff) {
             CursorX = x - 4;

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -233,7 +233,13 @@ as long as that screen was open **the recording carried no polls whatsoever** --
 not the frames, nothing. A replay reaching it had nothing to hand back and waited there forever,
 and no digest reported it, because a replay that is waiting is not a replay that is wrong.
 
-`GetAscii` takes the poll now, so the screen is in the stream like any other. The general form is
+The screen takes a poll of its own now, so it is in the stream like any other. The poll is
+deliberately at the screen rather than inside `GetAscii`: a reader that takes its own poll consumes
+a recorded one wherever it is called, and the other caller -- cheat-code entry -- already sits in a
+frame that polled. Putting it there consumed the stream faster than the session that wrote it, so a
+recording made beforehand replayed 128 ms behind and every actor's animation anchor moved with it.
+**A poll is a unit of the recording, so adding one anywhere a recording already covers rewrites what
+that recording means.** The general form is
 worth more than the case: **a loop that takes no input and advances no tick is invisible to the
 recorder in both directions** -- a replay cannot inject into it, and a command staged for it has
 neither a poll nor a tick to run at. The fix is to give such a loop the seam the recorder needs

--- a/tests/automation/last-run.md
+++ b/tests/automation/last-run.md
@@ -2,10 +2,10 @@
 
 # Control-harness last run
 
-- when: 2026-08-21 15:37 UTC
-- commit: `673d0932`
+- when: 2026-08-21 23:35 UTC
+- commit: `ecfdf336`
 - host: Linux x86_64
-- result: **73 passed, 2 skipped, 1 failed**
+- result: **74 passed, 2 skipped, 0 failed**
 
 A skip means a prerequisite was missing, not that the fixture agreed with the
 engine. Only the passes are evidence.
@@ -33,7 +33,7 @@ engine. Only the passes are evidence.
 | test_console_audio_cvars.sh | pass |
 | test_console_audio_stereo.sh | pass |
 | test_console_config_write.sh | pass |
-| test_demo.sh | **FAIL** |
+| test_demo.sh | pass |
 | test_demo_behaviour_menu.sh | pass |
 | test_dodge_direction.sh | pass |
 | test_dump.sh | pass |

--- a/tests/getascii/test_getascii.cpp
+++ b/tests/getascii/test_getascii.cpp
@@ -50,6 +50,16 @@ static void expect(S32 got, S32 want, const char *label) {
     }
 }
 
+/* What every caller does: take the sample, then read the character out of it.
+   InputPlayerName does exactly this per iteration; the menu loop's poll is
+   MyGetInput's. Split here rather than folded into GetAscii, because a reader
+   that takes its own poll consumes a recorded one wherever it is called, and
+   the callers already sit inside frames that poll. */
+static S32 pollThenGetAscii(void) {
+    ManageKeyboard();
+    return GetAscii();
+}
+
 static SDL_Keycode keycodeOf(U32 scancode) {
     return SDL_GetKeyFromScancode((SDL_Scancode)scancode, SDL_KMOD_NONE, true);
 }
@@ -73,13 +83,13 @@ int main() {
 
     // Nothing held: no character, and the sample says so too.
     g_injected = 0;
-    expect(GetAscii(), 0, "idle poll yields no character");
+    expect(pollThenGetAscii(), 0, "idle poll yields no character");
     expect(Key, 0, "idle poll leaves Key clear");
 
     // An injected key is a key. This is the whole change: before it, the answer
     // came from SDL and a run with no physical keyboard got 0 here forever.
     g_injected = kA;
-    expect(GetAscii(), (S32)keycodeOf(kA), "injected key yields its character");
+    expect(pollThenGetAscii(), (S32)keycodeOf(kA), "injected key yields its character");
 
     /* The poll ran rather than the answer coming from somewhere stale: the
        injected scancode is in this poll's table and in this poll's Key.
@@ -92,18 +102,18 @@ int main() {
 
     // Held, not struck again: one character per press.
     g_injected = kA;
-    expect(GetAscii(), 0, "a held key yields nothing further");
-    expect(GetAscii(), 0, "still nothing while it stays down");
+    expect(pollThenGetAscii(), 0, "a held key yields nothing further");
+    expect(pollThenGetAscii(), 0, "still nothing while it stays down");
 
     // A different key is a fresh press even with no gap between them.
     g_injected = kB;
-    expect(GetAscii(), (S32)keycodeOf(kB), "a different key yields its character");
+    expect(pollThenGetAscii(), (S32)keycodeOf(kB), "a different key yields its character");
 
     // Released and struck again: the edge is re-armed by the empty poll.
     g_injected = 0;
-    expect(GetAscii(), 0, "release yields nothing");
+    expect(pollThenGetAscii(), 0, "release yields nothing");
     g_injected = kA;
-    expect(GetAscii(), (S32)keycodeOf(kA), "the same key struck again yields its character");
+    expect(pollThenGetAscii(), (S32)keycodeOf(kA), "the same key struck again yields its character");
 
     /* Taking the poll must not put anything back that a caller upstream took
        away. SOURCES/INPUT.CPP clears Key, TabKeys and Input while the console is
@@ -117,15 +127,15 @@ int main() {
         DefineInputKeys(1, keys, masks);
 
         g_injected = 0;
-        GetAscii(); // re-arm the edge
+        pollThenGetAscii(); // re-arm the edge
         g_injected = kA;
 
         GetInput(0);
         expect((S32)Input, 1, "the funnel does turn that key into an action bit");
 
         Input = 0; // what MyGetInput does with the console open
-        GetAscii();
-        expect((S32)Input, 0, "GetAscii rebuilds no action bits");
+        pollThenGetAscii();
+        expect((S32)Input, 0, "reading a character rebuilds no action bits");
         expect(CheckKey(kA) ? 1 : 0, 1, "...though it does sample the key again");
 
         DefineInputKeys(0, NULL, NULL);


### PR DESCRIPTION
**#646 broke recordings made before it.** This restores them, and keeps everything #646 was for.

### What went wrong

#646 gave `GetAscii` the poll. That makes every character read consume a recorded poll — and one of
its two callers already sits inside a frame that polled: `GereCheatCode` runs from the menu loop,
after `MyGetInput`. So a replay of any session with menu input consumed the stream faster than the
session that wrote it. The menu closed sooner than it had live, fewer presents minted fewer
`--fixed-dt` steps, and every actor was stamped off a clock 128 ms behind.

One recording made on `f9bca648^1`, replayed on both binaries, `--headless --fixed-dt 16`, three
runs each and deterministic:

| | verdict |
|---|---|
| before #646 | `first hash mismatch -1, clock drift max 0 ms` |
| after #646 | `first hash mismatch 21, clock drift max 128 ms first at tick 21` |
| this branch | `first hash mismatch -1, clock drift max 0 ms` |

Telemetry names it rather than leaving it inferred:

```
obj[0].LastTimer 4271597/4271469   obj[1].LastTimer 4271597/4271469
obj[4].LastTimer 4271597/4271469   obj[5].LastTimer 4271597/4271469
```

The animation anchors, not the simulation. The clock moved and the actors were stamped off it.

### It hides from the field built to catch it

`stream drift first at poll -1` on **both** runs, and both end at poll 505, the file's own count.
The sync markers are sparse, `replay_take_sync` resynchronises after reporting, and the stream is
consumed whole either way. What moved is how many polls fall between two ticks, and nothing reports
that directly. A sweep reading either the drift field or the poll count would have cleared this.

### The fix

The poll goes where one is genuinely missing. `InputPlayerName` is the only loop that reads
characters and never reaches `MyGetInput`; it takes its own sample per iteration. `GetAscii` goes
back to reading the sample it is given — which is what closed the original defect and all that
closed it. An injected key reaches the screens that read characters because it is in `Key`, not
because of who called the poll.

**A poll is a unit of the recording, so adding one anywhere a recording already covers rewrites
what that recording means.** That is in `docs/RECORDING.md` beside the note it corrects.

### The test was asserting the shape

`tests/getascii` drove `GetAscii()` and expected it to take the poll, so it passed a design carrying
this regression and failed the one without it. It now polls the way the callers do and reads the
character out of the sample. Still reports five failures against the reader #646 replaced, so it
remains an oracle for the original defect.

### Verification

ctest 71/71, `check-arch`, `check-build-graph`, clang-format-18, both doc checkers clean. The #646
engine fixture passes unchanged: name entry lands live and on replay, cheat entry fires under
injection.

`tests/automation`: **74 passed, 2 skipped, 0 failed**, recorded at `ecfdf336` and committed here.
Run twice — the first pass reported the same counts on the parent commit, so the result is
reproduced rather than merely obtained. The two skips are the standing prerequisites (`polyrec`
needs `ENABLE_POLY_RECORDING`, `projection_demo` is opt-in). Recorded on this branch rather than on
main deliberately: main carries the regression this fixes, so a green record taken there would
certify a tree with a known fault in it — the same file lying in the other direction from the stale
red row it replaces.

Every arm that was red at any point today — `test_demo`, `test_getascii_text_input`,
`test_record_replay` — passes on this tree at the same time, which had not been true since before
any of this started.

Found by replaying a recording made before #646 against the binary after it, which is the case
#646 never tested. The corpus that prompted it came from the session holding the player recordings.
