### PR TITLE
fix(knowledge): match a file node graphify labels with its directory

### DIFF
--- a/scripts/dev/knowledge_graph.py
+++ b/scripts/dev/knowledge_graph.py
@@ -53,14 +53,16 @@ def main(argv):
     nodes = g["nodes"]
     edges = g.get("edges") if g.get("edges") is not None else g.setdefault("links", [])
 
-    # file node: the node whose label is the file's own name; routine nodes: by (file, label)
+    # file node: the node whose label is the file's own name, or its path suffix with the parent
+    # directory (graphify 0.9.57 labels a file that way when its basename collides); routine
+    # nodes: by (file, label)
     file_node, routine_node = {}, {}
     for n in nodes:
         sf = n.get("source_file") or ""
         if not sf:
             continue
         label = n.get("label") or ""
-        if label == os.path.basename(sf) and sf not in file_node:
+        if (label in (os.path.basename(sf), sf) or sf.endswith("/" + label)) and sf not in file_node:
             file_node[sf] = n["id"]
         routine_node[(sf, label.rstrip("()"))] = n["id"]
 


### PR DESCRIPTION
graphify 0.9.57 labels a file whose basename collides with another file's by its parent directory (`SYSTEM/TIMER.CPP`), or by its full path when the parent is a top-level directory (`SOURCES/INPUT.CPP`). `scripts/dev/knowledge_graph.py` recognised a file node only when its label was the bare basename, so every footnote citation into those files was skipped, and skipped quietly: 53 of the bundle's 276 `cites` edges across 33 files, and `graphify explain` on `SaveTimer()` listed no concept.

The match now accepts the bare name, the full path, or a slash-delimited suffix of the path. A routine label never contains a slash, so no other node can match.

Verified on a 0.9.57 graph of main at bd0057c0: the fixed exporter adds the 53 `cites` edges that graph was missing (44 from directory-prefixed labels, 9 from full-path labels), and the resulting citation set, with labels normalised to basenames, is identical to the one the 0.9.13 graph carried. `graphify explain lib386_system_timer_savetimer` lists the timing Subsystem and the SaveTimer Quirk again. ruff 0.16.3 passes.
