### PR TITLE
docs(rec): say which unit the record lengths are in, and what 0x52 stores

### DIFF
--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -30,9 +30,10 @@
  * nibble being full is only the first half.
  *
  * A record is [flags][payload] and nothing says how long the payload is. The poll's
- * length is in its own flag bits, a tick record is a fixed 16 bytes or 12, a marker 13,
- * and a keyframe, a telemetry block and a command each carry their count or length
- * *inside* the payload, where only a reader that already knows the layout can find it.
+ * length is in its own flag bits, a tick record's payload is a fixed 16 bytes or 12, a
+ * marker's 12, and a keyframe, a telemetry block and a command each carry their count or
+ * length *inside* the payload, where only a reader that already knows the layout can
+ * find it.
  * So a reader meeting a type it does not know cannot step past it: it does not know
  * where the record ends. Unrecognised means lost, not skippable, and the only recovery
  * is hunting for the next sync marker up to REC_SYNC_EVERY polls away. That is why the
@@ -224,6 +225,17 @@ extern "C" {
 
 /* Which device the player last used, as one byte behind the flags: 1 after a real
  * key-down, 0 after the mouse, the pad or the touch overlay.
+ *
+ * The type is named for the dimension; the payload answers one question of it, which is
+ * whether that device was a keyboard. The header says the same thing in the same words,
+ * `input.keyboard=`, and between them that is the whole of what is stored. "Not
+ * keyboard" is not a device: it is three of them, and nothing here tells them apart.
+ *
+ * The payload carries no count, so it cannot grow. A reader has no way to tell the one
+ * byte written today from the first byte of a wider record written later, which is the
+ * failure the keyframe's count exists to prevent and the reason nothing in this stream
+ * may be sized from the live build. So a later need to distinguish the mouse from the
+ * pad from the touch overlay wants a type of its own rather than more bytes here.
  *
  * It has to be carried rather than derived, and the stream looks for a moment as though
  * it already holds it. It does not. Touch pokes TabKeys directly, so a tap and a


### PR DESCRIPTION
Two comments in `SOURCES/RECORD.CPP`. No code, no format change.

## The length list mixed units

> a tick record is a fixed 16 bytes or 12, a marker 13

That is payload, payload, whole record. Counted off the writers:

| | writer | payload | record |
|---|---|---|---|
| sync marker | `put8` + `put32` x3 | 12 | 13 |
| tick record | `put8` + `put32` + `put32` + `put64`/`put32` | 16 or 12 | 17 or 13 |

Both figures came from prose already in this file, and both are correct where they sit.
The `REC_SYNC` define is pricing bytes on disk, so it says 13 per marker. `replay_poll`
is talking about what is left after the flags byte it has already consumed, so it says 16
or 12. Collecting them into one list deleted the context that carried the unit.

It is a bad place for it. The paragraph exists to say that a reader cannot skip a record
without knowing its length, and a skip table built from that list is one byte short on
every marker, which is the failure the paragraph is warning about.

Now uniformly payload, with the word said out loud.

## What 0x52 stores

`REC_DEVICE` names a dimension and the payload answers one question of it: was the device
a keyboard. Nothing else about the device is carried, and "not keyboard" is not a device,
it is three of them.

The constant is unchanged. Naming it for the keyboard would put it one letter from
`REC_KEY`, the keyframe, in a whitelist where a mistyped name still compiles. Instead the
comment states what the byte holds, ties it to the header's `input.keyboard=` so a reader
crossing from one to the other is not crossing an unmarked rename, and says where a
second device fact belongs.

Not inside this payload. It carries no count, so a reader cannot tell the one byte
written today from the first byte of a wider record written later, which is exactly the
failure the keyframe's count exists to prevent and which the top of this file already
warns about. A later need to tell the mouse from the pad from the touch overlay wants a
type of its own, and leaving `REC_DEVICE` meaning one thing is what keeps that cheap.

## Verification

Comment-only, so the engine is unchanged. It builds, and `clang-format-18` is clean. The
two numbers were re-derived by counting the writers rather than by trusting either of the
sentences they came from.
