### PR TITLE
fix(record): report the header traits a recording predates

### DIFF
--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -2023,6 +2023,7 @@ static void replay_report_mode(void) {
     char hdr[REC_HEADER_MAX];
     char *p, *nl;
     S32 diffs = 0;
+    S32 undeclared = 0;
 
     /* Said rather than returned quietly. This is the run's whole account of what it does
        not match, so skipping it looks exactly like a run with nothing to report. */
@@ -2061,9 +2062,69 @@ static void replay_report_mode(void) {
         diffs++;
     }
 
+    /* And the same comparison the other way. The walk above reports lines the recording
+       carries that this run does not match, which cannot report a key the recording does
+       not have at all: an older file simply has no line to walk. That is the direction an
+       old recording meets a new build in, and it is the one the versioning note at the top
+       of this file leans on when it rules that a change to what the engine computes is
+       reported by the header rather than refused by a version. Left one-directional, a
+       recording made before a trait existed replays straight into the divergence with
+       nothing said about why.
+
+       Measured on the fixtures in tests/automation/recordings: legacy-v10 (format 10) and
+       both combo files (format 12) carry no `numeric.digest`; legacy-v10 also predates
+       `mode.audio` and fourteen of the `settings.` lines, which are written from
+       CONTROL.CPP rather than from write_mode_lines below. Before this, replaying any of
+       them announced only `engine`, and legacy-v10 now names sixteen traits it predates.
+
+       The recorded header is rebuilt because the loop above consumed it: it terminates
+       each line in place to compare it, so what is left is the first line and a run of
+       trailing NULs. */
+    snprintf(hdr, sizeof hdr, "%s", s_headerBuf);
+
+    for (p = live; (nl = strchr(p, '\n')) != NULL; p = nl + 1) {
+        char key[64];
+        char theirs[128];
+        const char *eq;
+        size_t klen;
+
+        *nl = 0;
+        eq = strchr(p, '=');
+        if (eq == NULL || mode_line_ignored(p))
+            continue;
+
+        klen = (size_t)(eq - p) + 1;
+        if (klen >= sizeof key)
+            continue;
+        memcpy(key, p, klen);
+        key[klen] = 0;
+
+        /* Absence is the only thing this direction adds. A key the recording carries has
+           already been compared above, whatever the two sides said about it. */
+        if (RecFmt_ReadStr(hdr, key, theirs, sizeof theirs))
+            continue;
+
+        /* Its own prefix, deliberately not `mode differs`. The two are different claims:
+           a mismatch says the recording declared something this run contradicts, and is
+           evidence about reproduction. An absence says only that the recording predates
+           the trait, so this run cannot check that dimension -- which predicts nothing.
+           Folding them together would spend the warning below on files that reproduce
+           perfectly well, and the arm at tests/automation/test_record_replay.sh:556
+           exists because someone already met a mode warning that cried wolf on a clean
+           replay. Keeping the prefixes apart also leaves that arm, and the three that
+           match `mode differs:` positively, reading exactly what they read before. */
+        /* Without the trailing `=`: the key is a name here, not half a comparison. */
+        fprintf(stderr, "[rec] mode undeclared: %.*s (this run: %s)\n", (int)(klen - 1), key, p);
+        undeclared++;
+    }
+
     if (diffs)
         fprintf(stderr, "[rec] %d mode line(s) differ; this replay may not reproduce\n",
                 (int)diffs);
+    if (undeclared)
+        fprintf(stderr, "[rec] %d header trait(s) this recording predates; those were not "
+                        "checked\n",
+                (int)undeclared);
 }
 
 static void report_extent(void) {


### PR DESCRIPTION
`replay_report_mode` compares the recorded header against the live one, but it walks only the recorded side. It can report a line the recording carries and this run contradicts. It cannot report a key the recording does not have at all, because an older file has no line to walk.

That is the direction an old recording meets a new build in, and it is the one the versioning note at the top of `RECORD.CPP` depends on:

> A change to what the engine *computes* is a third case, and it does not belong here either way: the format still means what it meant [...] The header's `numeric.` lines are what report that class of difference, per recording, rather than a version refusing the whole file.

So the rule is that an engine-computation change gets no `REC_VERSION` bump and no version refusal, and the header announces it instead. With the walk one-directional the header could not announce it, and a recording made before a trait existed replayed straight into a divergence with nothing said about why. That has been true for as long as `numeric.digest` has existed.

## Measured on fixtures already in the tree

| fixture | format | carries `numeric.digest` |
| --- | --- | --- |
| `legacy-v10.rec` | 10 | no |
| `combo-controls.rec` | 12 | no |
| `combo-set.rec` | 12 | no |
| `legacy-v13.rec` | 13 | yes |
| `menu-esc.rec` | 14 | yes |

Three of five sit on the unreportable side. Replaying `legacy-v10` announced one line, `engine`, and now reads:

```
[rec] mode differs: engine=0.13.0-dev (this run: 0.13.0-dev-dirty)
[rec] mode undeclared: mode.audio (this run: mode.audio=0)
[rec] mode undeclared: numeric.digest (this run: numeric.digest=2)
[rec] mode undeclared: settings.MouseCamera (this run: settings.MouseCamera=1)
... 13 more ...
[rec] 1 mode line(s) differ; this replay may not reproduce
[rec] 16 header trait(s) this recording predates; those were not checked
```

## Why absences get their own prefix

They are a different claim. A mismatch says the recording declared something this run contradicts, and is evidence about reproduction. An absence says only that the recording predates the trait, so this run cannot check that dimension, which predicts nothing.

Folding them together would spend `this replay may not reproduce` on files that reproduce perfectly well. `tests/automation/test_record_replay.sh:556` exists because a mode warning already cried wolf on a clean replay once.

Splitting on the prefix rather than the wording also leaves existing output untouched. The three arms that match `mode differs:` positively read what they read before, and the arm that fails on any `mode differs` keeps working and gets more correct, since it now fires only on genuine contradictions.

## Not a replacement for naming a consequence

The `Control_InstallUncarried` branch of `replay_begin` already hand-writes this distinction for one trait: a recording predating the `state.` lines "installs nothing and is said so once, so a tick-0 report on such a file reads as the known gap rather than as a divergence".

That line predicts what the reader is about to see and tells them how to read it, which a generic line structurally cannot. Every trait now gets "this was not checked"; a trait whose absence has a known, nameable consequence can still earn a line saying what it is. The bespoke line is not made redundant here and should not be folded in without carrying its prediction.

## Testing

`tests/automation/run.sh`: 74 passed, 2 skipped, 1 failed.

The failure is `test_cli_flag_contract` (`--replay` writes `recordings/rec.boot.lba` and a differing `lba2.cfg`). It fails identically on `2727ea12` without this change, so it is pre-existing and reported separately.
