### PR TITLE
feat(record): carry the tick the deterministic step was armed on

### DIFF
--- a/SOURCES/CONTROL.CPP
+++ b/SOURCES/CONTROL.CPP
@@ -157,6 +157,11 @@ static long s_hook_calls = 0;
 /* Set when the load left a timer bracket open that could not be closed where it was
    opened. See the close below. */
 static int s_bracket_close_pending = 0;
+/* The tick the deterministic step was armed on, or -1 for a run that never armed one.
+   Not whether, which mode.fixed_dt already carries: Timer_EnableFixedDt seeds the virtual
+   clock where it is called, so two runs that agree on the step and disagree on the moment
+   it started are running different clocks with identical settings. */
+static long s_step_armed_tick = -1;
 static int s_finalized = 0;
 /* Why the run is ending, for the two cases that used to end it at exit 0 while saying
    nothing. A harness run is bounded by its tick budget, and both of these leave it
@@ -706,12 +711,18 @@ static int control_resolve_save(const char *name) {
 }
 
 int Control_Begin(void) {
+    /* Before the arming below rather than beside the rest of the hook state at the end of
+       this function, which runs after it and would erase what the arming just recorded. */
+    s_step_armed_tick = -1;
+
     /* Pin the deterministic clock before the boot/load path runs. With the virtual clock
        frozen (the hook only advances it once MainLoop starts), every ManageTime() during
        InitGame/ChangeCube banks a zero delta, so the base clock stays exactly the restored
        save value -- no boot wall-clock leaks into it. Harness-only; off by default. */
-    if (s_have_fixed_dt)
+    if (s_have_fixed_dt) {
         Timer_EnableFixedDt((U32)s_fixed_dt);
+        Control_NoteStepArmed();
+    }
 
     /* No human is watching a --exit run, so drop the ~60 fps vsync cap and let the loop
        run flat-out. Presentation only -- the rendered pixels and simulation state are
@@ -1232,6 +1243,20 @@ void Control_End(void) {
     if (!s_have_dump && !s_have_shot)
         return;
     control_capture();
+}
+
+/* Called wherever the deterministic step is armed. First caller wins: a run can reach
+   Timer_EnableFixedDt from the command line before the loop starts or from the recorder's
+   reload part-way through it, and it is the first of those that decides which clock the
+   session ran on. Recorded as a tick rather than a place, because both a recording and its
+   replay arm through the same call and differ only in when they reach it. */
+void Control_NoteStepArmed(void) {
+    if (s_step_armed_tick < 0)
+        s_step_armed_tick = s_hook_calls;
+}
+
+long Control_StepArmedTick(void) {
+    return s_step_armed_tick;
 }
 
 /* PERSO.CPP's ESC break, so the harness can tell this return from a benign one. Recorded

--- a/SOURCES/CONTROL.H
+++ b/SOURCES/CONTROL.H
@@ -96,6 +96,8 @@ int Control_UnfiredExecAt(void);
    enters MainLoop once, so this return ends the run. Told to the harness so it can tell
    that from the benign early returns (LM_THE_END, the demo watchdog). */
 void Control_NoteMainLoopEntered(void);
+void Control_NoteStepArmed(void);
+long Control_StepArmedTick(void);
 void Control_NoteLeftForMenu(void);
 int Control_LeftForMenu(void);
 /* The replay consumed its last poll. Ends the run there instead of at the tick budget,

--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -700,6 +700,7 @@ static S32 write_mode_lines(char *out, size_t n) {
                          "mode.headless=%d\n"
                          "mode.audio=%d\n"
                          "mode.fixed_dt=%d\n"
+                         "mode.step_armed_tick=%ld\n"
                          "mode.verbose=%d\n"
                          "build.flags=%s\n"
                          "build.platform=%s\n"
@@ -721,6 +722,7 @@ static S32 write_mode_lines(char *out, size_t n) {
                          Control_IsHeadless(),
                          Control_AudioActive(),
                          (int)Timer_FixedDtValue(),
+                         Control_StepArmedTick(),
                          s_teleWrite || Control_RecordTelemetry(),
                          BUILD_FLAGS_STR,
                          Sys_PlatformName(),
@@ -1302,6 +1304,11 @@ static void record_reload_issue(void) {
     if (s_reloadForPlay != REC_RELOAD_RESTORE && !Timer_FixedDtActive()) {
         Timer_EnableFixedDt((U32)(s_reloadDt > 0 ? s_reloadDt : REC_DEFAULT_DT));
         s_recArmedDt = 1;
+        /* The other place a run can arm one. A session started from the console reaches
+           here part-way through its own run, and a replay of that session reaches it
+           before the first tick, so the two arm the same step at different moments and
+           the header has to carry which. */
+        Control_NoteStepArmed();
     }
 
     /* Before the load, because the load is what reads it. A savegame restores the
@@ -1978,8 +1985,18 @@ static int mode_line_ignored(const char *line) {
         "clock.timer_ref_hr=", /* the recorded baseline: restored, not matched */
         "clock.sim_carry=",    /* the sub-step carry: restored with it */
         "clock.rng_seed=",     /* the boot scene load's seed: installed, not matched */
-        "setup.snapshot=",     /* the file it started from, named per recording */
-        "setup.reloaded=",     /* how it started, which the reader acts on rather than matches */
+        /* When the step was armed, which is provenance and not a contract. Measured: a
+           session that armed part-way through its own run replays clean against one that
+           armed before its first tick, same 598 ticks, first hash mismatch -1, no drift.
+           So a difference here predicts nothing on its own and reporting it would spend
+           "this replay may not reproduce" on runs that do. What it is for is the reader:
+           it says a window exists between the load and the arming that the two runs spent
+           in different clock regimes, which matters only to something that writes into
+           that window, and it is what a replay would need to arm the way the recording
+           did. */
+        "mode.step_armed_tick=",
+        "setup.snapshot=", /* the file it started from, named per recording */
+        "setup.reloaded=", /* how it started, which the reader acts on rather than matches */
         "setup.reload_clock=",
         "bindings.keyboard=", /* payload a replay installs; bindings.digest is the comparison */
         "bindings.gamepad=",

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -491,6 +491,57 @@ case "$wout" in
     ;;
 esac
 
+# --- the step's arming point, carried but not compared ---------------------------------
+#
+# Timer_EnableFixedDt seeds the virtual clock where it is called, so a session that armed
+# its step part-way through its own run spent the ticks before that on a different clock
+# from a replay that arms before its first. mode.fixed_dt cannot say so: it records that
+# the step was pinned and not when, and both runs write 16.
+#
+# Carried for the reader rather than compared, and the arm asserts both halves of that.
+# A difference here predicts nothing: measured, the mismatched pair replays exactly as
+# clean as the matched one, so reporting it would spend the mode warning on runs that
+# reproduce. What it records is that a window exists between the load and the arming which
+# the two runs spent differently, and that only matters to something writing into it.
+armdir="$(mktemp -d)"
+clean_add "$armdir"
+
+# Armed from the console part-way through the run, so the recorded tick is not 0.
+LBA2_USER_DIR="$armdir" ctl --load "$LBA2_TEST_SAVE" \
+    --exec-at 20 "rec start" --exec-at 120 "rec stop" --tick 200 --exit >/dev/null 2>&1 ||
+    fail "arming: the recording run exited non-zero ($?)"
+armrec="$(ls "$armdir"/recordings/*.rec 2>/dev/null | head -1)"
+[ -n "$armrec" ] || fail "arming: the run wrote no recording to $armdir/recordings"
+
+armtick="$(head -c 800 "$armrec" | tr -d '\0' | sed -n 's/.*mode\.step_armed_tick=\([0-9-]*\).*/\1/p' | head -1)"
+[ -n "$armtick" ] ||
+    fail "arming: the recording carries no mode.step_armed_tick, so nothing records when the step was armed"
+
+# Non-zero, because a field that wrote 0 everywhere would satisfy the quiet assertion
+# below by never differing rather than by working.
+[ "$armtick" -gt 0 ] ||
+    fail "arming: a session that armed its step from the console recorded mode.step_armed_tick=$armtick, which is where a run armed before its first tick would be"
+
+# And the replay, which arms before tick 0, must record the other value and say nothing
+# about the difference. Silence is the assertion: this is provenance, not a contract.
+armout="$(LBA2_USER_DIR="$armdir" ctl --load "$LBA2_TEST_SAVE" --replay "$armrec" \
+    --tick 300 --exit 2>&1 || true)"
+case "$armout" in
+*"step_armed_tick"*)
+    fail "arming: the arming point was reported as a difference on a replay that reproduces: $(
+        printf '%s\n' "$armout" | grep -m1 'step_armed_tick')"
+    ;;
+esac
+
+# The reason it may stay quiet, asserted rather than assumed: that replay reproduced.
+case "$armout" in
+*"first hash mismatch -1"*) ;;
+*)
+    fail "arming: the mismatched pair did not replay clean, so the field is withheld from a case that does diverge: $(
+        printf '%s\n' "$armout" | grep -m1 -e 'replay ended' -e 'consistency' || echo 'no verdict')"
+    ;;
+esac
+
 # The loop a player can drive: record in one session, replay in the next, with nothing
 # typed at either end and no flags at all.
 #
@@ -1378,4 +1429,4 @@ esac
 
 pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a video played to its end and replayed ($vidchecked ticks over $vidpolls polls); a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; mode.audio was written from the driver and reported both ways; a session recorded in one run replayed in the next with no flags and no paths; \
 'rec start verbose' carried telemetry and a plain one carried none; a recorded walk moved the hero and the replay walked it again; the recorder gave the step back and left the flag's alone; a playback put the player back where it found them, stopped early or run out; a window holding a scene change ran at ${modalrate}x real, not faster; a recording on a host-sampled clock crossed a scene change instead of wedging in the fade; \
-a command ran where the recording ran it, for an inline verb and for a deferred one; the state dump was the same at a 400 and a 4000 tick budget; a recording that opens a menu was replayed through it ($escchecked ticks); a replay with no --load booted from the recording's own starting state and still matched ($noloadchecked ticks); a deliberately diverging replay reported '$eqwith' with and without --load; a pre-inline recording loaded its sibling savegame with no --load and left it intact"
+a command ran where the recording ran it, for an inline verb and for a deferred one; the state dump was the same at a 400 and a 4000 tick budget; a recording that opens a menu was replayed through it ($escchecked ticks); a replay with no --load booted from the recording's own starting state and still matched ($noloadchecked ticks); a deliberately diverging replay reported '$eqwith' with and without --load; a pre-inline recording loaded its sibling savegame with no --load and left it intact; the step's arming point was carried ($armtick against a replay's 0) without being reported, on a pair that replays clean"


### PR DESCRIPTION
`mode.fixed_dt` says a run pinned its step. It does not say when, and `Timer_EnableFixedDt` seeds the virtual clock where it is called, so a session that armed part-way through its own run spent the ticks before that on a different clock from a replay that arms before its first. Both write `16`, and nothing else in the header separates them.

The shape it happens in: `rec start` arms mid-run, while a `--replay` of that recording arms before tick 0. Recorded as a tick rather than a place, because both reach the same call in `record_reload_issue` and a field naming the site would have been identical on both sides and reported nothing.

## Carried, not compared

Measured before deciding the disposition. The mismatched pair replays exactly as clean as the matched one:

| pair | recorded | replay | verdict |
| --- | --- | --- | --- |
| `rec start` mid-run | 21 | 0 | 98 ticks, `first hash mismatch -1`, no drift |
| `--fixed-dt` both | 0 | 0 | 98 ticks, `first hash mismatch -1`, no drift |

Both from `--load "001 Start.LBA" --exec-at 20 "rec start" --exec-at 120 "rec stop" --tick 200`, replayed at `--tick 300`; the second adds `--fixed-dt 16` to the recording run so it arms before tick 0 like its replay does.

So a difference here predicts nothing on its own, and reporting it would spend `this replay may not reproduce` on runs that reproduce. The field goes in `mode_line_ignored` beside `clock.timer_ref_hr` and `setup.snapshot`, which are there for the same reason: payload and provenance rather than contract.

What it is for is the reader. It records that a window exists between the load and the arming which the two runs spent in different clock regimes. That window is inert until something writes into it, and the field is what a replay would need in order to arm the way the recording did.

## Old recordings

No format version and no refusal, per the note at the top of `RECORD.CPP`: a change to what the engine computes is reported per recording rather than gated. A file predating the field says so itself, since the header comparison walks both ways:

```
[rec] mode undeclared: mode.step_armed_tick (this run: mode.step_armed_tick=0)
[rec] 1 header trait(s) this recording predates; those were not checked
```

and still exits 0.

## Testing

The arm asserts three things, because each covers a way the field could look right and be useless: the recorded value is non-zero for a console-armed session, the replay says nothing about the difference, and the pair it stays quiet about did reproduce. The last is asserted rather than assumed; if it stops holding, the field is being withheld from a case that diverges and the silence becomes the wrong answer.

Verified against a broken build rather than trusted: with the note stubbed to record 0 whatever the tick, the arm fails on the recorded value.

`tests/automation/run.sh` on this branch rebased onto `cc01c7ae`: **74 passed, 2 skipped, 1 failed**. The failure is `test_cli_flag_contract`, which fails on pristine `cc01c7ae` with byte-identical hashes (`< b6f2bb5a86e9abe9 ./lba2.cfg > 9df71b74a8228f0f ./lba2.cfg`), so it is not this branch. The two skips are `polyrec` (binary built without `ENABLE_POLY_RECORDING`) and `projection_demo` (opt-in).
