### PR TITLE
fix(record): a replay must not boot into a game that never started

### DIFF
--- a/SOURCES/RECORD.CPP
+++ b/SOURCES/RECORD.CPP
@@ -1385,9 +1385,28 @@ static int record_begin(const char *path, int haveSnapshot) {
     snprintf(s_lastRecorded, sizeof s_lastRecorded, "%s", path);
 
     char mode[REC_HEADER_MAX];
-    if (!haveSnapshot)
+    /* Nothing to snapshot without a scene, and what came out of trying was worse than
+       nothing. SaveGame writes NumCube and the load reads it straight back into NewCube
+       (SOURCES/SAVEGAME.CPP), so a save written with no cube live is one whose scene is
+       -1 -- and the loader does not refuse that, it walks ChangeCube off the end of the
+       scene arrays honouring it. Recording from the flag arms after InitGame, which sets
+       NumCube = -1 to force the first cube change, so that was every from-boot recording:
+       2.7 KB of husk that could only ever crash the run that loaded it.
+
+       `-` rather than a snapshot that cannot be loaded, because the header is what a
+       replay decides on, and it already reads `-` as "this session began where a fresh
+       boot begins" -- which is what a session with no scene did. The same predicate
+       Record_Start uses to route here, so the two cannot disagree about which start
+       this is. */
+    if (haveSnapshot) {
+        s_snapInline = 1;
+    } else if (Control_HasLiveScene()) {
         record_write_snapshot(s_snapshot, sizeof s_snapshot);
-    s_snapInline = 1;
+        s_snapInline = 1;
+    } else {
+        snprintf(s_snapshot, sizeof s_snapshot, "-");
+        s_snapInline = 0;
+    }
     /* Not fatal here, unlike the mid-session path above: a from-boot recording reloads
        nothing, so a snapshot it could not write costs it the state it started from and
        not the session. record_write_chunk says so and the header still records that the
@@ -1442,8 +1461,13 @@ static int record_begin(const char *path, int haveSnapshot) {
     /* The snapshot goes in before the first record, so a reader meets it where the
        stream would otherwise begin and never has to hunt for it. It is also the only
        order a forward-only writer can produce: a session's opening state is the one
-       thing about it that is known before it starts. */
-    record_write_chunk(REC_SNAP_START, s_snapshot);
+       thing about it that is known before it starts.
+
+       Only when the header said one is coming. A session with no cube has none, and the
+       chunk must not be attempted from `-`: the reader takes the header at its word, and
+       a failed write here would report a snapshot missing that was never promised. */
+    if (s_snapInline)
+        record_write_chunk(REC_SNAP_START, s_snapshot);
 
     memset(s_prevKeys, 0, sizeof s_prevKeys);
     memset(s_prevAnalog, 0, sizeof s_prevAnalog);
@@ -2971,10 +2995,14 @@ int Record_Play(const char *path) {
  * boot path can load. Returns 1 with *out set, 0 when this is none of our business, and
  * -1 when a replay is armed and its starting state cannot be obtained at all.
  *
- * Every recording carries that state. Until now only a replay already inside a game read
- * it back, so the state had to be reproduced on the command line with --load, and getting
- * it wrong is silent: the run replays the recording's input into whatever it did boot and
- * reports the divergence it caused itself, while exiting 0.
+ * Every recording made from inside a game carries that state. Until now only a replay
+ * already inside a game read it back, so the state had to be reproduced on the command
+ * line with --load, and getting it wrong is silent: the run replays the recording's input
+ * into whatever it did boot and reports the divergence it caused itself, while exiting 0.
+ *
+ * A session recorded with no cube live is the other case, and it is a 0: it began where a
+ * fresh boot begins, so booting fresh is what reproduces it. `setup.cube` says which, and
+ * it is read before the sources below rather than after -- see the comment on that check.
  *
  * Two sources, the same pair and the same order Record_Play uses: the file's own copy, and
  * a sibling named by `setup.snapshot=` for a recording made before the format carried one.
@@ -2997,6 +3025,7 @@ int Record_ArmedReplayLoad(const char **out) {
     char named[ADELINE_MAX_PATH];
     char line[512];
     const char *path;
+    S32 cube = 0;
 
     if (out)
         *out = NULL;
@@ -3023,6 +3052,21 @@ int Record_ArmedReplayLoad(const char **out) {
         if (line[0] == '\n' || line[0] == '\r')
             break;
         strncat(header, line, sizeof header - strlen(header) - 1);
+    }
+
+    /* A session recorded with no cube live began where a fresh boot begins, so a fresh
+       boot is what reproduces it: nothing to hand back, and nothing missing either. The
+       0 rather than the -1 is that distinction -- the refusal is for a recording that
+       started somewhere this run cannot reach, and this one did not.
+
+       Read before the chunk, because recordings made before the writer above stopped
+       carry a snapshot of a game that never started: a savegame whose cube is -1, which
+       the loader does not refuse but walks off the end of the scene arrays trying to
+       honour. Those files are already on disk and this is what keeps them replayable. */
+    if (RecFmt_ReadInt(header, "setup.cube=", &cube) && cube < 0) {
+        fclose(s_f);
+        s_f = NULL;
+        return 0;
     }
 
     if (replay_read_chunk(REC_SNAP_START, s_bootSnap, sizeof s_bootSnap, "boot")) {

--- a/SOURCES/RECORD.H
+++ b/SOURCES/RECORD.H
@@ -55,7 +55,8 @@ void Record_ArmReplay(const char *path);
 /* The armed replay's own starting state, as a savegame Control_Begin can load when no
    --load was given, so a replay boots into the state its recording began from instead of
    one supplied by hand. Returns 1 with *out set, 0 when no replay is armed (or its file
-   will not open, which Record_Play reports by name), and -1 when a replay is armed and
+   will not open, which Record_Play reports by name, or its session began with no cube
+   live and a fresh boot is the state it began from), and -1 when a replay is armed and
    carries no obtainable starting state -- which the caller must refuse rather than boot
    fresh into. */
 int Record_ArmedReplayLoad(const char **out);

--- a/tests/automation/test_record_replay.sh
+++ b/tests/automation/test_record_replay.sh
@@ -1216,6 +1216,71 @@ esac
 [ "$noloadrc" -eq 0 ] ||
     fail "no --load: replay run exited non-zero ($noloadrc) with a clean summary"
 
+# --- and the recording that began before there was a game ---------------------------
+#
+# The case above records from a save, so its session always had a cube. A session
+# recorded from a fresh boot has none: --record arms after InitGame, which sets
+# NumCube = -1 to force the first cube change. SaveGame writes NumCube and the load
+# reads it straight back into NewCube, so a snapshot written there is a savegame whose
+# scene is -1 -- and the loader does not refuse it, it walks ChangeCube off the end of
+# the scene arrays honouring it. A replay that boots into one dies of a SIGSEGV before
+# its first tick.
+#
+# Every recording checked in here was made from a save (setup.cube 3, 42 or 97), so
+# nothing in this file used to reach that path; it was test_cli_flag_contract.sh that
+# caught it, and only because a run that dies writes no config. Recorded here instead,
+# where the fault is, and against the exit status because that is what it costs.
+bootdir="$(mktemp -d)"
+clean_add "$bootdir"
+bootrec="$bootdir/fromboot.rec"
+
+ctl --fixed-dt 16 --record "$bootrec" --tick 60 --exit >/dev/null 2>&1 ||
+    fail "from boot: the recording run exited non-zero ($?); it hung or crashed"
+[ -s "$bootrec" ] || fail "from boot: no recording written to $bootrec"
+
+# The header is the contract the replay decides on, so it is asserted rather than
+# inferred from the replay agreeing. `-` is how a recording says it began where a fresh
+# boot begins; `(inline)` here means the husk is back.
+bootheader="$(head -c 4096 "$bootrec" | tr -d '\0')"
+case "$bootheader" in
+*"setup.cube=-1"*) ;;
+*) fail "from boot: the recording does not declare setup.cube=-1; this arm tested nothing" ;;
+esac
+case "$bootheader" in
+*"setup.snapshot=-"*) ;;
+*) fail "from boot: the recording carries a starting state its session never had:
+  $(printf '%s\n' "$bootheader" | grep -m1 'setup.snapshot=')" ;;
+esac
+
+bootrc=0
+bootout="$(ctl --fixed-dt 16 --replay "$bootrec" --tick 100 --exit 2>&1)" || bootrc=$?
+
+# The opposite of the case above: this one must NOT take the recording's own state,
+# because a fresh boot is the state it began from.
+case "$bootout" in
+*"booting from the recording's own starting state"*)
+    fail "from boot: the replay loaded a starting state from a session that had none" ;;
+esac
+case "$bootout" in
+*"carries no starting state"*)
+    fail "from boot: the replay refused a recording that only needed a fresh boot" ;;
+esac
+
+bootsummary="$(printf '%s\n' "$bootout" | grep -m1 'replay ended')" ||
+    fail "from boot: replay printed no summary (exit $bootrc); it cannot be said to have matched"
+case "$bootsummary" in
+*"first hash mismatch -1"*) ;;
+*) fail "from boot: $bootsummary" ;;
+esac
+[ "$bootrc" -eq 0 ] ||
+    fail "from boot: replay run exited non-zero ($bootrc) with a clean summary"
+
+# The staged snapshot is removed at exit, and a run that crashed ran no atexit handler.
+# So a file left here is the crash even on a build where the summary somehow read clean.
+bootleft="$(find "$(user_dir)/recordings" -name '*.boot.lba' 2>/dev/null | tr '\n' ' ')"
+[ -z "$bootleft" ] ||
+    fail "from boot: a staged boot snapshot was left behind: $bootleft"
+
 # The equivalence half, and it needs a file that does NOT replay clean.
 #
 # Everything above compares one -1 against another, which any change producing -1 passes
@@ -1429,4 +1494,4 @@ esac
 
 pass "replayed clean: $bounded ticks checked with --tick, $unbounded without; a video played to its end and replayed ($vidchecked ticks over $vidpolls polls); a cut and a corrupted snapshot were both refused; a bare name went to the recordings folder; format 10 still reads ($lchecked ticks); telemetry named the injected change; mode.audio was written from the driver and reported both ways; a session recorded in one run replayed in the next with no flags and no paths; \
 'rec start verbose' carried telemetry and a plain one carried none; a recorded walk moved the hero and the replay walked it again; the recorder gave the step back and left the flag's alone; a playback put the player back where it found them, stopped early or run out; a window holding a scene change ran at ${modalrate}x real, not faster; a recording on a host-sampled clock crossed a scene change instead of wedging in the fade; \
-a command ran where the recording ran it, for an inline verb and for a deferred one; the state dump was the same at a 400 and a 4000 tick budget; a recording that opens a menu was replayed through it ($escchecked ticks); a replay with no --load booted from the recording's own starting state and still matched ($noloadchecked ticks); a deliberately diverging replay reported '$eqwith' with and without --load; a pre-inline recording loaded its sibling savegame with no --load and left it intact; the step's arming point was carried ($armtick against a replay's 0) without being reported, on a pair that replays clean"
+a command ran where the recording ran it, for an inline verb and for a deferred one; the state dump was the same at a 400 and a 4000 tick budget; a recording that opens a menu was replayed through it ($escchecked ticks); a replay with no --load booted from the recording's own starting state and still matched ($noloadchecked ticks); a session recorded from a fresh boot carried no starting state and replayed into one; a deliberately diverging replay reported '$eqwith' with and without --load; a pre-inline recording loaded its sibling savegame with no --load and left it intact; the step's arming point was carried ($armtick against a replay's 0) without being reported, on a pair that replays clean"


### PR DESCRIPTION
`--replay` of a recording made from the main menu crashes before its first tick, and
`tests/automation/test_cli_flag_contract.sh` has been red on `main` because of it.

## What happens

`--record` arms after `InitGame`, which sets `NumCube = -1` to force the first cube
change, so a session recorded from a fresh boot has no scene. `record_begin` saved a
snapshot there anyway. `SaveGame` writes `NumCube` and the load reads it straight back
into `NewCube` (`SOURCES/SAVEGAME.CPP`), so what it wrote was a savegame whose scene is
-1: 2705 bytes of husk against 10–12 KB for a real save, and no run can load it.

Since #657 a `--replay` given no `--load` boots into the recording's own starting state,
so it loaded that. The loader does not refuse a negative cube — it walks `ChangeCube` off
the end of the scene arrays honouring it. `SIGSEGV` before the first tick, or a fortify
abort in `InitObject` past `ListObjet[MAX_OBJETS]`, depending on the run. An explicit
`--load` avoids it entirely, which is why it went unnoticed: that path never asks the
recording.

## The fix, at both ends

**Writer.** `record_begin` stores no snapshot without `Control_HasLiveScene()` — the same
predicate `Record_Start` already uses to route into it, so the two cannot disagree about
which kind of start this is — and the header says `-`.

**Reader.** `Record_ArmedReplayLoad` reads `setup.cube` before the chunk and returns 0 on
a negative one. Not `1` (the crash) and not `-1` (the refusal — nothing is missing here).
A fresh boot *is* the state such a session began from, and it replays exactly as one.

The reader half is what keeps recordings already on disk working, and those are the files
that matter: one recorded by a pre-fix build replays clean on this branch — 61 ticks
checked, `first hash mismatch -1`, config intact, nothing staged left behind.

## Why the fixture reported it as a settings difference

`test_cli_flag_contract.sh` compares each flag's user directory against a baseline, and
`--replay` came back with a different `lba2.cfg` and a stray `recordings/rec.boot.lba`.
That reads like the flag writing settings it should not, and it is not: **a run that dies
never writes its config at all.** The file left behind is the embedded template
`SOURCES/LBA2.CFG` that `INITADEL.C` writes at boot into a user directory that has none,
byte for byte — a clean run overwrites it at exit with the live 244-line config, and a
crashed one leaves the template. So the fixture was measuring the symptom's shadow, which
is also why the crash never surfaced as a crash anywhere in the suite. Worth stating
because a reader will otherwise re-derive it from a diff that looks like config
corruption. No settings are damaged: an existing config is untouched by an abnormal exit
(measured — clean run to a 244-line config, second run `SIGKILL`ed after boot, file
unchanged).

## Coverage

Every recording checked into `tests/automation/recordings/` was made from a save —
`setup.cube` 3, 42 or 97 — so `test_record_replay.sh` never replayed a session that began
at the main menu. That is the gap this fell through. The new arm records from a fresh
boot and replays it, asserting both halves, because either alone passes on half a fix:
the header says `setup.snapshot=-` rather than claiming a starting state its session never
had, and the replay neither loads one nor refuses the file, and exits 0. A `*.boot.lba`
left in the recordings folder fails it too — that file is removed at exit and a crash runs
no `atexit` handler, so its presence is the crash even on a build whose summary reads
clean.

## Verification

- `test_cli_flag_contract.sh` — PASS (27 modes, 5 writers)
- `test_record_replay.sh` — PASS, all arms
- `check-format.sh`, `clang-format`, `check-arch.py` — clean

The new arm was validated as an oracle rather than assumed: with the reader check
disabled the crash returns exactly (`rc=139`, the template config, the stray snapshot),
and the arm on its own fails at the *writer* assertion first, so it could not have proven
the reader half by itself.

Independently confirmed from outside this branch: pristine `cc01c7ae` in a throwaway
worktree fails `test_cli_flag_contract.sh` with byte-identical hashes
(`b6f2bb5a86e9abe9` / `9df71b74a8228f0f`), so this is the engine rather than anyone's
working tree.
