### PR TITLE
fix(record): withhold the replay verdict from a run that did not cover the file

### DIFF
--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -366,6 +366,10 @@ static S32 s_deviceSaved = -1;
 static long s_clockMismatchPoll = -1;
 static long s_hashMismatchTick = -1;
 static long s_ticksChecked = 0;
+/* What report_extent found, kept rather than printed and dropped. -1 is "not known": the
+   scan finds no marker in a file cut inside its start snapshot, and a run with no
+   denominator has to be judged on the numerator alone rather than on a divide. */
+static long s_extentTicks = -1;
 static int s_eof = 0;
 
 static char s_headerBuf[REC_HEADER_MAX];
@@ -1609,17 +1613,97 @@ static void record_restore_player(void) {
  * the rule lived only in the paragraph above, and any new exit path calling the end reporter
  * got the pass-shaped line for free. */
 typedef enum {
-    REPLAY_END_STREAM, /* the recording ran out: the run did what it was asked */
-    REPLAY_END_STALL,  /* waiting on input the recording does not contain */
-    REPLAY_END_MENU    /* the recording opened a menu; MainLoop returned under the harness */
+    REPLAY_END_STREAM,   /* the recording ran out: the run did what it was asked */
+    REPLAY_END_STALL,    /* waiting on input the recording does not contain */
+    REPLAY_END_MENU,     /* the recording opened a menu; MainLoop returned under the harness */
+    REPLAY_END_UNCOVERED /* the stream ended over too little of the file to answer from */
 } T_ReplayEnd;
 
+/* A switch rather than the ternary this replaced. `how == REPLAY_END_STALL ? "stall" : "menu"`
+   is correct for two outcomes and silently mislabels every one added after -- the fourth
+   value printed "at the menu:" with nothing from the compiler to say so. */
+static const char *replay_end_name(T_ReplayEnd how) {
+    switch (how) {
+    case REPLAY_END_STALL:
+        return "stall";
+    case REPLAY_END_MENU:
+        return "menu";
+    case REPLAY_END_UNCOVERED:
+        return "short stream";
+    case REPLAY_END_STREAM:
+        break;
+    }
+    return "end";
+}
+
+/* Did the run get through enough of the recording to be entitled to the verdict?
+ *
+ * Two limbs, one rule: do not print the success string without evidence that the session
+ * was replayed.
+ *
+ * Nothing checked is never a verdict, whatever the extent says. That is the mistyped
+ * --replay path, which boots, replays nothing and exits 0, and the torn recording whose
+ * start snapshot is refused: measured, `replay ended at poll 0: 0 ticks checked, first
+ * hash mismatch -1` -- the success string over no evidence at all.
+ *
+ * Otherwise compare against what the file holds. `s_extentTicks` is a structural
+ * UNDERCOUNT, not a noisy estimate: it is the tick stamped on the last sync marker in the
+ * trailing 64KB, so the ticks after that marker are uncounted and a healthy replay always
+ * checks MORE than the file "holds". Measured over seven clean runs across two formats,
+ * the ratio runs 1.006 to 1.472 -- the wide end is a legacy-format file whose markers are
+ * sparser. So 1.0 is a floor for healthy runs rather than the middle of a spread, and half
+ * is a wide margin below a floor rather than a tolerance around a mean: it clears the
+ * tightest healthy run by 2x and the one observed real failure (877 held, 51 checked) by
+ * 8.6x. Deliberately loose. Too tight turns green fixtures red, which gets the check
+ * reverted; too loose misses some short runs, which is where the tree already is.
+ *
+ * A missing extent with ticks checked is not judged. The scan can come back empty on a
+ * file this has no quarrel with, and inventing a failure from a denominator that was never
+ * read would be the same error in the other direction. */
+static int replay_covered_the_file(void) {
+    if (s_ticksChecked <= 0)
+        return 0;
+    if (s_extentTicks < 0)
+        return 1;
+    return s_ticksChecked >= s_extentTicks / 2;
+}
+
 static void replay_report(T_ReplayEnd how) {
+    /* The stream running out is how a healthy replay ends and how a truncated one ends, so
+       the call site cannot tell them apart -- it knows the stream stopped, not whether the
+       run got through the session. Coverage is what separates them, and it is asked here,
+       once, so both paths that report a stream end are covered by it. */
+    if (how == REPLAY_END_STREAM && !replay_covered_the_file())
+        how = REPLAY_END_UNCOVERED;
+
+    if (how == REPLAY_END_UNCOVERED) {
+        if (s_endSaid)
+            return;
+        s_endSaid = 1;
+        /* Both figures, so the reader sees why the verdict was withheld rather than being
+           told that it was. "%ld ticks checked" is kept verbatim: the torn-recording arms
+           parse the count out of whatever line carries it. */
+        if (s_extentTicks >= 0)
+            fprintf(stderr,
+                    "[rec] replay covered only part of the recording: %ld ticks checked of about "
+                    "%ld held, clock drift max %ld ms first at tick %ld, stream drift first at "
+                    "poll %ld\n",
+                    s_ticksChecked, s_extentTicks, s_refDriftMax, s_refDriftFirstTick,
+                    s_syncDriftPoll);
+        else
+            fprintf(stderr,
+                    "[rec] replay has nothing to be judged on: %ld ticks checked, and the file "
+                    "holds no extent to compare against, clock drift max %ld ms first at tick "
+                    "%ld, stream drift first at poll %ld\n",
+                    s_ticksChecked, s_refDriftMax, s_refDriftFirstTick, s_syncDriftPoll);
+        return;
+    }
+
     if (how != REPLAY_END_STREAM) {
         fprintf(stderr,
                 "[rec] at the %s: %ld ticks checked, clock drift max %ld ms first at tick %ld, "
                 "stream drift first at poll %ld\n",
-                how == REPLAY_END_STALL ? "stall" : "menu", s_ticksChecked, s_refDriftMax,
+                replay_end_name(how), s_ticksChecked, s_refDriftMax,
                 s_refDriftFirstTick, s_syncDriftPoll);
         return;
     }
@@ -2051,6 +2135,7 @@ static void report_extent(void) {
     free(buf);
     fseek(s_f, here, SEEK_SET);
 
+    s_extentTicks = bestTick;
     if (bestTick >= 0)
         fprintf(stderr, "[rec] holds about %ld ticks over %ld polls; give --tick more than that\n",
                 bestTick, bestPoll);
@@ -2543,6 +2628,12 @@ int Record_Play(const char *path) {
 
     if (s_recording || s_replaying)
         return 0;
+
+    /* The extent belongs to the file, not to the replay's counters, so it is cleared here
+       where one is opened rather than in replay_begin -- which runs after report_extent and
+       would wipe the scan a hundred lines after it was taken. report_extent returns early on
+       a file it cannot scan, so "not known" has to be written before it rather than by it. */
+    s_extentTicks = -1;
 
     /* No name means the last one recorded, which is what closes the loop: record, stop,
        play, without a path being typed at either end.
@@ -3548,6 +3639,19 @@ void Record_Report(const char *path) {
         if (s_replaying) {
             Console_Print("rec: ticks checked %ld, first hash mismatch %ld",
                           s_ticksChecked, s_hashMismatchTick);
+            /* The denominator, which is the thing a reader watching a live replay lacks.
+               Not a verdict and not a warning: this surface reports PROGRESS on a running
+               replay, never a result on a finished one, because Record_Stop clears
+               s_replaying before a completed run could be asked about. So there is nothing
+               here to withhold, and a coverage predicate would have exactly the wrong
+               polarity -- silent on the short run it was meant for, and alarming for the
+               first half of every healthy one, which is measured: `rec` typed at tick 20 of
+               a replay that went on to check 198 of 191 called it too little to have
+               reproduced. Unconditional for the same reason: a line that appeared and
+               vanished as a run crossed a threshold would be neither honest nor stable to
+               parse. */
+            if (s_extentTicks >= 0)
+                Console_Print("rec: of about %ld ticks held", s_extentTicks);
             Console_Print("rec: game-clock drift max %ld ms, first at tick %ld",
                           s_refDriftMax, s_refDriftFirstTick);
         }

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -252,6 +252,53 @@ for how in cut magic; do
 done
 rm -f "$torn"
 
+# A replay that stops short must not print the success string. `replay ended ... first hash
+# mismatch -1` is what a caller greps to mean the recording reproduced, and a run that
+# covered a fraction of the file can carry a -1 honestly -- it matched every tick it reached
+# -- while not having replayed the session. #656 gave the stall and the menu their own
+# outcomes for exactly this reason; a stream that runs out early is the third way and was
+# still printing the verdict.
+#
+# Driven with a short --tick rather than by reproducing the original: that failure was a
+# busy machine desyncing the poll stream inside a video, which is load-dependent and cannot
+# be asked for. Coverage is the property under test and an under-budget run produces it
+# deterministically. Measured: this recording holds about 255 ticks, so a 100-tick budget
+# covers 39% of it and the check fires; the arms above run 300+ and stay clean.
+short="$(ctl --fixed-dt 16 --load "$LBA2_TEST_SAVE" --replay "$rec" --tick 100 --exit 2>&1)" ||
+    fail "short-replay: run exited non-zero ($?) — hang or crash"
+
+case "$short" in
+*"first hash mismatch -1"*)
+    fail "short-replay: a run that covered part of the recording printed the success string; $(
+        printf '%s\n' "$short" | grep -m1 'replay ended')"
+    ;;
+esac
+
+case "$short" in
+*"covered only part of the recording"*) ;;
+*)
+    fail "short-replay: the verdict was withheld but nothing said why; $(
+        printf '%s\n' "$short" | grep -m1 '\[rec\]' || echo 'the replay said nothing')"
+    ;;
+esac
+
+# The count survives in whatever line replaces the verdict. Every caller that reads a tick
+# count out of this output -- the torn arms above included -- parses it this way, so the
+# withheld form has to keep carrying it.
+schecked="$(printf '%s\n' "$short" | sed -n 's/.*: \([0-9]*\) ticks checked.*/\1/p')"
+[ -n "$schecked" ] && [ "$schecked" -gt 0 ] ||
+    fail "short-replay: the withheld verdict dropped the tick count callers parse (${schecked:-empty})"
+
+# And a full run over the same recording still gets its verdict, so the check discriminates
+# on coverage rather than just refusing everything.
+full="$(ctl --fixed-dt 16 --load "$LBA2_TEST_SAVE" --replay "$rec" --tick 400 --exit 2>&1)" ||
+    fail "short-replay: the full-coverage control exited non-zero ($?)"
+case "$full" in
+*"first hash mismatch -1"*) ;;
+*) fail "short-replay: full coverage over the same recording was denied its verdict; $(
+       printf '%s\n' "$full" | grep -m1 '\[rec\]')" ;;
+esac
+
 # The default home. A name with no directory in it is a name in <userDir>/recordings/,
 # and the point of that is symmetry: the name a session was recorded under is the name it
 # replays under, from whatever directory the run happens to start in. Recorded and replayed from


### PR DESCRIPTION
`[rec] replay ended ... first hash mismatch -1` is what a caller greps to mean the recording reproduced. A replay that stopped short can carry a `-1` honestly — it matched every tick it reached — while not having replayed the session, and it was printing the verdict anyway.

#656 gave the stall and the menu their own outcomes for exactly this reason. A stream that runs out early is the third way and was not covered: it is `REPLAY_END_STREAM`, the correct classification and the wrong verdict.

## Two instances, neither exotic

- A recording replayed on a busy machine desynced inside a video and reported that it reproduced, over **51 of the 877 ticks** the file holds. Which way that build fails depends on machine load: idle it diverges honestly at tick 61; busy it false-passes.
- A recording cut inside its start snapshot has the snapshot refused and then prints the success string over **zero ticks checked**. Deterministic, needs no load and no video, and it is already in the suite.

## The denominator existed and was thrown away

`report_extent` scans the stream for the last sync marker, prints `holds about N ticks`, and returned `void`. It is retained now and consulted at the verdict.

Two limbs, one rule: do not print the success string without evidence the session was replayed. Nothing checked is never a verdict, whatever the extent says. Otherwise the check is coverage against what the file holds.

## The threshold is measured, not chosen

`s_extentTicks` is a structural **undercount**, not a noisy estimate: it is the tick on the last sync marker in the trailing 64KB, so ticks after that marker are uncounted and a healthy replay always checks *more* than the file holds. Over seven clean runs across two formats the ratio runs 1.006–1.472, the wide end being a legacy-format file whose markers are sparser.

So 1.0 is a floor for healthy runs, and half of held is a wide margin below a floor rather than a tolerance around a mean — clearing the tightest healthy run by 2x and the observed failure by 8.6x. Deliberately loose: too tight turns green fixtures red and gets the check reverted; too loose misses some short runs, which is where the tree already was.

| checked of 191 held | verdict |
|---|---|
| 198, 119, 95 | printed |
| 93, 19 | withheld |
| torn/cut — 0 checked, no extent | withheld |
| torn/magic — 301 checked, 255 held | printed |

## What this does not catch

Because the comparison is a wide margin below a structural floor, it catches gross truncation and nothing finer. **A replay that covers 60% of the file still prints the success string.** The band between half the file and all of it remains unguarded. This is a first cut, not a closed problem.

## Also in here

- The outcome is named for coverage rather than termination — a healthy replay also ends by the stream running out; what distinguishes this one is that it did not cover the file. Its line carries both figures, and keeps the `N ticks checked` substring callers parse.
- The printer's outcome label becomes a `switch`. It was `how == REPLAY_END_STALL ? "stall" : "menu"` — correct for two outcomes and silently mislabelling any third.
- The console `rec` surface gains the extent as plain progress. That surface reports on a *running* replay and never on a finished one, so there is nothing there to withhold.

## Not in here

A `mode differs` mismatch may be a sibling defect — announced at the start, ignored at the verdict, same shape. It is a different predicate on different evidence ("was this run comparable to the one recorded", not "did this run cover the file") and wants its own calibration, so it is deliberately out of scope.

## Testing

Full `tests/automation/test_record_replay.sh` green, including a new arm asserting a short replay withholds the success string, says why, still carries the tick count callers parse, and that a full-coverage control over the same recording still gets its verdict.

The `95` / `93` pair in the table above is deliberate, not an arbitrary sample. The first implementation of this change had a **dead ratio limb** — the extent's reset sat in `replay_begin()`, which `Record_Play` calls *after* `report_extent()`, so the scanned denominator was wiped a hundred lines after it was taken. Every case tested passed anyway: `torn/cut` reaches the zero-evidence limb, which never reads the extent, so the half of the fix that catches the reported bug was inert while the suite stayed green and a replay checking 19 of 191 ticks still printed the success string.

Sweeping the threshold is what exposed it. Endpoints give identical answers on a working check and a half-dead one; only the boundary shows the predicate discriminating.
