### PR TITLE
feat(control): let a harness replay survive the in-game menu

### DIFF
--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -1224,6 +1224,16 @@ void Control_NoteReplayStreamEnded(void) {
         s_replay_stream_done = 1;
 }
 
+/* Whether the MainLoop that just returned did so because the in-game menu opened, rather
+   than for one of the reasons the harness owns: its tick budget, the end of a replay's
+   stream, the end of the game. Cleared on every MainLoop entry, so it describes the last
+   return and not the run as a whole. The menu path re-enters on this and hands back on
+   anything else, which is what keeps a menu a pause without also making the harness
+   inherit the game's end-of-session handling. */
+int Control_LeftForMenu(void) {
+    return s_left_for_menu ? 1 : 0;
+}
+
 /* Non-zero when the run ended before it had replayed what it was given: the status a
    harness run must not report as success. Kept apart from the reporting above so main()
    decides the exit code in one place, beside the --exec-at check it already makes. */

--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -1163,7 +1163,14 @@ void Control_End(void) {
        stopped short. Outside one, an early return here is a run doing something this
        harness has no opinion about, and failing it would change the verdict of runs
        nobody has complained about. */
-    if (s_left_for_menu) {
+    /* And only when the menu is why the run stopped early. Once the menu is a pause the
+       run comes back from, a recording whose player ends a session at one is replayed to
+       its last poll and then reports here anyway, because the flag describes the final
+       MainLoop return and that return was the menu. Said then, it names a run that
+       reproduced the whole recording as one that stopped short, and withholds the
+       artifacts of a state the caller is entitled to. The stream having run out is what
+       separates the two, and it is already tracked. */
+    if (s_left_for_menu && !s_replay_stream_done) {
         if (Record_IsReplaying())
             fprintf(stderr,
                     "[control] replay: the recording opened the in-game menu at tick %ld and the "
@@ -1221,7 +1228,19 @@ void Control_NoteReplayStreamEnded(void) {
    harness run must not report as success. Kept apart from the reporting above so main()
    decides the exit code in one place, beside the --exec-at check it already makes. */
 int Control_ReplayCutShort(void) {
-    return (s_left_for_menu && Record_IsReplaying()) ? 1 : 0;
+    if (!Record_IsReplaying())
+        return 0;
+    /* The stream having run out is the run doing what it was asked, whatever the last
+       MainLoop return happened to be. Before the menu was survivable the two could not
+       come apart: leaving for a menu ended the run, so the stream never finished and the
+       flag alone was enough. Now a recording whose player ends the session at a menu is
+       replayed to its last poll and still leaves through one, and reading the flag on its
+       own calls that short. Asked in the reporter as well as at the exit check, and those
+       two run at different moments, so the answer has to be the same in both or a run
+       prints one verdict and exits with the other. */
+    if (s_replay_stream_done)
+        return 0;
+    return s_left_for_menu ? 1 : 0;
 }
 
 int Control_UnfiredExecAt(void) {

--- a/SOURCES/CONTROL.H
+++ b/SOURCES/CONTROL.H
@@ -97,6 +97,7 @@ int Control_UnfiredExecAt(void);
    that from the benign early returns (LM_THE_END, the demo watchdog). */
 void Control_NoteMainLoopEntered(void);
 void Control_NoteLeftForMenu(void);
+int Control_LeftForMenu(void);
 /* The replay consumed its last poll. Ends the run there instead of at the tick budget,
    which is larger than the recording by construction. */
 void Control_NoteReplayStreamEnded(void);

--- a/SOURCES/GAMEMENU.CPP
+++ b/SOURCES/GAMEMENU.CPP
@@ -3823,21 +3823,40 @@ void BuildGameMainMenu(S32 firstloop) {
 
 S32 GameInProgress = FALSE;
 
-S32 MainGameMenu(S32 load) {
+/* `resumeInGame` enters with a session the caller has already loaded and started, and
+   goes straight to gameplay: the loop below is what makes a menu a pause rather than the
+   end of the run, because MainLoop returns when the player opens one and this re-enters
+   it. The CLI harness is the only caller that wants that; it has done its own load and
+   must not have the menu's boot presentation done to it. Kept as its own argument rather
+   than a sentinel in `load`, because `load` is passed on to SetDemoSaveGame. */
+S32 MainGameMenu(S32 load, S32 resumeInGame) {
     S32 select;
     S32 flag = 0;
     S32 firstloop = TRUE;
     S32 savenewcube;
     S32 gogame = FALSE;
     S32 ret;
+    /* Cleared by the first pass through the gameplay branch, so it guards the entry and
+       nothing after it. */
+    S32 resumeFirstPass = resumeInGame;
     char tmpFilePathSave[ADELINE_MAX_PATH];
     char tmpFilePathScreen[ADELINE_MAX_PATH];
 
-    HQ_StopSample();
-    StopMusic(); // Pour Stopper la music du Logo
+    /* Boot housekeeping: silences the logo. A resume arrives with a loaded scene whose
+       ambience is already running, and stopping it here would be heard as the session
+       going quiet the moment it starts. */
+    if (!resumeInGame) {
+        HQ_StopSample();
+        StopMusic(); // Pour Stopper la music du Logo
+    }
 
-    InitPlasmaMenu();
-    FlagShadeMenu = FALSE;
+    /* The menu's own animated background, and the flag that tells the menu painters they
+       are drawing over a live scene. Both are menu presentation, and a resume goes
+       straight to gameplay without drawing one. */
+    if (!resumeInGame) {
+        InitPlasmaMenu();
+        FlagShadeMenu = FALSE;
+    }
 
 #ifdef DEMO
     GetSavePath(tmpFilePathSave, ADELINE_MAX_PATH, CURRENTSAVE_FILENAME);
@@ -3854,7 +3873,7 @@ S32 MainGameMenu(S32 load) {
         goto load_game;
     }
 #else
-    if (IsFirstGameLaunched()) {
+    if (!resumeInGame AND IsFirstGameLaunched()) {
         FlagPlayAcf = TRUE;
         goto new_game;
     }
@@ -3865,32 +3884,75 @@ S32 MainGameMenu(S32 load) {
         goto load_game;
 #endif
 
+    /* Outside the guard below, and that is the point: the loop reads tmpFilePathScreen on
+       its redraw paths, so this is the only write to a buffer used well after the setup
+       that fills it. Skipping the setup and keeping the reads would hand an uninitialised
+       stack buffer to Image_LoadStretched. Its sibling tmpFilePathSave is safe by accident
+       rather than design, because the loop re-derives that one where it uses it. */
     GetResPath(tmpFilePathScreen, ADELINE_MAX_PATH, SCREEN_HQR_NAME);
-    Image_LoadStretched(tmpFilePathScreen, Screen, PCR_MENU);
-    CopyScreen(Screen, Log);
-    BoxStaticFullflip();
-    FadeToPal(PtrPalNormal);
 
-    PtrPal = PtrPalNormal;
+    if (resumeInGame) {
+        /* Enter the loop already in gameplay. Nothing below is done: it paints the menu
+           background over the caller's scene and points PtrPal at the menu palette, and
+           the harness load path has just installed the scene's own by hand precisely
+           because it wants neither the fade nor the menu's screen. */
+        gogame = TRUE;
+        firstloop = FALSE;
+    } else {
+        Image_LoadStretched(tmpFilePathScreen, Screen, PCR_MENU);
+        CopyScreen(Screen, Log);
+        BoxStaticFullflip();
+        FadeToPal(PtrPalNormal);
 
-    BackupScreen(FALSE);
-    CopyScreen(Log, Screen);
+        PtrPal = PtrPalNormal;
 
-    MenuMouseAcquire();
+        BackupScreen(FALSE);
+        CopyScreen(Log, Screen);
+    }
+
+    /* Menu-only, and paired with the MenuMouseRelease the loop makes before MainLoop. A
+       resume goes straight to gameplay and takes neither half on its first pass. */
+    if (!resumeInGame)
+        MenuMouseAcquire();
 
     while (!flag) {
         if (gogame) {
-            DemoSlide = FALSE;
-            GameInProgress = FALSE;
+            /* Session-start state, and a resume must not have it done on the way in: the
+               caller has already started the session and owns these. DemoSlide is the one
+               that bites -- the harness sets it through BeginDemoSlide before calling here,
+               and clearing it turns an attract-mode run into an ordinary one. Only the
+               first pass is skipped; a genuine menu visit later in the run leaves through
+               the same code as any other and should reset them the normal way. */
+            /* A resume reaches MainLoop with the engine exactly as its caller left it.
+               Everything here is the menu handing a session over to gameplay: state it
+               owns because it set it up on the way in. The harness set its own up and did
+               not come through that path, so on the first pass none of it applies, and
+               doing it anyway perturbs the run this exists to replay. Cleared straight
+               away, so a real menu visit later leaves through this code as the game does. */
+            if (!resumeFirstPass) {
+                DemoSlide = FALSE;
+                GameInProgress = FALSE;
 
-            ClearPlasmaMenu(); // vire plasma menu
+                ClearPlasmaMenu(); // vire plasma menu
 
-            FlagShadeMenu = TRUE;
+                FlagShadeMenu = TRUE;
 
-            /* Menu mouse is for menu UI only; do not composite it during MainLoop (gameplay). */
-            MenuMouseRelease();
+                /* Menu mouse is for menu UI only; do not composite it during MainLoop (gameplay). */
+                MenuMouseRelease();
+            }
+            resumeFirstPass = FALSE;
 
             ret = MainLoop();
+
+            /* A resume hands control back the moment MainLoop returns for a reason that is
+               not the menu. The switch below is the game's end-of-session handling -- it
+               saves, rolls credits, plays the win cinematic -- and a harness run reaching
+               its tick budget or the end of a recording must reach its own reporting
+               instead. Only the menu is a pause worth re-entering for. */
+            if (resumeInGame AND !Control_LeftForMenu()) {
+                flag = TRUE;
+                continue;
+            }
 
             BackupScreen(FALSE);
 

--- a/SOURCES/GAMEMENU.H
+++ b/SOURCES/GAMEMENU.H
@@ -101,7 +101,7 @@ extern void DrawCadreSave(S32 x, S32 y);
 /*--------------------------------------------------------------------------*/
 extern S32 IsFirstGameLaunched(void);
 /*--------------------------------------------------------------------------*/
-extern S32 MainGameMenu(S32 load);
+extern S32 MainGameMenu(S32 load, S32 resumeInGame);
 /*--------------------------------------------------------------------------*/
 extern void GameAskChoice(S32 nummess);
 /* Harness hook: drive GameAskChoice's two modal waits with held keys, so a

--- a/SOURCES/PERSO.CPP
+++ b/SOURCES/PERSO.CPP
@@ -2988,7 +2988,13 @@ int main(int argc, char *argv[]) {
             TheEnd(PROGRAM_FAIL, "control: setup failed");
             return 1;
         }
-        MainLoop();
+        /* Through the menu loop rather than MainLoop directly. MainLoop RETURNS when the
+           player opens the in-game menu (the I_MENUS break), so calling it once ends the
+           run there: a replay of a session where the player pressed ESC stops at that
+           press with most of the stream unread. MainGameMenu's loop already does the
+           right thing, re-entering MainLoop when the session resumes, so route through it
+           instead of reimplementing it here. The load is already done, hence resumeInGame. */
+        MainGameMenu(0, TRUE);
         Control_End();
         /* Beside the --exec-at check and for the same reason: a run that did not do what
            the command line asked must not exit 0. Control_End has already said which of
@@ -3005,7 +3011,7 @@ int main(int argc, char *argv[]) {
         return 0;
     }
 
-    MainGameMenu(load);
+    MainGameMenu(load, FALSE);
 
 #ifdef DEMO
     if (!FlagShowEndDemo) {

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -1317,13 +1317,19 @@ end_loose="$(actors_of "$enddir/loose.json")"
     fail "budget: the state dump moved with the tick budget. The artifact is of the game running on past the recording with nothing driving it, not of where the replay ended. Differences:
 $(diff <(printf '%s\n' "$end_tight") <(printf '%s\n' "$end_loose") | head -8)"
 
-# --- a recording that opens a menu must not report success ---------------------------
+# --- a recording that opens a menu is replayed through it ----------------------------
 #
-# The in-game menu is a return from MainLoop (SOURCES/PERSO.CPP) and the harness calls
-# MainLoop once, so a replay that reaches an ESC ends there with its stream unread. What
-# makes it worth a fixture is how it used to end: exit 0 and `first hash mismatch -1`, the
-# string a caller greps to mean the replay reproduced, on a run that had replayed 201 of
-# 202 polls. Verified on the pristine engine before the fix, and on this file.
+# The in-game menu is a return from MainLoop (SOURCES/PERSO.CPP), and the harness used to
+# call MainLoop once, so a replay that reached an ESC ended there with its stream unread.
+# This fixture was written against that: it asserted the run exited non-zero and printed
+# no verdict, because exit 0 with `first hash mismatch -1` on a run that stopped at tick
+# 200 of 201 is the success-shaped lie.
+#
+# The harness now goes through the menu loop, so the same recording is replayed to its
+# last poll and the assertion inverts: this run reproduces the whole session and is
+# entitled to say so. The concern the old form protected has not gone away, it has moved
+# into the predicate: a run is short when it left for a menu AND the stream did not run
+# out, and the stall and short-stream prefixes carry the other ways of ending early.
 #
 # The recording is committed rather than made here because the ESC has to arrive through
 # the replay's own input path. `--exec-at "key esc"` reaches the same guard -- measured, it
@@ -1333,25 +1339,30 @@ escout="$(ctl --fixed-dt 16 --load "$LBA2_TEST_SAVE" \
     --tick 500 --dump-state "$(user_dir)/menu-esc.json" --exit 2>&1)" && escrc=0 || escrc=$?
 
 # The status first, because it is the whole point: a run that stopped short must not pass.
-[ "$escrc" -ne 0 ] ||
-    fail "menu: the replay exited 0 having stopped at the menu, which is the success-shaped run this fixture exists to catch"
+[ "$escrc" -eq 0 ] ||
+    fail "menu: the replay exited $escrc; a recording replayed to its last poll reproduced the session, whatever the player left through"
 
-# And it must not print the verdict line, whose -1 form is what a caller greps for. The
-# figures still go out, under a prefix that cannot be read as one.
+# The verdict line, and it has to be the pass form: this run did replay the recording.
+escchecked="$(printf '%s\n' "$escout" | sed -n 's/.*replay ended at poll [0-9]*: \([0-9]*\) ticks checked.*/\1/p' | head -1)"
+[ -n "$escchecked" ] ||
+    fail "menu: the run printed no verdict line, so it did not say whether it reproduced: $(printf '%s\n' "$escout" | grep -m1 -e 'at the' -e 'replay ended' || echo 'nothing')"
+
+# Counted rather than merely present. The recording holds 201 ticks, and a run that
+# survived the menu but stopped anywhere before the end would still print a verdict.
+[ "$escchecked" -ge 201 ] ||
+    fail "menu: the replay checked $escchecked ticks of the 201 the recording holds, so it did not get through the menu"
+
 case "$escout" in
-*"replay ended"*)
-    fail "menu: the run printed a verdict line: $(printf '%s\n' "$escout" | grep -m1 'replay ended')"
+*"at the menu:"*)
+    fail "menu: the run reported stopping at the menu, but it replayed the whole recording"
     ;;
 esac
-case "$escout" in
-*"at the menu:"*) ;;
-*) fail "menu: the run named no outcome; it has to say why it stopped" ;;
-esac
 
-# An artifact from here is of the state the ESC was pressed in, not of the recording.
-[ ! -e "$(user_dir)/menu-esc.json" ] ||
-    fail "menu: a --dump-state was written from a run that stopped at the menu"
+# And the artifact is owed: it describes where the recording ended, which is what the
+# caller asked for. Withholding it was right only while the run died at the ESC.
+[ -e "$(user_dir)/menu-esc.json" ] ||
+    fail "menu: no --dump-state was written from a run that replayed its whole recording"
 
 pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a video played to its end and replayed ($vidchecked ticks over $vidpolls polls); a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; mode.audio was written from the driver and reported both ways; a session recorded in one run replayed in the next with no flags and no paths; \
 'rec start verbose' carried telemetry and a plain one carried none; a recorded walk moved the hero and the replay walked it again; the recorder gave the step back and left the flag's alone; a playback put the player back where it found them, stopped early or run out; a window holding a scene change ran at ${modalrate}x real, not faster; a recording on a host-sampled clock crossed a scene change instead of wedging in the fade; \
-a command ran where the recording ran it, for an inline verb and for a deferred one; the state dump was the same at a 400 and a 4000 tick budget; a recording that opens a menu reported no verdict and exited non-zero; a replay with no --load booted from the recording's own starting state and still matched ($noloadchecked ticks); a deliberately diverging replay reported '$eqwith' with and without --load; a pre-inline recording loaded its sibling savegame with no --load and left it intact"
+a command ran where the recording ran it, for an inline verb and for a deferred one; the state dump was the same at a 400 and a 4000 tick budget; a recording that opens a menu was replayed through it ($escchecked ticks); a replay with no --load booted from the recording's own starting state and still matched ($noloadchecked ticks); a deliberately diverging replay reported '$eqwith' with and without --load; a pre-inline recording loaded its sibling savegame with no --load and left it intact"


### PR DESCRIPTION
The in-game menu is a return from `MainLoop`, not a modal loop, and the harness called `MainLoop` exactly once. So a replay of a session where the player pressed ESC ended at that press with the rest of the stream unread.

`SOURCES/PERSO.CPP` already said so at the break, and could not act on it:

> Leaving MainLoop for the menu. Under MainGameMenu that is a pause and the loop is re-entered; under the CLI harness, which calls MainLoop once, it is the end of the run — so a replay stops here with its stream unread. The harness cannot see the difference from the return value, which MainGameMenu's switch already spends.

`MainGameMenu`'s loop is what makes a menu a pause: it re-enters `MainLoop` when the session resumes. The harness now goes through that loop rather than reimplementing it.

## Effect

On a contributed 90,042-tick recording that opens the menu early:

| | ticks replayed | ends |
| --- | --- | --- |
| before | 50 | `at the menu` |
| after | 268 | `at the stall` |

## What a resume must not inherit

Measured rather than reasoned. Diffing `--dump-state` between this and the plain harness path on an identical command showed `obj[4].anim 279` against `277` at tick 2, so the entry was perturbing the simulation. The first pass was then made to touch nothing at all, confirmed byte-identical to `main`, and only what the loop pairs with was added back.

- `HQ_StopSample` / `StopMusic` silence the logo at boot; a resume arrives with a loaded scene whose ambience is running
- `InitPlasmaMenu`, `FlagShadeMenu`, `MenuMouseAcquire` are menu presentation, and a resume draws no menu
- `PtrPal = PtrPalNormal` points the palette at the menu's, over the scene palette the load path installs by hand precisely to avoid it
- `DemoSlide` / `GameInProgress` are the menu handing a session to gameplay; clearing `DemoSlide` turns an attract-mode run into an ordinary one

`GetResPath` stays **outside** the guard, and is the one that would have been a bug: it is the only write to `tmpFilePathScreen`, and the loop reads that buffer on its redraw paths. Its sibling `tmpFilePathSave` is safe by accident rather than design, because the loop re-derives that one where it uses it. The two look identical from the entry.

## Handing back

Only a menu is a pause worth re-entering for. `MainLoop` also returns when the game ends, and the switch below is the game's end-of-session handling: it saves, rolls credits, plays the win cinematic. A harness run reaching its tick budget or the end of a recording must reach its own reporting instead, so the loop leaves on any return that is not the menu. `Control_NoteLeftForMenu` already recorded which it was; this adds the accessor that was missing to read it.

## The verdict rule

First commit, separated because it has no observable effect on its own.

`Control_ReplayCutShort` answers "did this run end before replaying what it was given", and answered it by asking whether `MainLoop` last returned for the menu. Those were the same question only while the menu ended the run. A recording whose player ends the session at a menu is now replayed to its last poll and still leaves through one, and the flag alone calls that short. The stream having run out separates them, and is already tracked.

The two readers of that predicate disagreed before this: it is read in the replay reporter and in `main`'s exit check, which run at different moments, so a run could print `at the menu` and exit 0.

## Testing

`tests/automation/run.sh`: 74 passed, 2 skipped, 1 failed. The failure is `test_cli_flag_contract`, which fails identically on `b69360ca` without this change.

The menu arm asserted the opposite of what it now asserts, and was right to: before this, a replay reaching an ESC ended there, and `exit 0` with `first hash mismatch -1` on a run that had replayed 200 of 201 ticks is the success-shaped line a caller greps for. All three of its assertions invert, and the arm now counts the ticks rather than only checking that a verdict was printed, because a run that survived the menu and stopped early would still print one.
