### PR TITLE
feat(touch): show the on-screen controls on touch, stand down for a pad

### DIFF
--- a/LIB386/H/SYSTEM/KEYBOARD.H
+++ b/LIB386/H/SYSTEM/KEYBOARD.H
@@ -15,6 +15,16 @@ extern S32 AsciiMode;
 extern S32 Key;
 extern U8 TabKeys[TABKEYS_NUM_KEYS]; ///< Keyboard and Joysticks state
 
+/// 1 = the most recent user input was a finger on the touchscreen; 0 = any other
+/// device. Defined in KEYBOARD.CPP beside LastInputWasKeyboard, which answers a
+/// different question ("can we prompt for typed text") and cannot tell a pad from
+/// a finger, because both leave it 0. The touch overlay needs that distinction to
+/// stand down for a gamepad and come back for a finger.
+///
+/// Deliberately not cleared by the mouse: SDL synthesises mouse events from touch,
+/// so a mouse-side clear would cancel every touch the instant it arrived.
+extern S32 LastInputWasTouch;
+
 // --- Initialization ----------------------------------------------------------
 void InitKeyboard();
 void EndKeyboard();

--- a/LIB386/SYSTEM/KEYBOARD.CPP
+++ b/LIB386/SYSTEM/KEYBOARD.CPP
@@ -30,6 +30,17 @@ U8 TabKeys[TABKEYS_NUM_KEYS];
 // HandleEventsXxx consumers below.
 S32 LastInputWasKeyboard = 0;
 
+// 1 = the most recent user input was a finger on the touchscreen. Lives beside
+// LastInputWasKeyboard, and here for the same libsys.a linkage reason, but
+// answers a different question: that flag cannot tell a pad from a finger,
+// because both leave it 0. The touch overlay needs to, so that a pad clipped to
+// a phone takes the on-screen pills away and a finger brings them back.
+//
+// Deliberately NOT cleared by the mouse: SDL synthesises mouse events from
+// touch by default, so a mouse-side clear would cancel every touch the instant
+// it arrived.
+S32 LastInputWasTouch = 0;
+
 // Weak hook for virtual-input sources (touch overlay, etc.) to re-apply
 // their key states after UpdateKeyboardState clears TabKeys[0..255].
 void ApplyVirtualKeys(void);
@@ -183,6 +194,7 @@ void HandleEventsKeyboard(const void *event) {
     const SDL_Event *ev = (const SDL_Event *)event;
     if (ev->type == SDL_EVENT_KEY_DOWN) {
         LastInputWasKeyboard = 1;
+        LastInputWasTouch = 0;
     }
 
     /* Boundary 1's event side. Auto-repeat is excluded: a held key repeats at

--- a/SOURCES/C_EXTERN.H
+++ b/SOURCES/C_EXTERN.H
@@ -72,12 +72,6 @@ extern S32 MyKey;
 // GLOBAL.CPP) so the symbol is in libsys.a, which every test binary links.
 extern S32 LastInputWasKeyboard;
 
-// 1 = the most recent user input was a finger on the touchscreen; 0 = any other
-// device. Distinguishes a pad from a finger, which LastInputWasKeyboard cannot
-// (both leave it 0). Read by the touch overlay to decide whether to draw itself.
-// Defined in LIB386/SYSTEM/KEYBOARD.CPP for the same linkage reason.
-extern S32 LastInputWasTouch;
-
 extern S32 LastJoyFlag;
 extern S32 Jumping;
 extern S32 Pushing;

--- a/SOURCES/C_EXTERN.H
+++ b/SOURCES/C_EXTERN.H
@@ -72,6 +72,12 @@ extern S32 MyKey;
 // GLOBAL.CPP) so the symbol is in libsys.a, which every test binary links.
 extern S32 LastInputWasKeyboard;
 
+// 1 = the most recent user input was a finger on the touchscreen; 0 = any other
+// device. Distinguishes a pad from a finger, which LastInputWasKeyboard cannot
+// (both leave it 0). Read by the touch overlay to decide whether to draw itself.
+// Defined in LIB386/SYSTEM/KEYBOARD.CPP for the same linkage reason.
+extern S32 LastInputWasTouch;
+
 extern S32 LastJoyFlag;
 extern S32 Jumping;
 extern S32 Pushing;

--- a/SOURCES/JOYSTICK.CPP
+++ b/SOURCES/JOYSTICK.CPP
@@ -163,12 +163,16 @@ void HandleEventsJoystick(const void *event) {
         break;
     case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
         LastInputWasKeyboard = 0;
+        // The pad is in the player's hands: the touch overlay stands down until
+        // a finger says otherwise.
+        LastInputWasTouch = 0;
         break;
     case SDL_EVENT_GAMEPAD_AXIS_MOTION:
         // Past-deadzone test: rest-state jitter on the sticks fires constant
         // axis events and would otherwise pin the flag forever.
         if (ev->gaxis.value > JoystickDeadzone || ev->gaxis.value < -JoystickDeadzone) {
             LastInputWasKeyboard = 0;
+            LastInputWasTouch = 0;
         }
         break;
     default:

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2457,10 +2457,16 @@ int main(int argc, char *argv[]) {
     SetPrePresentCallback(ControlPrePresent);
 
     /* Touch virtual gamepad (Android / mobile). Init before Perftrace so
-       timing callbacks nest correctly. No-op on non-Android builds. */
+       timing callbacks nest correctly. No-op on non-Android builds.
+
+       Registered unconditionally rather than only when the overlay is visible
+       right now: it starts hidden until the first touch, and gating the
+       callback on the boot-time state is what would make that state
+       permanent -- the overlay would come back on and draw nothing, with
+       nothing to say why. TouchOverlay_Render is a no-op when there is
+       nothing to draw. */
     TouchOverlay_Init();
-    if (TouchOverlay_IsActive())
-        SetOverlayPrePresentCallback(TouchOverlay_Render);
+    SetOverlayPrePresentCallback(TouchOverlay_Render);
 
     /* Perftrace: ring-buffer per-frame timing capture; off by default, opt-in
        via the `perftrace` console verb. See docs/PERFTRACE.md. */

--- a/SOURCES/TOUCH_INPUT.CPP
+++ b/SOURCES/TOUCH_INPUT.CPP
@@ -1,5 +1,7 @@
 #include "TOUCH_INPUT.H"
 
+#include "JOYSTICK.H" /* JoystickIsPresent: the pad half of the visibility rule */
+
 #include <SYSTEM/ANDROID.H>
 #include <SYSTEM/KEYBOARD.H>
 #include <SYSTEM/KEYBOARD_KEYS.H>
@@ -24,10 +26,18 @@ extern "C" {
 /* The SDL window handle, defined in LIB386/SYSTEM/WINDOW.CPP under C linkage. */
 extern SDL_Window *sdlWindow;
 
-/* Last-input device flag (C linkage, defined in LIB386/SYSTEM/KEYBOARD.CPP).
- * A touch tap is not a physical keyboard, so clear it: the save menu then uses
- * the auto-name (controller) flow instead of a keyboard prompt we cannot fill. */
+/* Last-input device flags (C linkage, defined in LIB386/SYSTEM/KEYBOARD.CPP).
+ *
+ * LastInputWasKeyboard is the older of the two and answers "can we prompt for
+ * typed text": a touch tap is not a physical keyboard, so clear it and the save
+ * menu uses the auto-name flow instead of a prompt we cannot fill.
+ *
+ * LastInputWasTouch answers a question that one could not, because a pad and a
+ * finger both leave it 0: which of the two the player is holding right now.
+ * That is what lets the overlay step aside for a pad on a phone -- the case a
+ * device-class check for Android TV never covered. */
 extern S32 LastInputWasKeyboard;
+extern S32 LastInputWasTouch;
 
 /* ---------------------------------------------------------------------------
  * Constants
@@ -80,7 +90,7 @@ typedef struct {
 static const TouchButton kButtons[NUM_TOUCH_BUTTONS] = {
     /* Top-left: ESC */
     {BTN_ESC, "ESC", 0.065f, 0.045f, 0.055f, 0.038f, K_ESC},
-    /* Top-centre: HIDE toggle */
+    /* Top-centre: dismiss the overlay until the next touch */
     {BTN_HIDE, "HIDE", 0.48f, 0.045f, 0.055f, 0.038f, 0},
     /* Top-right: Menu (F10) + Camera toggle */
     {BTN_MENU, "MEN", 0.85f, 0.045f, 0.055f, 0.038f, K_F10},
@@ -100,10 +110,62 @@ static const TouchButton kButtons[NUM_TOUCH_BUTTONS] = {
 };
 
 /* ---------------------------------------------------------------------------
+ * Visibility policy
+ * ---------------------------------------------------------------------------
+ * One flag used to carry three unrelated facts -- whether the device has a
+ * touchscreen, whether the player wants the pills drawn, and whether touch
+ * input is accepted -- so there was nowhere to put a policy answer. They are
+ * separate now:
+ *
+ *   s_supported   this build can draw an overlay at all: Android only.
+ *   s_tvDevice    leanback, so assume no touchscreen until a finger proves otherwise.
+ *   s_lastTouchMs when a finger was last down, which drives the fade.
+ *
+ * From those, one rule covers both the touch-only phone and the phone with a
+ * pad clipped to it: THE OVERLAY FOLLOWS THE LAST INPUT THE PLAYER ACTUALLY
+ * USED. Touch shows it, a pad or a key hides it, and going idle fades it out.
+ * Nobody configures anything, and the pad case needs no device-class check --
+ * Android TV is just a screen nobody has ever touched.
+ *
+ * Why a fade rather than a mode check: this game holds a direction to walk, so
+ * a thumb is on the D-pad more or less continuously during play and the timer
+ * never fires. It fires during dialogue, cutscenes and FMVs -- which is a fair
+ * approximation of "the game is not asking for input" for the price of a
+ * timer, instead of the per-modal mode stack the engine does not have (each
+ * modal runs its own inner loop with its own exit sentinel; see docs/CONTROL.md).
+ *
+ * HIDE dismisses the overlay immediately rather than waiting out the fade, for
+ * when the player wants to see what is under it now. It is not a mode: the next
+ * touch brings the controls back, like any other touch. That is what removed the
+ * SHOW pill this used to need -- a widget whose whole job was to undo a state
+ * that touch already undoes, sitting on screen permanently in a design whose
+ * point is to keep the screen clear. It also made the misfire cheap. HIDE is at
+ * cx 0.48, cy 0.045, which is where a player taps to skip dialogue, so it does
+ * get hit by accident; costing them one touch is fine, stranding them in an
+ * unexplained state was not.
+ */
+
+/* Wall-clock, not the managed game clock: a UI fade should run in real time
+   whether or not the simulation is paused, and staying off the game clock
+   keeps this out of the recorder's determinism surface entirely. The overlay
+   only ever injects keys from a real finger, so a replay never sees it. */
+#define TOUCH_FULL_MS 1500u /* full opacity for this long after the last touch */
+#define TOUCH_DIM_MS 6000u  /* then recessive, then gone */
+
+typedef enum {
+    OVL_OFF = 0, /* not drawn */
+    OVL_DIM,     /* drawn faintly: still findable, no longer competing with the art */
+    OVL_FULL
+} OverlayLevel;
+
+/* ---------------------------------------------------------------------------
  * State
  * --------------------------------------------------------------------------- */
 
-static S32 s_active = 0; /* set to 1 on Android; also toggle-able */
+static S32 s_supported = 0;   /* Android build: an overlay is possible here */
+static S32 s_tvDevice = 0;    /* leanback: start off, but a finger still overrides */
+static S32 s_dismissed = 0;   /* HIDE was pressed; cleared by the next finger down */
+static U32 s_lastTouchMs = 0; /* SDL_GetTicks at the last finger-down/motion; 0 = never */
 static S32 s_pressed[NUM_TOUCH_BUTTONS];
 static U8 s_virtual_keys[256]; /* virtual key states in 0x80-bit format */
 
@@ -112,6 +174,7 @@ static struct {
     S32 buttonIndex; /* -1 = not touching any button */
     S32 touchId;     /* SDL finger ID */
     S32 active;      /* 1 = slot in use */
+    S32 actuate;     /* 0 = this finger only woke the overlay, it presses nothing */
 } s_fingers[MAX_FINGERS];
 
 /* ---------------------------------------------------------------------------
@@ -132,6 +195,65 @@ static S32 FindFingerByTouchId(S32 touchId) {
             return i;
     }
     return -1;
+}
+
+/* Any finger currently on the glass counts as activity for as long as it is
+   held. A held button fires one FINGER_DOWN and then nothing, so timing the
+   fade from events alone would dim the overlay in the middle of a walk. */
+static S32 AnyFingerDown(void) {
+    for (S32 i = 0; i < MAX_FINGERS; i++) {
+        if (s_fingers[i].active)
+            return 1;
+    }
+    return 0;
+}
+
+static void NoteTouchActivity(void) {
+    s_lastTouchMs = SDL_GetTicks();
+    LastInputWasTouch = 1;
+    /* A touch is not a physical keyboard: keep the save menu on the auto-name
+       flow, which is the one thing we cannot type into. */
+    LastInputWasKeyboard = 0;
+}
+
+/* What to draw this frame. The order is the priority order: an unsupported
+   device and an explicit HIDE both beat everything, then the pad, then time. */
+static OverlayLevel CurrentLevel(void) {
+    if (!s_supported)
+        return OVL_OFF;
+
+    /* HIDE, until the next finger clears it. */
+    if (s_dismissed)
+        return OVL_OFF;
+
+    /* Nobody has touched the glass yet. A pad attached makes it a pad session
+       and the pills would be 14 dead buttons over the art; a TV is a screen
+       nobody is going to touch. Otherwise it is a player who has not found the
+       controls yet, so leave a hint.
+
+       This is where leanback belongs, rather than in s_supported: as a hard
+       gate it was a hidden control stuck at off -- a leanback device that does
+       have a touchscreen could never raise the overlay, and there is no
+       setting to say otherwise. A first touch is better evidence than a
+       manifest feature flag, so let it win. */
+    if (s_lastTouchMs == 0)
+        return (s_tvDevice || JoystickIsPresent()) ? OVL_OFF : OVL_DIM;
+
+    /* The player picked up the pad. Step aside until a finger says otherwise --
+       and the pad drives the menus too (JoystickMenuAction), so nothing here
+       is reachable only by touch. */
+    if (!LastInputWasTouch)
+        return OVL_OFF;
+
+    if (AnyFingerDown())
+        return OVL_FULL;
+
+    U32 idleMs = SDL_GetTicks() - s_lastTouchMs;
+    if (idleMs < TOUCH_FULL_MS)
+        return OVL_FULL;
+    if (idleMs < TOUCH_DIM_MS)
+        return OVL_DIM;
+    return OVL_OFF;
 }
 
 /* Map a touch coordinate from display-normalised space (0..1 of the full
@@ -185,11 +307,6 @@ static void SetButtonState(S32 idx, S32 pressed) {
     if (s_pressed[idx] == pressed)
         return;
     s_pressed[idx] = pressed;
-    if (pressed) {
-        // A touch tap is not a physical keyboard; keep the save menu on the
-        // auto-name (controller) flow.
-        LastInputWasKeyboard = 0;
-    }
     U32 sc = kButtons[idx].scanCode;
     if (sc < 256) {
         if (pressed) {
@@ -218,51 +335,50 @@ void ApplyVirtualKeys(void) {
 
 void TouchOverlay_Init(void) {
 #ifdef __ANDROID__
-    if (IsAndroidTVDevice()) {
-        LogPrintf("TouchOverlay: Android TV detected, overlay disabled "
-                  "(use gamepad/remote)\n");
-        s_active = 0;
+    s_supported = 1;
+    s_tvDevice = IsAndroidTVDevice();
+    if (s_tvDevice) {
+        LogPrintf("TouchOverlay: Android TV detected, overlay starts off "
+                  "(use gamepad/remote; a touch still brings it up)\n");
     } else {
-        s_active = 1;
         LogPrintf("TouchOverlay: initialised for Android (%d buttons)\n",
                   NUM_TOUCH_BUTTONS);
     }
 #else
-    s_active = 0;
+    s_supported = 0;
 #endif
+    s_dismissed = 0;
+    s_lastTouchMs = 0;
+    /* s_tvDevice is set above and is not cleared here: it is a property of the
+       device, not of this session's input. */
     memset(s_pressed, 0, sizeof(s_pressed));
     memset(s_virtual_keys, 0, sizeof(s_virtual_keys));
     memset(s_fingers, 0, sizeof(s_fingers));
 }
 
-void TouchOverlay_Shutdown(void) {
+/* Let go of every key this overlay is holding. Called when it stops accepting
+   input, so a finger that was on a direction when the overlay went away does
+   not leave that direction latched in TabKeys forever. */
+static void ReleaseAllButtons(void) {
     for (S32 i = 0; i < NUM_TOUCH_BUTTONS; i++) {
         if (s_pressed[i])
             SetButtonState(i, 0);
     }
-    s_active = 0;
+    memset(s_fingers, 0, sizeof(s_fingers));
 }
 
-S32 TouchOverlay_IsActive(void) {
-    return s_active;
+void TouchOverlay_Shutdown(void) {
+    ReleaseAllButtons();
+    s_supported = 0;
 }
 
-void TouchOverlay_SetActive(S32 active) {
-    if (active == s_active)
-        return;
-    if (!active) {
-        for (S32 i = 0; i < NUM_TOUCH_BUTTONS; i++) {
-            if (s_pressed[i])
-                SetButtonState(i, 0);
-        }
-        memset(s_fingers, 0, sizeof(s_fingers));
-    }
-    s_active = active;
+S32 TouchOverlay_IsSupported(void) {
+    return s_supported;
 }
 
 S32 TouchOverlay_HandleEvent(const void *sdlEvent) {
 #ifdef __ANDROID__
-    if (sdlEvent == NULL)
+    if (sdlEvent == NULL || !s_supported)
         return 0;
 
     const SDL_Event *ev = (const SDL_Event *)sdlEvent;
@@ -277,18 +393,43 @@ S32 TouchOverlay_HandleEvent(const void *sdlEvent) {
         float ny = ev->tfinger.y;
         MapToGameCoords(&nx, &ny);
         S32 idx = HitTest(nx, ny);
+
+        /* Any finger anywhere brings the controls back: touch is the only
+           "show" this needs, which is why there is no pill. */
+        s_dismissed = 0;
+
+        /* Does this touch press what it landed on, or only wake the overlay?
+           Only a player already using touch can have been aiming at a button:
+           coming back from a pad or a keyboard there was nothing on screen to
+           aim at. That is also what protects a phone in a controller clip,
+           where the glass sits under the player's palms and a brush would
+           otherwise latch a direction. Read before NoteTouchActivity, which is
+           what makes the answer 1 from here on. */
+        const S32 actuate = LastInputWasTouch;
+        NoteTouchActivity();
+
         s_fingers[slot].active = 1;
         s_fingers[slot].touchId = (S32)ev->tfinger.fingerID;
         s_fingers[slot].buttonIndex = idx;
-        if (idx >= 0) {
-            /* HIDE button toggles visibility — always responsive */
-            if (kButtons[idx].id == BTN_HIDE) {
-                TouchOverlay_SetActive(!s_active);
-                consumed = 1;
-            } else if (s_active) {
-                SetButtonState(idx, 1);
-                consumed = 1;
+        s_fingers[slot].actuate = actuate;
+
+        if (idx < 0)
+            break; /* empty glass: the wake above was the whole effect */
+
+        if (kButtons[idx].id == BTN_HIDE) {
+            /* Gated like any other button: a palm brush from a pad session
+               wakes the overlay rather than dismissing it again. */
+            if (actuate) {
+                ReleaseAllButtons();
+                s_dismissed = 1;
             }
+            consumed = 1;
+            break;
+        }
+
+        if (actuate) {
+            SetButtonState(idx, 1);
+            consumed = 1;
         }
         break;
     }
@@ -297,9 +438,13 @@ S32 TouchOverlay_HandleEvent(const void *sdlEvent) {
         if (slot < 0)
             break;
         S32 idx = s_fingers[slot].buttonIndex;
-        if (idx >= 0 && kButtons[idx].id != BTN_HIDE)
+        if (idx >= 0)
             SetButtonState(idx, 0);
         s_fingers[slot].active = 0;
+        s_fingers[slot].actuate = 0;
+        /* The lift is what starts the idle clock: until it happens the finger
+           is still down and the overlay is held at full. */
+        s_lastTouchMs = SDL_GetTicks();
         consumed = 1;
         break;
     }
@@ -313,9 +458,12 @@ S32 TouchOverlay_HandleEvent(const void *sdlEvent) {
         S32 newIdx = HitTest(nx, ny);
         S32 oldIdx = s_fingers[slot].buttonIndex;
         if (newIdx != oldIdx) {
-            if (oldIdx >= 0 && kButtons[oldIdx].id != BTN_HIDE)
+            if (oldIdx >= 0)
                 SetButtonState(oldIdx, 0);
-            if (newIdx >= 0 && kButtons[newIdx].id != BTN_HIDE && s_active)
+            /* A finger that only woke the overlay keeps pressing nothing for as
+               long as it is down, however far it is dragged: the press it would
+               start was never aimed. */
+            if (newIdx >= 0 && s_fingers[slot].actuate)
                 SetButtonState(newIdx, 1);
             s_fingers[slot].buttonIndex = newIdx;
         }
@@ -443,31 +591,65 @@ static void DrawFilledRoundRect(U32 *fb, S32 pitchInPixels,
     }
 }
 
+/* Scale every alpha in a pass by one factor, so the dim level is the same
+   drawing at lower contrast rather than a second set of tuned constants. */
+static U8 ScaleAlpha(U8 a, U8 scale) {
+    return (U8)(((U32)a * (U32)scale) / 255u);
+}
+
+/* Pixel rect for a button, clamped to the framebuffer. Returns 0 if nothing of
+   it is on screen. Shared by the buttons and the pill so the thing the player
+   taps and the thing they see cannot drift apart. */
+static S32 ButtonRect(const TouchButton *btn, float shrink, U32 width, U32 height,
+                      S32 *x0, S32 *y0, S32 *x1, S32 *y1) {
+    *x0 = (S32)((btn->cx - btn->rx * shrink) * (float)width);
+    *y0 = (S32)((btn->cy - btn->ry * shrink) * (float)height);
+    *x1 = (S32)((btn->cx + btn->rx * shrink) * (float)width);
+    *y1 = (S32)((btn->cy + btn->ry * shrink) * (float)height);
+    if (*x0 < 0)
+        *x0 = 0;
+    if (*y0 < 0)
+        *y0 = 0;
+    if (*x1 >= (S32)width)
+        *x1 = (S32)width - 1;
+    if (*y1 >= (S32)height)
+        *y1 = (S32)height - 1;
+    return (*x0 <= *x1 && *y0 <= *y1);
+}
+
+static void DrawLabelCentred(U32 *fb, S32 pitchPixels, S32 x0, S32 y0, S32 x1, S32 y1,
+                             const char *label, U8 alpha, U32 width, U32 height) {
+    if (label == NULL || label[0] == 0)
+        return;
+    S32 textW = (S32)(strlen(label) * SizeChar);
+    S32 textH = (S32)SizeChar;
+    S32 tx = ((x0 + x1) / 2) - (textW / 2);
+    S32 ty = ((y0 + y1) / 2) - (textH / 2);
+    DrawStringARGB(fb, pitchPixels, tx, ty, label, 255, 255, 255, alpha, width, height);
+}
+
 void TouchOverlay_Render(U32 *frameBuffer, U32 pitch, U32 width, U32 height,
                          const U8 *palette_rgb) {
     (void)palette_rgb;
-    if (!s_active || frameBuffer == NULL || width == 0 || height == 0)
+    if (frameBuffer == NULL || width == 0 || height == 0)
         return;
 
     S32 pitchPixels = (S32)(pitch / sizeof(U32));
 
+    const OverlayLevel level = CurrentLevel();
+    if (level == OVL_OFF)
+        return;
+
+    /* 30% keeps the layout legible against the art without competing with it,
+       which is the point of dimming rather than vanishing: a player who is
+       looking rather than touching is idle by definition, and that is exactly
+       when a newcomer is deciding which button to reach for. */
+    const U8 scale = (level == OVL_FULL) ? 255 : 76;
+
     for (S32 i = 0; i < NUM_TOUCH_BUTTONS; i++) {
         const TouchButton *btn = &kButtons[i];
-        S32 x0 = (S32)((btn->cx - btn->rx) * (float)width);
-        S32 y0 = (S32)((btn->cy - btn->ry) * (float)height);
-        S32 x1 = (S32)((btn->cx + btn->rx) * (float)width);
-        S32 y1 = (S32)((btn->cy + btn->ry) * (float)height);
-
-        /* Clamp to framebuffer bounds */
-        if (x0 < 0)
-            x0 = 0;
-        if (y0 < 0)
-            y0 = 0;
-        if (x1 >= (S32)width)
-            x1 = (S32)width - 1;
-        if (y1 >= (S32)height)
-            y1 = (S32)height - 1;
-        if (x0 > x1 || y0 > y1)
+        S32 x0, y0, x1, y1;
+        if (!ButtonRect(btn, 1.0f, width, height, &x0, &y0, &x1, &y1))
             continue;
 
         U8 alpha = s_pressed[i] ? 180 : 100;
@@ -477,21 +659,14 @@ void TouchOverlay_Render(U32 *frameBuffer, U32 pitch, U32 width, U32 height,
         S32 radius = 6;
 
         DrawFilledRoundRect(frameBuffer, pitchPixels, x0, y0, x1, y1,
-                            r, g, b8, alpha, radius);
+                            r, g, b8, ScaleAlpha(alpha, scale), radius);
 
         /* Draw a simple outline */
         DrawFilledRoundRect(frameBuffer, pitchPixels, x0, y0, x1, y1,
-                            255, 255, 255, 60, radius);
+                            255, 255, 255, ScaleAlpha(60, scale), radius);
 
-        /* Draw the button label centred */
-        if (btn->label && btn->label[0]) {
-            S32 textW = (S32)(strlen(btn->label) * SizeChar);
-            S32 textH = (S32)SizeChar;
-            S32 tx = ((x0 + x1) / 2) - (textW / 2);
-            S32 ty = ((y0 + y1) / 2) - (textH / 2);
-            DrawStringARGB(frameBuffer, pitchPixels, tx, ty, btn->label,
-                           255, 255, 255, 220, width, height);
-        }
+        DrawLabelCentred(frameBuffer, pitchPixels, x0, y0, x1, y1,
+                         btn->label, ScaleAlpha(220, scale), width, height);
     }
 }
 

--- a/SOURCES/TOUCH_INPUT.CPP
+++ b/SOURCES/TOUCH_INPUT.CPP
@@ -35,9 +35,9 @@ extern SDL_Window *sdlWindow;
  * LastInputWasTouch answers a question that one could not, because a pad and a
  * finger both leave it 0: which of the two the player is holding right now.
  * That is what lets the overlay step aside for a pad on a phone -- the case a
- * device-class check for Android TV never covered. */
+ * device-class check for Android TV never covered. It is declared in
+ * SYSTEM/KEYBOARD.H, beside the module that defines it. */
 extern S32 LastInputWasKeyboard;
-extern S32 LastInputWasTouch;
 
 /* ---------------------------------------------------------------------------
  * Constants
@@ -208,6 +208,7 @@ static S32 AnyFingerDown(void) {
     return 0;
 }
 
+#ifdef __ANDROID__
 static void NoteTouchActivity(void) {
     s_lastTouchMs = SDL_GetTicks();
     LastInputWasTouch = 1;
@@ -215,6 +216,7 @@ static void NoteTouchActivity(void) {
        flow, which is the one thing we cannot type into. */
     LastInputWasKeyboard = 0;
 }
+#endif
 
 /* What to draw this frame. The order is the priority order: an unsupported
    device and an explicit HIDE both beat everything, then the pad, then time. */

--- a/SOURCES/TOUCH_INPUT.H
+++ b/SOURCES/TOUCH_INPUT.H
@@ -20,7 +20,29 @@ extern "C" {
  * Enabled at runtime via TouchOverlay_Init / TouchOverlay_Shutdown.
  * TouchOverlay_HandleEvent must be called from the event loop on
  * SDL_EVENT_FINGER_DOWN / SDL_EVENT_FINGER_UP / SDL_EVENT_FINGER_MOTION.
- * TouchOverlay_Render must be called from the PrePresent chain.
+ * TouchOverlay_Render must be called from the PrePresent chain -- unconditionally,
+ * once, at startup. It decides for itself whether to draw anything, so a caller
+ * that registers it only when the overlay happens to be visible at boot makes
+ * every later "show it again" silently draw nothing.
+ *
+ * WHEN IT SHOWS
+ * -------------
+ * The overlay follows the last input device the player actually used, and fades
+ * when they stop using it:
+ *
+ *   a finger down          -> full opacity, held for as long as it is down
+ *   ~1.5s after the lift   -> dimmed, still legible enough to aim by
+ *   ~6s after the lift     -> gone
+ *   a pad or keyboard used -> gone, until a finger says otherwise
+ *   HIDE pressed           -> gone now, without waiting out the fade
+ *
+ * Every one of those states is left by the same thing: a touch. HIDE is a
+ * dismiss, not a mode, which is why there is no SHOW control to undo it.
+ *
+ * The first touch after another device only wakes the overlay; it presses
+ * nothing. Every touch after that both wakes and presses, so a player who knows
+ * the layout never loses the press that mattered. See TOUCH_INPUT.CPP for why
+ * this is a timer rather than a per-screen layout.
  */
 
 void TouchOverlay_Init(void);
@@ -36,10 +58,11 @@ S32 TouchOverlay_HandleEvent(const void *sdlEvent);
 void TouchOverlay_Render(U32 *frameBuffer, U32 pitch, U32 width, U32 height,
                          const U8 *palette_rgb);
 
-/* Whether the overlay is currently visible and accepting input. Toggled at
- * runtime by TouchOverlay_Enable / TouchOverlay_Disable. */
-S32 TouchOverlay_IsActive(void);
-void TouchOverlay_SetActive(S32 active);
+/* Whether this device gets an overlay at all: false off Android and on a
+ * leanback (TV) device. Settled once by TouchOverlay_Init. Distinct from
+ * whether anything is drawn this frame, which the policy above decides. */
+S32 TouchOverlay_IsSupported(void);
+
 void ApplyVirtualKeys(void);
 
 #ifdef __cplusplus

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -142,7 +142,7 @@ The on-screen virtual gamepad uses the following layout:
 ```
 
 - **ESC** — Escape (quit/back)
-- **HIDE** — Show or hide the overlay (persistent pill when hidden)
+- **HIDE** — Dismiss the controls now; the next touch brings them back
 - **MEN** — Menu (F10 / in-game menu)
 - **CAM** — Camera toggle (Backspace)
 - **D-pad** — U/D/L/R → Arrow keys (movement)
@@ -155,6 +155,38 @@ The on-screen virtual gamepad uses the following layout:
 
 The layout is defined in `SOURCES/TOUCH_INPUT.CPP` and can be customised
 by editing the `kButtons[]` table (normalised 0..1 coordinates).
+
+## When the overlay shows
+
+It follows the last input device the player actually used, and fades when they
+stop using it:
+
+| state | overlay |
+|-------|---------|
+| a finger is down | full opacity, for as long as it is held |
+| ~1.5s after the lift | dimmed, still legible enough to aim by |
+| ~6s after the lift | gone |
+| a gamepad or key was the last input | gone, until a finger says otherwise |
+| nothing has been touched yet | dimmed, or gone if a pad is connected or the device is a TV |
+| HIDE was pressed | gone now, without waiting out the fade |
+
+The first touch after using another device only wakes the overlay; it presses
+nothing. Every touch after that both wakes and presses, so a player who knows
+the layout never loses the press that mattered. It also stops a phone in a
+controller clip latching a direction when a palm brushes the glass.
+
+Every one of those states is left by touching the screen. That is what removed
+the old "persistent pill when hidden": a control whose only job was to undo
+something a touch already undoes. HIDE is now a dismiss rather than a mode, so
+hitting it by accident (it sits where you tap to skip dialogue) costs one touch
+instead of stranding you in a state with an unexplained chip on screen.
+
+The buttons are placed in coordinates normalised over the whole SDL surface, so
+they sit on top of the game's letterbox bars rather than inside the rendered
+picture. That is only coherent because the surface fills the display, which the
+fullscreen coercion below guarantees on Android. Touch hit-testing does not
+depend on it either way: `MapToGameCoords` reads the live window size, so it
+follows the surface whatever size it is.
 
 ## Window and display
 
@@ -187,6 +219,7 @@ theme also styles the dialogs SDL builds against the activity.
   (window focus events). Surface re-creation is managed by the existing
   SDL3 infrastructure.
 - **Game data**: You must provide your own retail LBA2 data files.
-- **Android TV**: Touch overlay is automatically disabled when a TV device
-  is detected (`android.software.leanback` feature). Use a gamepad or
-  remote control instead.
+- **Android TV**: Touch overlay is off when a TV device is detected
+  (`android.software.leanback` feature). Use a gamepad or remote control
+  instead. This is only the starting value: the last-input rule reaches the
+  same answer on its own, because a TV is a screen nobody ever touches.

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -219,7 +219,9 @@ theme also styles the dialogs SDL builds against the activity.
   (window focus events). Surface re-creation is managed by the existing
   SDL3 infrastructure.
 - **Game data**: You must provide your own retail LBA2 data files.
-- **Android TV**: Touch overlay is off when a TV device is detected
+- **Android TV**: the touch overlay starts off when a TV device is detected
   (`android.software.leanback` feature). Use a gamepad or remote control
-  instead. This is only the starting value: the last-input rule reaches the
-  same answer on its own, because a TV is a screen nobody ever touches.
+  instead. Leanback is only the starting value, not a lock: a touch still
+  brings the overlay up, so a leanback device that does have a touchscreen can
+  use it. A first touch is better evidence than a manifest feature flag, and
+  the alternative was a control the player has no way to reach.

--- a/tests/input_device/test_input_device.cpp
+++ b/tests/input_device/test_input_device.cpp
@@ -12,6 +12,12 @@
  * same flag the same way the mouse handler does here; their end-to-end save
  * flow is verified on-device. The Android-TV guard (IsAndroidTVDevice) is a
  * no-op stub off Android, so it does not affect this host classification.
+ *
+ * It also covers the sibling flag LastInputWasTouch, which the touch overlay
+ * reads to decide whether to draw itself. The case worth a test is the one that
+ * looks like a bug: the mouse handler must NOT clear it. SDL synthesises mouse
+ * events from touch by default, so a mouse-side clear would cancel every touch
+ * the instant it arrived and the overlay would never appear on a phone.
  */
 #include <SYSTEM/EVENTS.H>   // ManageEvents (stubbed below)
 #include <SYSTEM/KEYBOARD.H> // HandleEventsKeyboard
@@ -23,6 +29,7 @@
 #include <cstdio>
 
 extern "C" S32 LastInputWasKeyboard; // defined in LIB386/SYSTEM/KEYBOARD.CPP
+extern "C" S32 LastInputWasTouch;    // likewise
 
 // --- Link stubs: symbols the handler TUs reference on paths this test never
 // drives, provided so the two real handlers link standalone. ---
@@ -42,6 +49,14 @@ static int fails = 0;
 static void expect(S32 got, S32 want, const char *label) {
     if (got != want) {
         std::fprintf(stderr, "FAIL: %s: LastInputWasKeyboard=%d (want %d)\n", label, got, want);
+        fails++;
+    }
+}
+
+static void expectTouch(S32 want, const char *label) {
+    if (LastInputWasTouch != want) {
+        std::fprintf(stderr, "FAIL: %s: LastInputWasTouch=%d (want %d)\n", label,
+                     LastInputWasTouch, want);
         fails++;
     }
 }
@@ -84,6 +99,34 @@ int main() {
     HandleEventsMouse(&mouseBtn); // -> 0
     HandleEventsKeyboard(&keyUp); // not a down event
     expect(LastInputWasKeyboard, 0, "key-up does not set keyboard");
+
+    // --- LastInputWasTouch -------------------------------------------------
+    // The overlay draws only while touch is the last device used, so what
+    // clears this flag decides whether it is ever on screen.
+    expectTouch(0, "touch flag default is 0");
+
+    // A real key means the player moved to a keyboard: the overlay stands down.
+    LastInputWasTouch = 1;
+    HandleEventsKeyboard(&keyDown);
+    expectTouch(0, "key-down -> not touch");
+
+    // ...but only a key-DOWN, on the same terms as the flag above.
+    LastInputWasTouch = 1;
+    HandleEventsKeyboard(&keyUp);
+    expectTouch(1, "key-up leaves touch alone");
+
+    // The one that would look like a tidy-up and is not. SDL turns touches into
+    // mouse events, so clearing here would undo the touch that produced them and
+    // the overlay would never appear. Both mouse paths must leave it set.
+    LastInputWasTouch = 1;
+    HandleEventsMouse(&mouseBtn);
+    expectTouch(1, "mouse button does NOT clear touch (SDL synthesises it from touch)");
+
+    LastInputWasTouch = 1;
+    HandleEventsMouse(&mouseWheel);
+    expectTouch(1, "mouse wheel does NOT clear touch");
+
+    LastInputWasTouch = 0;
 
     if (fails == 0) {
         std::printf("test_input_device: all checks passed\n");

--- a/tests/input_device/test_input_device.cpp
+++ b/tests/input_device/test_input_device.cpp
@@ -29,7 +29,7 @@
 #include <cstdio>
 
 extern "C" S32 LastInputWasKeyboard; // defined in LIB386/SYSTEM/KEYBOARD.CPP
-extern "C" S32 LastInputWasTouch;    // likewise
+                                     // (LastInputWasTouch comes from KEYBOARD.H)
 
 // --- Link stubs: symbols the handler TUs reference on paths this test never
 // drives, provided so the two real handlers link standalone. ---


### PR DESCRIPTION
The Android touch overlay was drawn on every frame from boot to exit. `PrePresent` is reached in every mode by design (that is why the console hangs off it), so the same 14 gameplay buttons sat over the logos, the menus, dialogue, cutscenes, FMVs and the credits. On most of those screens they are dead buttons over the art, because the layout maps to gameplay keys.

Two cases were unhandled entirely. A phone with a gamepad clipped to it got a permanent overlay where every button was redundant, with the screen under the player's palms so a brush could latch a direction. And a leanback device was locked out by a hard gate rather than a default.

## One rule

**The overlay follows the last input device the player actually used.**

| state | overlay |
|-------|---------|
| a finger is down | full opacity, for as long as it is held |
| ~1.5s after the lift | dimmed, still legible enough to aim by |
| ~6s after the lift | gone |
| a gamepad or key was the last input | gone, until a finger says otherwise |
| nothing touched yet | dimmed, or gone if a pad is connected or the device is a TV |
| HIDE pressed | gone now, without waiting out the fade |

Every one of those states is left by touching the screen.

### Why a timer and not a per-screen layout

This game holds a direction to walk, so a thumb is on the D-pad more or less continuously during play and the timer rarely fires. It fires during dialogue, cutscenes and FMVs. That approximates "the game is not asking for input" for the price of a timer, instead of the per-modal mode stack the engine does not have: each modal runs its own inner loop with its own exit sentinel, and there is no current-mode value to read (the digest's "what modal is up" is six scattered flags).

### Three decisions worth arguing with

**The first touch after another device wakes the overlay but presses nothing.** Coming back from a pad there was nothing on screen to aim at, so the touch cannot have been aimed. This is what stops a phone in a controller clip latching a direction. Every touch after that wakes *and* presses, so a player who knows the layout never loses the press that mattered.

**Dim rather than vanish at the first step.** A player deciding which button to reach for is idle by definition, which is exactly when a newcomer needs the layout to still be legible.

**HIDE is a dismiss, not a mode.** It drops the overlay immediately rather than waiting out the fade, and the next touch brings it back like any other touch. That removes the "persistent pill" the old sticky state needed: a widget whose only job was to undo something a touch already undoes, sitting on screen permanently in a design meant to keep the screen clear. It also makes the misfire cheap. HIDE sits at cx 0.48, cy 0.045, which is where a player taps to skip dialogue, so it does get hit by accident. Costing them one touch beats stranding them in an unexplained state.

Note that `docs/ANDROID.md` documented a "persistent pill when hidden" that the code never drew: `TouchOverlay_Render` returned early on the hidden state, so the only way back was an invisible hotspot.

## New state: `LastInputWasTouch`

`LastInputWasKeyboard` answers "can we prompt for typed text", and a pad and a finger both leave it 0. Telling those two apart is what lets the overlay stand down for a pad, so this adds a sibling flag beside it, defined in the same TU for the same `libsys.a` linkage reason.

It is deliberately **not** cleared by the mouse: SDL synthesises mouse events from touch by default, so a mouse-side clear would cancel every touch the instant it arrived and the overlay would never appear. `tests/input_device` covers that case specifically, because it is the one that looks like a tidy-up rather than a regression. That assertion was falsified before being trusted: injecting the clear into `HandleEventsMouse` makes the test fail, and reverting makes it pass.

## Verified on device

Two API 36 emulators.

**Phone, arm64:** full on a held finger, dim at ~3s, gone at ~9s, gone after a key event, back on the next touch.

**TV, armeabi-v7a, `android.software.leanback`:** nothing until touched, all buttons on a held touch, gone again after the fade. The middle case was unreachable before this change, because `HandleEvent` returned early on `!s_supported`.

## What this does not cover

- **The pad arm is not hardware-verified.** Neither emulator has a gamepad. The rule is one branch and the keyboard exercises the same path, but the pad's own clearing site in `JOYSTICK.CPP` has not run on a device. Ten minutes with a real pad would close it.
- **The fade constants are unjustified rather than wrong.** 1.5s and 6s are round numbers that looked right in screenshots. They encode the "a thumb is on the D-pad continuously" claim above, which is not measured. Dialogue in particular advances on a keypress with several seconds of reading between taps, which lands in the dim band, so the overlay may pulse through conversations. Two follow-ups would settle it cheaply: register both as console cvars so tuning does not cost a rebuild, and ramp the alpha instead of stepping it so the exact values matter less.
- Both emulators are translated ABIs (Berberis, ndk_translation) rather than native ARM, and the TV touch is injected on an image with no touchscreen, which is the population the leanback change is for.
- Diagonals are still unreachable on the D-pad: the four ellipses do not overlap and `HitTest` is first-match. Pre-existing, out of scope here.

## Rebased on #654

That PR added `CoerceFullscreenForPlatform`, which ignores a windowed request where `Window_SupportsWindowedMode()` is false. It strengthens this one: the overlay places its buttons in coordinates normalised over the whole SDL surface, so they sit on top of the game's letterbox bars rather than inside the rendered picture, and that is only coherent while the surface fills the display. Before #654 that held by luck (the embedded config template happens to seed fullscreen); now it holds by construction. Touch hit-testing never depended on it either way, since `MapToGameCoords` reads the live window size.

`docs/ANDROID.md` conflicted and is resolved by keeping both sections: "When the overlay shows" after the key mapping, then #654's "Window and display", with a sentence tying the coordinate space to the fullscreen guarantee.

## Reviewing

Four commits. The flag and its test; the visibility policy (carrying its own `docs/ANDROID.md` section); a small docs follow-up; and a fourth that moves the new extern out of `SOURCES/C_EXTERN.H` into `LIB386/H/SYSTEM/KEYBOARD.H`, beside the module that defines it.

That fourth commit is worth a glance rather than a skim: `check-arch` rule 4 caught it, and it was a real layering mistake rather than a counter tripping. I had put the declaration in the god header because its sibling `LastInputWasKeyboard` lives there, but the new flag is defined in `LIB386/SYSTEM/KEYBOARD.CPP`, so the game layer's shared-state bus was the wrong home. The sibling being there is the debt that ceiling exists to drain, not a precedent. `C_EXTERN.H` is back to 252 externs and this PR no longer touches it.
