### PR TITLE
fix(video): pace a cinematic on the clock that is timing the run

### DIFF
--- a/SOURCES/PLAYACF.CPP
+++ b/SOURCES/PLAYACF.CPP
@@ -36,6 +36,7 @@ int VideoLogIsEnabled(void) {
 #include <SVGA/VIDEO.H>
 #include <SYSTEM/KEYBOARD_KEYS.H>
 #include <SYSTEM/LOGPRINT.H>
+#include <SYSTEM/TIMER.H>
 #include <SDL3/SDL.h>
 #include <stdio.h>
 #include <string.h>
@@ -549,7 +550,7 @@ S32 PlayAcf(const char *name) {
         int videoFrozen = 0; // console open or focus lost -> hold the frame
         int everFocused = 0; // set once the window is focused; a never-focused run
                              // (e.g. a headless capture) then never freezes
-        U32 freezeStart = 0; // SDL_GetTicks when the freeze began
+        U32 freezeStart = 0; // clock reading when the freeze began
         for (unsigned long c = 0; c < f; c++) {
             /* Push this frame's audio (skip for c < prebufFrames, already in stream from pre-fill) */
             if (numTracks > 0 && c >= prebufFrames) {
@@ -581,10 +582,22 @@ S32 PlayAcf(const char *name) {
             BoxStaticAdd(0, 0, (S32)(ModeDesiredX - 1), (S32)(ModeDesiredY - 1));
             BoxUpdate();
 
-            /* Pace to real time with SDL so speed is correct and sleep reduces stutter */
+            /* Pace each frame against whatever clock is timing this run
+               (Timer_ClockSource): the host clock in an ordinary session, and the
+               pinned virtual clock under --fixed-dt or a session recording. An
+               ordinary session reads SDL_GetTicks either way and is unchanged.
+
+               Under a pinned clock the distinction is what makes a video replay. This
+               wait polls input every iteration, so how long it runs decides how much
+               of a recorded input stream the video consumes, and it is also the only
+               thing moving the clock across the video. Measured against the wall,
+               neither is the same twice: the same session recorded twice held 888
+               ticks over 35328 polls and 859 over 35264, and each replay diverged on
+               the tick the video started with 1.8 and 1.3 seconds of clock drift.
+               Measured against the pinned clock both are arithmetic. */
             if (c == 0)
-                videoStartTicks = SDL_GetTicks();
-            U32 now = SDL_GetTicks();
+                videoStartTicks = Timer_ClockSource();
+            U32 now = Timer_ClockSource();
             U32 nextAt = videoStartTicks + (c + 1) * frameMs;
             for (;;) {
                 MyGetInput();
@@ -596,17 +609,17 @@ S32 PlayAcf(const char *name) {
                 /* Freeze the cinematic while the console is open or the window has
                    lost focus (only once it was focused: a never-focused window such
                    as a headless capture keeps playing rather than freezing at frame
-                   0). Hold the current frame and pause its audio. The frame clock is
-                   wall-clock based (SDL_GetTicks), so re-base it on resume, otherwise
-                   playback fast-forwards to catch up and the (paused, then resumed)
-                   audio lags the video. */
+                   0). Hold the current frame and pause its audio. The frame schedule
+                   is a deadline on a clock that keeps running while the frame is
+                   held, so re-base it on resume, otherwise playback fast-forwards to
+                   catch up and the (paused, then resumed) audio lags the video. */
                 if (Console_IsOpen() || (everFocused && !AppActive)) {
                     if (!videoFrozen) {
                         if (numTracks > 0)
                             PauseVideoAudio();
                         if (VideoLogIsEnabled())
                             SDL_Log("[VIDEO] frozen (console open or unfocused)");
-                        freezeStart = SDL_GetTicks();
+                        freezeStart = Timer_ClockSource();
                         videoFrozen = 1;
                     }
                     BoxStaticAdd(0, 0, (S32)(ModeDesiredX - 1), (S32)(ModeDesiredY - 1));
@@ -614,7 +627,7 @@ S32 PlayAcf(const char *name) {
                     continue;
                 }
                 if (videoFrozen) {
-                    U32 pausedMs = SDL_GetTicks() - freezeStart;
+                    U32 pausedMs = Timer_ClockSource() - freezeStart;
                     videoStartTicks += pausedMs; // shift the whole schedule forward
                     nextAt += pausedMs;
                     if (numTracks > 0)
@@ -623,10 +636,26 @@ S32 PlayAcf(const char *name) {
                         SDL_Log("[VIDEO] resumed (rebased +%u ms)", (unsigned)pausedMs);
                     videoFrozen = 0;
                 }
-                now = SDL_GetTicks();
+                now = Timer_ClockSource();
                 if (now >= nextAt)
                     break;
-                SDL_Delay(1); /* sleep 1ms to avoid busy-spin, re-check input each time */
+                /* Nothing else moves a pinned clock in here: the tick advance is in
+                   MainLoop, which this loop is not, and the frame was presented before
+                   the wait rather than inside it. So the wait mints the step it is
+                   waiting out, or the deadline above never arrives. The polled form,
+                   because this loop takes a fresh reading every iteration; the other
+                   one would mint a second step and sleep out the real time it stands
+                   for (LIB386/H/SYSTEM/TIMER.H).
+
+                   The sleep is the alternative rather than a companion. It is what
+                   makes an unpinned wait cheap; under a pinned clock the pacing funnel
+                   already decides whether a minted step costs wall time (a player's
+                   recording pays for it, a batch replay does not), so sleeping here
+                   would charge for the same step twice. */
+                if (Timer_FixedDtActive())
+                    Timer_FixedDtPumpPolled();
+                else
+                    SDL_Delay(1); /* avoid busy-spin, re-check input each time */
             }
 
             smk_next(smkObject);

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -131,6 +131,7 @@ record_and_replay() { # record_and_replay <label> [extra record args...]
     esac
 
     CHECKED="$checked"
+    POLLS="$(printf '%s\n' "$summary" | sed -n 's/.*replay ended at poll \([0-9]*\).*/\1/p')"
 }
 
 record_and_replay "with --tick" --tick 300 --exit
@@ -142,6 +143,34 @@ bounded="$CHECKED"
 # a run that finalizes on its first tick never reaches tick 300 and times out here.
 record_and_replay "without --tick" --exec-at 300 "rec stop; exit"
 unbounded="$CHECKED"
+
+# Across a video. PlayAcf paces its frames in a wait of its own, outside MainLoop, and
+# that wait polls input every iteration, so it is the one place in a session where the
+# number of polls between two ticks is settled by something other than the recording. It
+# is also the only thing moving the clock while a video is on screen. Timed against the
+# wall neither is the same twice: the same session recorded twice on one idle machine
+# held 888 ticks over 35328 polls and 859 over 35264, and each replay diverged on the
+# tick the video started, 1.8 and 1.3 seconds of clock drift apart. Under load the replay
+# ran out of stream inside the video and reported "first hash mismatch -1" over 51 of 901
+# ticks, which is the shape that makes this worth an arm rather than a note: the verdict
+# line said the recording reproduced.
+#
+# No fixture reached this loop's exit before. test_ui_video.sh plays a video, but its
+# capture fires on frame 25 and leaves through fin_play, so what had been covered was
+# decode and letterbox centring and not the pacing at all.
+#
+# 60 rather than 30 so the video starts after the input above has been consumed, and the
+# ticks either side of it are ordinary ones.
+record_and_replay "across a video" --tick 300 --exit --exec-at 60 "playvideo BALDINO.SMK"
+
+# That the video played, which nothing above establishes: PlayAcf returns quietly when
+# there is no movie bank (the demo ships none), and a session that skipped the cutscene
+# replays perfectly for the wrong reason. A session without one polls about once a tick;
+# this one spends thousands of polls inside the cinematic and none of them are ticks.
+[ -n "${POLLS:-}" ] && [ "$POLLS" -gt $((CHECKED * 2)) ] ||
+    fail "across a video: ${POLLS:-0} polls over $CHECKED ticks — no video played, so the arm proved nothing"
+vidchecked="$CHECKED"
+vidpolls="$POLLS"
 
 # A recording cut off mid-snapshot, which is what a process killed while writing one
 # leaves behind. The frame's refusal is the whole safety argument for keeping the
@@ -1276,6 +1305,6 @@ esac
 [ ! -e "$(user_dir)/menu-esc.json" ] ||
     fail "menu: a --dump-state was written from a run that stopped at the menu"
 
-pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; mode.audio was written from the driver and reported both ways; a session recorded in one run replayed in the next with no flags and no paths; \
+pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a video played to its end and replayed ($vidchecked ticks over $vidpolls polls); a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; mode.audio was written from the driver and reported both ways; a session recorded in one run replayed in the next with no flags and no paths; \
 'rec start verbose' carried telemetry and a plain one carried none; a recorded walk moved the hero and the replay walked it again; the recorder gave the step back and left the flag's alone; a playback put the player back where it found them, stopped early or run out; a window holding a scene change ran at ${modalrate}x real, not faster; a recording on a host-sampled clock crossed a scene change instead of wedging in the fade; \
 a command ran where the recording ran it, for an inline verb and for a deferred one; the state dump was the same at a 400 and a 4000 tick budget; a recording that opens a menu reported no verdict and exited non-zero; a replay with no --load booted from the recording's own starting state and still matched ($noloadchecked ticks); a deliberately diverging replay reported '$eqwith' with and without --load; a pre-inline recording loaded its sibling savegame with no --load and left it intact"


### PR DESCRIPTION
`PlayAcf` waits out each video frame in a loop of its own, outside `MainLoop`, and that loop polls input every iteration. How long it runs settles two things a recording depends on: how much of the recorded input stream the video consumes, and, under a pinned clock, how far the clock moves while the video is on screen, because nothing else in there moves it. Both were measured against `SDL_GetTicks`, so neither was the same twice and a session with a cutscene in it did not replay.

The two mechanisms are worth keeping apart, because only one of them needs the poll counts to differ. The stream half is straightforward: a wait whose length is a race consumes a host-dependent number of polls, and the replay walks off the end of the recording inside the video. The clock half fires even when the poll counts come out equal, since the video's frame schedule is what advances the pinned clock across the cutscene, and that advance was being read from the wall.

## Measured

Recording the same session twice on one idle machine, `playvideo BALDINO.SMK` at tick 60 under `--fixed-dt 16`, the file held 888 ticks over 35328 polls one run and 859 over 35264 the next, and each replay diverged on the tick the video started, 1728 and 1328 ms of clock drift apart. After the change both recordings hold 896 ticks over 3520 polls, replay to `first hash mismatch -1` with no drift, and give the same answer under six competing CPU hogs as they do idle.

A session recorded across no video is byte-identical to one recorded before the change, which is the argument that an ordinary run is unaffected: with nothing pinning the clock, `Timer_ClockSource` reads the same `SDL_GetTicks` the loop read before.

## The change

Read `Timer_ClockSource` rather than `SDL_GetTicks`, at the four places the frame schedule is set and compared, the freeze and rebase path included, since that path was mixing units the moment the schedule stopped being wall-clock. Then let the wait mint the step it is waiting out, so the deadline arrives by arithmetic instead of by race.

No gate is needed on either half, which is smaller than this first looked. `Timer_ClockSource` is `FixedDtActive ? FixedDtNow : SDL_GetTicks()` and `Timer_FixedDtPumpPolled` is `if (FixedDtActive && FixedDtTicking) FixedDtStep()`, so both are inert on a run that has pinned nothing. This is the polled pump rather than the other one because the loop already takes a fresh clock reading every iteration; the wait-hook form is for a loop that takes none, and here it would mint a second step and sleep out the real time it stands for. It replaces the `SDL_Delay(1)` rather than joining it: the sleep is what makes an unpinned wait cheap, and under a pinned clock the pacing funnel already decides whether a step costs wall time, so keeping both would charge for one step twice. Read as step B of the tick-policy survey arriving at one more loop, joining twenty existing pump calls rather than adding a fifth minting policy.

The pump is inert while `FixedDtTicking` is 0, so a video playing before the first tick would spin on a held clock, and that is the introduction's path. It cannot be reached: both sites that pin the clock do so only on a path that enters `MainLoop`, `Control_TickHook` runs `Timer_FixedDtAdvance` at the top of the iteration before input and scripts, and an active harness calls `MainLoop` directly, so `MainGameMenu` and `Introduction` are never reached with a clock pinned. No defensive branch was added for it, deliberately.

## Test

The suite had no arm that played a video at all. `test_ui_video.sh` plays one, but its capture fires on frame 25 and leaves through `fin_play`, so what video playback had covered was decode and letterbox centring and never the pacing loop's exit. The new arm is the first fixture in the tree that runs a video to completion, which is a better reason to land it than being a regression arm.

It fails against the previous engine in both directions. Idle it reports `first hash mismatch 61` with 1728 ms of drift on the tick the video starts; busy it fails earlier, the replay running out of stream inside the video and stalling. A poll count guards it against passing for the wrong reason, because `PlayAcf` returns quietly when there is no movie bank and a session that skipped the cutscene would replay perfectly having proved nothing.

`test_ui_video.sh` passes untouched, as predicted: its capture is indexed by frame number rather than by clock, so changing how long a frame waits does not change which frame is the twenty-fifth. Also run: `test_record_analog.sh`, `test_record_input_device.sh`, the full `test_record_replay.sh`, and `scripts/ci/warning-baseline.sh` with no new warnings.

## Two things found on the way, neither in this PR

The control run turned up a false pass that is worse than the bug it was measuring. On a busy machine the previous engine reports `first hash mismatch -1` having checked 51 of the 901 ticks the file holds: the stream genuinely ran out, so the classification is correct and the verdict string is not. Which way a video session fails depends on machine load and one of the two ways looks like success. It is filed separately because it is a change to the verdict rather than to the video, and because the denominator it needs is already computed and discarded, `report_extent` printing "holds about N ticks over M polls" at the start of a run and never consulting it at the end.

Separately, two recordings of a video session still differ in exactly 3 bytes, inside the end savegame chunk, where two recordings of a session without one are identical. It does not move the digest, so nothing that exists today would catch a regression in it. The unverified candidate is `FadeOutSamples` and `FadeInSamples` in `LIB386/AIL/SDL/SAMPLE.CPP`, which read `SDL_GetTicks` directly and are reached from the fade that closes `PlayAcf`: the same class one layer down, and a different repair, since those sit inside fade loops that already pump correctly.
