### PR TITLE
feat(record): a replay loads the state its recording began from

### DIFF
--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -740,6 +740,41 @@ int Control_Begin(void) {
             fprintf(stderr, "[control] --projection-hash: hash capture not armed\n");
     }
 
+    /* A replay carries the state it started from, so it does not need to be handed one.
+       Only when the caller named no --load: an explicit one is the caller saying which
+       game to boot, and a recording is not entitled to overrule that.
+
+       This is what lets --replay stand on its own. Before it, both kinds of recording
+       needed a --load and needed it for different reasons -- a `rec start` file only to
+       have a live scene for its own deferred reload to land in (any save would do, the
+       target was discarded), a --record file to reproduce the state it began from (the
+       target mattered, and a wrong one diverged from tick 0 while still exiting 0). The
+       recording answers both.
+
+       The refusal is the other half and it is not optional. A replay whose starting state
+       cannot be obtained must say so and stop, because the alternative is to boot fresh
+       and replay the recording's input into a game it was never made in -- which produces
+       a divergence report about a fault the run itself introduced, at exit 0. Exiting here
+       and WITHOUT Control_End follows the setup-failure path directly below, and for the
+       same reason it gives: artifacts written from a game that never loaded are plausible
+       artifacts of the wrong scene. */
+    if (!s_load_name) {
+        const char *snap = NULL;
+        switch (Record_ArmedReplayLoad(&snap)) {
+        case 1:
+            s_load_name = snap;
+            fprintf(stderr, "[control] no --load; booting from the recording's own starting state\n");
+            break;
+        case -1:
+            fprintf(stderr, "[control] replay: this recording carries no starting state, and no --load\n"
+                            "[control]         was given. Pass the save the session was recorded from.\n");
+            fflush(stderr);
+            return 0;
+        default:
+            break;
+        }
+    }
+
     if (s_load_name) {
         if (!control_resolve_save(s_load_name)) {
             /* Report and bail without arming. The caller skips MainLoop and exits, so

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -405,6 +405,16 @@ static int s_snapInline = 0;
    none. Held rather than rebuilt because the reload happens a tick after the file is
    read, and the path is what says the reload has a staged file to clean up. */
 static char s_inlineSnap[ADELINE_MAX_PATH] = "";
+/* The same snapshot again, staged before MainLoop so a --replay run can boot into the
+   state the recording started from. Kept apart from s_inlineSnap because the two have
+   different lifetimes: this one has to outlive Control_Begin's load, and the reload path
+   drops its own as soon as the load has read it. */
+static char s_bootSnap[ADELINE_MAX_PATH] = "";
+/* Whether the path above is this run's to delete. A recording from before the format
+   carried its savegame names a sibling instead, and that file belongs to the recording:
+   removing it at exit would consume the very thing that makes those files replayable, and
+   they are the ones with no second run to replace them. */
+static int s_bootSnapOwned = 0;
 /* The file this session is on, after a bare name has been resolved to the recordings
    folder. Reported rather than the string the player typed: with a default home, the
    two are usually not the same and only one of them says where to look. */
@@ -1001,10 +1011,6 @@ static void record_scratch_path_as(char *out, size_t n, const char *suffix) {
     snprintf(out, n, "%s", p);
 }
 
-static void record_scratch_path(char *out, size_t n) {
-    record_scratch_path_as(out, n, "staging");
-}
-
 /* Stage a snapshot, and report whether one is actually there.
  *
  * The check is the point. Control_WriteSnapshot returns 1 whatever SaveGame did with
@@ -1102,7 +1108,7 @@ static S32 record_write_chunk(U8 op, const char *file) {
    the frame exists for: a recording cut off mid-snapshot would otherwise hand the save
    loader a file that is a valid savegame right up to where it stops, and a replay would
    begin from a state the session never had. */
-static S32 replay_read_chunk(U8 want, char *outPath, size_t n) {
+static S32 replay_read_chunk(U8 want, char *outPath, size_t n, const char *suffix) {
     U8 head[REC_CHUNK_HEAD], tail[REC_CHUNK_TAIL];
     U8 op = 0;
     U32 len = 0;
@@ -1136,7 +1142,7 @@ static S32 replay_read_chunk(U8 want, char *outPath, size_t n) {
         return 1;
     }
 
-    record_scratch_path(outPath, n);
+    record_scratch_path_as(outPath, n, suffix);
     out = fopen(outPath, "wb");
     if (!out) {
         free(buf);
@@ -1184,6 +1190,12 @@ static void record_flush_at_exit(void) {
     if (s_inlineSnap[0]) {
         remove(s_inlineSnap);
         s_inlineSnap[0] = 0;
+    }
+    if (s_bootSnap[0]) {
+        if (s_bootSnapOwned)
+            remove(s_bootSnap);
+        s_bootSnap[0] = 0;
+        s_bootSnapOwned = 0;
     }
     /* The player's session, if the run ends before it could be put back. Removing it is
        all that is left to do here: there are no more ticks, so the reload Record_Stop
@@ -2616,7 +2628,7 @@ int Record_Play(const char *path) {
         RecFmt_ReadInt(s_headerBuf, "setup.reloaded=", &reloads);
         s_inlineSnap[0] = 0;
         if (!replay_read_chunk(REC_SNAP_START, reloads ? s_inlineSnap : NULL,
-                               sizeof s_inlineSnap))
+                               sizeof s_inlineSnap, "staging"))
             fseek(s_f, at, SEEK_SET);
     }
 
@@ -2783,6 +2795,85 @@ int Record_Play(const char *path) {
     }
 
     replay_begin();
+    return 1;
+}
+
+/* The starting state of the recording this run was armed to replay, as a savegame the
+ * boot path can load. Returns 1 with *out set, 0 when this is none of our business, and
+ * -1 when a replay is armed and its starting state cannot be obtained at all.
+ *
+ * Every recording carries that state. Until now only a replay already inside a game read
+ * it back, so the state had to be reproduced on the command line with --load, and getting
+ * it wrong is silent: the run replays the recording's input into whatever it did boot and
+ * reports the divergence it caused itself, while exiting 0.
+ *
+ * Two sources, the same pair and the same order Record_Play uses: the file's own copy, and
+ * a sibling named by `setup.snapshot=` for a recording made before the format carried one.
+ * Both, because those older files are sessions somebody played and there is no second run
+ * of them to replace them with -- and they are the likeliest to be replayed by someone who
+ * no longer has the save, which is the case this whole function exists to serve.
+ *
+ * The -1 is the point of the tri-state. Reporting "there is no snapshot" with the same
+ * NULL as "no replay is armed" would boot fresh and replay into it, which is the failure
+ * above wearing the fix's clothes. A file that will not open is NOT -1: that is
+ * Record_Play's to report by name, and it does.
+ *
+ * Called from Control_Begin: late enough that GetRecordingsPath resolves -- the constraint
+ * that keeps replay_peek_seed out of Record_ArmReplay -- and early enough to still be the
+ * run's first load. Record_Play opens the file again for itself afterwards; this only
+ * borrows s_f, which is NULL until then and NULL again on every path out. */
+int Record_ArmedReplayLoad(const char **out) {
+    char resolved[ADELINE_MAX_PATH];
+    char header[REC_HEADER_MAX];
+    char named[ADELINE_MAX_PATH];
+    char line[512];
+    const char *path;
+
+    if (out)
+        *out = NULL;
+    if (s_armed != 2 || !s_armReplay[0])
+        return 0;
+    if (s_bootSnap[0]) { /* resolved already; one load per run */
+        if (out)
+            *out = s_bootSnap;
+        return 1;
+    }
+
+    path = rec_resolve(s_armReplay, resolved, sizeof resolved, 0);
+    if (!path[0])
+        return 0;
+    s_f = fopen(path, "rb");
+    if (!s_f)
+        return 0; /* Record_Play reports a file it cannot open, by name */
+
+    /* Past the text header to the blank line, keeping it: the snapshot chunk begins there,
+       and `setup.snapshot=` is read out of what we walk over. The chunk cannot be found by
+       probing, because a savegame contains every byte a record header can. */
+    header[0] = 0;
+    while (fgets(line, sizeof line, s_f)) {
+        if (line[0] == '\n' || line[0] == '\r')
+            break;
+        strncat(header, line, sizeof header - strlen(header) - 1);
+    }
+
+    if (replay_read_chunk(REC_SNAP_START, s_bootSnap, sizeof s_bootSnap, "boot")) {
+        s_bootSnapOwned = 1; /* staged out of the file: ours to remove */
+    } else if (RecFmt_ReadStr(header, "setup.snapshot=", named, sizeof named) &&
+               strcmp(named, "-") != 0 && strcmp(named, "(inline)") != 0) {
+        char beside[ADELINE_MAX_PATH];
+        snapshot_beside(path, named, beside, sizeof beside);
+        if (ExistsFileOrDir(beside)) {
+            snprintf(s_bootSnap, sizeof s_bootSnap, "%s", beside);
+            s_bootSnapOwned = 0; /* the recording's, not ours: never removed */
+        }
+    }
+    fclose(s_f);
+    s_f = NULL;
+
+    if (!s_bootSnap[0])
+        return -1;
+    if (out)
+        *out = s_bootSnap;
     return 1;
 }
 

--- a/SOURCES/RECORD.H
+++ b/SOURCES/RECORD.H
@@ -52,6 +52,13 @@ void Record_CommandHook(const char *line);
    MainLoop's tick hook, because the menus never reach that hook. */
 void Record_ArmRecord(const char *path);
 void Record_ArmReplay(const char *path);
+/* The armed replay's own starting state, as a savegame Control_Begin can load when no
+   --load was given, so a replay boots into the state its recording began from instead of
+   one supplied by hand. Returns 1 with *out set, 0 when no replay is armed (or its file
+   will not open, which Record_Play reports by name), and -1 when a replay is armed and
+   carries no obtainable starting state -- which the caller must refuse rather than boot
+   fresh into. */
+int Record_ArmedReplayLoad(const char **out);
 unsigned long Record_Squeeze(const char *path);
 /* The file the last Record_Start / Record_Play resolved to. A bare name is a name in
    the recordings folder, so this is where it actually went, which is not the string the

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -17,8 +17,8 @@ The design work behind it, and what was measured rather than assumed, is in
 # Record a session you play yourself. Quit through the menu, or type `exit` at the console.
 lba2cc --fixed-dt 16 --load "/path/to/save.lba" --record session.rec
 
-# Replay it. Same --load, because the recording does not reload its own snapshot (see below).
-lba2cc --fixed-dt 16 --load "/path/to/save.lba" --replay session.rec --tick 4000 --exit
+# Replay it. No --load needed: the recording carries the state it started from (see below).
+lba2cc --fixed-dt 16 --replay session.rec --tick 4000 --exit
 ```
 
 A clean replay ends with `first hash mismatch -1`. Anything else names the tick:
@@ -564,16 +564,35 @@ guessed:
 [rec] holds about 3699 ticks over 134410 polls; give --tick more than that
 ```
 
-**A replay needs the same `--load` the recording ran under.** For a recording made with a
-boot-time `--load` that is unsurprising: `setup.reloaded` records whether the session reloaded its
-own snapshot, a `--load` at boot is not that, and so nothing in the file restores the start state.
+**A replay no longer needs `--load`; the recording carries the state it began from.** Every
+recording holds the savegame its session started at -- inside the file, or, for one made before the
+format carried it, in the sibling `setup.snapshot=` names. A `--replay` run given no `--load` loads
+that and says so:
 
-A mid-session `rec start` does reload its own snapshot, and still needs it. Measured: the same
-mid-session recording replays with no mismatch when the replay is given the same `--load`, and
-diverges at tick 4 without it, from both `--replay` and `rec play`. So something the reload does
-not restore differs between a run that booted into the save and one that booted fresh, and a
-mid-session recording is not yet self-contained either. Naming the save the session started from is
-the outstanding work; until then, pass it.
+```
+[control] no --load; booting from the recording's own starting state
+```
+
+An explicit `--load` still wins, because naming one is the caller saying which game to boot. And a
+recording whose starting state cannot be obtained at all is refused by name rather than booted
+fresh into -- that case used to replay the recording's input into a game it was never made in and
+report the divergence it had caused itself, at exit 0.
+
+This is a statement about the flag, not about the file. It does not mean mid-session recordings
+replay clean; it means passing `--load` no longer changes the verdict. Measured both ways on
+recordings made from an early save and from a deep one, and on a pre-inline recording replayed
+from its sibling: `first hash mismatch -1` with `--load`, without it, and with a *different* save
+passed. A replay made to diverge deliberately reports the same divergence either way.
+
+The limits below are unaffected by it.
+
+**A deep exterior save can diverge at tick 0, and `--load` is not what decides it.** The camera
+fields the digest mixes -- `BetaCam` and `VueOffsetX/Y/Z` -- come out differently from the
+recorder's own deferred reload than from a cold load of the same savegame bytes, so a recording
+made mid-session in a deep exterior scene reports a tick 0 mismatch in them and never converges
+(issue #642). It fires whether or not the replay is given a `--load`, and an early-game save does
+not show it, which is why the shipped fixtures never see it. Nothing in the file is wrong: the same
+bytes read two ways.
 
 **Some settings have to match, and they are not in the save.** A replay reads the live config, so a
 config edited between recording and replay reads as the simulation diverging. Each of these was

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -1018,6 +1018,165 @@ command_position "inline verb" "ui inventory $cmdposdir/ui.png" "$cmdposdir/ui.p
 # the deferred work no longer lands would show here and nowhere else.
 command_position "deferred verb" "cube 154"
 
+# --- a replay supplies its own starting state --------------------------------------
+#
+# Every recording carries the savegame its session began from, so a replay does not need
+# to be handed one. What makes this worth a test rather than a convenience note is the
+# way it used to fail: the staging was gated on `setup.reloaded=1`, so a --record file
+# carried the state it began from and the replay ignored it. Without a --load the run
+# then replayed the recording's input into whatever the fresh-start path had built, and
+# reported the divergence it had caused itself -- while exiting 0.
+#
+# So the assertion is on the verdict, not the exit code. Measured before the fix, with
+# no --load: `tick 0 differs: cube 3/0 hero.x 6619/10496 ...` and exit 0. An arm that
+# checked only the status passes on that.
+noloaddir="$(mktemp -d)"
+clean_add "$noloaddir"
+noloadrec="$noloaddir/noload.rec"
+
+ctl --fixed-dt 16 --load "$LBA2_TEST_SAVE" --record "$noloadrec" \
+    --exec-at 30 "key up 60 2" --tick 300 --exit >/dev/null 2>&1 ||
+    fail "no --load: the recording run exited non-zero ($?); it hung or crashed"
+[ -s "$noloadrec" ] || fail "no --load: no recording written to $noloadrec"
+
+# The whole point of the arm: no --load anywhere on this command line.
+#
+# The status is taken but not acted on yet. A replay's exit code is not its verdict --
+# a diverging run can leave by several doors and they do not agree on a number -- so the
+# summary is read first and the status only reported if nothing better was found. Without
+# that order this arm's failure on an engine that lacks the fix reads "hang or crash",
+# which is the one thing it is not.
+noloadrc=0
+noloadout="$(ctl --fixed-dt 16 --replay "$noloadrec" --tick 400 --exit 2>&1)" || noloadrc=$?
+
+# Said out loud, because a replay that quietly fell back to a fresh start would still
+# reach the checks below and could still match on a session that never left cube 0.
+case "$noloadout" in
+*"booting from the recording's own starting state"*) ;;
+*) fail "no --load: the run did not report booting from the recording's own starting state" ;;
+esac
+
+case "$noloadout" in
+*"consistency failure"*)
+    fail "no --load: $(printf '%s\n' "$noloadout" | grep -m1 'consistency failure')"
+    ;;
+esac
+
+noloadsummary="$(printf '%s\n' "$noloadout" | grep -m1 'replay ended')" ||
+    fail "no --load: replay printed no summary; it cannot be said to have matched"
+noloadchecked="$(printf '%s\n' "$noloadsummary" | sed -n 's/.*: \([0-9]*\) ticks checked.*/\1/p')"
+[ -n "$noloadchecked" ] && [ "$noloadchecked" -gt 100 ] ||
+    fail "no --load: only ${noloadchecked:-0} ticks checked, so the oracle barely ran ($noloadsummary)"
+case "$noloadsummary" in
+*"first hash mismatch -1"*) ;;
+*) fail "no --load: $noloadsummary" ;;
+esac
+
+# Last, so anything above gets to name the real fault first.
+[ "$noloadrc" -eq 0 ] ||
+    fail "no --load: replay run exited non-zero ($noloadrc) with a clean summary"
+
+# The equivalence half, and it needs a file that does NOT replay clean.
+#
+# Everything above compares one -1 against another, which any change producing -1 passes
+# -- including one that ignored the snapshot and got clean runs because this save would
+# replay clean under anything. What distinguishes "the snapshot is being used" from
+# "these files are easy" is a replay with a known non-clean verdict coming out the SAME
+# with and without --load. Both diverging at the same tick is the passing result here.
+#
+# The divergence is manufactured rather than found, so the arm does not depend on a bug
+# staying unfixed: the recording ran under the config the engine defaults to and the
+# replay is given FollowCamera flipped, which docs/RECORDING.md's settings table records
+# as a tick 0 divergence because the camera is in the digest.
+eqdir="$(mktemp -d)"
+clean_add "$eqdir"
+eqrec="$eqdir/eq.rec"
+
+ctl --fixed-dt 16 --load "$LBA2_TEST_SAVE" --record "$eqrec" \
+    --exec-at 30 "key up 60 2" --tick 300 --exit >/dev/null 2>&1 ||
+    fail "equivalence: the recording run exited non-zero ($?); it hung or crashed"
+[ -s "$eqrec" ] || fail "equivalence: no recording written to $eqrec"
+
+# Out of the header region rather than the whole file: `settings.FollowCamera=` could
+# in principle occur inside the inline savegame, and a match there would be read as the
+# value the session ran under. tr drops the NULs, as the header check above does.
+eqcam="$(head -c 2048 "$eqrec" | tr -d '\0' | grep -o -m1 'settings.FollowCamera=[01]' | cut -d= -f2)"
+[ -n "$eqcam" ] || fail "equivalence: the recording does not declare settings.FollowCamera"
+eqflip=$((1 - eqcam))
+
+# Same replay twice, differing only in whether --load is passed.
+eqverdict() { # eqverdict <label> [--load ...]
+    local label="$1"
+    shift
+    local dir
+    dir="$(mktemp -d)"
+    clean_add "$dir"
+    printf 'FollowCamera=%s\n' "$eqflip" >"$dir/lba2.cfg"
+    local out
+    out="$(LBA2_USER_DIR="$dir" ctl --fixed-dt 16 "$@" --replay "$eqrec" \
+        --tick 400 --exit 2>&1)" ||
+        fail "equivalence/$label: replay run exited non-zero ($?); it hung or crashed"
+    EQ="$(printf '%s\n' "$out" | grep -m1 'replay ended' |
+        sed -n 's/.*\(first hash mismatch -\?[0-9]*\).*/\1/p')"
+    [ -n "$EQ" ] || fail "equivalence/$label: replay printed no verdict"
+
+    # The arm's self-description, checked. A one-line cfg leaves every other setting at
+    # its default, so the replay could be differing on more than the flip and the
+    # comparison would still pass -- saying nothing about the flip. The engine names what
+    # it disagrees about, so require that it named this.
+    case "$out" in
+    *"mode differs: settings.FollowCamera"*) ;;
+    *) fail "equivalence/$label: the run did not report differing on settings.FollowCamera; the arm is not testing what it says" ;;
+    esac
+}
+
+eqverdict "with --load" --load "$LBA2_TEST_SAVE"
+eqwith="$EQ"
+eqverdict "no --load"
+eqwithout="$EQ"
+
+# Teeth: a clean pair would mean the flip did not bite and the comparison proved nothing.
+case "$eqwith" in
+*" -1"*) fail "equivalence: the FollowCamera flip did not diverge ($eqwith); the arm cannot fail" ;;
+esac
+[ "$eqwith" = "$eqwithout" ] ||
+    fail "equivalence: --load changed the verdict ($eqwith with, $eqwithout without)"
+
+# A recording older than the format that carries its savegame inside it. legacy-v10.rec
+# names a sibling in `setup.snapshot=` instead, and the boot load has to find it there or
+# the run boots fresh and replays into a game the session was never made in -- the same
+# silent wrong answer, reached by the path that was supposed to have removed it. Measured
+# on an engine without the fallback: exit 124 having printed `first hash mismatch 0`, a
+# divergence report about a fault the run introduced itself.
+#
+# The sibling belongs to the recording, not to the run, so this also asserts it is still
+# there afterwards. Nothing else in the suite would notice it being consumed, and these
+# are the files with no second run to replace them.
+legdir="$(mktemp -d)"
+clean_add "$legdir"
+legsib="$REPO/tests/automation/recordings/legacy-v10.rec.lba"
+[ -e "$legsib" ] || fail "legacy no --load: the sibling savegame is missing from the repo"
+legsum_before="$(md5sum <"$legsib")"
+
+legout="$(LBA2_USER_DIR="$legdir" ctl --fixed-dt 16 \
+    --replay "$REPO/tests/automation/recordings/legacy-v10.rec" --tick 400 --exit 2>&1)" ||
+    fail "legacy no --load: replay run exited non-zero ($?); it hung or crashed"
+
+case "$legout" in
+*"consistency failure"*)
+    fail "legacy no --load: $(printf '%s\n' "$legout" | grep -m1 'consistency failure')"
+    ;;
+esac
+legsummary="$(printf '%s\n' "$legout" | grep -m1 'replay ended')" ||
+    fail "legacy no --load: replay printed no summary"
+case "$legsummary" in
+*"first hash mismatch -1"*) ;;
+*) fail "legacy no --load: $legsummary" ;;
+esac
+
+[ "$(md5sum <"$legsib")" = "$legsum_before" ] ||
+    fail "legacy no --load: the run modified or removed the recording's sibling savegame"
+
 # --- the artifact belongs to the recording, not to the tick budget -------------------
 #
 # --tick has to exceed what the recording holds or the replay is cut short (the engine
@@ -1119,4 +1278,4 @@ esac
 
 pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; mode.audio was written from the driver and reported both ways; a session recorded in one run replayed in the next with no flags and no paths; \
 'rec start verbose' carried telemetry and a plain one carried none; a recorded walk moved the hero and the replay walked it again; the recorder gave the step back and left the flag's alone; a playback put the player back where it found them, stopped early or run out; a window holding a scene change ran at ${modalrate}x real, not faster; a recording on a host-sampled clock crossed a scene change instead of wedging in the fade; \
-a command ran where the recording ran it, for an inline verb and for a deferred one; the state dump was the same at a 400 and a 4000 tick budget; a recording that opens a menu reported no verdict and exited non-zero"
+a command ran where the recording ran it, for an inline verb and for a deferred one; the state dump was the same at a 400 and a 4000 tick budget; a recording that opens a menu reported no verdict and exited non-zero; a replay with no --load booted from the recording's own starting state and still matched ($noloadchecked ticks); a deliberately diverging replay reported '$eqwith' with and without --load; a pre-inline recording loaded its sibling savegame with no --load and left it intact"


### PR DESCRIPTION
Every recording carries the savegame its session started from. Only a replay already inside a game read it back, so the caller had to reproduce that state by hand with `--load`, and getting it wrong was silent.

```
$ lba2cc --replay session.rec --tick 400 --exit          # a --record session, no --load
[rec] tick 0 differs: cube 3/0 hero.x 6619/10496 hero.y 1024/2048 hero.z 15109/4352
[rec] replay ended at poll 301: 301 ticks checked, first hash mismatch 0
$ echo $?
0
```

The run booted fresh, replayed the recording's input into a game it was never made in, and reported the divergence it had caused itself. With the same file given its own starting state the verdict is `first hash mismatch -1`.

## What changes

`--replay` loads the state the recording began from when no `--load` was named:

```
[control] no --load; booting from the recording's own starting state
```

An explicit `--load` still wins, because naming one is the caller saying which game to boot.

The staging in `Record_Play` is gated on `setup.reloaded=1`, so this reads the same two sources in the same order: the file's own copy, and the sibling named by `setup.snapshot=` for a recording made before the format carried one. Both, because those older files are sessions somebody played with no second run to replace them, and they are the likeliest to be replayed by someone who no longer has the save.

A recording whose starting state cannot be obtained at all is refused by name and exits non-zero, rather than booting fresh and replaying into it.

## Two things worth a reviewer's eye

`Record_ArmedReplayLoad` returns a tri-state, not a pointer. NULL was answering two questions, and returning it for "there is no state" as well as "no replay is armed" reintroduces the defect. A file that will not open is deliberately not the refusing case: `Record_Play` reports that by name.

The sibling belongs to the recording, not the run, so it is never removed at exit. `legacy-v10.rec`'s sibling is a checked-in fixture, and treating both sources alike deletes it on the first run.

## Docs

The Limits section said a replay needs the same `--load`, and that a mid-session recording diverges at tick 4 without it. The first is no longer true; the second does not reproduce, including from `rec play` booted fresh with no `--load`, which is the configuration it was measured in.

It is written as a statement about the flag, not the file: passing `--load` no longer changes the verdict, which is not the same as mid-session recordings replaying clean. The quickstart taught the old rule and is the part a reader meets first, so it changes too, and the command as printed was run.

The camera divergence a deep exterior save shows at tick 0 gets an entry of its own. It was documented nowhere, it fires with `--load` and without it, and a reader meeting the new section without it could take it as fixed.

## Tests

Three arms. A replay with no `--load` matching the one with it. A pre-inline recording loading its sibling and leaving its md5 unchanged. And a deliberately diverging replay reporting the same verdict either way, which is what makes the comparison able to fail: the other two compare a `-1` against a `-1`, and any change producing `-1` passes those.

The divergence is manufactured by flipping `FollowCamera` on the replay side rather than borrowing a live bug, so the arm does not depend on something staying broken, and it asserts the run reported differing on that setting so it cannot go vacuous.

All three recorder suites pass here. `test_record_replay.sh` fails on `ea3113fa`.
