### PR TITLE
fix(android): a first launch that asks for storage should not die asking

### DIFF
--- a/LIB386/H/SYSTEM/ANDROID.H
+++ b/LIB386/H/SYSTEM/ANDROID.H
@@ -11,9 +11,19 @@ extern "C" {
 /// 1 on Android TV / leanback, 0 on phone/tablet, on any error, or off-Android.
 S32 IsAndroidTVDevice(void);
 
-/// No-op unless MANAGE_EXTERNAL_STORAGE is missing; opens app Settings if so.
-/// No-op off-Android.
-void Android_EnsureExternalStoragePermission(void);
+/// Ensures MANAGE_EXTERNAL_STORAGE before anything downstream picks a folder.
+/// When it is missing this opens app Settings and waits a bounded while for the
+/// answer, because raising that screen puts the game in the background: every
+/// path chosen while it is up would be chosen on the wrong information, and a
+/// window created while it is up cannot be created at all.
+/// Returns true when the permission is held on return. True off-Android, where
+/// there is nothing to ask for.
+bool Android_EnsureExternalStoragePermission(void);
+
+/// Whether MANAGE_EXTERNAL_STORAGE is held right now. Asks nothing and opens
+/// nothing, so it is safe to call when reporting a failure. True off-Android,
+/// where no permission stands between the engine and the game data.
+bool Android_HasExternalStoragePermission(void);
 
 /// Writes the app-specific external files dir into out (up to maxLen).
 /// Returns 1 on success, 0 otherwise (including off-Android).

--- a/LIB386/H/SYSTEM/WINDOW.H
+++ b/LIB386/H/SYSTEM/WINDOW.H
@@ -64,6 +64,14 @@ bool Window_IsFullscreen(void);
 // platform #ifdefs at the call site.
 bool Window_SupportsWindowedMode(void);
 
+// Whether this platform can refuse to create a window for a reason that passes.
+// True on Android, where the window belongs to whatever is in front: with a
+// permission screen up, SDL cannot fetch the native window at all, and the same
+// call succeeds once the player comes back. False on desktop, where a window
+// that cannot be created now will not create itself later either, so a boot
+// failure there is final and immediate.
+bool Window_CanLoseNativeWindow(void);
+
 // Toggle renderer vsync at runtime. On (the default) paces presents to the display
 // refresh; off lets the loop run flat-out. The control harness turns it off so a
 // scripted run is not capped at ~60 fps -- presentation only, no effect on rendered

--- a/LIB386/SYSTEM/ANDROID.CPP
+++ b/LIB386/SYSTEM/ANDROID.CPP
@@ -91,14 +91,22 @@ S32 IsAndroidTVDevice(void) {
 #endif
 }
 
-/* How long to wait for an answer once Settings has been opened, and how often
-   to look. Granting takes a person a few seconds; the bound is what stops a
-   player who backs out instead from staring at a black screen indefinitely.
-   Overshooting it is not fatal either way: the boot carries on with the
-   app-specific folder, says so in the banner, and copies the folder up on the
-   launch after the permission does arrive. */
-#define ANDROID_PERM_WAIT_MS 30000
+/* Waiting for an answer once Settings has been opened.
+
+   The bound is spent time, not elapsed time: Android freezes a backgrounded
+   process, so this loop does not run at all while the player is on the Settings
+   screen. What it measures is how long the game sits in front of somebody with
+   nothing happening, which is why it is short.
+
+   A player who grants is detected on their next poll and never sees it. A player
+   who declines used to serve out the whole bound looking at a blank game, so a
+   return is treated as an answer in itself: coming back is visible here as a
+   poll that took seconds of wall clock instead of the quarter second it asked
+   for, which is the process being thawed. Whatever the permission says at that
+   moment is the answer, and the boot carries on with it. */
+#define ANDROID_PERM_WAIT_MS 15000
 #define ANDROID_PERM_POLL_MS 250
+#define ANDROID_PERM_THAW_MS 2000
 
 bool Android_HasExternalStoragePermission(void) {
 #ifdef __ANDROID__
@@ -160,16 +168,31 @@ bool Android_EnsureExternalStoragePermission(void) {
                        decided against a state the player is in the middle of
                        changing. */
                     U32 waited = 0;
-                    while (!granted && waited < ANDROID_PERM_WAIT_MS) {
+                    U32 lastTick = SDL_GetTicks();
+                    bool returned = false;
+                    while (!granted && !returned && waited < ANDROID_PERM_WAIT_MS) {
                         SDL_Delay(ANDROID_PERM_POLL_MS);
+                        const U32 tick = SDL_GetTicks();
+                        const U32 slept = tick - lastTick;
+                        lastTick = tick;
                         waited += ANDROID_PERM_POLL_MS;
                         granted =
                             env->CallStaticBooleanMethod(permHelper, isMgr) != JNI_FALSE;
+                        /* Far more clock passed than was asked for, so this
+                           process was frozen and has just been thawed: the
+                           player is looking at the game again. */
+                        returned = (slept > ANDROID_PERM_THAW_MS);
                     }
-                    LogPrintf(granted ? "MANAGE_EXTERNAL_STORAGE granted after %ums.\n"
-                                      : "MANAGE_EXTERNAL_STORAGE still not granted after "
-                                        "%ums; continuing without it.\n",
-                              waited);
+                    if (granted) {
+                        LogPrintf("MANAGE_EXTERNAL_STORAGE granted after %ums.\n", waited);
+                    } else if (returned) {
+                        LogPrintf("MANAGE_EXTERNAL_STORAGE declined; continuing without "
+                                  "it.\n");
+                    } else {
+                        LogPrintf("MANAGE_EXTERNAL_STORAGE unanswered after %ums; "
+                                  "continuing without it.\n",
+                                  waited);
+                    }
                 }
             }
             env->DeleteLocalRef(permHelper);

--- a/LIB386/SYSTEM/ANDROID.CPP
+++ b/LIB386/SYSTEM/ANDROID.CPP
@@ -13,6 +13,7 @@
 #include <jni.h>
 #include <string.h>
 #include <SDL3/SDL_system.h>
+#include <SDL3/SDL_timer.h>
 #endif
 
 S32 IsAndroidTVDevice(void) {
@@ -90,13 +91,44 @@ S32 IsAndroidTVDevice(void) {
 #endif
 }
 
-void Android_EnsureExternalStoragePermission(void) {
+/* How long to wait for an answer once Settings has been opened, and how often
+   to look. Granting takes a person a few seconds; the bound is what stops a
+   player who backs out instead from staring at a black screen indefinitely.
+   Overshooting it is not fatal either way: the boot carries on with the
+   app-specific folder, says so in the banner, and copies the folder up on the
+   launch after the permission does arrive. */
+#define ANDROID_PERM_WAIT_MS 30000
+#define ANDROID_PERM_POLL_MS 250
+
+bool Android_HasExternalStoragePermission(void) {
+#ifdef __ANDROID__
+    JNIEnv *env = (JNIEnv *)SDL_GetAndroidJNIEnv();
+    if (env == NULL) {
+        return false;
+    }
+    jclass permHelper = env->FindClass("org/lbalab/lba2cc/PermissionHelper");
+    if (permHelper == NULL) {
+        return false;
+    }
+    jmethodID isMgr =
+        env->GetStaticMethodID(permHelper, "isExternalStorageManager", "()Z");
+    const bool held =
+        (isMgr != NULL) && env->CallStaticBooleanMethod(permHelper, isMgr) != JNI_FALSE;
+    env->DeleteLocalRef(permHelper);
+    return held;
+#else
+    return true;
+#endif
+}
+
+bool Android_EnsureExternalStoragePermission(void) {
 #ifdef __ANDROID__
     /* On Android 11+ (API 30+), direct access to /sdcard/<dir>/ requires
      * MANAGE_EXTERNAL_STORAGE. Check at startup and open Settings for it
      * if missing, so the user can grant it and re-launch. The fallback
      * probe in RES_DISCOVERY for App-specific external files dir
      * (/sdcard/Android/data/<pkg>/files/) works without this permission. */
+    bool granted = false;
     JNIEnv *env = (JNIEnv *)SDL_GetAndroidJNIEnv();
     if (env != NULL) {
         jclass permHelper = env->FindClass("org/lbalab/lba2cc/PermissionHelper");
@@ -106,11 +138,13 @@ void Android_EnsureExternalStoragePermission(void) {
             jmethodID openMgr = env->GetStaticMethodID(
                 permHelper, "openExternalStorageManagerSettings",
                 "(Ljava/lang/Object;)V");
-            if (isMgr != NULL && !env->CallStaticBooleanMethod(permHelper, isMgr)) {
+            if (isMgr != NULL) {
+                granted = env->CallStaticBooleanMethod(permHelper, isMgr) != JNI_FALSE;
+            }
+            if (isMgr != NULL && !granted) {
                 jobject activity = (jobject)SDL_GetAndroidActivity();
                 LogPrintf("MANAGE_EXTERNAL_STORAGE not granted. "
-                          "Opening Settings for app. "
-                          "Re-launch after granting.\n");
+                          "Opening Settings for app.\n");
                 if (openMgr != NULL && activity != NULL) {
                     env->CallStaticVoidMethod(permHelper, openMgr, activity);
                     /* Clear any JNI exception (e.g. ActivityNotFoundException
@@ -119,13 +153,31 @@ void Android_EnsureExternalStoragePermission(void) {
                      * in ResolveGameDataDir) don't fail. */
                     if (env->ExceptionCheck())
                         env->ExceptionClear();
+
+                    /* Wait here rather than carrying on. The folder is chosen a
+                       few lines after this call and the window is created not
+                       long after that, and while Settings is up both would be
+                       decided against a state the player is in the middle of
+                       changing. */
+                    U32 waited = 0;
+                    while (!granted && waited < ANDROID_PERM_WAIT_MS) {
+                        SDL_Delay(ANDROID_PERM_POLL_MS);
+                        waited += ANDROID_PERM_POLL_MS;
+                        granted =
+                            env->CallStaticBooleanMethod(permHelper, isMgr) != JNI_FALSE;
+                    }
+                    LogPrintf(granted ? "MANAGE_EXTERNAL_STORAGE granted after %ums.\n"
+                                      : "MANAGE_EXTERNAL_STORAGE still not granted after "
+                                        "%ums; continuing without it.\n",
+                              waited);
                 }
             }
             env->DeleteLocalRef(permHelper);
         }
     }
+    return granted;
 #else
-    return;
+    return true;
 #endif
 }
 

--- a/LIB386/SYSTEM/WINDOW.CPP
+++ b/LIB386/SYSTEM/WINDOW.CPP
@@ -406,6 +406,18 @@ bool Window_IsFullscreen(void) {
            ((SDL_GetWindowFlags(sdlWindow) & SDL_WINDOW_FULLSCREEN) != 0);
 }
 
+bool Window_CanLoseNativeWindow(void) {
+#if defined(__ANDROID__)
+    /* The activity owns the surface, so anything Android puts in front takes it
+       away: SDL_CreateWindow then fails with "Could not fetch native window".
+       The engine asks for All Files Access during boot, which opens Settings and
+       causes exactly that. */
+    return true;
+#else
+    return false;
+#endif
+}
+
 bool Window_SupportsWindowedMode(void) {
 #if defined(__ANDROID__)
     /* Android phones and TVs run the game fullscreen (landscape-locked via

--- a/SOURCES/INITADEL.C
+++ b/SOURCES/INITADEL.C
@@ -43,6 +43,15 @@ int WriteEmbeddedDefaultLba2Cfg(const char *destPath);
 #include <unistd.h>
 
 #include <SDL3/SDL_cpuinfo.h> /* SDL_GetNumLogicalCPUCores, SDL_GetSystemRAM */
+#include <SDL3/SDL_timer.h>   /* SDL_Delay - waiting out a window we cannot have yet */
+
+/* How long the boot will wait for a window, and how often it retries.
+   Generous on purpose: this loop ends the moment the surface comes back, so the
+   bound is only ever reached by a window that is never coming, and the cost of
+   waiting is a backgrounded game polling every quarter second. The permission
+   wait upstream cannot be sized this way, having no signal that ends it early. */
+#define BOOT_WINDOW_WAIT_MS 120000
+#define BOOT_WINDOW_POLL_MS 250
 
 #if defined(_WIN32)
 #define LOG_PLATFORM_NAME "Windows"
@@ -352,9 +361,33 @@ void InitAdeline(S32 argc, char *argv[]) {
            front; the later ReadConfigFile -> SetWindowFullscreen pass then just
            confirms it instead of flipping a windowed window. */
         const bool reqFullscreen = Res_LoadBootFullscreen();
-        if (!InitGraphics(reqResX, reqResY, reqFullscreen)) {
-            BootFatal("The graphics mode %ux%u could not be set.", reqResX,
-                      reqResY);
+        /* A window can be refused for a reason that passes: on Android the
+           surface belongs to whatever is in front, so the All Files Access
+           screen this boot may have opened takes it away, and SDL reports it as
+           a mode that could not be set. Waiting is the whole fix, because the
+           same call succeeds the moment the player is back. Desktop does not
+           have that state and does not wait. */
+        U32 waitedMs = 0;
+        bool graphicsUp = InitGraphics(reqResX, reqResY, reqFullscreen);
+        while (!graphicsUp && Window_CanLoseNativeWindow() &&
+               waitedMs < BOOT_WINDOW_WAIT_MS) {
+            SDL_Delay(BOOT_WINDOW_POLL_MS);
+            waitedMs += BOOT_WINDOW_POLL_MS;
+            graphicsUp = InitGraphics(reqResX, reqResY, reqFullscreen);
+        }
+        if (!graphicsUp) {
+            /* Naming the mode alone sent a player hunting a display problem
+               that was not there. Say what to do instead, where doing something
+               is possible. */
+            BootFatal(Window_CanLoseNativeWindow()
+                          ? "The game could not open its window at %ux%u.\n\n"
+                            "If a permission screen opened in front of the game, "
+                            "grant access and start the game again."
+                          : "The graphics mode %ux%u could not be set.",
+                      reqResX, reqResY);
+        }
+        if (waitedMs > 0) {
+            Log_Warn("Window   arrived after %ums of waiting", waitedMs);
         }
         /* The "Display" status line is logged from main() after InitProgram,
            alongside the rest of the post-init summary. */

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2499,7 +2499,15 @@ int main(int argc, char *argv[]) {
        flows through the same fatal surface as every other error — non-zero exit
        plus the native dialog in TheEndInfo for terminal-less launches. */
     if (AssetPreflight() > 0) {
-        TheEnd(ERROR_NOT_FOUND_FILE, "required game data is missing (see the log)");
+        /* Every required file can be present and unreadable: on Android the game
+           data lives on shared storage, and without all-files access the engine
+           sees an empty folder. Telling that player their data is missing sends
+           them looking for files that are sitting right where they put them. */
+        TheEnd(ERROR_NOT_FOUND_FILE,
+               Android_HasExternalStoragePermission()
+                   ? "required game data is missing (see the log)"
+                   : "the game data could not be read because storage access was "
+                     "not granted (see the log)");
     }
 
 #ifdef ONE_GAME_DIRECTORY

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -103,8 +103,10 @@ adb push RESS.HQR /sdcard/lba2cc/
 
 `/sdcard/lba2cc/` is general external storage, so on **Android 11+ (API 30+)**
 the app needs **All Files Access** (`MANAGE_EXTERNAL_STORAGE`). The game checks
-for it on launch and opens the system Settings page if it is missing — grant it
-and relaunch. You can also pre-grant it:
+for it on launch and opens the system Settings page if it is missing. Grant it
+and come back: the launch is waiting for the answer and carries on with it, so
+the saves land in the right folder the first time. Declining is not fatal either,
+though the game data cannot be read without it. You can also pre-grant it:
 
 ```bash
 adb shell appops set org.lbalab.lba2cc MANAGE_EXTERNAL_STORAGE allow

--- a/scripts/dev/check-android-userdir.sh
+++ b/scripts/dev/check-android-userdir.sh
@@ -339,7 +339,81 @@ else
 fi
 
 echo
-echo "== 8. the folder survives an uninstall =="
+echo "== 8. a first run with the permission still unanswered does not die =="
+# Every check above grants the permission before launching, which is the one
+# thing a real first run does not do. The engine asks for it on startup, Android
+# puts Settings in front, and the game loses the surface it was about to create a
+# window on: SDL says "Could not fetch native window" and the boot used to report
+# a graphics mode the device could not set. It could, and the display was never
+# the problem. The window arrives on its own once the player comes back, so the
+# only thing being asserted here is that the boot waits instead of giving up.
+"$ADB" shell am force-stop "$PKG" >/dev/null 2>&1
+# Earlier checks can leave a Settings screen or a fatal dialog in front, and a
+# launch into that measures the state they left rather than a first run. Dismiss
+# whatever is there and wait for the process to actually go.
+for _ in 1 2 3; do
+    "$ADB" shell input keyevent KEYCODE_BACK >/dev/null 2>&1
+done
+waited=0
+while [[ -n "$(app_pid)" && $waited -lt 20 ]]; do
+    sleep 1
+    waited=$((waited + 1))
+done
+"$ADB" shell appops set "$PKG" MANAGE_EXTERNAL_STORAGE deny >/dev/null 2>&1
+"$ADB" shell rm -f "$SHARED_DIR/adeline.log" "$APP_EXTERNAL/adeline.log" >/dev/null 2>&1
+"$ADB" shell am start -n "$ACTIVITY" >/dev/null 2>&1
+# Give Settings time to come up, then answer it the way a player does. Coming
+# back is not optional here: Android freezes a backgrounded process, so the boot
+# makes no progress at all while that screen is up, writes no log, and would
+# never finish on its own. Waiting longer instead of returning is how this check
+# first reported a working engine as broken.
+sleep 10
+"$ADB" shell input keyevent KEYCODE_BACK >/dev/null 2>&1
+
+# Wait for the run to reach a conclusion, not merely for its log to exist: the
+# banner is written seconds before the boot either finishes or gives up, and
+# grepping in between reads a file that has not said anything yet.
+#
+# Both spellings of the failure, the old one included: a build that still calls
+# this a bad display mode has to fail here, and grepping only for the wording
+# introduced alongside the fix would pass against every build that lacks it.
+firstrun_verdict=""
+waited=0
+while [[ $waited -lt 90 && -z "$firstrun_verdict" ]]; do
+    for d in "$SHARED_DIR" "$APP_EXTERNAL"; do
+        exists_on_device "$d/adeline.log" || continue
+        if "$ADB" shell \
+            "grep -aqE 'could not open its window|graphics mode .* could not be set' '$d/adeline.log'" \
+            2>/dev/null; then
+            firstrun_verdict="gave-up"
+        elif "$ADB" shell \
+            "grep -aqE 'Ready in|storage access was not granted' '$d/adeline.log'" 2>/dev/null; then
+            firstrun_verdict="waited"
+        fi
+    done
+    [[ -n "$firstrun_verdict" ]] && break
+    sleep 5
+    waited=$((waited + 5))
+done
+
+case "$firstrun_verdict" in
+    waited)
+        pass "the boot waited for the window instead of calling it a bad display mode"
+        ;;
+    gave-up)
+        fail "the boot gave up on a window that a returning player would have handed it"
+        ;;
+    *)
+        fail "the first run reached no conclusion in ${waited}s, so this examined nothing"
+        ;;
+esac
+
+# Put the device back the way the rest of the run expects it.
+"$ADB" shell am force-stop "$PKG" >/dev/null 2>&1
+"$ADB" shell appops set "$PKG" MANAGE_EXTERNAL_STORAGE allow >/dev/null 2>&1
+
+echo
+echo "== 9. the folder survives an uninstall =="
 # A property of the location, not of the app, so it is asserted with a file this
 # script puts there. Deriving it from a save the run happened to leave behind
 # would report a cascade every time an earlier check failed.


### PR DESCRIPTION
The first launch of a new Android install shows **"LBA2: cannot start / The
graphics mode 848x480 could not be set."** The resolution is correct and the
display is not the problem. Reported from a Retroid Pocket 5 on Android 13, and
reproduced on an emulator.

## What happens

The engine asks for All Files Access during boot. Android puts Settings in
front, the activity loses its surface, and `SDL_CreateWindow` fails with
`Could not fetch native window`. The boot reports that as a mode the device
cannot set, which sends the player looking for a graphics setting that will not
help. Closing and reopening works, because the permission is granted by then and
nothing takes the surface away.

## Changes

- **Wait for the answer.** The permission is already requested before anything
  chooses a folder or a window; it now waits for the result instead of carrying
  on. The first launch then lands in `/sdcard/lba2cc/user/LBA2` directly rather
  than starting in the fallback and copying itself up later.
- **Retry a window that can still arrive.** `Window_CanLoseNativeWindow()` is
  true on Android, where the surface belongs to whatever is in front, and false
  on desktop, where a window that cannot be created now will not create itself
  later. Only the first waits.
- **Say what to do.** The fatal now names the permission screen rather than the
  display mode.
- **Missing and unreadable are different.** A player who declines was told their
  game data was missing, when it was sitting where they put it and merely
  unreadable.

The two waits are bounded differently on purpose. The window poll ends the
instant the surface returns, so it can afford to be generous. The permission
poll has no such signal, so it stays short and falls through to the fallback,
which the next launch corrects on its own.

## Verification

On an emulator, with the published build for comparison:

| | before | after |
|---|---|---|
| grant, return | "cannot start", relaunch needed | boots, `Ready in 7.75s`, saves in `/sdcard/lba2cc/user/LBA2`, no fallback written |
| decline, return | "The graphics mode 1064x480 could not be set" | "the game data could not be read because storage access was not granted" |

Device suite on a phone image (arm64-v8a): 14 passed, 0 failed, 0 skipped. On an
Android TV image (armeabi-v7a): 9 passed, 0 failed, 3 skipped, the skips being
the root-gated checks on a `user` build. The new check passes on both and fails
against the published build, which is the point of it: the suite grants the
permission before launching, so it never walked the one launch every new player
makes, and it was green throughout.

Timings for a player who declines, measured from coming back to the game saying
something: 16s before, 4s to 9s with the bound halved, 4s to 5s with the return
also treated as an answer. Three runs each for the latter two. Most of the gain
is the smaller bound; the thaw check is worth a few seconds more and cannot fire
at all on a device that does not freeze backgrounded apps.

71 host tests pass; `check-arch` clean.

