### PR TITLE
fix(display): no title bar on Android, and a fullscreen default everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,8 +65,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   built-in one, which asks for fullscreen. GOG ships a settings file that never
   mentions the setting, so it fell through to the engine default, which was
   windowed. Both start fullscreen now. An existing settings file is left alone,
-  and the Display menu still moves it on desktop. Android has no fullscreen row
-  in that menu, so a player who started windowed there had no way back.
+  and the Display menu still moves it on desktop.
+- Android always runs fullscreen now. The Display menu has no fullscreen row
+  there, so a player whose settings said windowed, which is what an original-disc
+  or GOG install gave them, sat behind the system bars with no way back. The
+  setting is still recorded, so carrying a profile to desktop keeps it.
 - Replaying a recorded session saved under a different name than the session
   had typed. Whether the save menu offers a text field or names the slot after
   the island and the date depends on which device the player last used, and that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,17 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- On Android a bar across the top of the screen read "LBA2 Classic Community"
+  and the version number, taking a strip of the picture with it. The app named
+  no theme, so Android picked one with a title bar, and SDL puts the game's
+  window title into it. The app now names a theme with no title bar.
+- GOG installs started windowed where Steam installs started fullscreen, from
+  the same build. An install shipping no settings file is given the game's
+  built-in one, which asks for fullscreen. GOG ships a settings file that never
+  mentions the setting, so it fell through to the engine default, which was
+  windowed. Both start fullscreen now. An existing settings file is left alone,
+  and the Display menu still moves it on desktop. Android has no fullscreen row
+  in that menu, so a player who started windowed there had no way back.
 - Replaying a recorded session saved under a different name than the session
   had typed. Whether the save menu offers a text field or names the slot after
   the island and the date depends on which device the player last used, and that

--- a/LIB386/SYSTEM/WINDOW.CPP
+++ b/LIB386/SYSTEM/WINDOW.CPP
@@ -94,9 +94,20 @@ bool IsWindowInitialized() {
 }
 
 // --- Interface ---------------------------------------------------------------
+/* A platform with no windowed mode has no way back out of a windowed window:
+   the Display submenu drops its Fullscreen row (Window_SupportsWindowedMode),
+   so a cfg asking for windowed strands the player behind the system bars with
+   no control to undo it. Honour only fullscreen there. The cfg value itself is
+   left alone, so a profile carried to desktop keeps the player's choice. */
+static bool CoerceFullscreenForPlatform(bool fullscreen) {
+    return Window_SupportsWindowedMode() ? fullscreen : true;
+}
+
 bool CreateWindowSurface(U32 resX, U32 resY, bool fullscreen) {
     assert(windowSystemInitialized == true);
     assert(sdlWindow == NULL);
+
+    fullscreen = CoerceFullscreenForPlatform(fullscreen);
 
     /* Seed the cached state from the caller's choice so a fullscreen boot is
        fullscreen from the first frame. The create-time property below asks SDL
@@ -362,6 +373,7 @@ void SetWindowRelativeMouse(bool enable) {
 }
 
 void SetWindowFullscreen(bool fullscreen) {
+    fullscreen = CoerceFullscreenForPlatform(fullscreen);
     windowFullscreenEnabled = fullscreen;
 
     if (sdlWindow == NULL) {

--- a/SOURCES/CONFIG_FILE.CPP
+++ b/SOURCES/CONFIG_FILE.CPP
@@ -101,7 +101,7 @@ static const T_SETTING BootSettings[] = {
     {"FollowCamera", "AutoCameraCenter", NULL, &FollowCamera, SETTING_OR_DEFAULT, FALSE, 0, 1, NULL, NULL, NULL},
     {"DetailLevel", NULL, NULL, &DetailLevel, SETTING_CLAMP, MAX_DETAIL_LEVEL, 0, MAX_DETAIL_LEVEL, NULL, NULL, NULL},
     {"FullScreen", NULL, NULL, &VideoFullScreen, SETTING_OR_DEFAULT, TRUE, 0, 1, NULL, NULL, NULL},
-    {"DisplayFullScreen", NULL, NULL, &DisplayFullScreen, SETTING_OR_DEFAULT, FALSE, 0, 1, NULL, NULL, NULL},
+    {"DisplayFullScreen", NULL, NULL, &DisplayFullScreen, SETTING_OR_DEFAULT, TRUE, 0, 1, NULL, NULL, NULL},
     {"VSync", NULL, NULL, &DisplayVSync, SETTING_OR_DEFAULT, TRUE, 0, 1, &StoredVSync, ForcedVSync, NULL, &SourceVSync},
     {"DitherShading", NULL, "gfx_dither", &GfxDitherShading, SETTING_OR_DEFAULT, FALSE, 0, 1, NULL, NULL, NULL, NULL,
      "Ordered dither on Gouraud shade rows (softens 16-step banding)"},

--- a/SOURCES/GLOBAL.CPP
+++ b/SOURCES/GLOBAL.CPP
@@ -79,7 +79,7 @@ U32 ParmSampleFrequence = 0;
 S32 DetailLevel = MAX_DETAIL_LEVEL;
 
 S32 VideoFullScreen = TRUE;
-S32 DisplayFullScreen = FALSE;
+S32 DisplayFullScreen = TRUE;
 S32 DisplayVSync = TRUE;
 
 // #358: min ms of game-time between simulation steps (0 = off, per-frame sim as before).

--- a/SOURCES/RES_SWITCH.CPP
+++ b/SOURCES/RES_SWITCH.CPP
@@ -478,20 +478,20 @@ bool Res_LoadBootFullscreen(void) {
        same value later; on boot that becomes a no-op since the state matches,
        and it remains the authoritative path for the in-game menu toggle.
 
-       Default windowed, matching ReadConfigFile's DisplayFullScreen default
-       (FALSE) and its <0/>1 clamp — keep the two in sync. */
+       Default fullscreen, matching ReadConfigFile's DisplayFullScreen default
+       (TRUE) and its <0/>1 clamp; keep the two in sync. */
     if (PathConfigFile[0] != '\0' && ExistsFileOrDir(PathConfigFile)) {
         static char tmpCfgBuf[RES_BOOT_CFG_BUFSZ];
         T_DEFFILE_STATE savedDef;
         DefFileBufferSaveState(&savedDef);
         if (DefFileBufferInit(PathConfigFile, tmpCfgBuf, (S32)sizeof tmpCfgBuf)) {
-            const long fs = DefFileBufferReadValueDefault("DisplayFullScreen", 0);
+            const long fs = DefFileBufferReadValueDefault("DisplayFullScreen", 1);
             DefFileBufferRestoreState(&savedDef);
             return fs == 1;
         }
         DefFileBufferRestoreState(&savedDef);
     }
-    return false;
+    return true;
 }
 
 /*══════════════════════════════════════════════════════════════════════════*

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -156,6 +156,20 @@ The on-screen virtual gamepad uses the following layout:
 The layout is defined in `SOURCES/TOUCH_INPUT.CPP` and can be customised
 by editing the `kButtons[]` table (normalised 0..1 coordinates).
 
+## Window and display
+
+`Window_SupportsWindowedMode()` (`LIB386/SYSTEM/WINDOW.CPP`) returns false on
+Android, so the Display submenu drops its Fullscreen/Windowed row. A player who
+does boot windowed there has no in-game way back, which is why the
+`DisplayFullScreen` default matters more here than on desktop.
+
+The manifest names `@android:style/Theme.DeviceDefault.NoActionBar.Fullscreen`.
+With no theme the framework picks one that has an action bar, and SDL puts the
+SDL window title into the activity title, so that bar draws the product name and
+version over the game. DeviceDefault rather than the legacy
+`Theme.NoTitleBar.Fullscreen` from SDL's android-project template, because the
+theme also styles the dialogs SDL builds against the activity.
+
 ## Limitations
 
 - **Software renderer**: The game uses a software 8-bit→ARGB pipeline.

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -159,9 +159,11 @@ by editing the `kButtons[]` table (normalised 0..1 coordinates).
 ## Window and display
 
 `Window_SupportsWindowedMode()` (`LIB386/SYSTEM/WINDOW.CPP`) returns false on
-Android, so the Display submenu drops its Fullscreen/Windowed row. A player who
-does boot windowed there has no in-game way back, which is why the
-`DisplayFullScreen` default matters more here than on desktop.
+Android, so the Display submenu drops its Fullscreen/Windowed row and the window
+is always fullscreen. `CoerceFullscreenForPlatform` ignores a windowed request
+there: with the row gone, a player whose config asked for windowed would sit
+behind the system bars with no control to undo it. The config value is kept
+rather than rewritten, so a profile carried to desktop still honours it.
 
 The manifest names `@android:style/Theme.DeviceDefault.NoActionBar.Fullscreen`.
 With no theme the framework picks one that has an action bar, and SDL puts the

--- a/packaging/android/AndroidManifest.xml
+++ b/packaging/android/AndroidManifest.xml
@@ -31,8 +31,15 @@
          Runtime detection in TOUCH_INPUT.CPP disables the overlay on TV. -->
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
 
+    <!-- Without an explicit theme the framework applies an action-bar theme, and
+         that bar draws the SDL window title (product name + version) across the
+         top of the game. SDL's own android-project template uses the legacy
+         Theme.NoTitleBar.Fullscreen; the DeviceDefault one below is the same
+         no-bar fullscreen behaviour, but it also styles the AlertDialogs SDL
+         builds against this activity, such as its fatal startup error. -->
     <!-- Landscape orientation required for the game's aspect ratio -->
     <application android:label="@string/app_name"
+        android:theme="@android:style/Theme.DeviceDefault.NoActionBar.Fullscreen"
         android:allowBackup="true"
         android:hasCode="true"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
A player on a Retroid Pocket 5 (Android 13), using an original disc, reported a bar across the top of the game reading "LBA2 Classic Community 0.12.0".

## Cause

Three things compound.

The manifest set no `android:theme`, so the framework applies `Theme.DeviceDefault.Light.DarkActionBar` (the default for `targetSdk >= 17`) and the activity gets an action bar. SDL writes its window title into the activity title (`Android_SetWindowTitle` -> `Android_JNI_SetActivityTitle` -> `Activity.setTitle`), and that title is `APPNAME` in `SOURCES/INITADEL.C`: product name plus version.

That bar is hidden only while SDLActivity's fullscreen system-UI flags are set. `ActionBarOverlayLayout` hides it when both `SYSTEM_UI_FLAG_FULLSCREEN` and `SYSTEM_UI_FLAG_LAYOUT_STABLE` are on the window. The windowed branch sets `LAYOUT_STABLE` alone, and the bar returns.

So the bar appears whenever the game boots windowed. On Android that is unrecoverable: `Window_SupportsWindowedMode()` returns false, `GAMEMENU` drops the Display submenu's Fullscreen row, and nothing acted on that claim, so a config saying `DisplayFullScreen: 0` produced a windowed window with no control left to undo it.

A disc or GOG install is how a player gets that 0. Both ship a 1997-era `LBA2.CFG`, which has no `DisplayFullScreen` line, because the key is a port addition. Its presence suppresses the embedded template (`SOURCES/LBA2.CFG`) that would have said 1, so the value fell through to the settings-table default, which was 0. Steam ships no config, gets the template, and boots fullscreen.

## Changes

**Theme** (`5737356e`). Sets `Theme.DeviceDefault.NoActionBar.Fullscreen`. SDL's android-project template sets a theme here; this manifest was written from scratch and omitted it. DeviceDefault rather than SDL's legacy `Theme.NoTitleBar.Fullscreen`, because the legacy one inherits pre-Honeycomb `Theme` and SDL builds its `AlertDialog`s against this activity. API 14, minSdk is 24.

**Default** (`fbf74bd0`). `docs/CONFIG.md` documents `DisplayFullScreen` as defaulting to 1; the settings table, the `GLOBAL.CPP` initialiser and `Res_LoadBootFullscreen`'s no-cfg return all said 0. Measured against the same GOG data directory:

```
main + GOG data   ->  [INFO] Display    640x480 (CLI) windowed
this + GOG data   ->  [INFO] Display    640x480 (CLI) fullscreen
```

This fixes fresh installs only. Existing profiles keep their value, since the install layer is written to the player's own config on first exit (#495).

**Android always fullscreen** (`904ce544`). Which is why the default alone is not enough: the reporter has already played, so their config holds a 0 that no default will override. `CoerceFullscreenForPlatform` applies `Window_SupportsWindowedMode()` at the two entry points that set window state, so boot and config load agree and there is no windowed first frame. The config value is coerced on use rather than rewritten, so a profile carried to desktop still honours it.

## Verified

The reported symptom, reproduced and fixed. API 36 emulator, retail data, `DisplayFullScreen: 0` forced into the app's config to match the reporter's state. Pre-fix build:

```
decor_content_parent   [0,0][2400,1017]
action_bar             [136,74][2400,200]
TextView               "LBA2 Classic Community 0.13.0-dev-dirty"
content, SurfaceView   [136,74][2400,1017]
```

Then upgrading in place, config untouched and still `0`:

```
LinearLayout           [0,0][2400,1080]
content, SurfaceView   [0,0][2400,1080]
```

No action bar, and no `statusBarBackground` or `navigationBarBackground`. Note the content origin: it moves from `[136,74]` to `[0,0]`, so anything measuring against the surface sees a different rect on an affected device.

Android TV (`sdk_google_atv_x86`, API 36, armeabi-v7a, leanback present), covering the `IsAndroidTVDevice()` window-creation branch: same result at `[0,0][1280,720]`, no bar, no touch overlay.

Host: the GOG A/B and the profile check above; `test_ui_display`'s golden passes and is sensitive to this key (same cfg, `0` fails, `1` passes); `host_quick` 71/71; `check-format`, `check-arch`, `check-docs-symbols`, `check-docs-links` clean. The coercion is a no-op where `Window_SupportsWindowedMode()` is true.

## Not verified

Not confirmed on the reporter's own device. Both Android results are on translated ABIs rather than native ARM.

A system-drawn caption bar (DeX, ChromeOS, desktop windowing) is painted outside the app's decor and would survive this, but the Retroid Pocket 5 is a phone-class handheld with none of those, so that case does not apply here.

## Note for the touch overlay

The overlay draws in surface-normalised coordinates, so on an affected device its buttons and their hit boxes move together with the surface but stop matching the letterboxed art. The `[136,74]` measurement above is that case. Raised by the session working on `TOUCH_INPUT` (#655).
